### PR TITLE
Handled overflow in evaluation for TableChart only

### DIFF
--- a/src/components/evaluation/charts/TableChart.tsx
+++ b/src/components/evaluation/charts/TableChart.tsx
@@ -172,6 +172,8 @@ function TableChart({
       <style jsx>{`
         .tableChart {
           width: 100%;
+          height: 100%;
+          overflow-y: auto;
         }
       `}</style>
     </div>

--- a/src/components/layouts/EvaluationLayout.tsx
+++ b/src/components/layouts/EvaluationLayout.tsx
@@ -294,7 +294,7 @@ function EvaluationLayout({
               .chart {
                 flex: 1 0 50vh;
                 order: 5;
-                overflow-y: scroll;
+                overflow-y: hidden;
               }
 
               .questionDetails {

--- a/src/components/layouts/EvaluationLayout.tsx
+++ b/src/components/layouts/EvaluationLayout.tsx
@@ -294,6 +294,7 @@ function EvaluationLayout({
               .chart {
                 flex: 1 0 50vh;
                 order: 5;
+                overflow-y: scroll;
               }
 
               .questionDetails {


### PR DESCRIPTION
The overflow is now only handled for the TableChart with the scrollbar. Did not find out how to fix the header of the semantic-ui table...
