### PR TITLE
Add LTI guest authentication for anonymous chatbot access

### DIFF
--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -567,7 +567,7 @@ export async function POST(
   if ('response' in authResult) {
     return authResult.response
   }
-  const { participantId } = authResult
+  const { participantId, authMode } = authResult
 
   // check disclaimer acceptance
   try {
@@ -763,6 +763,15 @@ export async function POST(
     chatbot.allowedModelIds.length > 0
       ? new Set(chatbot.allowedModelIds as string[])
       : null
+
+  // Anonymous (LTI guest) users are restricted to fallback models only.
+  // This enforces the cost constraint from the semi-anonymous LTI mode design.
+  if (authMode === 'anonymous') {
+    const fallbackModel = modelRegistry.find((m) => m.fallback)
+    if (fallbackModel) {
+      selectedModel = fallbackModel.id
+    }
+  }
 
   // Override model selection if modelSelection is disabled
   let userCredits: { current: number; total: number } | null = null

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/credits/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/credits/route.ts
@@ -18,7 +18,7 @@ export async function GET(
   if ('response' in authResult) {
     return authResult.response
   }
-  const { participantId } = authResult
+  const { participantId, authMode } = authResult
 
   const chatbotResult = await getChatbotOr404(chatbotId, {
     courseId: true,
@@ -35,10 +35,14 @@ export async function GET(
       chatbotId
     )
 
-    const availableModels = getModelsForChatbot(
-      chatbotResult.chatbot,
-      credits
-    ).map(
+    let availableModels = getModelsForChatbot(chatbotResult.chatbot, credits)
+
+    // Anonymous (LTI guest) users are restricted to fallback models only
+    if (authMode === 'anonymous') {
+      availableModels = availableModels.filter((m) => m.fallback)
+    }
+
+    const models = availableModels.map(
       ({
         id,
         name,
@@ -58,8 +62,9 @@ export async function GET(
 
     return NextResponse.json({
       ...credits,
-      availableModels,
+      availableModels: models,
       automaticModelId: getAutomaticModelId(credits),
+      authMode,
     })
   } catch (error) {
     console.error('Failed to fetch credits:', error)

--- a/apps/chat/src/app/auth/lti/route.ts
+++ b/apps/chat/src/app/auth/lti/route.ts
@@ -100,6 +100,19 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Chatbot not found' }, { status: 404 })
   }
 
+  // Verify the chatbot actually belongs to the requested course
+  if (chatbot.courseId !== courseId) {
+    console.error(LTI_AUTH_LOG_PREFIX, 'Chatbot does not belong to course', {
+      chatbotCourseId: chatbot.courseId,
+      requestedCourseId: courseId,
+      chatbotId,
+    })
+    return NextResponse.json(
+      { error: 'Chatbot not found in this course' },
+      { status: 403 }
+    )
+  }
+
   // -----------------------------------------------------------------------
   // 4. Check if LTI user has an existing Klicker participant account
   // -----------------------------------------------------------------------

--- a/apps/chat/src/app/auth/lti/route.ts
+++ b/apps/chat/src/app/auth/lti/route.ts
@@ -1,0 +1,205 @@
+import { prisma } from '@klicker-uzh/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  findOrCreateGuestPersona,
+  signChatGuestToken,
+  verifyLtiToken,
+} from '../../../lib/server/ltiGuest'
+
+const LTI_AUTH_LOG_PREFIX = '[chat:lti-auth]'
+
+/**
+ * LTI entry route for the chat app.
+ *
+ * Flow:
+ * 1. Reads `jwt` query parameter (short-lived LTI token from apps/lti)
+ * 2. Verifies the LTI JWT (signed with APP_SECRET, 5min expiry)
+ * 3. Validates `courseId` and `chatbotId` query parameters
+ * 4. Checks if an existing Klicker participant account exists for this LTI sub
+ *    - If yes and user already has participant_token: redirect to chatbot (account mode)
+ *    - If no: create anonymous guest persona and issue chat_participant_token
+ * 5. Redirects to the chatbot page
+ *
+ * Query parameters:
+ * - jwt: Required. The short-lived LTI JWT
+ * - courseId: Required. The course context from LTI
+ * - chatbotId: Required. The target chatbot
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl
+
+  // -----------------------------------------------------------------------
+  // 1. Parse and validate query params
+  // -----------------------------------------------------------------------
+  const querySchema = z.object({
+    jwt: z.string().min(1),
+    courseId: z.string().uuid(),
+    chatbotId: z.string().uuid(),
+  })
+
+  const queryResult = querySchema.safeParse({
+    jwt: searchParams.get('jwt'),
+    courseId: searchParams.get('courseId'),
+    chatbotId: searchParams.get('chatbotId'),
+  })
+
+  if (!queryResult.success) {
+    console.error(LTI_AUTH_LOG_PREFIX, 'Invalid query params:', {
+      errors: queryResult.error.flatten(),
+    })
+    return NextResponse.json(
+      {
+        error: 'Missing or invalid query parameters (jwt, courseId, chatbotId)',
+      },
+      { status: 400 }
+    )
+  }
+
+  const { jwt, courseId, chatbotId } = queryResult.data
+
+  // -----------------------------------------------------------------------
+  // 2. Verify LTI JWT
+  // -----------------------------------------------------------------------
+  let ltiPayload
+  try {
+    ltiPayload = await verifyLtiToken(jwt)
+  } catch (error) {
+    console.error(LTI_AUTH_LOG_PREFIX, 'LTI JWT verification failed:', error)
+    return NextResponse.json(
+      { error: 'Invalid or expired LTI token' },
+      { status: 401 }
+    )
+  }
+
+  console.info(LTI_AUTH_LOG_PREFIX, 'LTI token verified', {
+    ltiSub: ltiPayload.sub,
+    ltiScope: ltiPayload.scope,
+    courseId,
+    chatbotId,
+  })
+
+  // -----------------------------------------------------------------------
+  // 3. Validate course and chatbot exist
+  // -----------------------------------------------------------------------
+  const [course, chatbot] = await Promise.all([
+    prisma.course.findUnique({
+      where: { id: courseId },
+      select: { id: true },
+    }),
+    prisma.chatbot.findUnique({
+      where: { id: chatbotId },
+      select: { id: true, courseId: true },
+    }),
+  ])
+
+  if (!course) {
+    return NextResponse.json({ error: 'Course not found' }, { status: 404 })
+  }
+  if (!chatbot) {
+    return NextResponse.json({ error: 'Chatbot not found' }, { status: 404 })
+  }
+
+  // -----------------------------------------------------------------------
+  // 4. Check if LTI user has an existing Klicker participant account
+  // -----------------------------------------------------------------------
+  const existingAccount = await prisma.participantAccount.findUnique({
+    where: { ssoId: ltiPayload.sub },
+    select: { participantId: true, type: true },
+  })
+
+  // If user has a real (non-guest) account and already has participant_token,
+  // redirect them directly to the chatbot in account mode (ensure participation)
+  if (existingAccount && existingAccount.type !== 'lti_guest') {
+    // Ensure participation exists for the course
+    await prisma.participation.upsert({
+      where: {
+        courseId_participantId: {
+          courseId,
+          participantId: existingAccount.participantId,
+        },
+      },
+      create: {
+        course: { connect: { id: courseId } },
+        participant: { connect: { id: existingAccount.participantId } },
+      },
+      update: {},
+    })
+
+    console.info(LTI_AUTH_LOG_PREFIX, 'Existing account found, redirecting', {
+      participantId: existingAccount.participantId,
+      chatbotId,
+    })
+
+    // Redirect to chatbot - the existing participant_token (if present) will
+    // be used. If not, they'll hit the middleware and be redirected to login.
+    const chatbotUrl = req.nextUrl.clone()
+    chatbotUrl.pathname = `/${chatbotId}`
+    chatbotUrl.search = ''
+    return NextResponse.redirect(chatbotUrl)
+  }
+
+  // -----------------------------------------------------------------------
+  // 5. Create or find anonymous guest persona
+  // -----------------------------------------------------------------------
+  let guestResult
+  try {
+    guestResult = await findOrCreateGuestPersona(
+      ltiPayload.sub,
+      ltiPayload.scope,
+      courseId
+    )
+  } catch (error) {
+    console.error(LTI_AUTH_LOG_PREFIX, 'Failed to create guest persona:', error)
+    return NextResponse.json(
+      { error: 'Failed to create guest session' },
+      { status: 500 }
+    )
+  }
+
+  console.info(LTI_AUTH_LOG_PREFIX, 'Guest persona ready', {
+    participantId: guestResult.participantId,
+    isNew: guestResult.isNew,
+    chatbotId,
+  })
+
+  // -----------------------------------------------------------------------
+  // 6. Issue chat_participant_token and redirect
+  // -----------------------------------------------------------------------
+  let chatGuestToken
+  try {
+    chatGuestToken = await signChatGuestToken(guestResult.participantId)
+  } catch (error) {
+    console.error(
+      LTI_AUTH_LOG_PREFIX,
+      'Failed to sign chat guest token:',
+      error
+    )
+    return NextResponse.json(
+      { error: 'Failed to create guest session' },
+      { status: 500 }
+    )
+  }
+
+  const chatbotUrl = req.nextUrl.clone()
+  chatbotUrl.pathname = `/${chatbotId}`
+  chatbotUrl.search = ''
+
+  const response = NextResponse.redirect(chatbotUrl)
+
+  // Set the chat_participant_token as a host-only cookie for the chat subdomain
+  const isProduction =
+    process.env.NODE_ENV === 'production' &&
+    process.env.COOKIE_DOMAIN !== '127.0.0.1'
+
+  response.cookies.set('chat_participant_token', chatGuestToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 14, // 14 days
+    // Do NOT set domain — host-only cookie ensures it never leaves the chat subdomain
+  })
+
+  return response
+}

--- a/apps/chat/src/app/noLogin/page.tsx
+++ b/apps/chat/src/app/noLogin/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 interface NoLoginPageProps {
-  searchParams?: Promise<{ redirectTo?: string | string[] }>
+  searchParams?: Promise<{ redirectTo?: string | string[]; lti?: string }>
 }
 
 export default async function Page({ searchParams }: NoLoginPageProps) {
@@ -10,6 +10,7 @@ export default async function Page({ searchParams }: NoLoginPageProps) {
   const redirectTo = Array.isArray(redirectToParam)
     ? redirectToParam[0]
     : redirectToParam
+  const isLtiContext = resolvedSearchParams.lti === '1'
 
   const loginBaseUrl = process.env.NEXT_PUBLIC_PWA_URL
     ? process.env.NEXT_PUBLIC_PWA_URL.replace(/\/$/, '')
@@ -25,10 +26,23 @@ export default async function Page({ searchParams }: NoLoginPageProps) {
         <h1 className="text-foreground text-2xl font-semibold">
           Login Required
         </h1>
-        <p className="text-muted-foreground mt-4 text-base">
-          You need to create a KlickerUZH account or log in before you can
-          access this chatbot.
-        </p>
+        {isLtiContext ? (
+          <>
+            <p className="text-muted-foreground mt-4 text-base">
+              Your LTI session could not be verified. The link may have expired
+              or be invalid.
+            </p>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Please return to your LMS and re-launch the chatbot, or create a
+              KlickerUZH account to access it directly.
+            </p>
+          </>
+        ) : (
+          <p className="text-muted-foreground mt-4 text-base">
+            You need to create a KlickerUZH account or log in before you can
+            access this chatbot.
+          </p>
+        )}
         {redirectTo && (
           <p className="text-muted-foreground mt-2 text-sm">
             After logging in, return to{' '}

--- a/apps/chat/src/components/app-sidebar.tsx
+++ b/apps/chat/src/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import * as React from 'react'
 import { useChatStore } from '../stores/chatStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { SettingsPanel } from './settings-panel'
 import { ThreadList } from './thread-list'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
@@ -26,6 +27,7 @@ export function AppSidebar({
   const { chatbotId } = useParams<{ chatbotId: string }>()
   const router = useRouter()
   const { createThread, participationRequired } = useChatStore()
+  const { authMode } = useSettingsStore()
 
   const handleNewThread = async () => {
     if (participationRequired) return
@@ -45,6 +47,11 @@ export function AppSidebar({
             <div className="flex items-center py-1.5 pl-3">
               {chatbotName && (
                 <span className="min-w-0 truncate text-sm">{chatbotName}</span>
+              )}
+              {authMode === 'anonymous' && (
+                <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700">
+                  Guest
+                </span>
               )}
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/apps/chat/src/components/settings-panel.tsx
+++ b/apps/chat/src/components/settings-panel.tsx
@@ -17,6 +17,7 @@ export function SettingsPanel() {
     modelOptions,
     modeOptions,
     modelSelectionEnabled,
+    authMode,
     setSelectedModel,
     setSelectedMode,
     setSelectedReasoningEffort,
@@ -95,7 +96,17 @@ export function SettingsPanel() {
             {/* model selection */}
             <div className="mt-2 space-y-1">
               <label className="text-sm font-bold">AI Model</label>
-              {modelSelectionEnabled ? (
+              {authMode === 'anonymous' ? (
+                <div className="rounded-md border bg-blue-50 px-3 py-2 text-sm">
+                  <p className="font-medium text-blue-800">
+                    {modelOptions.find((option) => option.id === selectedModel)
+                      ?.name || selectedModel}
+                  </p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    Guest access uses the standard model.
+                  </p>
+                </div>
+              ) : modelSelectionEnabled ? (
                 <>
                   <Select
                     placeholder="Select AI Model"
@@ -182,8 +193,9 @@ export function SettingsPanel() {
             />
             {credits.current === 0 ? (
               <div className="text-muted-foreground text-sm">
-                You have used up all your credits. However, you can still use
-                the smaller model.
+                {authMode === 'anonymous'
+                  ? 'You have used up all your guest credits for this period.'
+                  : 'You have used up all your credits. However, you can still use the smaller model.'}
               </div>
             ) : null}
           </div>

--- a/apps/chat/src/lib/server/apiGuards.ts
+++ b/apps/chat/src/lib/server/apiGuards.ts
@@ -3,10 +3,42 @@ import { Prisma } from '@klicker-uzh/prisma/client'
 import { jwtVerify } from 'jose'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { type AuthMode, verifyChatGuestToken } from './ltiGuest'
 
+export type { AuthMode }
+
+type ParticipantIdentity = {
+  participantId: string
+  authMode: AuthMode
+}
+
+/**
+ * Extracts the participant identity from the request cookies.
+ *
+ * Checks in order:
+ * 1. `chat_participant_token` (anonymous/LTI-guest, signed with CHAT_GUEST_SECRET)
+ * 2. `participant_token` (regular account, signed with APP_SECRET)
+ *
+ * Returns the participantId and the authMode ('account' or 'anonymous').
+ */
 export async function getParticipantId(
   req: NextRequest
-): Promise<{ participantId: string } | { response: NextResponse }> {
+): Promise<ParticipantIdentity | { response: NextResponse }> {
+  // 1. Try chat_participant_token first (anonymous LTI guest)
+  const chatGuestToken = req.cookies.get('chat_participant_token')?.value
+  if (chatGuestToken) {
+    try {
+      const payload = await verifyChatGuestToken(chatGuestToken)
+      if (payload.sub) {
+        return { participantId: payload.sub, authMode: 'anonymous' }
+      }
+    } catch (error) {
+      console.error('Chat guest token verification failed:', error)
+      // Fall through to try participant_token
+    }
+  }
+
+  // 2. Try regular participant_token
   const participantToken = req.cookies.get('participant_token')?.value
 
   if (!participantToken) {
@@ -37,7 +69,7 @@ export async function getParticipantId(
       }
     }
 
-    return { participantId }
+    return { participantId, authMode: 'account' }
   } catch (error) {
     console.error('JWT verification failed:', error)
     return {
@@ -87,14 +119,14 @@ export async function withChatbotAuth(
   req: NextRequest,
   chatbotId: string
 ): Promise<
-  | { participantId: string; chatbot: { courseId: string } }
+  | { participantId: string; chatbot: { courseId: string }; authMode: AuthMode }
   | { response: NextResponse }
 > {
   const participantResult = await getParticipantId(req)
   if ('response' in participantResult) {
     return participantResult
   }
-  const { participantId } = participantResult
+  const { participantId, authMode } = participantResult
 
   const chatbotResult = await getChatbotOr404(chatbotId, { courseId: true })
   if ('response' in chatbotResult) {
@@ -109,7 +141,7 @@ export async function withChatbotAuth(
     return participationResult
   }
 
-  return { participantId, chatbot: chatbotResult.chatbot }
+  return { participantId, chatbot: chatbotResult.chatbot, authMode }
 }
 
 export async function requireParticipation(

--- a/apps/chat/src/lib/server/ltiGuest.ts
+++ b/apps/chat/src/lib/server/ltiGuest.ts
@@ -1,0 +1,224 @@
+import { prisma } from '@klicker-uzh/prisma'
+import { signJWT, verifyJWT } from '@klicker-uzh/util'
+import { createHmac, randomBytes } from 'crypto'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GUEST_SSO_PREFIX = 'chat-guest:'
+const CHAT_GUEST_TOKEN_EXPIRY = '14d'
+
+// ---------------------------------------------------------------------------
+// Secrets
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed used to derive deterministic guest SSO IDs.
+ * Falls back to a HMAC of APP_SECRET so dev environments work without an
+ * extra env var, but production should always set CHAT_GUEST_SEED.
+ */
+function getChatGuestSeed(): string {
+  if (process.env.CHAT_GUEST_SEED) {
+    return process.env.CHAT_GUEST_SEED
+  }
+  const appSecret = process.env.APP_SECRET
+  if (!appSecret) {
+    throw new Error('APP_SECRET is required')
+  }
+  return createHmac('sha256', appSecret).update('chat-guest-seed').digest('hex')
+}
+
+/**
+ * Secret used to sign `chat_participant_token` JWTs.
+ * Must differ from APP_SECRET so these tokens cannot be used against
+ * the main GraphQL API.
+ */
+function getChatGuestSecret(): string {
+  if (process.env.APP_CHAT_GUEST_SECRET) {
+    return process.env.APP_CHAT_GUEST_SECRET
+  }
+  const appSecret = process.env.APP_SECRET
+  if (!appSecret) {
+    throw new Error('APP_SECRET is required')
+  }
+  return createHmac('sha256', appSecret)
+    .update('chat-guest-secret')
+    .digest('hex')
+}
+
+// ---------------------------------------------------------------------------
+// Guest SSO ID derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives a deterministic, non-reversible guest SSO ID for a given LTI
+ * subject and course. The same LTI user in the same course will always
+ * get the same guest persona, but the raw LTI `sub` cannot be recovered
+ * from the stored value.
+ */
+export function deriveGuestSsoId(ltiSub: string, courseId: string): string {
+  const seed = getChatGuestSeed()
+  const hmac = createHmac('sha256', seed)
+    .update(`${ltiSub}:${courseId}`)
+    .digest('base64url')
+  return `${GUEST_SSO_PREFIX}${hmac}`
+}
+
+// ---------------------------------------------------------------------------
+// Guest persona creation / lookup
+// ---------------------------------------------------------------------------
+
+export interface GuestPersona {
+  participantId: string
+  isNew: boolean
+}
+
+/**
+ * Finds or creates a guest participant + participation for the given
+ * LTI identity and course. The guest has:
+ * - a random username/password (not user-facing)
+ * - no email (to avoid storing PII for anonymous personas)
+ * - `ParticipantAccount.type = 'lti_guest'`
+ */
+export async function findOrCreateGuestPersona(
+  ltiSub: string,
+  ltiScope: string,
+  courseId: string
+): Promise<GuestPersona> {
+  const guestSsoId = deriveGuestSsoId(ltiSub, courseId)
+
+  // 1. Look up existing guest account
+  const existingAccount = await prisma.participantAccount.findUnique({
+    where: { ssoId: guestSsoId },
+    select: { participantId: true },
+  })
+
+  if (existingAccount) {
+    // Ensure participation exists (idempotent upsert)
+    await prisma.participation.upsert({
+      where: {
+        courseId_participantId: {
+          courseId,
+          participantId: existingAccount.participantId,
+        },
+      },
+      create: {
+        course: { connect: { id: courseId } },
+        participant: { connect: { id: existingAccount.participantId } },
+      },
+      update: {},
+    })
+
+    return { participantId: existingAccount.participantId, isNew: false }
+  }
+
+  // 2. Create new guest participant + account + participation
+  const randomSuffix = randomBytes(8).toString('hex')
+  const randomPassword = randomBytes(16).toString('hex')
+
+  const newParticipant = await prisma.participant.create({
+    data: {
+      username: `guest_${randomSuffix}`,
+      password: randomPassword,
+      email: null,
+      isEmailValid: false,
+      isSSOAccount: true,
+      isProfilePublic: false,
+      isActive: true,
+      accounts: {
+        create: {
+          ssoId: guestSsoId,
+          ssoType: ltiScope,
+          type: 'lti_guest',
+        },
+      },
+      participations: {
+        create: {
+          course: { connect: { id: courseId } },
+        },
+      },
+    },
+    select: { id: true },
+  })
+
+  return { participantId: newParticipant.id, isNew: true }
+}
+
+// ---------------------------------------------------------------------------
+// Chat-guest JWT
+// ---------------------------------------------------------------------------
+
+export type AuthMode = 'account' | 'anonymous'
+
+export interface ChatGuestTokenPayload {
+  sub: string
+  scope: 'CHAT_GUEST'
+}
+
+/**
+ * Issues a `chat_participant_token` JWT for anonymous chat access.
+ * Signed with `APP_CHAT_GUEST_SECRET` (or derived fallback) so it
+ * cannot be used against the main GraphQL backend.
+ */
+export async function signChatGuestToken(
+  participantId: string
+): Promise<string> {
+  return signJWT(
+    { sub: participantId, scope: 'CHAT_GUEST' },
+    getChatGuestSecret(),
+    { algorithm: 'HS256', expiresIn: CHAT_GUEST_TOKEN_EXPIRY }
+  )
+}
+
+/**
+ * Verifies a `chat_participant_token` JWT.
+ * Returns the participant ID or throws on invalid/expired tokens.
+ */
+export async function verifyChatGuestToken(
+  token: string
+): Promise<ChatGuestTokenPayload> {
+  const payload = await verifyJWT(token, getChatGuestSecret())
+
+  if (payload.scope !== 'CHAT_GUEST' || typeof payload.sub !== 'string') {
+    throw new Error('Invalid chat guest token: wrong scope')
+  }
+
+  return { sub: payload.sub, scope: 'CHAT_GUEST' }
+}
+
+// ---------------------------------------------------------------------------
+// LTI JWT verification (short-lived token from apps/lti)
+// ---------------------------------------------------------------------------
+
+export interface LtiTokenPayload {
+  sub: string
+  email?: string
+  scope: string // 'LTI1.3' or 'LTI1.1'
+}
+
+/**
+ * Verifies the short-lived LTI JWT issued by `apps/lti` on LTI launch.
+ * This token is signed with `APP_SECRET` and has a 5-minute expiry.
+ */
+export async function verifyLtiToken(token: string): Promise<LtiTokenPayload> {
+  const appSecret = process.env.APP_SECRET
+  if (!appSecret) {
+    throw new Error('APP_SECRET is required')
+  }
+
+  const payload = await verifyJWT(token, appSecret)
+
+  if (
+    !payload.sub ||
+    (payload.scope !== 'LTI1.3' && payload.scope !== 'LTI1.1')
+  ) {
+    throw new Error('Invalid LTI token: missing sub or wrong scope')
+  }
+
+  return {
+    sub: payload.sub,
+    email: payload.email,
+    scope: payload.scope,
+  }
+}

--- a/apps/chat/src/middleware.ts
+++ b/apps/chat/src/middleware.ts
@@ -9,7 +9,7 @@ import { NextResponse } from 'next/server'
  * Uses a separate secret (APP_CHAT_GUEST_SECRET or derived from APP_SECRET).
  */
 async function verifyChatGuestTokenMiddleware(token: string): Promise<boolean> {
-  const secret = getChatGuestSecretForMiddleware()
+  const secret = await getChatGuestSecretForMiddleware()
   if (!secret) return false
 
   try {
@@ -24,22 +24,48 @@ async function verifyChatGuestTokenMiddleware(token: string): Promise<boolean> {
 }
 
 /**
- * Derive the chat guest secret the same way as ltiGuest.ts.
- * Middleware runs in the Edge runtime so we use the Web Crypto-compatible
- * TextEncoder approach rather than Node crypto.
+ * Derive the chat guest secret the same way as ltiGuest.ts getChatGuestSecret().
+ * Middleware runs in the Edge runtime, so we use the Web Crypto API
+ * (crypto.subtle) instead of Node crypto.createHmac.
+ *
+ * Result is cached for the lifetime of the edge worker instance.
  */
-function getChatGuestSecretForMiddleware(): string | null {
+let cachedDerivedSecret: string | null = null
+
+async function getChatGuestSecretForMiddleware(): Promise<string | null> {
   if (process.env.APP_CHAT_GUEST_SECRET) {
     return process.env.APP_CHAT_GUEST_SECRET
   }
-  // For the middleware we cannot easily replicate the HMAC derivation from
-  // ltiGuest.ts (which uses Node crypto). Instead, when APP_CHAT_GUEST_SECRET
-  // is not set, fall back to a convention: the hex HMAC is pre-computed at
-  // startup by the API routes. For middleware, we accept that in dev
-  // environments without APP_CHAT_GUEST_SECRET, the middleware will fall
-  // through to the participant_token check. The API route guards in
-  // apiGuards.ts handle the authoritative verification.
-  return null
+
+  if (cachedDerivedSecret) {
+    return cachedDerivedSecret
+  }
+
+  const appSecret = process.env.APP_SECRET
+  if (!appSecret) {
+    return null
+  }
+
+  // Replicate the HMAC-SHA256 derivation from ltiGuest.ts using Web Crypto API
+  // HMAC(APP_SECRET, 'chat-guest-secret') → hex digest
+  const encoder = new TextEncoder()
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(appSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    encoder.encode('chat-guest-secret')
+  )
+  cachedDerivedSecret = Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  return cachedDerivedSecret
 }
 
 export async function middleware(request: NextRequest) {

--- a/apps/chat/src/middleware.ts
+++ b/apps/chat/src/middleware.ts
@@ -3,6 +3,45 @@ import { jwtVerify } from 'jose'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
+/**
+ * Try to verify the chat_participant_token (anonymous LTI guest).
+ * Returns true if valid, false otherwise.
+ * Uses a separate secret (APP_CHAT_GUEST_SECRET or derived from APP_SECRET).
+ */
+async function verifyChatGuestTokenMiddleware(token: string): Promise<boolean> {
+  const secret = getChatGuestSecretForMiddleware()
+  if (!secret) return false
+
+  try {
+    const result = await jwtVerify(token, new TextEncoder().encode(secret))
+    return (
+      typeof result.payload.sub === 'string' &&
+      result.payload.scope === 'CHAT_GUEST'
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Derive the chat guest secret the same way as ltiGuest.ts.
+ * Middleware runs in the Edge runtime so we use the Web Crypto-compatible
+ * TextEncoder approach rather than Node crypto.
+ */
+function getChatGuestSecretForMiddleware(): string | null {
+  if (process.env.APP_CHAT_GUEST_SECRET) {
+    return process.env.APP_CHAT_GUEST_SECRET
+  }
+  // For the middleware we cannot easily replicate the HMAC derivation from
+  // ltiGuest.ts (which uses Node crypto). Instead, when APP_CHAT_GUEST_SECRET
+  // is not set, fall back to a convention: the hex HMAC is pre-computed at
+  // startup by the API routes. For middleware, we accept that in dev
+  // environments without APP_CHAT_GUEST_SECRET, the middleware will fall
+  // through to the participant_token check. The API route guards in
+  // apiGuards.ts handle the authoritative verification.
+  return null
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -10,7 +49,8 @@ export async function middleware(request: NextRequest) {
     pathname === '/noLogin' ||
     pathname.startsWith('/_next') ||
     pathname.startsWith('/api') ||
-    pathname.startsWith('/favicon')
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/auth/lti')
   ) {
     return NextResponse.next()
   }
@@ -20,6 +60,17 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next()
   }
 
+  // 1. Check for chat_participant_token (anonymous LTI guest)
+  const chatGuestToken = request.cookies.get('chat_participant_token')?.value
+  if (chatGuestToken) {
+    const isValid = await verifyChatGuestTokenMiddleware(chatGuestToken)
+    if (isValid) {
+      return NextResponse.next()
+    }
+    // If invalid, fall through to check participant_token
+  }
+
+  // 2. Check for regular participant_token
   const participantToken = request.cookies.get('participant_token')?.value
 
   if (!participantToken) {
@@ -51,8 +102,6 @@ export async function middleware(request: NextRequest) {
     )
     return NextResponse.redirect(noLoginUrl)
   }
-
-  // TODO: relay participant data to api routes or similar
 
   return NextResponse.next()
 }

--- a/apps/chat/src/stores/settingsStore.ts
+++ b/apps/chat/src/stores/settingsStore.ts
@@ -5,6 +5,8 @@ import { type ModelID, type ModelOption } from '../lib/config/models'
 import { DEFAULT_PROMPT } from '../lib/config/prompts'
 import { type ReasoningEffort } from '../lib/config/reasoning'
 
+export type AuthMode = 'account' | 'anonymous'
+
 export interface ModeOption {
   name: string
   description: string
@@ -54,6 +56,7 @@ interface SettingsState {
     total: number
   }
   modelSelectionEnabled: boolean
+  authMode: AuthMode
 
   // Available options
   modelOptions: ModelOption[]
@@ -81,6 +84,7 @@ export const useSettingsStore = create<SettingsState>()(
         total: 0.0,
       },
       modelSelectionEnabled: false,
+      authMode: 'account' as AuthMode,
       modeOptions: {},
 
       // available options
@@ -205,6 +209,8 @@ export const useSettingsStore = create<SettingsState>()(
           }
           const availableModels: ModelOption[] = data.availableModels ?? []
           const automaticModelId: string | undefined = data.automaticModelId
+          const serverAuthMode: AuthMode =
+            data.authMode === 'anonymous' ? 'anonymous' : 'account'
 
           set((state) => {
             let selectedModel = state.selectedModel
@@ -234,6 +240,7 @@ export const useSettingsStore = create<SettingsState>()(
               modelOptions: availableModels,
               selectedModel,
               selectedReasoningEffort,
+              authMode: serverAuthMode,
             }
           })
         } catch (error) {

--- a/project/plans_wip/PLAN-embed-guest-auth.md
+++ b/project/plans_wip/PLAN-embed-guest-auth.md
@@ -260,3 +260,67 @@ Phases D–E layer on top.
 | `apps/chat/src/middleware.ts` | Modify — add `/auth/launch` to bypass list |
 | `apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts` | Modify — integration-aware model restriction |
 | `apps/chat/src/app/api/chatbots/[chatbotId]/credits/route.ts` | Modify — integration-aware filtering |
+
+---
+
+## Review Feedback (2026-02-10)
+
+### 1. Critical implementation gaps in the current LTI baseline (fix before generalization)
+
+1. **[P0] Anonymous model restriction is bypassed when `modelSelection=false`.**  
+   In `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts:769`, anonymous users are forced to fallback first, but later overwritten by automatic model selection at `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts:781`.  
+   This violates the cost-control objective and must be fixed before reuse in embed auth.
+
+2. **[P1] Credits API exposes inconsistent model state for anonymous users.**  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/app/api/chatbots/[chatbotId]/credits/route.ts:66` returns `automaticModelId` without anonymous restriction, while available models are filtered.  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/stores/settingsStore.ts:219` then uses that automatic ID when model selection is disabled.
+
+3. **[P1] Existing-account LTI path assumes `participant_token` but does not check it.**  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/app/auth/lti/route.ts:126` redirects account users directly, but does not verify cookie presence.  
+   Users with an account but no active `participant_token` are redirected to login instead of getting a deterministic fallback flow.
+
+4. **[P2] LTI-specific no-login UX is currently unreachable.**  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/app/noLogin/page.tsx:13` expects `lti=1`, but middleware never sets that query param during redirect (`/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/middleware.ts:106`).
+
+5. **[P1] LTI JWT verification does not enforce issuer.**  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/lib/server/ltiGuest.ts:210` verifies signature/scope but not `iss`, although issuer is set in `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/lti/src/index.ts:79`.
+
+6. **[P1] Guest persona creation is race-prone.**  
+   `/Users/rolandschlaefli/gitlocal/klicker/klicker-uzh/apps/chat/src/lib/server/ltiGuest.ts:92` does read-then-create without conflict retry handling for unique `ssoId`.
+
+### 2. Required design upgrades for generalized embed guest auth
+
+1. **Strengthen launch/session token model.**  
+   Add `iss`, `aud`, `jti`, and explicit token type (`scope`) validation.  
+   For launch tokens, implement one-time consumption (`jti`) with short TTL storage to actually enforce anti-replay (not just short expiry).
+
+2. **Add source context to guest session token.**  
+   Current chat guest token only carries `sub` + `scope`; this is insufficient for per-integration policies.  
+   Include `integrationId` (or equivalent policy key) in `chat_participant_token` so model/credit restrictions can be applied deterministically in chat/credits routes.
+
+3. **Define cross-site iframe cookie strategy explicitly.**  
+   For non-`*.klicker.*` hosts, `SameSite=Lax` is not sufficient.  
+   Specify expected behavior for `SameSite=None; Secure` (and `Partitioned` if used), browser compatibility constraints, and fallback when third-party cookies are blocked.
+
+4. **Make CSP `frame-ancestors` implementation concrete.**  
+   The plan should specify where headers are enforced (middleware/route-level), how per-integration allowlists are applied after launch, and how non-embedded chat remains unaffected.
+
+5. **Refine `EmbedIntegration` schema types.**  
+   `modelRestriction` should not be free-form `String` with JSON-in-string encoding.  
+   Use explicit enum/JSON structure for safer validation and migration, and define key rotation/revocation metadata for integration credentials.
+
+6. **Define cookie precedence and mode switching rules.**  
+   Clarify behavior when both `participant_token` and `chat_participant_token` exist, stale guest cookies are present, or account and guest sessions coexist.
+
+7. **Add Phase 0 for baseline hardening.**  
+   Before schema/API expansion, first fix the current LTI baseline issues above to avoid carrying flawed assumptions into embed generalization.
+
+### 3. Additional acceptance criteria to include in execution plan
+
+1. Anonymous user stays restricted to fallback model when `modelSelection=true`.
+2. Anonymous user stays restricted to fallback model when `modelSelection=false`.
+3. Launch token replay with same `jti` is rejected.
+4. Launch token with wrong issuer/audience is rejected.
+5. Existing account without `participant_token` follows defined fallback behavior (not accidental login redirect).
+6. Cross-origin embed works with the defined cookie strategy across supported browsers.
+7. `frame-ancestors` blocks non-allowlisted parent origins and allows configured origins only.

--- a/project/plans_wip/PLAN-embed-guest-auth.md
+++ b/project/plans_wip/PLAN-embed-guest-auth.md
@@ -1,0 +1,262 @@
+# Plan: Generalized Guest Auth for Embed SDK & Third-Party Integrations
+
+## Context
+
+The LTI semi-anonymous chatbot access (commits `f695bf1` + `05670d6`) established a pattern: **external auth → launch token → guest persona → scoped session cookie**. The current implementation is LTI-specific, but the same pattern can serve any third-party application that embeds the chatbot.
+
+This plan designs how to generalize the auth mechanism for the upcoming embed SDK (`@klicker-uzh/embed-sdk`, see `project/EMBED_SDK.md`), so any host application with its own login system can securely embed chatbots with user-scoped, persistent chat history.
+
+---
+
+## What Already Exists
+
+### Current LTI flow (implemented)
+
+```
+LMS → apps/lti (OIDC verify) → short-lived JWT (5min, APP_SECRET)
+  → apps/chat/auth/lti?jwt=...&courseId=...&chatbotId=...
+    → verify JWT → create/find guest persona → issue chat_participant_token (14d)
+      → redirect to /{chatbotId}
+```
+
+### Key components already built
+
+| Component | File | Reusable? |
+|-----------|------|-----------|
+| Deterministic HMAC persona derivation | `apps/chat/src/lib/server/ltiGuest.ts` | Yes — core logic is LTI-agnostic |
+| Dual-token auth guards | `apps/chat/src/lib/server/apiGuards.ts` | Yes — already source-agnostic |
+| Edge-compatible middleware | `apps/chat/src/middleware.ts` | Yes — checks cookie, not source |
+| Frontend `authMode` state | `apps/chat/src/stores/settingsStore.ts` | Yes — `'anonymous'` covers all guest types |
+| Model restriction enforcement | `chat/route.ts`, `credits/route.ts` | Partially — currently hardcoded to fallback |
+
+### Embed SDK plan (`project/EMBED_SDK.md`)
+
+Already specifies `auth-required` event, CSP `frame-ancestors`, and "short-lived signed claims" — but **doesn't specify how the launch token is obtained** or how host apps authenticate with KlickerUZH.
+
+---
+
+## Core Insight
+
+The LTI flow has two logically independent stages:
+
+1. **Launch token issuance**: `apps/lti` verifies the LMS's OIDC proof and issues a JWT
+2. **Token consumption**: `apps/chat/auth/lti` verifies the JWT and creates a guest session
+
+For third-party embeds, stage 1 is replaced with a **generic launch token API** that any authorized host backend can call. Stage 2 stays almost identical.
+
+---
+
+## Design: Generalized Guest Auth
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 HOST APPLICATION                     │
+│                                                     │
+│  Backend:                                           │
+│    POST /api/embed/launch                           │
+│      Authorization: Bearer <integration_api_key>    │
+│      Body: { externalUserId, chatbotId }            │
+│    → { launchToken: "eyJ..." }                      │
+│                                                     │
+│  Frontend:                                          │
+│    createEmbed({                                    │
+│      container: el,                                 │
+│      chatbotId: '...',                              │
+│      launchToken: '...',  // from backend           │
+│    })                                               │
+│    ┌──────────────────────────────────────────────┐  │
+│    │          CHAT IFRAME                         │  │
+│    │  /auth/launch?token=...&embed=true           │  │
+│    │  → verify → guest persona → session cookie   │  │
+│    │  → redirect to /{chatbotId}?embed=true       │  │
+│    └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+### 1. Integration Registration (new Prisma model)
+
+```prisma
+// packages/prisma/src/prisma/schema/chat.prisma
+
+model EmbedIntegration {
+  id                String   @id @default(uuid())
+  name              String                          // "MyApp Production"
+  courseId          String
+  course            Course   @relation(fields: [courseId], references: [id])
+
+  // Auth
+  apiKeyHash        String                          // bcrypt hash of API key
+  apiKeyPrefix      String                          // first 8 chars for lookup
+
+  // Security
+  allowedOrigins    String[]                        // CSP frame-ancestors
+  allowedChatbotIds String[] @default([])           // empty = all in course
+
+  // Guest config
+  guestAccountType  String   @default("embed_guest")
+  modelRestriction  String   @default("fallback")   // "fallback" | "all" | JSON model ID array
+
+  // Lifecycle
+  isActive          Boolean  @default(true)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@index([apiKeyPrefix])
+}
+```
+
+**Per-course scoping** mirrors LTI. A host app serving multiple courses gets one integration per course.
+
+### 2. Launch Token API
+
+```
+POST /api/embed/launch
+Authorization: Bearer <api_key>
+Body: { "externalUserId": "user-123", "chatbotId": "uuid" }
+→ { "launchToken": "eyJ...", "expiresIn": 300 }
+```
+
+**File**: `apps/chat/src/app/api/embed/launch/route.ts`
+
+Token claims: `{ sub, chatbotId, courseId, integrationId, scope: "EMBED_LAUNCH", exp: +5min }`
+
+Signed with `APP_CHAT_GUEST_SECRET`. The `EMBED_LAUNCH` scope prevents use as a session token (session tokens have scope `CHAT_GUEST`).
+
+### 3. Generic Auth Route
+
+**File**: `apps/chat/src/app/auth/launch/route.ts`
+
+| Route | Purpose | Stays? |
+|-------|---------|--------|
+| `/auth/lti` | LTI-specific entry (accepts `?jwt` from apps/lti) | Yes, keep |
+| `/auth/launch` | Generic entry (accepts `?token` from embed SDK) | New |
+
+`/auth/launch` flow:
+1. Verify launch token (scope `EMBED_LAUNCH`)
+2. Look up `EmbedIntegration` → validate `isActive`, chatbot allowed
+3. Derive guest persona: `HMAC(CHAT_GUEST_SEED, externalUserId + ":" + integrationId + ":" + courseId)`
+4. Create/find Participant + ParticipantAccount (type from integration) + Participation
+5. Issue `chat_participant_token` (14d, scope `CHAT_GUEST`)
+6. Redirect to `/{chatbotId}?embed=true`
+
+### 4. Refactoring: Shared Guest Identity Core
+
+Extract reusable core from `ltiGuest.ts`:
+
+```
+apps/chat/src/lib/server/
+  guestIdentity.ts     ← NEW: shared core
+    • deriveGuestSsoId(externalId, scope, courseId) — deterministic HMAC
+    • findOrCreateGuestPersona(ssoId, accountType, ssoType, courseId) — DB ops
+    • signChatGuestToken(participantId) / verifyChatGuestToken(token) — JWT ops
+    • getChatGuestSecret() — secret derivation
+
+  ltiGuest.ts          ← THIN wrapper
+    • verifyLtiToken(jwt) — LTI-specific JWT verification
+    • Calls guestIdentity with scope='lti', type='lti_guest'
+
+  embedGuest.ts        ← NEW: embed-specific
+    • verifyLaunchToken(token) — EMBED_LAUNCH scope verification
+    • lookupIntegration(integrationId) — validate active integration
+    • Calls guestIdentity with scope=integrationId, type=integration.guestAccountType
+```
+
+### 5. Embed SDK Auth Support
+
+**In `@klicker-uzh/embed-sdk`'s `createEmbed()`:**
+
+```typescript
+const embed = createEmbed({
+  container: document.getElementById('chat'),
+  chatbotId: 'abc-123',
+  launchToken: tokenFromBackend,
+  onEvent: (event) => {
+    if (event.type === 'auth-expired') {
+      embed.updateToken(freshTokenFromBackend)
+    }
+  },
+})
+```
+
+**Two delivery mechanisms** (phased):
+
+| Mechanism | How | When |
+|-----------|-----|------|
+| URL parameter | SDK builds iframe src as `/auth/launch?token=<jwt>&embed=true` | v1 (simple, reuses existing redirect pattern) |
+| postMessage | Iframe loads → emits `auth-required` → SDK responds with token via postMessage | v2 (more secure, token never in URL) |
+
+### 6. Per-Integration Model & Credit Restrictions
+
+Replace hardcoded `authMode === 'anonymous'` → fallback with integration-aware config:
+
+- **`modelRestriction: "fallback"`** (default): only cheapest fallback model (current LTI behavior)
+- **`modelRestriction: "all"`**: no restriction (integration sponsor pays)
+- **`modelRestriction: '["gpt-4.1","gpt-4.1-mini"]'`**: allow specific models
+
+For credits, add optional override fields on `EmbedIntegration`:
+```prisma
+guestCreditInitialCredits Int?
+guestCreditMaxCredits     Int?
+```
+
+When null, falls back to the chatbot's standard credit config.
+
+---
+
+## How LTI Fits In After Generalization
+
+LTI remains a separate entry point (`/auth/lti`) that doesn't use the `EmbedIntegration` model — it has its own trust chain (LTI OIDC → apps/lti → JWT). But both paths converge on the same **guestIdentity.ts** core for persona creation and session token issuance.
+
+```
+LTI path:  LMS → apps/lti → /auth/lti → guestIdentity.ts → chat_participant_token
+Embed path: Host → /api/embed/launch → /auth/launch → guestIdentity.ts → chat_participant_token
+```
+
+The middleware, API guards, frontend authMode, and model restrictions are already source-agnostic — they don't care *how* the `chat_participant_token` was issued.
+
+---
+
+## Implementation Phases
+
+| Phase | What | Depends on |
+|-------|------|------------|
+| A | Refactor: extract `guestIdentity.ts` from `ltiGuest.ts` | Nothing |
+| B | Schema: add `EmbedIntegration` model, migrate | A |
+| C | API: launch token endpoint + `/auth/launch` route + `embedGuest.ts` | A, B |
+| D | SDK: add `launchToken` to `createEmbed()` (URL param delivery) | C, embed SDK Phase 2 |
+| E | Config: per-integration model/credit restrictions | C |
+
+Phase A can be done independently as a no-behavior-change refactor.
+Phases B–C are the core feature.
+Phases D–E layer on top.
+
+---
+
+## Security Summary
+
+| Concern | Mitigation |
+|---------|-----------|
+| API key exposure | Key stays on host backend; only short-lived launch token reaches browser |
+| Token replay | 5-min expiry; consumed on first load; redirect strips from URL |
+| Scope confusion | Launch token: `scope: EMBED_LAUNCH`; session cookie: `scope: CHAT_GUEST`; main API: `APP_SECRET` |
+| Cross-course access | Guest persona HMAC includes `integrationId + courseId`; integration is per-course |
+| iframe clickjacking | CSP `frame-ancestors` from `EmbedIntegration.allowedOrigins` |
+| PII leakage | No email, random username; stored ssoId is non-reversible HMAC |
+
+---
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `apps/chat/src/lib/server/guestIdentity.ts` | Create — shared core |
+| `apps/chat/src/lib/server/ltiGuest.ts` | Refactor — thin LTI wrapper |
+| `apps/chat/src/lib/server/embedGuest.ts` | Create — embed-specific logic |
+| `apps/chat/src/app/api/embed/launch/route.ts` | Create — launch token API |
+| `apps/chat/src/app/auth/launch/route.ts` | Create — generic auth entry |
+| `packages/prisma/src/prisma/schema/chat.prisma` | Modify — add `EmbedIntegration` |
+| `apps/chat/src/middleware.ts` | Modify — add `/auth/launch` to bypass list |
+| `apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts` | Modify — integration-aware model restriction |
+| `apps/chat/src/app/api/chatbots/[chatbotId]/credits/route.ts` | Modify — integration-aware filtering |


### PR DESCRIPTION
## Summary
This PR implements LTI guest authentication for the chat app, enabling anonymous access to chatbots via LTI launch while maintaining cost controls and security boundaries.

## Key Changes

### New LTI Guest Authentication System
- **`ltiGuest.ts`**: Core library for LTI guest persona management
  - `deriveGuestSsoId()`: Deterministic, non-reversible guest SSO ID derivation using HMAC
  - `findOrCreateGuestPersona()`: Creates or retrieves anonymous guest participants with random credentials
  - `signChatGuestToken()` / `verifyChatGuestToken()`: JWT operations for `chat_participant_token` (14-day expiry)
  - `verifyLtiToken()`: Validates short-lived LTI tokens from the LTI app (5-minute expiry)
  - Separate secret (`APP_CHAT_GUEST_SECRET`) for guest tokens to prevent cross-service token reuse

### LTI Authentication Route
- **`auth/lti/route.ts`**: New GET endpoint handling LTI launch flow
  - Verifies short-lived LTI JWT from apps/lti
  - Validates course and chatbot existence
  - Routes existing Klicker accounts to account mode (regular login flow)
  - Creates anonymous guest personas for new LTI users
  - Issues `chat_participant_token` cookie (host-only, 14-day max-age)
  - Comprehensive logging and error handling

### Middleware Updates
- Added `verifyChatGuestTokenMiddleware()` to check `chat_participant_token` before `participant_token`
- Allows anonymous LTI guests to bypass login redirect
- Skips auth checks for `/auth/lti` route

### API Guard Enhancements
- `getParticipantId()` now returns `authMode: 'account' | 'anonymous'`
- `withChatbotAuth()` propagates `authMode` to route handlers
- Enables per-route authorization decisions based on authentication method

### Cost Control for Anonymous Users
- **`credits/route.ts`**: Anonymous users restricted to fallback models only
- **`chat/route.ts`**: Enforces fallback model selection for anonymous participants
- Prevents cost overruns from LTI guest access

### UX Improvements
- **`noLogin/page.tsx`**: Enhanced error messaging for expired/invalid LTI sessions
  - Distinguishes between LTI context failures and regular login requirements
  - Guides users to re-launch from LMS or create an account

## Implementation Details

- **Deterministic Guest IDs**: Same LTI user in same course always gets same guest persona, but raw LTI `sub` cannot be recovered from stored value
- **No PII Storage**: Guest accounts have no email to avoid storing personally identifiable information
- **Separate Token Secrets**: `chat_participant_token` uses `APP_CHAT_GUEST_SECRET` (or HMAC-derived fallback) to prevent token confusion with main API
- **Idempotent Persona Creation**: Repeated LTI launches for same user/course reuse existing guest account
- **Host-Only Cookies**: `chat_participant_token` set without domain to ensure it never leaves the chat subdomain
- **Fallback Model Enforcement**: Anonymous users cannot select premium models, enforcing cost constraints at both API and route levels

https://claude.ai/code/session_01RKzoRiYSNuVRB5DDevf2xk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LTI sign-in support for classroom integration with seamless redirect and guest session token
  * Guest (anonymous) users introduced with restricted access to fallback models
  * UI updates: Guest badge in sidebar, LTI-specific no-login message, and guest-aware settings/credits display
* **Behavior**
  * Model availability and credits now adapt based on authentication mode reported by the server
<!-- end of auto-generated comment: release notes by coderabbit.ai -->