### PR TITLE
feat(adaptive): add persistence and seed fixtures

### DIFF
--- a/.github/workflows/test-adaptive-learning.yml
+++ b/.github/workflows/test-adaptive-learning.yml
@@ -1,0 +1,118 @@
+name: Test adaptive-learning package functionalities
+
+on:
+  push:
+    branches: ['v3', 'v3*']
+    paths:
+      - 'apps/frontend-manage/**'
+      - 'apps/frontend-pwa/**'
+      - 'packages/adaptive-learning/**'
+      - 'packages/grading/**'
+      - 'packages/graphql/**'
+      - 'packages/i18n/**'
+      - 'packages/prisma/**'
+      - 'packages/prisma-data/**'
+      - 'packages/shared-components/**'
+      - 'playwright/**'
+      - '.github/workflows/test-adaptive-learning.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'apps/frontend-manage/**'
+      - 'apps/frontend-pwa/**'
+      - 'packages/adaptive-learning/**'
+      - 'packages/grading/**'
+      - 'packages/graphql/**'
+      - 'packages/i18n/**'
+      - 'packages/prisma/**'
+      - 'packages/prisma-data/**'
+      - 'packages/shared-components/**'
+      - 'playwright/**'
+      - '.github/workflows/test-adaptive-learning.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 11.5.0
+          run_install: false
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.16.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check adaptive-learning package
+        run: pnpm --filter @klicker-uzh/adaptive-learning check
+      - name: Test adaptive-learning package
+        run: pnpm --filter @klicker-uzh/adaptive-learning test:run
+      - name: Generate adaptive-learning simulation report
+        run: pnpm --filter @klicker-uzh/adaptive-learning test:simulation:report
+      - name: Verify deterministic adaptive-learning simulation report
+        run: pnpm --filter @klicker-uzh/adaptive-learning verify:simulation:report:determinism
+      - name: Reject adaptive-learning simulation report drift
+        run: git diff --exit-code -- packages/adaptive-learning/reports
+      - name: Upload adaptive-learning simulation report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: adaptive-learning-simulation-report-${{ github.sha }}
+          path: |
+            packages/adaptive-learning/reports/simulation-report.json
+            packages/adaptive-learning/reports/simulation-summary.md
+          if-no-files-found: error
+          retention-days: 30
+
+  migration-rehearsal:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: klicker-prod
+          POSTGRES_USER: klicker
+          POSTGRES_PASSWORD: ${{ github.run_id }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U klicker -d klicker-prod"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 11.5.0
+          run_install: false
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.16.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Rehearse adaptive IRT v2 migrations
+        run: pnpm --filter @klicker-uzh/prisma verify:adaptive-irt-v2-migration
+        env:
+          DATABASE_URL: postgresql://klicker:${{ github.run_id }}@localhost:5432/klicker-prod

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -128,6 +128,7 @@ jobs:
             apps/olat-api/dist
             apps/response-api/dist
             packages/export/dist
+            packages/adaptive-learning/dist
             packages/grading/dist
             packages/graphql/dist
             packages/hatchet/dist

--- a/apps/analytics/prisma/schema/adaptive.prisma
+++ b/apps/analytics/prisma/schema/adaptive.prisma
@@ -1,0 +1,220 @@
+// LEGACY standalone adaptive assessment schema.
+// New adaptive learning work targets competence trees and PracticeQuizMode.ADAPTIVE
+// in competence.prisma / quiz.prisma. Do not expose these models through new
+// GraphQL or UI surfaces; remove them after the no-data or migration decision.
+
+enum AdaptiveAssessmentAttemptStatus {
+  IN_PROGRESS
+  COMPLETED
+  ABANDONED
+}
+
+model AdaptiveAssessment {
+  id String @id @default(uuid()) @db.Uuid
+
+  name        String
+  displayName String
+  description String?
+  status      PublicationStatus @default(DRAFT)
+  isDeleted   Boolean           @default(false)
+
+  thetaMin               Float @default(-3)
+  thetaMax               Float @default(3)
+  discrimination         Float @default(1.5)
+  standardErrorThreshold Float @default(0.4)
+  questionThreshold      Int   @default(50)
+  topInformationRatio    Float @default(0.8)
+
+  showTimer           Boolean @default(true)
+  showCompetenceNames Boolean @default(true)
+  showFinalResult     Boolean @default(true)
+  showSolutions       Boolean @default(false)
+
+  levels         AdaptiveAssessmentLevel[]
+  competences    AdaptiveAssessmentCompetence[]
+  subCompetences AdaptiveAssessmentSubCompetence[]
+  elements       AdaptiveAssessmentElement[]
+  attempts       AdaptiveAssessmentAttempt[]
+  resultMessages AdaptiveAssessmentResultMessage[]
+
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([courseId])
+  @@index([ownerId])
+  @@index([status])
+}
+
+model AdaptiveAssessmentLevel {
+  id Int @id @default(autoincrement())
+
+  label String
+  order Int
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  elements       AdaptiveAssessmentElement[]
+  resultMessages AdaptiveAssessmentResultMessage[]
+
+  @@unique([assessmentId, label])
+  @@unique([assessmentId, order])
+}
+
+model AdaptiveAssessmentCompetence {
+  id Int @id @default(autoincrement())
+
+  name                   String
+  tagName                String?
+  enabled                Boolean @default(true)
+  order                  Int
+  weight                 Float   @default(1)
+  questionThreshold      Int?
+  standardErrorThreshold Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  subCompetences AdaptiveAssessmentSubCompetence[]
+  elements       AdaptiveAssessmentElement[]
+
+  @@unique([assessmentId, name])
+  @@unique([assessmentId, order])
+}
+
+model AdaptiveAssessmentSubCompetence {
+  id Int @id @default(autoincrement())
+
+  name                   String
+  tagName                String?
+  enabled                Boolean @default(true)
+  order                  Int
+  questionThreshold      Int?
+  standardErrorThreshold Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  competence   AdaptiveAssessmentCompetence @relation(fields: [competenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  competenceId Int
+
+  elements AdaptiveAssessmentElement[]
+
+  @@unique([assessmentId, competenceId, name])
+  @@unique([assessmentId, competenceId, order])
+}
+
+model AdaptiveAssessmentElement {
+  id Int @id @default(autoincrement())
+
+  enabled        Boolean @default(true)
+  exposure       Int     @default(0)
+  discrimination Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int
+
+  competence   AdaptiveAssessmentCompetence @relation(fields: [competenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  competenceId Int
+
+  subCompetence   AdaptiveAssessmentSubCompetence @relation(fields: [subCompetenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  subCompetenceId Int
+
+  level   AdaptiveAssessmentLevel @relation(fields: [levelId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  levelId Int
+
+  responses AdaptiveAssessmentResponse[]
+
+  @@unique([assessmentId, elementId, competenceId, subCompetenceId, levelId])
+  @@index([elementId])
+  @@index([assessmentId, enabled])
+}
+
+model AdaptiveAssessmentAttempt {
+  id String @id @default(uuid()) @db.Uuid
+
+  status               AdaptiveAssessmentAttemptStatus @default(IN_PROGRESS)
+  currentTheta         Float                           @default(0)
+  currentStandardError Float?
+  finalTheta           Float?
+  finalStandardError   Float?
+  finalLevelLabel      String?
+  elapsedSeconds       Int?
+  thetaHistory         Json?
+  standardErrorHistory Json?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participantId String      @db.Uuid
+
+  participation   Participation @relation(fields: [participationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participationId Int
+
+  responses AdaptiveAssessmentResponse[]
+
+  startedAt   DateTime  @default(now())
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([assessmentId, participantId, status])
+  @@index([participationId])
+}
+
+model AdaptiveAssessmentResponse {
+  id Int @id @default(autoincrement())
+
+  order              Int
+  response           Json
+  correct            Boolean
+  thetaBefore        Float
+  thetaAfter         Float
+  standardErrorAfter Float
+  elapsedSeconds     Int?
+
+  attempt   AdaptiveAssessmentAttempt @relation(fields: [attemptId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  attemptId String                    @db.Uuid
+
+  adaptiveElement   AdaptiveAssessmentElement @relation(fields: [adaptiveElementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  adaptiveElementId Int
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, order])
+  @@index([attemptId])
+  @@index([adaptiveElementId])
+  @@index([elementId])
+}
+
+model AdaptiveAssessmentResultMessage {
+  id Int @id @default(autoincrement())
+
+  order      Int
+  message    String
+  minTheta   Float?
+  maxTheta   Float?
+  isFallback Boolean @default(false)
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  level   AdaptiveAssessmentLevel? @relation(fields: [levelId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  levelId Int?
+
+  @@unique([assessmentId, order])
+  @@index([assessmentId, isFallback])
+}

--- a/apps/analytics/prisma/schema/adaptivePracticeQuiz.prisma
+++ b/apps/analytics/prisma/schema/adaptivePracticeQuiz.prisma
@@ -1,0 +1,559 @@
+model PracticeQuizAdaptiveConfig {
+  id String @id @default(uuid()) @db.Uuid
+
+  practiceQuiz   PracticeQuiz @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String       @unique(map: "pqac_practice_quiz_key") @db.Uuid
+
+  competenceTree   CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  measurementVersion       AdaptiveMeasurementVersion @default(IRT_V1)
+  calibrationPolicyVersion Int?
+
+  scaleVersion   CompetenceTreeScaleVersion? @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String?                     @db.Uuid
+
+  preset                 AdaptivePracticeQuizPreset     @default(DIAGNOSTIC)
+  attemptSelectionPolicy AdaptiveAttemptSelectionPolicy @default(LATEST_COMPLETED)
+
+  totalQuestionCap      Int                      @default(50)
+  perLeafQuestionCap    Int?
+  minQuestionsPerLeaf   Int                      @default(2)
+  classificationZ       Float                    @default(1.28)
+  topInformationRatio   Float                    @default(0.8)
+  defaultDiscrimination Float                    @default(1.2)
+  levelMappingRule      AdaptiveLevelMappingRule @default(NEAREST)
+
+  showTimer Boolean @default(true)
+
+  nodeOverrides        PracticeQuizAdaptiveNodeOverride[]
+  elementOverrides     PracticeQuizAdaptiveElementOverride[]
+  publishedPool        PracticeQuizAdaptivePoolItem[]
+  attempts             AdaptivePracticeQuizAttempt[]
+  cohortSnapshots      AdaptivePracticeQuizCohortSnapshot[]
+  publications         PracticeQuizAdaptivePublication[]
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+
+  poolPublishedAt DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([id, competenceTreeId], map: "pqac_id_tree_key")
+  @@unique([id, practiceQuizId], map: "pqac_id_quiz_key")
+  @@unique([id, practiceQuizId, competenceTreeId], map: "pqac_id_quiz_tree_key")
+  @@index([competenceTreeId], map: "pqac_tree_idx")
+}
+
+model PracticeQuizAdaptivePublication {
+  id String @id @default(uuid()) @db.Uuid
+
+  version Int
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  tree             CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "pqap_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  measurementVersion             AdaptiveMeasurementVersion
+  preset                         AdaptivePracticeQuizPreset
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+
+  /// [PrismaAdaptiveCutScoreSnapshot]
+  cutScoreSnapshot Json
+
+  priorMean              Float
+  priorStandardDeviation Float
+  gridMin                Float
+  gridMax                Float
+  gridStep               Float
+
+  classificationProbabilityThreshold Float?
+
+  /// [PrismaAdaptiveHierarchicalWeightSnapshot]
+  hierarchicalWeightSnapshot Json
+
+  /// [PrismaAdaptiveEvidenceMinimumSnapshot]
+  evidenceMinimumSnapshot Json
+
+  totalQuestionCap Int
+  showTimer        Boolean
+
+  /// [PrismaAdaptiveQuestionCapSnapshot]
+  questionCapSnapshot Json
+
+  candidateSetPolicyVersion  String
+  randomizationPolicyVersion String
+  exposureCeiling            Float
+  overlapPolicyVersion       String
+  retakePolicy               AdaptiveAttemptSelectionPolicy
+  retakeCooldownDays         Int
+
+  /// [PrismaAdaptiveResearchAllocationPolicy]
+  researchAllocationPolicy Json?
+
+  stoppingPolicyVersion String
+  rolloutPolicyVersion  Int
+
+  empiricalValidation   AdaptivePracticeQuizEmpiricalValidation? @relation(fields: [empiricalValidationId, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], references: [id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], onDelete: Restrict, onUpdate: Cascade)
+  empiricalValidationId String?                                  @db.Uuid
+
+  publishedBy   User?   @relation("PracticeQuizAdaptivePublicationPublishedBy", fields: [publishedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  publishedById String? @db.Uuid
+
+  poolItems       PracticeQuizAdaptivePoolItem[]
+  attempts        AdaptivePracticeQuizAttempt[]
+  exposures       AdaptivePracticeQuizItemExposure[]
+  cohortSnapshots AdaptivePracticeQuizCohortSnapshot[]
+
+  publishedAt   DateTime  @default(now())
+  sealedAt      DateTime?
+  supersededAt  DateTime?
+  unpublishedAt DateTime?
+  createdAt     DateTime  @default(now())
+
+  @@unique([configId, version], map: "pqap_config_version_key")
+  @@unique([configId, id], map: "pqap_config_id_key")
+  @@unique([competenceTreeId, id], map: "pqap_tree_id_key")
+  @@unique([id, scaleVersionId, measurementVersion], map: "pqap_id_scale_measurement_key")
+  @@unique([id, configId, competenceTreeId], map: "pqap_id_config_tree_key")
+  @@unique([id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], map: "pqap_dispatch_identity_key")
+  @@index([scaleVersionId], map: "pqap_scale_idx")
+  @@index([empiricalValidationId], map: "pqap_validation_idx")
+  @@index([publishedById], map: "pqap_published_by_idx")
+}
+
+model AdaptiveCalibrationExportRequest {
+  id String @id @default(uuid()) @db.Uuid
+
+  status   AdaptiveCalibrationExportStatus @default(REQUESTED)
+  runToken String?                         @db.Uuid
+
+  datasetVersion     String
+  splitPolicyVersion String @default("HMAC_80_20_V1")
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  requestedBy   User?   @relation("AdaptiveCalibrationExportRequestedBy", fields: [requestedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  requestedById String? @db.Uuid
+
+  artifactKey      String?
+  artifactChecksum String?
+  rowCount         Int?
+
+  manifestArtifactKey String?
+  manifestChecksum    String?
+
+  holdoutArtifactKey      String?
+  holdoutArtifactChecksum String?
+  holdoutRowCount         Int?
+
+  criterionArtifactKey      String?
+  criterionArtifactChecksum String?
+
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+
+  failureCode String?
+
+  createdAt   DateTime  @default(now())
+  startedAt   DateTime?
+  completedAt DateTime?
+  expiresAt   DateTime
+  updatedAt   DateTime  @updatedAt
+
+  @@index([treeId, scaleVersionId, status], map: "acer_tree_scale_status_idx")
+  @@index([requestedById, createdAt], map: "acer_requester_created_idx")
+  @@index([status, expiresAt], map: "acer_status_expiry_idx")
+}
+
+model AdaptivePracticeQuizEmpiricalValidation {
+  id String @id @default(uuid()) @db.Uuid
+
+  status AdaptiveEmpiricalValidationStatus @default(SUBMITTED)
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  tree             CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "apqev_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  exportRequest   AdaptiveCalibrationExportRequest @relation(fields: [exportRequestId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  exportRequestId String                           @db.Uuid
+
+  bankFingerprint   String
+  configFingerprint String
+
+  measurementVersion             AdaptiveMeasurementVersion
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+  validationProtocolVersion      String
+  approvedProbabilityThreshold   Float
+
+  calibrationDatasetVersion  String
+  calibrationDatasetChecksum String
+  holdoutDatasetVersion      String
+  holdoutDatasetChecksum     String
+  disjointSplitProofChecksum String
+  criterionArtifactChecksum  String
+
+  /// [PrismaAdaptiveValidationMetrics]
+  aggregateMetrics Json
+
+  /// [PrismaAdaptiveValidationStratumMetrics]
+  stratumMetrics Json
+
+  artifactChecksum String
+  artifactKey      String
+
+  submittedBy   User?   @relation("AdaptiveEmpiricalValidationSubmittedBy", fields: [submittedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  submittedById String? @db.Uuid
+
+  approvedBy   User?   @relation("AdaptiveEmpiricalValidationApprovedBy", fields: [approvedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  approvedById String? @db.Uuid
+
+  publications PracticeQuizAdaptivePublication[]
+
+  submittedAt DateTime  @default(now())
+  reviewedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], map: "apqev_publication_identity_key")
+  @@unique([configId, bankFingerprint, configFingerprint, scaleVersionId, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion, validationProtocolVersion, approvedProbabilityThreshold, exportRequestId, criterionArtifactChecksum], map: "apqev_evidence_identity_key")
+  @@index([configId, status], map: "apqev_config_status_idx")
+  @@index([scaleVersionId], map: "apqev_scale_idx")
+  @@index([exportRequestId], map: "apqev_export_request_idx")
+  @@index([submittedById], map: "apqev_submitted_by_idx")
+  @@index([approvedById], map: "apqev_approved_by_idx")
+}
+
+model AdaptivePracticeQuizItemExposure {
+  id Int @id @default(autoincrement())
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  publicationId String                          @db.Uuid
+
+  poolItem   PracticeQuizAdaptivePoolItem @relation(fields: [publicationId, poolItemId], references: [publicationId, id], onDelete: Cascade, onUpdate: Cascade)
+  poolItemId Int
+
+  servedCount   BigInt   @default(0)
+  answeredCount BigInt   @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([publicationId, poolItemId], map: "apqie_publication_pool_key")
+  @@index([publicationId, servedCount], map: "apqie_publication_served_idx")
+}
+
+model PracticeQuizAdaptiveNodeOverride {
+  id Int @id @default(autoincrement())
+
+  enabled     Boolean @default(true)
+  weight      Float?
+  questionCap Int?
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Cascade, onUpdate: Cascade, map: "pqan_config_tree_same_tree_fkey")
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  node   CompetenceTreeNode @relation(fields: [competenceTreeId, nodeId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade, map: "pqan_node_same_tree_fkey")
+  nodeId Int
+
+  @@unique([configId, nodeId], map: "pqan_config_node_key")
+  @@index([competenceTreeId, nodeId], map: "pqan_tree_node_idx")
+}
+
+model PracticeQuizAdaptiveElementOverride {
+  id Int @id @default(autoincrement())
+
+  enabled        Boolean @default(true)
+  discrimination Float?
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Cascade, onUpdate: Cascade, map: "pqae_config_tree_same_tree_fkey")
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [competenceTreeId, assignmentId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade, map: "pqae_assignment_same_tree_fkey")
+  assignmentId Int
+
+  @@unique([configId, assignmentId], map: "pqae_config_assignment_key")
+  @@index([competenceTreeId, assignmentId], map: "pqae_tree_assignment_idx")
+}
+
+model PracticeQuizAdaptivePoolItem {
+  id Int @id @default(autoincrement())
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId, configId, competenceTreeId], references: [id, configId, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  publicationId String                          @db.Uuid
+
+  scaleVersionId String @db.Uuid
+
+  calibration   AdaptiveItemCalibration @relation(fields: [competenceTreeId, scaleVersionId, calibrationId, sourceAssignmentId, elementId, elementVersion], references: [treeId, scaleVersionId, id, assignmentId, elementId, elementVersion], onDelete: Restrict, onUpdate: Cascade)
+  calibrationId String                  @db.Uuid
+
+  sourceAssignment   CompetenceTreeElementAssignment @relation(fields: [sourceAssignmentId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  sourceAssignmentId Int
+
+  elementId      Int
+  elementVersion Int
+  elementType    ElementType
+  elementName    String
+
+  /// [PrismaElementData]
+  elementData Json
+
+  leafNodeId   Int
+  nodePath     Int[]
+  nodeNamePath String[]
+
+  levelId    Int
+  levelLabel String
+  levelOrder Int
+
+  discrimination             Float
+  difficulty                 Float
+  guessing                   Float
+  measurementVersion         AdaptiveMeasurementVersion
+  calibrationVersion         Int
+  calibrationStatus          AdaptiveItemCalibrationStatus
+  itemModel                  AdaptiveItemModel
+  modelImplementationVersion String
+  role                       AdaptivePoolItemRole          @default(SCORING)
+  contributesToEstimate      Boolean                       @default(true)
+  enablePercentInput         Boolean                       @default(false)
+
+  nextAttempts AdaptivePracticeQuizAttempt[]     @relation("AdaptivePracticeQuizAttemptNextPoolItem")
+  responses    AdaptivePracticeQuizResponse[]
+  exposure     AdaptivePracticeQuizItemExposure?
+
+  createdAt DateTime @default(now())
+
+  @@unique([publicationId, sourceAssignmentId], map: "pqapi_publication_assignment_key")
+  @@unique([publicationId, id], map: "pqapi_publication_id_key")
+  @@unique([publicationId, id, sourceAssignmentId, elementId], map: "pqapi_publication_response_key")
+  @@unique([configId, id], map: "pqapi_config_id_key")
+  @@unique([configId, id, sourceAssignmentId, elementId], map: "pqapi_response_identity_key")
+  @@index([publicationId, leafNodeId, levelId], map: "pqapi_publication_leaf_level_idx")
+  @@index([elementId, elementVersion], map: "pqapi_element_version_idx")
+  @@index([calibrationId], map: "pqapi_calibration_idx")
+}
+
+model AdaptivePracticeQuizAttempt {
+  id String @id @default(uuid()) @db.Uuid
+
+  status                        AdaptivePracticeQuizAttemptStatus @default(IN_PROGRESS)
+  stopReason                    AdaptivePracticeQuizStopReason?
+  currentTheta                  Float                             @default(0)
+  currentStandardError          Float?
+  finalTheta                    Float?
+  finalStandardError            Float?
+  finalLevelId                  Int?
+  finalScaleLevelId             Int?
+  elapsedSeconds                Int?
+  nextPoolItemId                Int?
+  nextAdministrationProbability Float?
+  nextCollectionDesignVersion   String?
+  nextRandomizationVersion      String?
+  nextRandomDraw                BigInt?
+  nextCandidateSetHash          String?
+  nextItemRole                  AdaptivePoolItemRole?
+  resultStatus                  AdaptiveResultStatus?
+  finalBandProbability          Float?
+  credibleLower                 Float?
+  credibleUpper                 Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  bandProbabilities Json?
+
+  config           PracticeQuizAdaptiveConfig @relation(fields: [configId, practiceQuizId, competenceTreeId], references: [id, practiceQuizId, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId         String                     @db.Uuid
+  competenceTreeId String                     @db.Uuid
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], references: [id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], onDelete: Restrict, onUpdate: Cascade, map: "apqa_publication_dispatch_fkey")
+  publicationId String                          @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "apqa_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  measurementVersion             AdaptiveMeasurementVersion
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+
+  practiceQuiz   PracticeQuiz @relation(fields: [practiceQuizId, courseId], references: [id, courseId], onDelete: Restrict, onUpdate: Cascade)
+  practiceQuizId String       @db.Uuid
+
+  course   Course @relation("AdaptivePracticeQuizAttemptCourse", fields: [courseId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participantId String      @db.Uuid
+
+  participation   Participation @relation(fields: [participationId, participantId, courseId], references: [id, participantId, courseId], onDelete: Cascade, onUpdate: Cascade)
+  participationId Int
+
+  finalLevel CompetenceTreeLevel? @relation("AdaptivePracticeQuizAttemptFinalLevel", fields: [competenceTreeId, finalLevelId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+
+  finalScaleLevel CompetenceTreeScaleLevel? @relation("AdaptivePracticeQuizAttemptFinalScaleLevel", fields: [competenceTreeId, scaleVersionId, finalScaleLevelId], references: [treeId, scaleVersionId, id], onDelete: NoAction, onUpdate: Cascade, map: "apqa_final_scale_level_fkey")
+
+  nextPoolItem PracticeQuizAdaptivePoolItem? @relation("AdaptivePracticeQuizAttemptNextPoolItem", fields: [publicationId, nextPoolItemId], references: [publicationId, id], onDelete: NoAction, onUpdate: Cascade)
+
+  responses AdaptivePracticeQuizResponse[]
+  estimates AdaptivePracticeQuizEstimate[]
+
+  startedAt   DateTime  @default(now())
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([id, configId], map: "apqa_id_config_key")
+  @@unique([id, configId, competenceTreeId], map: "apqa_id_config_tree_key")
+  @@unique([id, configId, publicationId], map: "apqa_id_config_publication_key")
+  @@index([practiceQuizId, participantId, status], map: "apqa_quiz_participant_status_idx")
+  @@index([participationId, practiceQuizId], map: "apqa_participation_quiz_idx")
+  @@index([finalLevelId], map: "apqa_final_level_idx")
+  @@index([nextPoolItemId], map: "apqa_next_pool_item_idx")
+  @@index([configId, practiceQuizId], map: "apqa_config_quiz_idx")
+  @@index([practiceQuizId, status, completedAt, id], map: "apqa_quiz_status_completed_idx")
+  @@index([practiceQuizId, participantId, status, completedAt, id], map: "apqa_quiz_participant_completed_idx")
+  @@index([courseId], map: "apqa_course_retention_idx")
+  @@index([participationId, participantId, courseId], map: "apqa_participation_identity_idx")
+  @@index([configId, nextPoolItemId], map: "apqa_config_next_pool_idx")
+  @@index([publicationId, nextPoolItemId], map: "apqa_publication_next_pool_idx")
+  @@index([scaleVersionId], map: "apqa_scale_version_idx")
+}
+
+model AdaptivePracticeQuizResponse {
+  id Int @id @default(autoincrement())
+
+  order                     Int
+  response                  Json
+  normalizedResponse        Json
+  score                     Float
+  correct                   Boolean
+  overallThetaBefore        Float?
+  overallThetaAfter         Float?
+  overallStandardErrorAfter Float?
+  overallCredibleLowerAfter Float?
+  overallCredibleUpperAfter Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  overallBandProbabilitiesAfter Json?
+
+  administrationProbability Float?
+  collectionDesignVersion   String?
+  randomizationVersion      String?
+  randomDraw                BigInt?
+  candidateSetHash          String?
+  itemRole                  AdaptivePoolItemRole @default(SCORING)
+  isCalibrationAnchor       Boolean              @default(false)
+  elapsedSeconds            Int?
+
+  attempt       AdaptivePracticeQuizAttempt @relation(fields: [attemptId, configId, publicationId], references: [id, configId, publicationId], onDelete: Cascade, onUpdate: Cascade)
+  attemptId     String                      @db.Uuid
+  configId      String                      @db.Uuid
+  publicationId String                      @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [assignmentId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  assignmentId Int
+
+  poolItem   PracticeQuizAdaptivePoolItem? @relation(fields: [publicationId, poolItemId, assignmentId, elementId], references: [publicationId, id, sourceAssignmentId, elementId], onDelete: NoAction, onUpdate: Cascade)
+  poolItemId Int?
+
+  elementId       Int
+  elementSnapshot Json?
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, order], map: "apqr_attempt_order_key")
+  @@unique([attemptId, assignmentId], map: "apqr_attempt_assignment_key")
+  @@index([assignmentId], map: "apqr_assignment_idx")
+  @@index([poolItemId], map: "apqr_pool_item_idx")
+  @@index([configId, poolItemId], map: "apqr_config_pool_idx")
+  @@index([configId, poolItemId, attemptId], map: "apqr_config_pool_attempt_idx")
+  @@index([publicationId, poolItemId, attemptId], map: "apqr_publication_pool_attempt_idx")
+}
+
+model AdaptivePracticeQuizEstimate {
+  id Int @id @default(autoincrement())
+
+  nodeKind                  AdaptiveEstimateNodeKind
+  theta                     Float?
+  standardError             Float?
+  responseCount             Int
+  stopReason                AdaptivePracticeQuizStopReason?
+  resultStatus              AdaptiveResultStatus?
+  classificationProbability Float?
+  credibleLower             Float?
+  credibleUpper             Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  bandProbabilities Json?
+
+  attempt          AdaptivePracticeQuizAttempt @relation(fields: [attemptId, configId, competenceTreeId], references: [id, configId, competenceTreeId], onDelete: Cascade, onUpdate: Cascade)
+  attemptId        String                      @db.Uuid
+  configId         String                      @db.Uuid
+  competenceTreeId String                      @db.Uuid
+
+  node   CompetenceTreeNode? @relation(fields: [competenceTreeId, nodeId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+  nodeId Int?
+
+  level   CompetenceTreeLevel? @relation(fields: [competenceTreeId, levelId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+  levelId Int?
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, nodeKind, nodeId], map: "apqe_attempt_kind_node_key")
+  @@index([attemptId, nodeKind, nodeId, levelId], map: "apqe_attempt_node_level_idx")
+  @@index([nodeKind, levelId], map: "apqe_kind_level_idx")
+  @@index([configId, competenceTreeId], map: "apqe_config_tree_idx")
+}
+
+model AdaptivePracticeQuizCohortSnapshot {
+  id String @id @default(uuid()) @db.Uuid
+
+  config         PracticeQuizAdaptiveConfig @relation(fields: [configId, practiceQuizId], references: [id, practiceQuizId], onDelete: Restrict, onUpdate: Cascade)
+  configId       String                     @db.Uuid
+  practiceQuizId String                     @db.Uuid
+
+  publication        PracticeQuizAdaptivePublication @relation(fields: [publicationId, scaleVersionId, measurementVersion], references: [id, scaleVersionId, measurementVersion], onDelete: Restrict, onUpdate: Cascade)
+  publicationId      String                          @db.Uuid
+  scaleVersionId     String                          @db.Uuid
+  measurementVersion AdaptiveMeasurementVersion
+
+  releaseSize            Int
+  releaseWatermark       DateTime
+  policyVersion          Int                            @default(1)
+  attemptSelectionPolicy AdaptiveAttemptSelectionPolicy
+
+  /// [PrismaAdaptivePracticeQuizCohortSnapshot]
+  aggregate Json
+
+  invalidatedAt DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@unique([publicationId, releaseSize, policyVersion, attemptSelectionPolicy], map: "apqcs_publication_release_policy_key")
+  @@index([configId, invalidatedAt, releaseSize], map: "apqcs_config_valid_release_idx")
+  @@index([practiceQuizId], map: "apqcs_quiz_retention_idx")
+}

--- a/apps/analytics/prisma/schema/competence.prisma
+++ b/apps/analytics/prisma/schema/competence.prisma
@@ -1,0 +1,271 @@
+enum PracticeQuizMode {
+  STANDARD
+  ADAPTIVE
+}
+
+enum AdaptivePracticeQuizPreset {
+  PLACEMENT
+  DIAGNOSTIC
+  RESEARCH
+}
+
+enum AdaptiveAttemptSelectionPolicy {
+  FIRST_COMPLETED
+  LATEST_COMPLETED
+}
+
+enum AdaptiveLevelMappingRule {
+  NEAREST
+  MASTERY
+}
+
+enum AdaptiveNodeKind {
+  COMPETENCE
+  SUBCOMPETENCE
+}
+
+enum AdaptiveEstimateNodeKind {
+  OVERALL
+  COMPETENCE
+  SUBCOMPETENCE
+}
+
+enum AdaptivePracticeQuizAttemptStatus {
+  IN_PROGRESS
+  COMPLETED
+  ABANDONED
+}
+
+enum AdaptivePracticeQuizStopReason {
+  CLASSIFIED
+  ALL_ROOTS_CLASSIFIED
+  TOTAL_QUESTION_CAP
+  NODE_QUESTION_CAP
+  POOL_EXHAUSTED
+  INSUFFICIENT_DATA
+  ABANDONED
+}
+
+enum AdaptiveMeasurementVersion {
+  IRT_V1
+  IRT_V2_EAP_GRID_1
+}
+
+enum AdaptiveScaleVersionStatus {
+  DRAFT
+  IN_REVIEW
+  APPROVED
+  ACTIVE
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveScaleLinkStatus {
+  DRAFT
+  IN_REVIEW
+  APPROVED
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveItemCalibrationStatus {
+  PROVISIONAL
+  PILOT
+  CALIBRATED
+  FLAGGED
+  RETIRED
+}
+
+enum AdaptiveItemModel {
+  TWO_PL
+  THREE_PL_FIXED_C
+}
+
+enum AdaptiveCalibrationExportStatus {
+  REQUESTED
+  RUNNING
+  READY
+  FAILED
+  EXPIRED
+}
+
+enum AdaptiveEmpiricalValidationStatus {
+  SUBMITTED
+  APPROVED
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveResultStatus {
+  CLASSIFIED
+  BETWEEN_LEVELS
+  INSUFFICIENT_EVIDENCE
+  POOL_LIMITED
+  RESEARCH_ONLY
+}
+
+enum AdaptivePoolItemRole {
+  SCORING
+  ANCHOR
+  FIELD_TEST
+}
+
+model CompetenceTree {
+  id String @id @default(uuid()) @db.Uuid
+
+  name        String
+  displayName String
+  description String?
+  isDeleted   Boolean @default(false)
+  isArchived  Boolean @default(false)
+
+  maxDepth Int   @default(5)
+  thetaMin Float @default(-3)
+  thetaMax Float @default(3)
+
+  defaultDiscrimination Float                    @default(1.2)
+  levelMappingRule      AdaptiveLevelMappingRule @default(NEAREST)
+
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  ownerId String @db.Uuid
+
+  courseLinks                 CompetenceTreeCourse[]
+  levels                      CompetenceTreeLevel[]
+  nodes                       CompetenceTreeNode[]
+  levelCoverages              CompetenceTreeLeafLevelCoverage[]
+  elementAssignments          CompetenceTreeElementAssignment[]
+  adaptivePracticeQuizConfigs PracticeQuizAdaptiveConfig[]
+  scaleVersions               CompetenceTreeScaleVersion[]
+  scaleLinks                  CompetenceTreeScaleLink[]
+  itemCalibrations            AdaptiveItemCalibration[]
+  adaptivePublications        PracticeQuizAdaptivePublication[]
+  calibrationExportRequests   AdaptiveCalibrationExportRequest[]
+  empiricalValidations        AdaptivePracticeQuizEmpiricalValidation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([ownerId], map: "ct_owner_idx")
+}
+
+model CompetenceTreeCourse {
+  id Int @id @default(autoincrement())
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  linkedBy   User?   @relation("CompetenceTreeCourseLinkedBy", fields: [linkedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  linkedById String? @db.Uuid
+
+  createdAt DateTime @default(now())
+
+  @@unique([treeId, courseId], map: "ctc_tree_course_key")
+  @@index([courseId], map: "ctc_course_idx")
+  @@index([linkedById], map: "ctc_linked_by_idx")
+}
+
+model CompetenceTreeLevel {
+  id Int @id @default(autoincrement())
+
+  label String
+  order Int
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  elementAssignments CompetenceTreeElementAssignment[]
+  levelCoverages     CompetenceTreeLeafLevelCoverage[]
+  estimates          AdaptivePracticeQuizEstimate[]
+
+  finalAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptFinalLevel")
+  scaleLevels   CompetenceTreeScaleLevel[]
+
+  @@unique([treeId, label], map: "ctl_tree_label_key")
+  @@unique([treeId, order], map: "ctl_tree_order_key")
+  @@unique([treeId, id], map: "ctl_tree_id_key")
+}
+
+model CompetenceTreeNode {
+  id Int @id @default(autoincrement())
+
+  kind        AdaptiveNodeKind
+  name        String
+  description String?
+  order       Int
+  depth       Int
+  weight      Float            @default(1)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  parent   CompetenceTreeNode?  @relation("CompetenceTreeNodeChildren", fields: [parentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  parentId Int?
+  children CompetenceTreeNode[] @relation("CompetenceTreeNodeChildren")
+
+  elementAssignments CompetenceTreeElementAssignment[]
+  levelCoverages     CompetenceTreeLeafLevelCoverage[]
+  quizNodeOverrides  PracticeQuizAdaptiveNodeOverride[]
+  estimates          AdaptivePracticeQuizEstimate[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, parentId, order], map: "ctn_tree_parent_order_key")
+  @@unique([treeId, id], map: "ctn_tree_id_key")
+  @@index([treeId, order], map: "ctn_tree_order_idx")
+  @@index([treeId, parentId], map: "ctn_tree_parent_idx")
+}
+
+model CompetenceTreeLeafLevelCoverage {
+  id Int @id @default(autoincrement())
+
+  targetItemCount Int     @default(5)
+  enabled         Boolean @default(true)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  leafNode   CompetenceTreeNode @relation(fields: [leafNodeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  leafNodeId Int
+
+  level   CompetenceTreeLevel @relation(fields: [levelId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  levelId Int
+
+  @@unique([treeId, leafNodeId, levelId], map: "ctlc_tree_leaf_level_key")
+}
+
+model CompetenceTreeElementAssignment {
+  id Int @id @default(autoincrement())
+
+  enabled            Boolean @default(true)
+  discrimination     Float?
+  enablePercentInput Boolean @default(false)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  elementId Int
+
+  leafNode   CompetenceTreeNode @relation(fields: [leafNodeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  leafNodeId Int
+
+  level   CompetenceTreeLevel @relation(fields: [levelId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  levelId Int
+
+  quizElementOverrides PracticeQuizAdaptiveElementOverride[]
+  publishedPoolItems   PracticeQuizAdaptivePoolItem[]
+  responses            AdaptivePracticeQuizResponse[]
+  calibrations         AdaptiveItemCalibration[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, elementId], map: "ctea_tree_element_key")
+  @@unique([treeId, id], map: "ctea_tree_id_key")
+  @@index([elementId], map: "ctea_element_idx")
+  @@index([treeId, leafNodeId, enabled], map: "ctea_tree_leaf_enabled_idx")
+}

--- a/apps/analytics/prisma/schema/competenceScale.prisma
+++ b/apps/analytics/prisma/schema/competenceScale.prisma
@@ -1,0 +1,226 @@
+model CompetenceTreeScaleVersion {
+  id String @id @default(uuid()) @db.Uuid
+
+  version                     Int
+  status                      AdaptiveScaleVersionStatus @default(DRAFT)
+  priorMean                   Float                      @default(0)
+  priorStandardDeviation      Float                      @default(1)
+  gridMin                     Float                      @default(-6)
+  gridMax                     Float                      @default(6)
+  gridStep                    Float                      @default(0.1)
+  classificationPolicyVersion Int                        @default(1)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  supersedesVersion    CompetenceTreeScaleVersion?  @relation("CompetenceTreeScaleVersionSupersession", fields: [supersedesVersionId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  supersedesVersionId  String?                      @db.Uuid
+  supersededByVersions CompetenceTreeScaleVersion[] @relation("CompetenceTreeScaleVersionSupersession")
+
+  createdBy   User?   @relation("CompetenceTreeScaleVersionCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  levels               CompetenceTreeScaleLevel[]
+  approvals            CompetenceTreeScaleApproval[]
+  calibrations         AdaptiveItemCalibration[]
+  sourceScaleLinks     CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkFrom")
+  targetScaleLinks     CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkTo")
+  adaptiveConfigs      PracticeQuizAdaptiveConfig[]
+  publications         PracticeQuizAdaptivePublication[]
+  exportRequests       AdaptiveCalibrationExportRequest[]
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+  attempts             AdaptivePracticeQuizAttempt[]
+
+  submittedForReviewAt DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@unique([treeId, version], map: "ctsv_tree_version_key")
+  @@unique([treeId, id], map: "ctsv_tree_id_key")
+  @@index([treeId, status], map: "ctsv_tree_status_idx")
+  @@index([createdById], map: "ctsv_created_by_idx")
+}
+
+model CompetenceTreeScaleLevel {
+  id Int @id @default(autoincrement())
+
+  order               Int
+  label               String
+  lowerBound          Float?
+  itemDifficultyPrior Float
+
+  treeId String @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  sourceLevel   CompetenceTreeLevel? @relation(fields: [treeId, sourceLevelId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  sourceLevelId Int?
+
+  finalAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptFinalScaleLevel")
+
+  @@unique([scaleVersionId, order], map: "ctsl_scale_order_key")
+  @@unique([scaleVersionId, id], map: "ctsl_scale_id_key")
+  @@unique([treeId, scaleVersionId, id], map: "ctsl_tree_scale_id_key")
+  @@index([treeId, sourceLevelId], map: "ctsl_tree_source_level_idx")
+}
+
+model CompetenceTreeScaleApproval {
+  id String @id @default(uuid()) @db.Uuid
+
+  treeId String @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  method              String
+  methodVersion       String
+  panelSize           Int
+  standardSettingDate DateTime
+
+  /// [PrismaAdaptiveCutRationale]
+  cutRationale Json
+
+  artifactChecksum String
+  artifactKey      String
+  decision         AdaptiveScaleVersionStatus?
+
+  submittedBy   User?   @relation("CompetenceTreeScaleApprovalSubmittedBy", fields: [submittedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  submittedById String? @db.Uuid
+
+  reviewer   User?   @relation("CompetenceTreeScaleApprovalReviewer", fields: [reviewerId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  reviewerId String? @db.Uuid
+
+  reviewedAt DateTime?
+  createdAt  DateTime  @default(now())
+
+  @@index([treeId, scaleVersionId], map: "ctsa_tree_scale_idx")
+  @@index([submittedById], map: "ctsa_submitted_by_idx")
+  @@index([reviewerId], map: "ctsa_reviewer_idx")
+}
+
+model CompetenceTreeScaleLink {
+  id String @id @default(uuid()) @db.Uuid
+
+  status AdaptiveScaleLinkStatus @default(DRAFT)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  fromScaleVersion   CompetenceTreeScaleVersion @relation("CompetenceTreeScaleLinkFrom", fields: [treeId, fromScaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  fromScaleVersionId String                     @db.Uuid
+
+  toScaleVersion   CompetenceTreeScaleVersion @relation("CompetenceTreeScaleLinkTo", fields: [treeId, toScaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  toScaleVersionId String                     @db.Uuid
+
+  method                String
+  implementationVersion String
+
+  /// [PrismaAdaptiveScaleLinkMetrics]
+  fitMetrics Json
+
+  /// [PrismaAdaptiveScaleLinkMetrics]
+  uncertaintyMetrics Json
+
+  artifactChecksum String
+  artifactKey      String
+
+  createdBy   User?   @relation("CompetenceTreeScaleLinkCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  reviewedBy   User?   @relation("CompetenceTreeScaleLinkReviewedBy", fields: [reviewedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  reviewedById String? @db.Uuid
+
+  anchors CompetenceTreeScaleLinkAnchor[]
+
+  submittedForReviewAt DateTime?
+  reviewedAt           DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@unique([treeId, fromScaleVersionId, toScaleVersionId], map: "ctslk_tree_versions_key")
+  @@index([createdById], map: "ctslk_created_by_idx")
+  @@index([reviewedById], map: "ctslk_reviewed_by_idx")
+}
+
+model CompetenceTreeScaleLinkAnchor {
+  id Int @id @default(autoincrement())
+
+  scaleLink   CompetenceTreeScaleLink @relation(fields: [scaleLinkId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  scaleLinkId String                  @db.Uuid
+
+  fromCalibration   AdaptiveItemCalibration @relation("CompetenceTreeScaleLinkAnchorFrom", fields: [fromCalibrationId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  fromCalibrationId String                  @db.Uuid
+
+  toCalibration   AdaptiveItemCalibration @relation("CompetenceTreeScaleLinkAnchorTo", fields: [toCalibrationId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  toCalibrationId String                  @db.Uuid
+
+  order Int
+
+  @@unique([scaleLinkId, order], map: "ctsla_link_order_key")
+  @@unique([scaleLinkId, fromCalibrationId], map: "ctsla_link_from_key")
+  @@unique([scaleLinkId, toCalibrationId], map: "ctsla_link_to_key")
+  @@index([fromCalibrationId], map: "ctsla_from_calibration_idx")
+  @@index([toCalibrationId], map: "ctsla_to_calibration_idx")
+}
+
+model AdaptiveItemCalibration {
+  id String @id @default(uuid()) @db.Uuid
+
+  version Int
+  model   AdaptiveItemModel
+  status  AdaptiveItemCalibrationStatus @default(PROVISIONAL)
+
+  discrimination Float
+  difficulty     Float
+  guessing       Float
+
+  /// [PrismaAdaptiveParameterUncertainty]
+  parameterUncertainty Json
+
+  responseCount    Int @default(0)
+  participantCount Int @default(0)
+
+  /// [PrismaAdaptiveCalibrationDiagnostics]
+  diagnostics Json
+
+  datasetVersion             String
+  datasetChecksum            String
+  calibrationJobId           String?
+  modelImplementationVersion String
+  elementContentChecksum     String
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [treeId, assignmentId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  assignmentId Int
+
+  element        Element @relation(fields: [elementId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  elementId      Int
+  elementVersion Int
+
+  createdBy   User?   @relation("AdaptiveItemCalibrationCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  approvedBy   User?     @relation("AdaptiveItemCalibrationApprovedBy", fields: [approvedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  approvedById String?   @db.Uuid
+  approvedAt   DateTime?
+
+  poolItems         PracticeQuizAdaptivePoolItem[]
+  sourceLinkAnchors CompetenceTreeScaleLinkAnchor[] @relation("CompetenceTreeScaleLinkAnchorFrom")
+  targetLinkAnchors CompetenceTreeScaleLinkAnchor[] @relation("CompetenceTreeScaleLinkAnchorTo")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, scaleVersionId, assignmentId, elementId, elementVersion, version], map: "aic_measurement_version_key")
+  @@unique([treeId, scaleVersionId, id], map: "aic_tree_scale_id_key")
+  @@unique([treeId, scaleVersionId, id, assignmentId, elementId, elementVersion], map: "aic_pool_identity_key")
+  @@index([assignmentId, elementId, elementVersion], map: "aic_assignment_element_version_idx")
+  @@index([scaleVersionId, status], map: "aic_scale_status_idx")
+  @@index([approvedById], map: "aic_approved_by_idx")
+}

--- a/apps/analytics/prisma/schema/course.prisma
+++ b/apps/analytics/prisma/schema/course.prisma
@@ -20,47 +20,52 @@ model Course {
   authType CourseAuthType @default(PIN)
   pinCode  Int?           @unique
 
-  isGamificationEnabled  Boolean @default(true)
-  isGroupCreationEnabled Boolean @default(true)
-  isAssessmentEnabled    Boolean @default(false)
+  isGamificationEnabled                Boolean @default(true)
+  isGroupCreationEnabled               Boolean @default(true)
+  isAssessmentEnabled                  Boolean @default(false)
+  isAdaptiveLearningEnabled            Boolean @default(false)
+  isAdaptiveLearningCalibrationEnabled Boolean @default(false)
 
   groupDeadlineDate         DateTime
   preferredGroupSize        Int      @default(3)
   maxGroupSize              Int      @default(5)
   randomAssignmentFinalized Boolean  @default(false)
 
-  elementStacks              ElementStack[]
-  practiceQuizzes            PracticeQuiz[]
-  groupActivities            GroupActivity[]
-  leaderboard                LeaderboardEntry[]
-  awards                     AwardEntry[]
-  classAchievements          ClassAchievementInstance[]
-  achievements               Achievement[]
-  titles                     Title[]
-  participations             Participation[]
-  subscriptions              PushSubscription[]
-  participantGroups          ParticipantGroup[]
-  microLearnings             MicroLearning[]
-  liveQuizzes                LiveQuiz[]
-  participantAnalytics       ParticipantAnalytics[]
-  aggregatedAnalytics        AggregatedAnalytics[]
-  aggregatedCourseAnalytics  AggregatedCourseAnalytics?
-  participantCourseAnalytics ParticipantCourseAnalytics[]
-  participantPerformances    ParticipantPerformance[]
-  instancePerformances       InstancePerformance[]
-  activityPerformances       ActivityPerformance[]
-  activityProgresses         ActivityProgress[]
-  responses                  QuestionResponse[]
-  groupAssignmentPoolEntries GroupAssignmentPoolEntry[]
-  timelineEntries            TimelineEntry[]
-  chatbots                   Chatbot[]
-  participantInvitations     ParticipantInvitation[]
+  elementStacks                ElementStack[]
+  practiceQuizzes              PracticeQuiz[]
+  groupActivities              GroupActivity[]
+  leaderboard                  LeaderboardEntry[]
+  awards                       AwardEntry[]
+  classAchievements            ClassAchievementInstance[]
+  achievements                 Achievement[]
+  titles                       Title[]
+  participations               Participation[]
+  subscriptions                PushSubscription[]
+  participantGroups            ParticipantGroup[]
+  microLearnings               MicroLearning[]
+  liveQuizzes                  LiveQuiz[]
+  participantAnalytics         ParticipantAnalytics[]
+  aggregatedAnalytics          AggregatedAnalytics[]
+  aggregatedCourseAnalytics    AggregatedCourseAnalytics?
+  participantCourseAnalytics   ParticipantCourseAnalytics[]
+  participantPerformances      ParticipantPerformance[]
+  instancePerformances         InstancePerformance[]
+  activityPerformances         ActivityPerformance[]
+  activityProgresses           ActivityProgress[]
+  responses                    QuestionResponse[]
+  groupAssignmentPoolEntries   GroupAssignmentPoolEntry[]
+  timelineEntries              TimelineEntry[]
+  chatbots                     Chatbot[]
+  participantInvitations       ParticipantInvitation[]
+  adaptiveAssessments          AdaptiveAssessment[]
+  adaptivePracticeQuizAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptCourse")
+  competenceTreeLinks          CompetenceTreeCourse[]
 
-  directPermissions  Permission[]
-  permissions        DerivedPermission[]
-  accessRequests     AccessRequest[]
-  catalogAssignments CatalogCollectionAssignment[]
-  activityLog        ActivityLogEntry[]
+  directPermissions   Permission[]
+  permissions         DerivedPermission[]
+  accessRequests      AccessRequest[]
+  catalogAssignments  CatalogCollectionAssignment[]
+  activityLog         ActivityLogEntry[]
   verificationRecords VerifiableCredential[]
 
   competencyTree   CompetencyTree? @relation(fields: [competencyTreeId], references: [id], onDelete: SetNull, onUpdate: Cascade)

--- a/apps/analytics/prisma/schema/element.prisma
+++ b/apps/analytics/prisma/schema/element.prisma
@@ -24,6 +24,9 @@ model Element {
   version    Int     @default(1) // used to track question versions, incremented on each update
   originalId String?
 
+  creationRequestId          String? @unique(map: "element_creation_request_key") @db.Uuid
+  creationRequestFingerprint String? @db.VarChar(64)
+
   isArchived Boolean @default(false)
   isDeleted  Boolean @default(false)
 
@@ -42,8 +45,12 @@ model Element {
 
   tags Tag[]
 
-  elementInstances ElementInstance[]
-  feedbacks        ElementFeedback[]
+  elementInstances            ElementInstance[]
+  feedbacks                   ElementFeedback[]
+  adaptiveAssessmentElements  AdaptiveAssessmentElement[]
+  adaptiveAssessmentResponses AdaptiveAssessmentResponse[]
+  competenceTreeAssignments   CompetenceTreeElementAssignment[]
+  adaptiveItemCalibrations    AdaptiveItemCalibration[]
 
   answerCollectionItems AnswerCollectionEntry[] @relation("ElementAnswerCollectionUsedItems")
   answerCollection      AnswerCollection?       @relation(fields: [answerCollectionId], references: [id], onDelete: SetNull, onUpdate: Cascade)

--- a/apps/analytics/prisma/schema/participant.prisma
+++ b/apps/analytics/prisma/schema/participant.prisma
@@ -93,6 +93,8 @@ model Participant {
   invitations                     ParticipantInvitation[]
   pointCorrections                PointCorrection[]
   individualPointCorrections      PointCorrection[]                @relation("PointCorrectionParticipants")
+  adaptiveAssessmentAttempts      AdaptiveAssessmentAttempt[]
+  adaptivePracticeQuizAttempts    AdaptivePracticeQuizAttempt[]
   verificationRecords             VerifiableCredential[]
 
   createdAt DateTime @default(now())
@@ -161,16 +163,19 @@ model Participation {
   sessionLeaderboards LeaderboardEntry[] @relation("SessionLeaderboards")
   timelineEntries     TimelineEntry[]
 
-  responses               QuestionResponse[]
-  detailResponses         QuestionResponseDetail[]
-  subscriptions           PushSubscription[]
-  completedMicroLearnings String[]
-  bookmarkedElementStacks ElementStack[]
+  responses                    QuestionResponse[]
+  detailResponses              QuestionResponseDetail[]
+  subscriptions                PushSubscription[]
+  completedMicroLearnings      String[]
+  bookmarkedElementStacks      ElementStack[]
+  adaptiveAssessmentAttempts   AdaptiveAssessmentAttempt[]
+  adaptivePracticeQuizAttempts AdaptivePracticeQuizAttempt[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@unique([courseId, participantId])
+  @@unique([id, participantId, courseId], map: "participation_identity_key")
 }
 
 model GroupAssignmentPoolEntry {

--- a/apps/analytics/prisma/schema/quiz.prisma
+++ b/apps/analytics/prisma/schema/quiz.prisma
@@ -29,6 +29,7 @@ model PracticeQuiz {
   pointsMultiplier Int               @default(1)
   resetTimeDays    Int               @default(6)
   orderType        ElementOrderType  @default(SPACED_REPETITION)
+  mode             PracticeQuizMode  @default(STANDARD)
   status           PublicationStatus @default(DRAFT)
 
   availableFrom              DateTime?
@@ -41,6 +42,9 @@ model PracticeQuiz {
   isDeleted             Boolean @default(false)
 
   stacks ElementStack[]
+
+  adaptiveConfig   PracticeQuizAdaptiveConfig?
+  adaptiveAttempts AdaptivePracticeQuizAttempt[]
 
   responses               QuestionResponse[]
   responseDetails         QuestionResponseDetail[]
@@ -68,6 +72,8 @@ model PracticeQuiz {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([id, courseId], map: "practice_quiz_id_course_key")
 }
 
 // #endregion

--- a/apps/analytics/prisma/schema/sharing.prisma
+++ b/apps/analytics/prisma/schema/sharing.prisma
@@ -1,170 +1,170 @@
 // ----- SHARING & PERMISSIONS -----
 // #region
 enum PermissionLevel {
-    READ // read access (no modifications, no deletion, no sharing)
-    WRITE // edit access (no deletion, no sharing)
-    EXECUTE // e.g. for live quizzes: only inspect evaluation
-    ADMIN // e.g. admins can not only edit (= WRITE) but also change access rights
-    OWNER // (derived permissions only)
+  READ // read access (no modifications, no deletion, no sharing)
+  WRITE // edit access (no deletion, no sharing)
+  EXECUTE // e.g. for live quizzes: only inspect evaluation
+  ADMIN // e.g. admins can not only edit (= WRITE) but also change access rights
+  OWNER // (derived permissions only)
 }
 
 model UserGroup {
-    id   Int    @id @default(autoincrement())
-    name String
+  id   Int    @id @default(autoincrement())
+  name String
 
-    members User[] @relation("UserGroupMembers") // can view / edit / admin shared objects according to permissions
-    admins  User[] @relation("UserGroupAdmins") // member + can add & remove members and provide & remove admin access
+  members User[] @relation("UserGroupMembers") // can view / edit / admin shared objects according to permissions
+  admins  User[] @relation("UserGroupAdmins") // member + can add & remove members and provide & remove admin access
 
-    permissions Permission[]
+  permissions Permission[]
 
-    owner   User   @relation(name: "UserGroupOwner", fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    ownerId String @db.Uuid
+  owner   User   @relation(name: "UserGroupOwner", fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    @@unique([ownerId, name])
+  @@unique([ownerId, name])
 }
 
 // explicitly granted permissions for a user or user group to access an object
 model Permission {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // user or user group requesting access
-    user   User?   @relation("DirectlySharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String? @db.Uuid
+  // user or user group requesting access
+  user   User?   @relation("DirectlySharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String? @db.Uuid
 
-    userGroup   UserGroup? @relation(fields: [userGroupId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userGroupId Int?
+  userGroup   UserGroup? @relation(fields: [userGroupId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userGroupId Int?
 
-    // define if only minimal permissions should be propagated or if the explicitly granted
-    // permission level should be propagated according to the permission scheme
-    // & link all permissions that are derived from this permission to it
-    propagation        Boolean             @default(false)
-    derivedPermissions DerivedPermission[]
+  // define if only minimal permissions should be propagated or if the explicitly granted
+  // permission level should be propagated according to the permission scheme
+  // & link all permissions that are derived from this permission to it
+  propagation        Boolean             @default(false)
+  derivedPermissions DerivedPermission[]
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one permission per object and user / user group
-    @@unique([catalogCollectionId, userId])
-    @@unique([answerCollectionId, userId])
-    @@unique([elementId, userId])
-    @@unique([courseId, userId])
-    @@unique([liveQuizId, userId])
-    @@unique([practiceQuizId, userId])
-    @@unique([microLearningId, userId])
-    @@unique([groupActivityId, userId])
-    @@unique([catalogCollectionId, userGroupId])
-    @@unique([answerCollectionId, userGroupId])
-    @@unique([elementId, userGroupId])
-    @@unique([courseId, userGroupId])
-    @@unique([liveQuizId, userGroupId])
-    @@unique([practiceQuizId, userGroupId])
-    @@unique([microLearningId, userGroupId])
-    @@unique([groupActivityId, userGroupId])
+  // only one permission per object and user / user group
+  @@unique([catalogCollectionId, userId])
+  @@unique([answerCollectionId, userId])
+  @@unique([elementId, userId])
+  @@unique([courseId, userId])
+  @@unique([liveQuizId, userId])
+  @@unique([practiceQuizId, userId])
+  @@unique([microLearningId, userId])
+  @@unique([groupActivityId, userId])
+  @@unique([catalogCollectionId, userGroupId])
+  @@unique([answerCollectionId, userGroupId])
+  @@unique([elementId, userGroupId])
+  @@unique([courseId, userGroupId])
+  @@unique([liveQuizId, userGroupId])
+  @@unique([practiceQuizId, userGroupId])
+  @@unique([microLearningId, userGroupId])
+  @@unique([groupActivityId, userGroupId])
 }
 
 // permissions requested by a user (default: READ, after granting higher access level can be requested)
 // to avoid the need for a separate table of derived access requests, duplicates are stored for every object owner / admin
 model AccessRequest {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // user requesting access
-    user   User   @relation("RequestedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String @db.Uuid
+  // user requesting access
+  user   User   @relation("RequestedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String @db.Uuid
 
-    // user id of owner / admin to which the request is sent
-    objectAdminOrOwner   User   @relation("PendingRequests", fields: [objectAdminOrOwnerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    objectAdminOrOwnerId String @db.Uuid
+  // user id of owner / admin to which the request is sent
+  objectAdminOrOwner   User   @relation("PendingRequests", fields: [objectAdminOrOwnerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  objectAdminOrOwnerId String @db.Uuid
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one access request per object and user (duplicates for every owner / admin; upsert when creating a new request)
-    @@unique([catalogCollectionId, userId, objectAdminOrOwnerId])
-    @@unique([answerCollectionId, userId, objectAdminOrOwnerId])
-    @@unique([elementId, userId, objectAdminOrOwnerId])
-    @@unique([courseId, userId, objectAdminOrOwnerId])
-    @@unique([liveQuizId, userId, objectAdminOrOwnerId])
-    @@unique([practiceQuizId, userId, objectAdminOrOwnerId])
-    @@unique([microLearningId, userId, objectAdminOrOwnerId])
-    @@unique([groupActivityId, userId, objectAdminOrOwnerId])
-    // indices to efficiently query all access requests for a user or object admin / owner
-    @@index([userId])
-    @@index([objectAdminOrOwnerId])
-    // indices to efficiently query all instances of an object request for a specific user
-    // -> efficiently delete entries when access is granted / rejected or the user withdrew the request
-    @@index([catalogCollectionId, userId])
-    @@index([answerCollectionId, userId])
-    @@index([elementId, userId])
-    @@index([courseId, userId])
-    @@index([liveQuizId, userId])
-    @@index([practiceQuizId, userId])
-    @@index([microLearningId, userId])
-    @@index([groupActivityId, userId])
-    // indices to efficiently query all object requests for a specific object and object admin / owner
-    // -> efficiently delete entries when admin access is revoked / ownership is transferred
-    @@index([catalogCollectionId, objectAdminOrOwnerId])
-    @@index([answerCollectionId, objectAdminOrOwnerId])
-    @@index([elementId, objectAdminOrOwnerId])
-    @@index([courseId, objectAdminOrOwnerId])
-    @@index([liveQuizId, objectAdminOrOwnerId])
-    @@index([practiceQuizId, objectAdminOrOwnerId])
-    @@index([microLearningId, objectAdminOrOwnerId])
-    @@index([groupActivityId, objectAdminOrOwnerId])
+  // only one access request per object and user (duplicates for every owner / admin; upsert when creating a new request)
+  @@unique([catalogCollectionId, userId, objectAdminOrOwnerId])
+  @@unique([answerCollectionId, userId, objectAdminOrOwnerId])
+  @@unique([elementId, userId, objectAdminOrOwnerId])
+  @@unique([courseId, userId, objectAdminOrOwnerId])
+  @@unique([liveQuizId, userId, objectAdminOrOwnerId])
+  @@unique([practiceQuizId, userId, objectAdminOrOwnerId])
+  @@unique([microLearningId, userId, objectAdminOrOwnerId])
+  @@unique([groupActivityId, userId, objectAdminOrOwnerId])
+  // indices to efficiently query all access requests for a user or object admin / owner
+  @@index([userId])
+  @@index([objectAdminOrOwnerId])
+  // indices to efficiently query all instances of an object request for a specific user
+  // -> efficiently delete entries when access is granted / rejected or the user withdrew the request
+  @@index([catalogCollectionId, userId])
+  @@index([answerCollectionId, userId])
+  @@index([elementId, userId])
+  @@index([courseId, userId])
+  @@index([liveQuizId, userId])
+  @@index([practiceQuizId, userId])
+  @@index([microLearningId, userId])
+  @@index([groupActivityId, userId])
+  // indices to efficiently query all object requests for a specific object and object admin / owner
+  // -> efficiently delete entries when admin access is revoked / ownership is transferred
+  @@index([catalogCollectionId, objectAdminOrOwnerId])
+  @@index([answerCollectionId, objectAdminOrOwnerId])
+  @@index([elementId, objectAdminOrOwnerId])
+  @@index([courseId, objectAdminOrOwnerId])
+  @@index([liveQuizId, objectAdminOrOwnerId])
+  @@index([practiceQuizId, objectAdminOrOwnerId])
+  @@index([microLearningId, objectAdminOrOwnerId])
+  @@index([groupActivityId, objectAdminOrOwnerId])
 }
 
 // derived permissions that have been computed based on the user's direct permissions on parent objects or user group permissions
@@ -172,66 +172,66 @@ model AccessRequest {
 // for every user only the highest available access level is stored here for efficient querying
 // direct permissions are also copied to the derived permissions table for more efficient access (and deduplication)
 model DerivedPermission {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // permission from which this derived permission was created (not required to allow storing owner permission also as derived permission)
-    directPermission   Permission? @relation(fields: [directPermissionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    directPermissionId Int?
+  // permission from which this derived permission was created (not required to allow storing owner permission also as derived permission)
+  directPermission   Permission? @relation(fields: [directPermissionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  directPermissionId Int?
 
-    // true if the permission is not based on a direct permission (user or user group), but derived from another object (e.g. element -> answer collection)
-    derived Boolean @default(false)
+  // true if the permission is not based on a direct permission (user or user group), but derived from another object (e.g. element -> answer collection)
+  derived Boolean @default(false)
 
-    // user or user group requesting access
-    user   User   @relation("SharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String @db.Uuid
+  // user or user group requesting access
+  user   User   @relation("SharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String @db.Uuid
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one access request per object and user (upsert when creating a new request)
-    @@unique([catalogCollectionId, userId])
-    @@unique([answerCollectionId, userId])
-    @@unique([elementId, userId])
-    @@unique([courseId, userId])
-    @@unique([liveQuizId, userId])
-    @@unique([practiceQuizId, userId])
-    @@unique([microLearningId, userId])
-    @@unique([groupActivityId, userId])
-    // index on permission level and object id to efficiently retrieve all users with a specific access level to the object
-    @@index([catalogCollectionId, permissionLevel])
-    @@index([answerCollectionId, permissionLevel])
-    @@index([elementId, permissionLevel])
-    @@index([courseId, permissionLevel])
-    @@index([liveQuizId, permissionLevel])
-    @@index([practiceQuizId, permissionLevel])
-    @@index([microLearningId, permissionLevel])
-    @@index([groupActivityId, permissionLevel])
+  // only one access request per object and user (upsert when creating a new request)
+  @@unique([catalogCollectionId, userId])
+  @@unique([answerCollectionId, userId])
+  @@unique([elementId, userId])
+  @@unique([courseId, userId])
+  @@unique([liveQuizId, userId])
+  @@unique([practiceQuizId, userId])
+  @@unique([microLearningId, userId])
+  @@unique([groupActivityId, userId])
+  // index on permission level and object id to efficiently retrieve all users with a specific access level to the object
+  @@index([catalogCollectionId, permissionLevel])
+  @@index([answerCollectionId, permissionLevel])
+  @@index([elementId, permissionLevel])
+  @@index([courseId, permissionLevel])
+  @@index([liveQuizId, permissionLevel])
+  @@index([practiceQuizId, permissionLevel])
+  @@index([microLearningId, permissionLevel])
+  @@index([groupActivityId, permissionLevel])
 }
 
 // #endregion
@@ -239,28 +239,28 @@ model DerivedPermission {
 // ----- ACTIVITY TEMPLATES -----
 // #region
 model ActivityTemplate {
-    id String @id @default(uuid()) @db.Uuid
+  id String @id @default(uuid()) @db.Uuid
 
-    description  String // description of the activity template (to be shown in the catalog)
-    instructions String // instructions for the user (to be shown in the template editor)
+  description  String // description of the activity template (to be shown in the catalog)
+  instructions String // instructions for the user (to be shown in the template editor)
 
-    // link to at least one activity for which this template is used
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @unique @db.Uuid
+  // link to at least one activity for which this template is used
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @unique @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @unique @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @unique @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @unique @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @unique @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @unique @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @unique @db.Uuid
 
-    // optional link to answer collections, if any question in the activity is based on these collections
-    answerCollections     AnswerCollection[]      @relation("TemplateAnswerCollectionUsages")
-    // optional link to answer collection items, if any question in the activity is based on these items
-    answerCollectionItems AnswerCollectionEntry[] @relation("TemplateAnswerCollectionUsedItems")
+  // optional link to answer collections, if any question in the activity is based on these collections
+  answerCollections     AnswerCollection[]      @relation("TemplateAnswerCollectionUsages")
+  // optional link to answer collection items, if any question in the activity is based on these items
+  answerCollectionItems AnswerCollectionEntry[] @relation("TemplateAnswerCollectionUsedItems")
 }
 
 // #endregion
@@ -268,80 +268,80 @@ model ActivityTemplate {
 // ----- CATALOG -----
 // #region
 enum ObjectAccess {
-    RESTRICTED
-    PUBLIC
+  RESTRICTED
+  PUBLIC
 }
 
 // many-to-many join table between catalog collection and shared object with access information
 model CatalogCollectionAssignment {
-    id Int @id @default(autoincrement())
+  id Int @id @default(autoincrement())
 
-    // access level for this specific assignment
-    access ObjectAccess @default(RESTRICTED)
+  // access level for this specific assignment
+  access ObjectAccess @default(RESTRICTED)
 
-    // catalog collection assignment
-    catalogCollection   CatalogCollection @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String            @db.Uuid
+  // catalog collection assignment
+  catalogCollection   CatalogCollection @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String            @db.Uuid
 
-    // object in the catalog collection
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  // object in the catalog collection
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // for each assignment of an object to a catalog collection there is only allowed to be one entry
-    @@unique([answerCollectionId, catalogCollectionId])
-    @@unique([elementId, catalogCollectionId])
-    @@unique([courseId, catalogCollectionId])
-    @@unique([liveQuizId, catalogCollectionId])
-    @@unique([practiceQuizId, catalogCollectionId])
-    @@unique([microLearningId, catalogCollectionId])
-    @@unique([groupActivityId, catalogCollectionId])
+  // for each assignment of an object to a catalog collection there is only allowed to be one entry
+  @@unique([answerCollectionId, catalogCollectionId])
+  @@unique([elementId, catalogCollectionId])
+  @@unique([courseId, catalogCollectionId])
+  @@unique([liveQuizId, catalogCollectionId])
+  @@unique([practiceQuizId, catalogCollectionId])
+  @@unique([microLearningId, catalogCollectionId])
+  @@unique([groupActivityId, catalogCollectionId])
 }
 
 model CatalogCollection {
-    id          String  @id @default(uuid()) @db.Uuid
-    name        String
-    description String?
+  id          String  @id @default(uuid()) @db.Uuid
+  name        String
+  description String?
 
-    // access level determines who can browse a collection's content (public = everyone, restricted = only users with access)
-    access ObjectAccess @default(RESTRICTED)
+  // access level determines who can browse a collection's content (public = everyone, restricted = only users with access)
+  access ObjectAccess @default(RESTRICTED)
 
-    // users / user groups that are allowed to import / request elements from this collection (read access)
-    // users / user groups that are allowed to add elements to this collection (write access)
-    // users / user groups that are allowed to edit the access rights of other users / user groups (admin access)
-    directPermissions Permission[]
-    permissions       DerivedPermission[]
-    accessRequests    AccessRequest[]
+  // users / user groups that are allowed to import / request elements from this collection (read access)
+  // users / user groups that are allowed to add elements to this collection (write access)
+  // users / user groups that are allowed to edit the access rights of other users / user groups (admin access)
+  directPermissions Permission[]
+  permissions       DerivedPermission[]
+  accessRequests    AccessRequest[]
 
-    // link to the join-table containing all associated objects
-    objectAssignments CatalogCollectionAssignment[]
+  // link to the join-table containing all associated objects
+  objectAssignments CatalogCollectionAssignment[]
 
-    // owner connection needs to remain optional for the top-level catalog collection to work as expected
-    owner   User?   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    ownerId String? @db.Uuid
+  // owner connection needs to remain optional for the top-level catalog collection to work as expected
+  owner   User?   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String? @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // #endregion
@@ -349,110 +349,111 @@ model CatalogCollection {
 // ----- AUDIT LOG -----
 // #region
 enum AuditLogType {
-    PERMISSION_GRANTED // granted direct permission
-    PERMISSION_REVOKED // revoked direct permission (by owner / admin)
-    PERMISSION_REMOVED // removed direct permission (by user himself)
-    PERMISSION_MODIFIED // modified direct permission
-    OWNER_TRANSFERRED // ownership of an object was transferred
-    REQUEST_CREATED // created object access request
-    REQUEST_CANCELLED // cancelled object access request
-    REQUEST_RESOLVED // resolved object access request
-    CATALOG_ASSIGNMENT_CREATED // created catalog assignment
-    CATALOG_ASSIGNMENT_DELETED // deleted catalog assignment
-    CATALOG_ASSIGNMENT_MODIFIED // created catalog collection
-    USER_GROUP_CREATED // created user group
-    USER_GROUP_MODIFIED // modified user group
-    USER_GROUP_DELETED // deleted user group
-    USER_GROUP_USER_ADDED // added user to user group
-    USER_GROUP_USER_REMOVED // removed user from user group
-    USER_GROUP_USER_MODIFIED // modified user in user group (promotion / demotion)
+  PERMISSION_GRANTED // granted direct permission
+  PERMISSION_REVOKED // revoked direct permission (by owner / admin)
+  PERMISSION_REMOVED // removed direct permission (by user himself)
+  PERMISSION_MODIFIED // modified direct permission
+  OWNER_TRANSFERRED // ownership of an object was transferred
+  REQUEST_CREATED // created object access request
+  REQUEST_CANCELLED // cancelled object access request
+  REQUEST_RESOLVED // resolved object access request
+  CATALOG_ASSIGNMENT_CREATED // created catalog assignment
+  CATALOG_ASSIGNMENT_DELETED // deleted catalog assignment
+  CATALOG_ASSIGNMENT_MODIFIED // created catalog collection
+  USER_GROUP_CREATED // created user group
+  USER_GROUP_MODIFIED // modified user group
+  USER_GROUP_DELETED // deleted user group
+  USER_GROUP_USER_ADDED // added user to user group
+  USER_GROUP_USER_REMOVED // removed user from user group
+  USER_GROUP_USER_MODIFIED // modified user in user group (promotion / demotion)
 }
 
 enum ObjectType {
-    USER_GROUP
-    CATALOG_COLLECTION
-    ANSWER_COLLECTION
-    ELEMENT
-    COURSE
-    LIVE_QUIZ
-    PRACTICE_QUIZ
-    MICRO_LEARNING
-    GROUP_ACTIVITY
+  USER_GROUP
+  CATALOG_COLLECTION
+  ANSWER_COLLECTION
+  ELEMENT
+  COURSE
+  LIVE_QUIZ
+  PRACTICE_QUIZ
+  MICRO_LEARNING
+  GROUP_ACTIVITY
+  COMPETENCE_TREE
 }
 
 model AuditLogEntry {
-    id   Int          @id @default(autoincrement())
-    type AuditLogType // type of the audit log entry
+  id   Int          @id @default(autoincrement())
+  type AuditLogType // type of the audit log entry
 
-    // object information
-    objectType ObjectType
-    objectId   String
+  // object information
+  objectType ObjectType
+  objectId   String
 
-    // users / user groups involved in the action
-    sourceUserId      String  @db.Uuid // id of the user who performed the action
-    targetUserId      String? @db.Uuid // id of the user who was affected by the action (can be the same as sourceUserId)
-    targetUserGroupId Int? // id of the user group who was affected by the action (can include the source user)
+  // users / user groups involved in the action
+  sourceUserId      String  @db.Uuid // id of the user who performed the action
+  targetUserId      String? @db.Uuid // id of the user who was affected by the action (can be the same as sourceUserId)
+  targetUserGroupId Int? // id of the user group who was affected by the action (can include the source user)
 
-    // generic message containing more information on the action
-    message String
+  // generic message containing more information on the action
+  message String
 
-    // timestamp of the action
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  // timestamp of the action
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 enum ActivityLogType {
-    MESSAGE // message sent by one of the users with access to the object
-    MODIFICATION // modification of the object (field modified, etc.)
-    CREATION // creation of the object
-    SHARING // sharing of the object
+  MESSAGE // message sent by one of the users with access to the object
+  MODIFICATION // modification of the object (field modified, etc.)
+  CREATION // creation of the object
+  SHARING // sharing of the object
 }
 
 model ActivityLogEntry {
-    id         Int             @id @default(autoincrement())
-    type       ActivityLogType // type of the change log entry
-    objectType ObjectType // type of the object
+  id         Int             @id @default(autoincrement())
+  type       ActivityLogType // type of the change log entry
+  objectType ObjectType // type of the object
 
-    // generic message containing more information on the action
-    message String?
+  // generic message containing more information on the action
+  message String?
 
-    // structured data about modifications (for type MODIFICATION)
-    /// [PrismaActivityLogModificationDetails]
-    modificationDetails Json?
+  // structured data about modifications (for type MODIFICATION)
+  /// [PrismaActivityLogModificationDetails]
+  modificationDetails Json?
 
-    // whether the entry has been resolved (for type MESSAGE)
-    resolved   Boolean   @default(false)
-    resolvedAt DateTime?
+  // whether the entry has been resolved (for type MESSAGE)
+  resolved   Boolean   @default(false)
+  resolvedAt DateTime?
 
-    // user who performed the action
-    user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-    userId String? @db.Uuid
+  // user who performed the action
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  userId String? @db.Uuid
 
-    // object in affected by the change
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  // object in affected by the change
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    // timestamps for the creation and modification of the entry
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  // timestamps for the creation and modification of the entry
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // #endregion

--- a/apps/analytics/prisma/schema/user.prisma
+++ b/apps/analytics/prisma/schema/user.prisma
@@ -110,23 +110,37 @@ model User {
   publicPreview  Boolean @default(false)
   privatePreview Boolean @default(false)
 
-  logins                     UserLogin[]
-  session                    Session[]
-  accounts                   Account[]
-  courses                    Course[]
-  questions                  Element[]
-  mediaFiles                 MediaFile[]
-  tags                       Tag[]
-  groupActivities            GroupActivity[]
-  elementInstances           ElementInstance[]
-  practiceQuizzes            PracticeQuiz[]
-  microLearnings             MicroLearning[]
-  liveQuizzes                LiveQuiz[]
-  competencyTrees            CompetencyTree[]
-  answerCollections          AnswerCollection[]
-  chatbots                   Chatbot[]
-  chatbotDisclaimers         ChatbotDisclaimer[]
-  revokedVerificationRecords VerifiableCredential[] @relation("RevokedVerifiableCredentials")
+  logins                          UserLogin[]
+  session                         Session[]
+  accounts                        Account[]
+  courses                         Course[]
+  questions                       Element[]
+  mediaFiles                      MediaFile[]
+  tags                            Tag[]
+  groupActivities                 GroupActivity[]
+  elementInstances                ElementInstance[]
+  practiceQuizzes                 PracticeQuiz[]
+  microLearnings                  MicroLearning[]
+  liveQuizzes                     LiveQuiz[]
+  competencyTrees                 CompetencyTree[]
+  answerCollections               AnswerCollection[]
+  chatbots                        Chatbot[]
+  chatbotDisclaimers              ChatbotDisclaimer[]
+  adaptiveAssessments             AdaptiveAssessment[]
+  competenceTrees                 CompetenceTree[]
+  linkedCompetenceTreeCourses     CompetenceTreeCourse[]                    @relation("CompetenceTreeCourseLinkedBy")
+  adaptiveScaleVersionsCreated    CompetenceTreeScaleVersion[]              @relation("CompetenceTreeScaleVersionCreatedBy")
+  adaptiveScaleApprovalsSubmitted CompetenceTreeScaleApproval[]             @relation("CompetenceTreeScaleApprovalSubmittedBy")
+  adaptiveScaleApprovals          CompetenceTreeScaleApproval[]             @relation("CompetenceTreeScaleApprovalReviewer")
+  adaptiveScaleLinksCreated       CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkCreatedBy")
+  adaptiveScaleLinksReviewed      CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkReviewedBy")
+  adaptiveCalibrationsCreated     AdaptiveItemCalibration[]                 @relation("AdaptiveItemCalibrationCreatedBy")
+  adaptiveCalibrationsApproved    AdaptiveItemCalibration[]                 @relation("AdaptiveItemCalibrationApprovedBy")
+  adaptivePublications            PracticeQuizAdaptivePublication[]         @relation("PracticeQuizAdaptivePublicationPublishedBy")
+  adaptiveExportRequests          AdaptiveCalibrationExportRequest[]        @relation("AdaptiveCalibrationExportRequestedBy")
+  adaptiveValidationsSubmitted    AdaptivePracticeQuizEmpiricalValidation[] @relation("AdaptiveEmpiricalValidationSubmittedBy")
+  adaptiveValidationsApproved     AdaptivePracticeQuizEmpiricalValidation[] @relation("AdaptiveEmpiricalValidationApprovedBy")
+  revokedVerificationRecords      VerifiableCredential[]                    @relation("RevokedVerifiableCredentials")
 
   userGroups                UserGroup[]         @relation("UserGroupMembers")
   adminUserGroups           UserGroup[]         @relation("UserGroupAdmins")

--- a/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizWizard.tsx
@@ -58,9 +58,14 @@ interface PracticeQuizWizardProps {
   title: string
   courses: ElementSelectCourse[]
   closeWizard: () => void
-  initialValues?: Omit<
+  initialValues?: Pick<
     PracticeQuiz,
-    'id' | 'orderType' | 'resetTimeDays' | 'status'
+    | 'name'
+    | 'displayName'
+    | 'description'
+    | 'stacks'
+    | 'pointsMultiplier'
+    | 'course'
   > & {
     id?: string
     orderType?: string

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -637,6 +637,15 @@ async function seedActivities() {
 
 async function cleanupDatabase() {
   try {
+    // Review evidence is immutable under normal DELETE operations. This runs
+    // only in the disposable Cypress database and clears the two adaptive
+    // aggregate roots before the generic activity cleanup below.
+    await prisma.$executeRawUnsafe(`
+      TRUNCATE TABLE
+        "PracticeQuizAdaptiveConfig",
+        "CompetenceTreeScaleVersion"
+      RESTART IDENTITY CASCADE
+    `)
     // delete all activities
     await prisma.liveQuiz.deleteMany()
     await prisma.microLearning.deleteMany()

--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -35,8 +35,38 @@ The Python twin (`apps/analytics/prisma/schema/py.prisma`) uses `prisma-client-p
 
 ## Migrations
 
-- Prisma migrations live in `packages/prisma/src/prisma/schema/migrations/` (~170 since 2022). Migrations may contain data backfills (SQL `ROW_NUMBER()` etc.), not just DDL.
-- Separately, the backend runs a **homegrown boot-time data-migration runner** (`apps/backend-docker/src/migration.ts:migrate`) with its own `Migration` table for one-off data fixes — currently an empty list; don't confuse it with `prisma migrate deploy`. Where `migrate deploy` runs in deployment is **not documented in-repo** (open question — verify before making deploy claims).
+- Prisma migrations live in `packages/prisma/src/prisma/schema/migrations/` (189 as of 2026-07-14). Migrations may contain data backfills (SQL `ROW_NUMBER()` etc.), not just DDL.
+- Separately, the backend runs a **homegrown boot-time data-migration runner** (`apps/backend-docker/src/migration.ts:migrate`) with its own `Migration` table for one-off data fixes — currently an empty list; don't confuse it with `prisma migrate deploy`.
+- The repository exposes explicit Prisma deploy commands: `pnpm --filter @klicker-uzh/prisma run prisma:deploy:qa` and `prisma:deploy:prod` inject the staging/production database URL through Infisical and run `prisma migrate deploy`. No automated production migration job is defined in this repository. Until the deployment repository names one, a release engineer is the executor and a database-operations owner must approve the backup/restore point, observe the run, and own an abort or forward fix. Record the people and command output in the restricted change record; do not infer that application startup applies Prisma migrations.
+
+### Adaptive Phase 10 deployment contract
+
+The three forward-only Phase 10 migrations are, in order:
+
+1. `20260713210000_adaptive_runtime_constraint_validation` repairs deterministic lifecycle gaps, preflight-aborts ambiguous/corrupt values, and validates all six runtime checks. It uses a 5-second lock timeout and a 15-minute statement timeout inside its transaction.
+2. `20260713212000_adaptive_competence_tree_audit_type` adds the internal `COMPETENCE_TREE` audit object type.
+3. `20260713213000_adaptive_history_retention` replaces destructive owner/config/quiz foreign keys with validated `RESTRICT` constraints, adds a direct attempt-to-course retention constraint, and deliberately preserves participant/participation erasure cascades.
+
+Before either environment is changed, replay the complete chain plus the populated pre-repair fixture on a disposable PostgreSQL 17 database server. `DATABASE_URL` must name an expendable administrative database on that disposable server because the verifier creates and drops a temporary database:
+
+```bash
+DATABASE_URL="$DISPOSABLE_POSTGRES_ADMIN_URL" \
+  pnpm --filter @klicker-uzh/prisma run verify:adaptive-migration
+```
+
+Then follow the backup, aggregate preflight, monitoring, abort, and post-deploy procedure in [Adaptive Learning Operations](./adaptive-learning-operations.md#phase-10-migration-procedure). The migrations have no destructive down migration. Before the first application write, an operations-approved restore may return to the backup; after writes begin, keep the course gate disabled and use a reviewed forward fix so retained attempt history is not silently discarded.
+
+### Adaptive Phase 11 contract cleanup
+
+`20260713220000_adaptive_remove_inert_settings` is a forward-only contract cleanup. It removes `PracticeQuizAdaptiveConfig.standardErrorThreshold`, `showFinalResult`, `showLiveEstimate`, and `enableSelfAssessmentWarmup`, then recreates the numeric and preset checks without those columns. Completion level bands remain mandatory, `classificationZ` remains the only confidence-interval classification setting, and `minimumReachableStandardError` remains a computed readiness diagnostic rather than persisted runtime state. The migration uses a 5-second lock timeout and 5-minute statement timeout and must run with adaptive course flags disabled under the same backup/abort procedure as the preceding adaptive migrations.
+
+A clean PostgreSQL 17 replay of all 189 migrations through the Phase 13 aggregate-release migration is local engineering evidence only. The populated Phase 10 verifier also passes after applying 184 prior migrations and its malformed pre-repair fixture. Staging and production still require the aggregate preflight, named operations owner, tested restore point, timed rehearsal, and forward-fix decision described in the operations runbook.
+
+### Adaptive Phase 13 aggregate releases
+
+`20260714075147_adaptive_cohort_snapshots` adds the typed `AdaptivePracticeQuizCohortSnapshot` aggregate read model, fixed-boundary/policy uniqueness, release/schema checks, completed-attempt/participant/estimate/response indexes, and an attempt-delete trigger that invalidates every snapshot for the affected config. The JSON check admits only schema version 1; the application type contains released aggregate results and no participant, attempt, username, answer, theta, level-result, or person-level timing field.
+
+Snapshot generation is lazy on an authorized lecturer read and runs under the config lock. Participant submission does not write this table. Deleting an attempt, including the participant-erasure cascade, invalidates prior releases before a lower complete boundary can be recomputed. Treat this migration as additive but privacy-sensitive: verify the trigger, unique index, typed JSON generation, concurrent first-read idempotency, and five/ten-person erasure cases on the deployment clone.
 
 ## Seeding
 
@@ -78,6 +108,8 @@ Json columns are typed via `prisma-json-types-generator`: a `/// [TypeName]` doc
 
 ## Schema-level gotchas
 
+- **Some adaptive integrity rules are migration-only PostgreSQL DDL.** `20260707120000_adaptive_practice_quiz_competence_trees` contains partial unique indexes for root ordering, in-progress attempts, and overall estimates. `20260710152000_adaptive_tree_integrity` adds same-tree composite foreign keys and an estimate node-kind check. `20260710190000_adaptive_practice_quiz_configuration` persists preset/attempt policy, preserves advanced legacy rows as Research, resets legacy warm-up/schedules, adds same-tree quiz overrides plus config/quiz/participant/participation/course/pool response constraints, installs numeric/preset/no-gamification checks, and creates immutable `PracticeQuizAdaptivePoolItem` snapshots. `20260710210000_adaptive_practice_quiz_runtime` removes the live-assignment next pointer and duplicate trajectory arrays, requires attempt/config/tree and estimate/config/tree identities, renames response trajectory columns to explicit overall semantics, and adds attempt-state, response-score/snapshot, and estimate-consistency checks. Its preflight identifies cross-tree final-level, estimate-node, and estimate-level rows before adding validated foreign keys. `20260712120000_competence_tree_archive_state` adds the explicit `isArchived` state so Manage can distinguish archival from destructive deletion while preserving linked and quiz-referenced trees. `20260713100504_course_adaptive_learning_rollout` adds only the default-false, non-null course rollout flag; it was curated after Prisma attempted to remove migration-only constraints and then verified through a clean 184-migration replay. The runtime checks were initially `NOT VALID` so new writes were protected while legacy rows remained readable; `20260713210000_adaptive_runtime_constraint_validation` now repairs deterministic gaps, rejects ambiguous corruption, and validates all six. `20260713220000_adaptive_remove_inert_settings` recreates adaptive numeric/preset checks after dropping four unsupported configuration columns. `20260714075147_adaptive_cohort_snapshots` adds fixed-boundary aggregate releases and erasure invalidation, plus indexes for bounded cohort selection and diagnostics. Pool-backed responses bind config, pool row, source assignment, and element id as one database identity. Invalid legacy numbers or inconsistent attempt identities fail with explicit migration preconditions instead of being silently normalized. Prisma cannot represent every partial index/check constraint; do not remove migration-only checks merely because they are absent from Prisma schemas.
+- **Terminal adaptive attempts are backfilled before the runtime stop-reason constraint.** `20260710210000_adaptive_practice_quiz_runtime` maps abandoned attempts to `ABANDONED`, prefers an existing completed overall-estimate reason, maps a completed row with a final level to `CLASSIFIED`, and otherwise records `INSUFFICIENT_DATA`. A populated pre-runtime upgrade fixture must exercise all four paths; do not replace this with a blanket default that destroys historical meaning.
 - **Prisma `Decimal` is an object, never truthy-check it** — `Decimal(0)` is truthy. Convert with a `toNumber()` helper and compare with `!= null` (pattern in `packages/graphql/src/services/chatbots.ts`).
 - **`Participant` email is unique per auth mode**: `@@unique([email, isSSOAccount])` means the same normalized email can exist once as manual and once as SSO. Queries by email alone can return the wrong account; blocking new cross-mode duplicates must happen in service logic (`packages/graphql/src/services/accounts.ts`).
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -2,7 +2,7 @@
 type: Domain Model
 title: Domain Model
 description: Core entities (User vs Participant, Course, Element, activities), status lifecycles, and the two-track gamification system.
-timestamp: '2026-07-07'
+timestamp: '2026-07-13'
 tags:
   - backend
   - prisma
@@ -30,6 +30,7 @@ They are unrelated models — never conflate them. A `Participant` joins a `Cour
 - **`Element`** (`element.prisma`) — a question-bank item owned by a `User`; versioned via `version`/`originalId`; `type: ElementType`; options live in a typed `Json` field.
 - **`ElementInstance`** — a _placement_ of an Element inside an activity. `type: ElementInstanceType` = `LIVE_QUIZ | PRACTICE_QUIZ | MICROLEARNING | GROUP_ACTIVITY`. It **snapshots** `elementData`/`options` at publication time and accumulates `results` — editing the source Element does not change published instances.
 - Grouping differs by activity: **`ElementStack`** (ordered instance group) for PracticeQuiz/MicroLearning/GroupActivity; **`ElementBlock`** (with scheduling status) for LiveQuiz only.
+- **`CompetenceTree`** (`competence.prisma`) — reusable, user-owned adaptive structure linked to zero or more courses. It contains ordered level bands, root competences, nested subcompetences to depth 5, leaf/level coverage targets, and assignments for scorable `SC`, `MC`, `KPRIM`, `NUMERICAL`, and controlled-answer `FREE_TEXT` Elements. A tree is structurally locked once an adaptive PracticeQuiz references it; duplicate it for structural changes.
 
 `ElementType`: `SC, MC, KPRIM, FREE_TEXT, NUMERICAL, CONTENT, FLASHCARD, SELECTION, CASE_STUDY`. Type-specific behavior is dispatched in `packages/graphql/src/services/stacks.ts` (correctness: `evaluateChoicesAnswerCorrectness`; per-type grading and response-format branches). Pure scoring math is in `packages/grading/src/index.ts`: `gradeQuestionSC`, `gradeQuestionMC` (hamming-distance partial credit), `gradeQuestionKPRIM` (0 wrong → full, 1 wrong → half, else 0), `gradeQuestionNumerical`.
 
@@ -37,11 +38,14 @@ They are unrelated models — never conflate them. A `Participant` joins a `Cour
 
 Four activity models in `quiz.prisma`: `LiveQuiz` (formerly "session" — `originalId` and old code names survive), `PracticeQuiz`, `MicroLearning`, `GroupActivity` (plus `GroupActivityInstance`, parameters/clues). The Prisma **view** `UserActivities` unifies all four for listing.
 
+`PracticeQuiz.mode` is `STANDARD` or `ADAPTIVE`; adaptive learning is a mode of the existing activity, never a fifth activity model. STANDARD quizzes use stacks and normal scoring. ADAPTIVE quizzes use one `PracticeQuizAdaptiveConfig`, an immutable publication pool, participant attempts/responses/estimates, no points, and the same PracticeQuiz URL and lifecycle. `Course.isAdaptiveLearningEnabled` is default false and gates adaptive setup, publication, discovery, and participant runtime without gating competence-tree authoring or standard quizzes.
+
 Lifecycle enums:
 
 | Enum                 | Values                                               | Applies to           |
 | -------------------- | ---------------------------------------------------- | -------------------- |
 | `PublicationStatus`  | DRAFT, SCHEDULED, PUBLISHED, ENDED, GRADED, TEMPLATE | all four activities  |
+| `PracticeQuizMode`   | STANDARD, ADAPTIVE                                   | PracticeQuiz         |
 | `ElementStatus`      | DRAFT, REVIEW, READY                                 | Element              |
 | `ReviewStatus`       | INCOMPLETE, REVIEWED, MODIFIED_AFTER_REVIEW          | activity review flow |
 | `ElementBlockStatus` | SCHEDULED, ACTIVE, EXECUTED                          | LiveQuiz blocks      |

--- a/packages/graphql/src/schema/sharing.ts
+++ b/packages/graphql/src/schema/sharing.ts
@@ -14,8 +14,10 @@ export const ObjectAccess = builder.enumType('ObjectAccess', {
 
 export const ObjectType = builder.enumType('ObjectType', {
   values: Object.values(DB.ObjectType).filter(
-    // exclude user group from the graphql object type
-    (type) => type !== DB.ObjectType.USER_GROUP
+    // Competence trees use feature-specific authorization rather than generic sharing.
+    (type) =>
+      type !== DB.ObjectType.USER_GROUP &&
+      type !== DB.ObjectType.COMPETENCE_TREE
   ) as DB.ObjectType[],
 })
 

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -418,6 +418,7 @@ export default {
       CATALOG_COLLECTION: 'Katalog-Sammlung',
       ELEMENT: 'Element',
       COURSE: 'Kurs',
+      COMPETENCE_TREE: 'Kompetenzbaum',
       SC: 'Single Choice Frage',
       MC: 'Multiple Choice Frage',
       KPRIM: 'Kprim Frage',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -416,6 +416,7 @@ export default {
       CATALOG_COLLECTION: 'Catalog Collection',
       ELEMENT: 'Element',
       COURSE: 'Course',
+      COMPETENCE_TREE: 'Competence Tree',
       SC: 'Single Choice Question',
       MC: 'Multiple Choice Question',
       KPRIM: 'Kprim Question',

--- a/packages/prisma-data/package.json
+++ b/packages/prisma-data/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.0-alpha.4",
   "license": "AGPL-3.0",
   "devDependencies": {
+    "@klicker-uzh/adaptive-learning": "workspace:*",
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/transactional": "workspace:*",
     "@klicker-uzh/types": "workspace:*",

--- a/packages/prisma-data/src/data/adaptiveLearningElementFixtures.ts
+++ b/packages/prisma-data/src/data/adaptiveLearningElementFixtures.ts
@@ -1,0 +1,273 @@
+import * as Prisma from '@klicker-uzh/prisma/client'
+
+export function adaptiveElementContent({
+  competenceName,
+  subCompetenceName,
+  levelLabel,
+  itemIndex,
+  type,
+}: {
+  competenceName: string
+  subCompetenceName: string
+  levelLabel: string
+  itemIndex: number
+  type: Prisma.ElementType
+}) {
+  const task = adaptiveEnglishTask({
+    competenceName,
+    subCompetenceName,
+    levelLabel,
+    itemIndex,
+  })
+  const responseInstruction =
+    type === Prisma.ElementType.SC
+      ? 'Choose the best answer.'
+      : type === Prisma.ElementType.MC
+        ? 'Select all answers that are appropriate.'
+        : type === Prisma.ElementType.KPRIM
+          ? 'Mark each statement that is true.'
+          : 'Write the requested word or short phrase.'
+
+  return `## ${competenceName} - ${subCompetenceName} (${levelLabel})
+
+${task}
+
+${responseInstruction}`
+}
+
+function adaptiveEnglishTask({
+  competenceName,
+  subCompetenceName,
+  levelLabel,
+  itemIndex,
+}: {
+  competenceName: string
+  subCompetenceName: string
+  levelLabel: string
+  itemIndex: number
+}) {
+  if (competenceName === 'Reading') {
+    const text = cefrReadingText(levelLabel, subCompetenceName)
+    return `Read the text.
+
+> ${text}
+
+Question ${itemIndex + 1}: What does the task mainly test in this text?`
+  }
+
+  if (competenceName === 'Writing') {
+    return `Improve this ${levelLabel} learner sentence for ${subCompetenceName.toLowerCase()}:
+
+> ${cefrWritingSentence(levelLabel, subCompetenceName)}
+
+Question ${itemIndex + 1}: Which response best improves the writing?`
+  }
+
+  return `Complete or judge the sentence for ${subCompetenceName.toLowerCase()}:
+
+> ${cefrGrammarSentence(levelLabel, subCompetenceName)}
+
+Question ${itemIndex + 1}: Which form is grammatically appropriate?`
+}
+
+export function adaptiveElementExplanation({
+  competenceName,
+  subCompetenceName,
+  levelLabel,
+}: {
+  competenceName: string
+  subCompetenceName: string
+  levelLabel: string
+}) {
+  return `${levelLabel} ${competenceName.toLowerCase()} item focused on ${subCompetenceName.toLowerCase()}. The correct answer matches the CEFR-aligned language feature described in the prompt.`
+}
+
+export function adaptiveSeedChoices({
+  type,
+  competenceName,
+  subCompetenceName,
+  levelLabel,
+}: {
+  type: Prisma.ElementType
+  competenceName: string
+  subCompetenceName: string
+  levelLabel: string
+}) {
+  if (type === Prisma.ElementType.FREE_TEXT) return undefined
+
+  if (type === Prisma.ElementType.MC) {
+    return [
+      {
+        value: adaptiveCorrectChoice(competenceName, subCompetenceName),
+        correct: true,
+        feedback: 'Correct.',
+      },
+      {
+        value: adaptiveDistractorChoice(competenceName, levelLabel, 0),
+        feedback: 'This answer does not match the prompt closely enough.',
+      },
+      {
+        value: adaptiveSecondCorrectChoice(competenceName, subCompetenceName),
+        correct: true,
+        feedback: 'Correct.',
+      },
+      {
+        value: adaptiveDistractorChoice(competenceName, levelLabel, 1),
+        feedback: 'This choice changes the meaning or register.',
+      },
+    ]
+  }
+
+  if (type === Prisma.ElementType.KPRIM) {
+    return [
+      {
+        value: adaptiveCorrectChoice(competenceName, subCompetenceName),
+        correct: true,
+        feedback: 'True.',
+      },
+      {
+        value: adaptiveDistractorChoice(competenceName, levelLabel, 0),
+        feedback: 'False.',
+      },
+      {
+        value: adaptiveSecondCorrectChoice(competenceName, subCompetenceName),
+        correct: true,
+        feedback: 'True.',
+      },
+      {
+        value: adaptiveDistractorChoice(competenceName, levelLabel, 1),
+        feedback: 'False.',
+      },
+    ]
+  }
+
+  return [
+    {
+      value: adaptiveCorrectChoice(competenceName, subCompetenceName),
+      correct: true,
+      feedback: 'Correct.',
+    },
+    {
+      value: adaptiveDistractorChoice(competenceName, levelLabel, 0),
+      feedback: 'This answer does not fit the task.',
+    },
+    {
+      value: adaptiveDistractorChoice(competenceName, levelLabel, 1),
+      feedback: 'This answer is too vague or inaccurate.',
+    },
+    {
+      value: adaptiveDistractorChoice(competenceName, levelLabel, 2),
+      feedback: 'This changes the intended meaning.',
+    },
+  ]
+}
+
+export function adaptiveSeedOptions(type: Prisma.ElementType) {
+  if (type === Prisma.ElementType.FREE_TEXT) {
+    return {
+      hasSampleSolution: true,
+      restrictions: { maxLength: 160 },
+      solutions: ['because', 'however', 'clear conclusion', 'main idea'],
+    }
+  }
+
+  return {
+    hasSampleSolution: true,
+    hasAnswerFeedbacks: true,
+    displayMode: 'LIST',
+  }
+}
+
+function cefrReadingText(levelLabel: string, subCompetenceName: string) {
+  const texts: Record<string, string> = {
+    A1: 'Mia is at the station. Her train leaves at nine. She buys a ticket and waits near platform two.',
+    A2: 'The college library closes early on Friday because the staff are preparing a weekend exhibition for new students.',
+    B1: 'Although the online course was convenient, Karim missed the informal discussions that helped him test his ideas.',
+    B2: 'The article argues that remote work can improve concentration, but only when teams deliberately protect informal communication.',
+    C1: "The reviewer praises the author's elegant style while questioning whether the central argument relies too heavily on anecdotal evidence.",
+    C2: 'The editorial uses irony to expose a contradiction: institutions celebrate innovation while quietly rewarding only familiar forms of success.',
+  }
+
+  return `${texts[levelLabel] ?? texts.B1} Focus: ${subCompetenceName.toLowerCase()}.`
+}
+
+function cefrWritingSentence(levelLabel: string, subCompetenceName: string) {
+  const sentences: Record<string, string> = {
+    A1: 'I go to class every Monday and I like my teacher.',
+    A2: 'Yesterday I visited the museum because I wanted to learn about local history.',
+    B1: 'The city should create more bike lanes because they are cheaper and healthier than car traffic.',
+    B2: 'While the proposal has clear benefits, it would require careful planning to avoid excluding smaller schools.',
+    C1: 'The policy is persuasive insofar as it links funding to evidence, yet its implementation risks widening regional inequality.',
+    C2: "What appears to be a minor stylistic choice subtly reframes the reader's moral judgement of the narrator.",
+  }
+
+  return `${sentences[levelLabel] ?? sentences.B1} Focus: ${subCompetenceName.toLowerCase()}.`
+}
+
+function cefrGrammarSentence(levelLabel: string, subCompetenceName: string) {
+  const sentences: Record<string, string> = {
+    A1: 'She ___ from Zurich and studies English in the morning.',
+    A2: 'We ___ dinner when the phone rang.',
+    B1: 'If I had more time, I ___ a longer report.',
+    B2: 'The article, ___ was published last week, has already been widely discussed.',
+    C1: 'Had the committee consulted students earlier, the transition ___ smoother.',
+    C2: 'Rarely ___ such a concise explanation changed the direction of a complex debate.',
+  }
+
+  return `${sentences[levelLabel] ?? sentences.B1} Focus: ${subCompetenceName.toLowerCase()}.`
+}
+
+function adaptiveCorrectChoice(
+  competenceName: string,
+  subCompetenceName: string
+) {
+  if (competenceName === 'Reading') {
+    return `It identifies the relevant ${subCompetenceName.toLowerCase()} evidence in the text.`
+  }
+  if (competenceName === 'Writing') {
+    return `It improves ${subCompetenceName.toLowerCase()} while keeping the meaning clear.`
+  }
+  return `It uses the correct form for ${subCompetenceName.toLowerCase()}.`
+}
+
+function adaptiveSecondCorrectChoice(
+  competenceName: string,
+  subCompetenceName: string
+) {
+  if (competenceName === 'Reading') {
+    return `It keeps the answer grounded in the wording of the passage.`
+  }
+  if (competenceName === 'Writing') {
+    return `It matches the expected register and links ideas logically.`
+  }
+  return `It fits both the grammar pattern and the sentence meaning.`
+}
+
+function adaptiveDistractorChoice(
+  competenceName: string,
+  levelLabel: string,
+  index: number
+) {
+  const distractors = {
+    Reading: [
+      `It adds information that is not stated in the ${levelLabel} text.`,
+      'It focuses on a minor word and misses the main point.',
+      'It contradicts the passage.',
+    ],
+    Writing: [
+      `It makes the ${levelLabel} sentence less precise.`,
+      'It changes the intended meaning.',
+      'It uses a register that does not fit the task.',
+    ],
+    Grammar: [
+      `It uses a form that is too simple for the ${levelLabel} sentence.`,
+      'It breaks the agreement or word order.',
+      'It does not fit the time reference.',
+    ],
+  } as const
+
+  return (
+    distractors[competenceName as keyof typeof distractors][index] ??
+    'It does not answer the question.'
+  )
+}

--- a/packages/prisma-data/src/data/helpers.ts
+++ b/packages/prisma-data/src/data/helpers.ts
@@ -65,6 +65,7 @@ export function prepareCourse({
   description?: string
   isGamificationEnabled: boolean
   isAssessmentEnabled?: boolean
+  isAdaptiveLearningEnabled?: boolean
   ownerId: string
   color?: string
   pinCode?: number | null
@@ -78,6 +79,7 @@ export function prepareCourse({
 }) {
   const data = {
     ...args,
+    isAdaptiveLearningEnabled: args.isAdaptiveLearningEnabled ?? false,
     authType: args.isAssessmentEnabled
       ? Prisma.CourseAuthType.SSO
       : Prisma.CourseAuthType.PIN,

--- a/packages/prisma-data/src/data/seedAdaptiveLearning.ts
+++ b/packages/prisma-data/src/data/seedAdaptiveLearning.ts
@@ -1,0 +1,926 @@
+import {
+  deriveGuessingParameter,
+  getAdaptivePresetDefaults,
+} from '@klicker-uzh/adaptive-learning'
+import * as Prisma from '@klicker-uzh/prisma/client'
+import {
+  processElementData,
+  recomputeDerivedPermissions,
+} from '@klicker-uzh/util'
+import { createHash } from 'node:crypto'
+import {
+  adaptiveElementContent,
+  adaptiveElementExplanation,
+  adaptiveSeedChoices,
+  adaptiveSeedOptions,
+} from './adaptiveLearningElementFixtures.js'
+import { COURSE_ID_TEST, COURSE_ID_TEST2, USER_ID_TEST } from './constants.js'
+import { prepareQuestion } from './helpers.js'
+
+const ADAPTIVE_COMPETENCE_TREE_ID_TEST = 'b9a9e488-cc25-4cef-bd6f-4fe18cfa9d74'
+const ADAPTIVE_PRACTICE_QUIZ_ID_TEST = '6bd53b30-77df-41c4-973b-ff1caa8c9028'
+const ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS =
+  getAdaptivePresetDefaults('DIAGNOSTIC')
+const ADAPTIVE_PRACTICE_QUIZ_LEVELS = [
+  'Foundation',
+  'Independent',
+  'Advanced',
+] as const
+const ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES = [
+  Prisma.ElementType.SC,
+  Prisma.ElementType.MC,
+  Prisma.ElementType.KPRIM,
+  Prisma.ElementType.NUMERICAL,
+  Prisma.ElementType.FREE_TEXT,
+] as const
+const ADAPTIVE_PRACTICE_QUIZ_VARIANTS_PER_TYPE = 2
+const ADAPTIVE_PRACTICE_QUIZ_ITEMS_PER_COVERAGE_CELL =
+  ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES.length *
+  ADAPTIVE_PRACTICE_QUIZ_VARIANTS_PER_TYPE
+const ADAPTIVE_PRACTICE_QUIZ_LEAVES = [
+  {
+    key: 'transfer',
+    competenceName: 'Reading',
+    subCompetenceName: 'Transfer',
+  },
+  {
+    key: 'clarity',
+    competenceName: 'Writing',
+    subCompetenceName: 'Clarity',
+  },
+] as const
+const ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY = {
+  totalQuestionCap:
+    ADAPTIVE_PRACTICE_QUIZ_LEAVES.length *
+    ADAPTIVE_PRACTICE_QUIZ_LEVELS.length *
+    ADAPTIVE_PRACTICE_QUIZ_ITEMS_PER_COVERAGE_CELL,
+  perLeafQuestionCap:
+    ADAPTIVE_PRACTICE_QUIZ_LEVELS.length *
+    ADAPTIVE_PRACTICE_QUIZ_ITEMS_PER_COVERAGE_CELL,
+  minQuestionsPerLeaf: 2,
+} as const
+const ADAPTIVE_LEGACY_ESTIMATOR_VERSION = 'irt-v1-legacy'
+const ADAPTIVE_LEGACY_CALIBRATION_MODEL_VERSION = 'irt-v1-author-prior'
+const ADAPTIVE_LEGACY_CALIBRATION_DATASET_VERSION = 'legacy-author-prior-v1'
+
+type AdaptiveSeedElementSpec = {
+  originalId: string
+  name: string
+  type: Prisma.ElementType
+  content: string
+  explanation: string
+  choices?: { value: string; feedback?: string; correct?: boolean }[]
+  options: any
+  competenceName: string
+  subCompetenceName: string
+  levelLabel: string
+}
+
+type AdaptivePracticeQuizSeedElementSpec = AdaptiveSeedElementSpec & {
+  leafKey: (typeof ADAPTIVE_PRACTICE_QUIZ_LEAVES)[number]['key']
+  levelOrder: number
+  enablePercentInput: boolean
+}
+
+async function seedAdaptivePracticeQuizElements(prisma: Prisma.PrismaClient) {
+  const elements: Array<{
+    element: Prisma.Element
+    leafKey: AdaptivePracticeQuizSeedElementSpec['leafKey']
+    levelOrder: number
+    enablePercentInput: boolean
+  }> = []
+
+  for (const spec of buildAdaptivePracticeQuizSeedElementSpecs()) {
+    const data = prepareQuestion({
+      originalId: spec.originalId,
+      name: spec.name,
+      type: spec.type,
+      ownerId: USER_ID_TEST,
+      content: spec.content,
+      explanation: spec.explanation,
+      choices: spec.choices,
+      options: spec.options,
+    })
+    const existingElement = await prisma.element.findFirst({
+      where: { originalId: spec.originalId },
+    })
+    const element = existingElement
+      ? await prisma.element.update({
+          where: { id: existingElement.id },
+          data: {
+            ...data,
+            status: Prisma.ElementStatus.READY,
+            isArchived: false,
+            isDeleted: false,
+          },
+        })
+      : await prisma.element.create({
+          data: {
+            ...data,
+            status: Prisma.ElementStatus.READY,
+          },
+        })
+
+    await recomputeDerivedPermissions(
+      { elementId: element.id, userId: USER_ID_TEST },
+      prisma
+    )
+    elements.push({
+      element,
+      leafKey: spec.leafKey,
+      levelOrder: spec.levelOrder,
+      enablePercentInput: spec.enablePercentInput,
+    })
+  }
+
+  return elements
+}
+
+function buildAdaptivePracticeQuizSeedElementSpecs(): AdaptivePracticeQuizSeedElementSpec[] {
+  return ADAPTIVE_PRACTICE_QUIZ_LEAVES.flatMap((leaf, leafIndex) =>
+    ADAPTIVE_PRACTICE_QUIZ_LEVELS.flatMap((levelLabel, levelOrder) =>
+      ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES.flatMap((type, typeIndex) =>
+        Array.from(
+          { length: ADAPTIVE_PRACTICE_QUIZ_VARIANTS_PER_TYPE },
+          (_, variantIndex) => {
+            const itemIndex =
+              typeIndex * ADAPTIVE_PRACTICE_QUIZ_VARIANTS_PER_TYPE +
+              variantIndex
+            const numericalSolution =
+              20 + levelOrder * 20 + leafIndex * 5 + variantIndex
+            const isNumerical = type === Prisma.ElementType.NUMERICAL
+            return {
+              originalId: [
+                'adaptive-practice-quiz',
+                leaf.key,
+                levelOrder + 1,
+                type.toLowerCase(),
+                variantIndex + 1,
+              ].join('-'),
+              name: `Adaptive ${leaf.subCompetenceName} ${levelLabel} ${type} ${variantIndex + 1}`,
+              type,
+              content: isNumerical
+                ? `## ${leaf.competenceName} - ${leaf.subCompetenceName} (${levelLabel})
+
+A learner completed ${numericalSolution} percent of the assigned language exercises.
+
+Enter the percentage as a number.`
+                : adaptiveElementContent({
+                    competenceName: leaf.competenceName,
+                    subCompetenceName: leaf.subCompetenceName,
+                    levelLabel,
+                    itemIndex,
+                    type,
+                  }),
+              explanation: isNumerical
+                ? `The correct response is ${numericalSolution}.`
+                : adaptiveElementExplanation({
+                    competenceName: leaf.competenceName,
+                    subCompetenceName: leaf.subCompetenceName,
+                    levelLabel,
+                  }),
+              choices: isNumerical
+                ? undefined
+                : adaptiveSeedChoices({
+                    type,
+                    competenceName: leaf.competenceName,
+                    subCompetenceName: leaf.subCompetenceName,
+                    levelLabel,
+                  }),
+              options: isNumerical
+                ? {
+                    hasSampleSolution: true,
+                    accuracy: 0,
+                    unit: '%',
+                    restrictions: { min: 0, max: 100 },
+                    exactSolutions: [numericalSolution],
+                  }
+                : adaptiveSeedOptions(type),
+              competenceName: leaf.competenceName,
+              subCompetenceName: leaf.subCompetenceName,
+              levelLabel,
+              leafKey: leaf.key,
+              levelOrder,
+              enablePercentInput: isNumerical,
+            }
+          }
+        )
+      )
+    )
+  )
+}
+
+export async function seedAdaptivePracticeQuizV2(
+  prisma: Prisma.PrismaClient,
+  allParticipantIds: readonly string[]
+) {
+  const elements = await seedAdaptivePracticeQuizElements(prisma)
+  const expectedElementCount =
+    ADAPTIVE_PRACTICE_QUIZ_LEAVES.length *
+    ADAPTIVE_PRACTICE_QUIZ_LEVELS.length *
+    ADAPTIVE_PRACTICE_QUIZ_ITEMS_PER_COVERAGE_CELL
+  if (elements.length !== expectedElementCount) {
+    throw new Error(
+      `Expected ${expectedElementCount} adaptive PracticeQuiz seed elements, received ${elements.length}.`
+    )
+  }
+
+  for (const type of ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES) {
+    if (!elements.some(({ element }) => element.type === type)) {
+      throw new Error(`Missing ${type} element for adaptive v2 seed.`)
+    }
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const existingSeed = await tx.practiceQuiz.findUnique({
+      where: { id: ADAPTIVE_PRACTICE_QUIZ_ID_TEST },
+      select: {
+        adaptiveConfig: {
+          select: {
+            poolPublishedAt: true,
+            _count: { select: { attempts: true } },
+            publications: {
+              where: {
+                sealedAt: { not: null },
+                supersededAt: null,
+                unpublishedAt: null,
+              },
+              select: { _count: { select: { poolItems: true } } },
+            },
+          },
+        },
+      },
+    })
+    const existingConfig = existingSeed?.adaptiveConfig
+    if (
+      existingConfig?.poolPublishedAt &&
+      existingConfig.publications.length === 1 &&
+      existingConfig.publications[0]!._count.poolItems === expectedElementCount
+    ) {
+      return
+    }
+    if (existingConfig && existingConfig._count.attempts > 0) {
+      throw new Error(
+        'The adaptive PracticeQuiz seed has attempts but an incomplete publication. Reset the development database before reseeding.'
+      )
+    }
+    if (existingConfig) {
+      const retiredAt = new Date()
+      await tx.practiceQuizAdaptivePublication.updateMany({
+        where: {
+          config: { practiceQuizId: ADAPTIVE_PRACTICE_QUIZ_ID_TEST },
+          unpublishedAt: null,
+        },
+        data: { unpublishedAt: retiredAt },
+      })
+      await tx.practiceQuizAdaptivePoolItem.deleteMany({
+        where: { config: { practiceQuizId: ADAPTIVE_PRACTICE_QUIZ_ID_TEST } },
+      })
+      await tx.practiceQuizAdaptivePublication.deleteMany({
+        where: { config: { practiceQuizId: ADAPTIVE_PRACTICE_QUIZ_ID_TEST } },
+      })
+    }
+    await tx.practiceQuiz.deleteMany({
+      where: { id: ADAPTIVE_PRACTICE_QUIZ_ID_TEST },
+    })
+    await tx.adaptiveItemCalibration.deleteMany({
+      where: { treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST },
+    })
+    await tx.competenceTreeScaleVersion.deleteMany({
+      where: { treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST },
+    })
+    await tx.competenceTree.deleteMany({
+      where: { id: ADAPTIVE_COMPETENCE_TREE_ID_TEST },
+    })
+
+    await tx.competenceTree.create({
+      data: {
+        id: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        name: 'adaptive-language-foundations',
+        displayName: 'Adaptive language foundations',
+        description:
+          'Reusable depth-5 competence tree for adaptive Practice Quiz development.',
+        maxDepth: 5,
+        thetaMin: -3,
+        thetaMax: 3,
+        defaultDiscrimination: 1.2,
+        levelMappingRule: Prisma.AdaptiveLevelMappingRule.NEAREST,
+        ownerId: USER_ID_TEST,
+        courseLinks: {
+          create: [
+            { courseId: COURSE_ID_TEST, linkedById: USER_ID_TEST },
+            { courseId: COURSE_ID_TEST2, linkedById: USER_ID_TEST },
+          ],
+        },
+      },
+    })
+
+    await tx.competenceTreeLevel.createMany({
+      data: [
+        {
+          treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          label: 'Foundation',
+          order: 0,
+        },
+        {
+          treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          label: 'Independent',
+          order: 1,
+        },
+        {
+          treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          label: 'Advanced',
+          order: 2,
+        },
+      ],
+    })
+    const levels = await tx.competenceTreeLevel.findMany({
+      where: { treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST },
+      orderBy: { order: 'asc' },
+    })
+
+    const comprehension = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        kind: Prisma.AdaptiveNodeKind.COMPETENCE,
+        name: 'Comprehension',
+        order: 0,
+        depth: 1,
+        weight: 3,
+      },
+    })
+    const evidence = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        parentId: comprehension.id,
+        kind: Prisma.AdaptiveNodeKind.SUBCOMPETENCE,
+        name: 'Evidence',
+        order: 0,
+        depth: 2,
+      },
+    })
+    const interpretation = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        parentId: evidence.id,
+        kind: Prisma.AdaptiveNodeKind.SUBCOMPETENCE,
+        name: 'Interpretation',
+        order: 0,
+        depth: 3,
+      },
+    })
+    const evaluation = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        parentId: interpretation.id,
+        kind: Prisma.AdaptiveNodeKind.SUBCOMPETENCE,
+        name: 'Evaluation',
+        order: 0,
+        depth: 4,
+      },
+    })
+    const transfer = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        parentId: evaluation.id,
+        kind: Prisma.AdaptiveNodeKind.SUBCOMPETENCE,
+        name: 'Transfer',
+        order: 0,
+        depth: 5,
+      },
+    })
+    const communication = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        kind: Prisma.AdaptiveNodeKind.COMPETENCE,
+        name: 'Communication',
+        order: 1,
+        depth: 1,
+        weight: 2,
+      },
+    })
+    const clarity = await tx.competenceTreeNode.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        parentId: communication.id,
+        kind: Prisma.AdaptiveNodeKind.SUBCOMPETENCE,
+        name: 'Clarity',
+        order: 0,
+        depth: 2,
+      },
+    })
+
+    const leafNodes = { transfer, clarity }
+    const assignmentSpecs = elements.map(
+      ({ element, leafKey, levelOrder, enablePercentInput }) => ({
+        elementId: element.id,
+        leafNodeId: leafNodes[leafKey].id,
+        levelId: levels[levelOrder]!.id,
+        enablePercentInput,
+      })
+    )
+    const coverageSpecs = Object.values(leafNodes).flatMap((leafNode) =>
+      levels.map((level) => ({
+        leafNodeId: leafNode.id,
+        levelId: level.id,
+      }))
+    )
+
+    await tx.competenceTreeLeafLevelCoverage.createMany({
+      data: coverageSpecs.map(({ leafNodeId, levelId }) => ({
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        leafNodeId,
+        levelId,
+        targetItemCount: ADAPTIVE_PRACTICE_QUIZ_ITEMS_PER_COVERAGE_CELL,
+        enabled: true,
+      })),
+    })
+    await tx.competenceTreeElementAssignment.createMany({
+      data: assignmentSpecs.map((assignment) => ({
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        ...assignment,
+      })),
+    })
+
+    const practiceQuiz = await tx.practiceQuiz.create({
+      data: {
+        id: ADAPTIVE_PRACTICE_QUIZ_ID_TEST,
+        name: 'adaptive-language-check',
+        displayName: 'Adaptive language check',
+        description:
+          'Published adaptive Practice Quiz for running the complete development flow.',
+        mode: Prisma.PracticeQuizMode.ADAPTIVE,
+        status: Prisma.PublicationStatus.PUBLISHED,
+        pointsMultiplier: 0,
+        ownerId: USER_ID_TEST,
+        courseId: COURSE_ID_TEST,
+        adaptiveConfig: {
+          create: {
+            competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+            preset: Prisma.AdaptivePracticeQuizPreset.DIAGNOSTIC,
+            attemptSelectionPolicy:
+              Prisma.AdaptiveAttemptSelectionPolicy.LATEST_COMPLETED,
+            ...ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY,
+            classificationZ: ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.classificationZ,
+            topInformationRatio:
+              ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.topInformationRatio,
+            defaultDiscrimination:
+              ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.defaultDiscrimination,
+            levelMappingRule: Prisma.AdaptiveLevelMappingRule.NEAREST,
+            showTimer: ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.showTimer,
+          },
+        },
+      },
+      include: { adaptiveConfig: true },
+    })
+
+    const adaptiveConfig = practiceQuiz.adaptiveConfig
+    if (!adaptiveConfig) {
+      throw new Error('Missing adaptive configuration for adaptive v2 seed.')
+    }
+
+    const scale = await tx.competenceTreeScaleVersion.create({
+      data: {
+        treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        version: 1,
+        status: Prisma.AdaptiveScaleVersionStatus.DRAFT,
+        priorMean: 0,
+        priorStandardDeviation: 1,
+        gridMin: -6,
+        gridMax: 6,
+        gridStep: 0.1,
+        classificationPolicyVersion: 1,
+        createdById: USER_ID_TEST,
+        levels: {
+          create: levels.map((level, index) => ({
+            sourceLevelId: level.id,
+            order: level.order,
+            label: level.label,
+            lowerBound: index === 0 ? null : index === 1 ? -1.5 : 1.5,
+            itemDifficultyPrior: [-3, 0, 3][index]!,
+          })),
+        },
+      },
+      include: { levels: { orderBy: { order: 'asc' } } },
+    })
+    await tx.practiceQuizAdaptiveConfig.update({
+      where: { id: adaptiveConfig.id },
+      data: {
+        measurementVersion: Prisma.AdaptiveMeasurementVersion.IRT_V1,
+        calibrationPolicyVersion: 1,
+        scaleVersionId: scale.id,
+      },
+    })
+
+    const nodePathByLeafId = new Map([
+      [
+        transfer.id,
+        [comprehension, evidence, interpretation, evaluation, transfer],
+      ],
+      [clarity.id, [communication, clarity]],
+    ])
+    const levelThetaByOrder = [-3, 0, 3]
+    const publishedAssignments =
+      await tx.competenceTreeElementAssignment.findMany({
+        where: { treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST },
+        include: { element: true, level: true },
+        orderBy: { id: 'asc' },
+      })
+    if (publishedAssignments.length !== expectedElementCount) {
+      throw new Error(
+        `Expected ${expectedElementCount} adaptive PracticeQuiz pool items, received ${publishedAssignments.length}.`
+      )
+    }
+
+    const calibrationByAssignment = new Map<
+      number,
+      Prisma.AdaptiveItemCalibration
+    >()
+    for (const assignment of publishedAssignments) {
+      const scaleLevel = scale.levels.find(
+        ({ sourceLevelId }) => sourceLevelId === assignment.levelId
+      )
+      if (!scaleLevel) {
+        throw new Error(
+          `Cannot map adaptive assignment ${assignment.id} to the seeded scale.`
+        )
+      }
+      const type = assignment.element
+        .type as (typeof ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES)[number]
+      const choiceCount = adaptiveChoiceCount(type, assignment.element.options)
+      const calibration = await tx.adaptiveItemCalibration.create({
+        data: {
+          treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          scaleVersionId: scale.id,
+          assignmentId: assignment.id,
+          elementId: assignment.element.id,
+          elementVersion: assignment.element.version,
+          version: 1,
+          model:
+            type === Prisma.ElementType.NUMERICAL ||
+            type === Prisma.ElementType.FREE_TEXT
+              ? Prisma.AdaptiveItemModel.TWO_PL
+              : Prisma.AdaptiveItemModel.THREE_PL_FIXED_C,
+          status: Prisma.AdaptiveItemCalibrationStatus.PROVISIONAL,
+          discrimination:
+            assignment.discrimination ??
+            ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.defaultDiscrimination,
+          difficulty: scaleLevel.itemDifficultyPrior,
+          guessing: deriveGuessingParameter({ type, choiceCount }),
+          parameterUncertainty: {
+            discriminationStandardError: null,
+            difficultyStandardError: null,
+            guessingStandardError: null,
+            discriminationInterval: null,
+            difficultyInterval: null,
+            guessingInterval: null,
+          },
+          responseCount: 0,
+          participantCount: 0,
+          diagnostics: {
+            fitStatus: 'WARN',
+            difStatus: 'WARN',
+            driftStatus: 'WARN',
+            fitStatistics: {},
+            warningCodes: ['LEGACY_AUTHOR_PRIOR_NOT_EMPIRICALLY_CALIBRATED'],
+            dif: {},
+            drift: {},
+          },
+          datasetVersion: ADAPTIVE_LEGACY_CALIBRATION_DATASET_VERSION,
+          datasetChecksum: adaptiveSeedChecksum({
+            treeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+            assignmentId: assignment.id,
+            elementVersion: assignment.element.version,
+          }),
+          modelImplementationVersion: ADAPTIVE_LEGACY_CALIBRATION_MODEL_VERSION,
+          elementContentChecksum: adaptiveSeedChecksum({
+            elementId: assignment.element.id,
+            elementVersion: assignment.element.version,
+            content: assignment.element.content,
+            options: assignment.element.options,
+          }),
+          createdById: USER_ID_TEST,
+        },
+      })
+      calibrationByAssignment.set(assignment.id, calibration)
+    }
+
+    const nodes = [
+      comprehension,
+      evidence,
+      interpretation,
+      evaluation,
+      transfer,
+      communication,
+      clarity,
+    ]
+    const nodePathByNodeId = new Map([
+      [comprehension.id, [comprehension]],
+      [evidence.id, [comprehension, evidence]],
+      [interpretation.id, [comprehension, evidence, interpretation]],
+      [evaluation.id, [comprehension, evidence, interpretation, evaluation]],
+      [
+        transfer.id,
+        [comprehension, evidence, interpretation, evaluation, transfer],
+      ],
+      [communication.id, [communication]],
+      [clarity.id, [communication, clarity]],
+    ])
+    const rootWeightTotal = comprehension.weight + communication.weight
+    const effectiveLeafWeightById = new Map([
+      [transfer.id, comprehension.weight / rootWeightTotal],
+      [clarity.id, communication.weight / rootWeightTotal],
+    ])
+    const publicationTimestamp = new Date(Date.UTC(2026, 6, 12, 11, 0, 0))
+    const publication = await tx.practiceQuizAdaptivePublication.create({
+      data: {
+        version: 1,
+        configId: adaptiveConfig.id,
+        competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        scaleVersionId: scale.id,
+        measurementVersion: Prisma.AdaptiveMeasurementVersion.IRT_V1,
+        preset: Prisma.AdaptivePracticeQuizPreset.DIAGNOSTIC,
+        estimatorImplementationVersion: ADAPTIVE_LEGACY_ESTIMATOR_VERSION,
+        classificationPolicyVersion: 1,
+        calibrationPolicyVersion: 1,
+        cutScoreSnapshot: scale.levels.map((level) => ({
+          scaleLevelId: level.id,
+          sourceLevelId: level.sourceLevelId,
+          order: level.order,
+          label: level.label,
+          lowerBound: level.lowerBound,
+          itemDifficultyPrior: level.itemDifficultyPrior,
+        })),
+        priorMean: scale.priorMean,
+        priorStandardDeviation: scale.priorStandardDeviation,
+        gridMin: scale.gridMin,
+        gridMax: scale.gridMax,
+        gridStep: scale.gridStep,
+        classificationProbabilityThreshold: null,
+        hierarchicalWeightSnapshot: nodes.map((node) => ({
+          nodeId: node.id,
+          name: node.name,
+          parentId: node.parentId,
+          kind: node.kind,
+          depth: node.depth,
+          order: node.order,
+          nodePath: nodePathByNodeId.get(node.id)!.map(({ id }) => id),
+          enabled: true,
+          normalizedWeight:
+            node.parentId === null ? node.weight / rootWeightTotal : 1,
+          effectiveLeafWeight: effectiveLeafWeightById.get(node.id) ?? null,
+        })),
+        evidenceMinimumSnapshot: {
+          minimumResponsesPerLeaf:
+            ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY.minQuestionsPerLeaf,
+          minimumResponsesPerRoot:
+            ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY.minQuestionsPerLeaf,
+          requiredRootIds: [comprehension.id, communication.id],
+          classificationZ: ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.classificationZ,
+          topInformationRatio:
+            ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.topInformationRatio,
+          levelMappingRule: Prisma.AdaptiveLevelMappingRule.NEAREST,
+          thetaMin: -3,
+          thetaMax: 3,
+        },
+        totalQuestionCap:
+          ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY.totalQuestionCap,
+        showTimer: ADAPTIVE_DIAGNOSTIC_SEED_DEFAULTS.showTimer,
+        questionCapSnapshot: {
+          root: {
+            [comprehension.id]: null,
+            [communication.id]: null,
+          },
+          node: Object.fromEntries(nodes.map(({ id }) => [id, null])),
+          leaf: {
+            [transfer.id]:
+              ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY.perLeafQuestionCap,
+            [clarity.id]:
+              ADAPTIVE_DIAGNOSTIC_SEED_STRESS_OVERLAY.perLeafQuestionCap,
+          },
+        },
+        candidateSetPolicyVersion: 'irt-v1-max-information',
+        randomizationPolicyVersion: 'irt-v1-deterministic',
+        exposureCeiling: 1,
+        overlapPolicyVersion: 'irt-v1-no-exposure-control',
+        retakePolicy: Prisma.AdaptiveAttemptSelectionPolicy.LATEST_COMPLETED,
+        retakeCooldownDays: practiceQuiz.resetTimeDays,
+        researchAllocationPolicy: Prisma.Prisma.JsonNull,
+        stoppingPolicyVersion: 'irt-v1-z-interval',
+        rolloutPolicyVersion: 1,
+        publishedById: USER_ID_TEST,
+        publishedAt: publicationTimestamp,
+        createdAt: publicationTimestamp,
+      },
+    })
+
+    await tx.practiceQuizAdaptivePoolItem.createMany({
+      data: publishedAssignments.map((assignment) => {
+        const nodePath = nodePathByLeafId.get(assignment.leafNodeId)
+        const difficulty = levelThetaByOrder[assignment.level.order]
+        if (!nodePath || difficulty === undefined) {
+          throw new Error(
+            `Cannot materialize adaptive assignment ${assignment.id}.`
+          )
+        }
+        const type = assignment.element
+          .type as (typeof ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES)[number]
+        const calibration = calibrationByAssignment.get(assignment.id)
+        if (!calibration) {
+          throw new Error(
+            `Cannot materialize adaptive assignment ${assignment.id} without a calibration.`
+          )
+        }
+
+        return {
+          configId: adaptiveConfig.id,
+          competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          publicationId: publication.id,
+          scaleVersionId: scale.id,
+          calibrationId: calibration.id,
+          sourceAssignmentId: assignment.id,
+          elementId: assignment.element.id,
+          elementVersion: assignment.element.version,
+          elementType: type,
+          elementName: assignment.element.name,
+          elementData: processElementData(assignment.element),
+          leafNodeId: assignment.leafNodeId,
+          nodePath: nodePath.map((node) => node.id),
+          nodeNamePath: nodePath.map((node) => node.name),
+          levelId: assignment.level.id,
+          levelLabel: assignment.level.label,
+          levelOrder: assignment.level.order,
+          discrimination: calibration.discrimination,
+          difficulty: calibration.difficulty,
+          guessing: calibration.guessing,
+          measurementVersion: Prisma.AdaptiveMeasurementVersion.IRT_V1,
+          calibrationVersion: calibration.version,
+          calibrationStatus: calibration.status,
+          itemModel: calibration.model,
+          modelImplementationVersion: calibration.modelImplementationVersion,
+          role: Prisma.AdaptivePoolItemRole.SCORING,
+          contributesToEstimate: true,
+          enablePercentInput: assignment.enablePercentInput,
+        }
+      }),
+    })
+    const poolItems = await tx.practiceQuizAdaptivePoolItem.findMany({
+      where: { publicationId: publication.id },
+      select: { id: true },
+    })
+    await tx.adaptivePracticeQuizItemExposure.createMany({
+      data: poolItems.map(({ id }) => ({
+        publicationId: publication.id,
+        poolItemId: id,
+      })),
+    })
+    await tx.practiceQuizAdaptivePublication.update({
+      where: { id: publication.id },
+      data: { sealedAt: publicationTimestamp },
+    })
+    await tx.practiceQuizAdaptiveConfig.update({
+      where: { id: adaptiveConfig.id },
+      data: {
+        poolPublishedAt: publicationTimestamp,
+      },
+    })
+
+    const participantIds = allParticipantIds.slice(0, 15)
+    const participations = await tx.participation.findMany({
+      where: {
+        courseId: COURSE_ID_TEST,
+        participantId: { in: participantIds },
+      },
+    })
+    const participationByParticipantId = new Map(
+      participations.map((participation) => [
+        participation.participantId,
+        participation,
+      ])
+    )
+    if (participationByParticipantId.size !== participantIds.length) {
+      throw new Error(
+        'Missing Testkurs participations for adaptive v2 cohort seed.'
+      )
+    }
+
+    const thetaByLevel = [-2, 0, 2]
+    const attempts = participantIds.map((participantId, index) => {
+      const participation = participationByParticipantId.get(participantId)!
+      const level = levels[index % levels.length]!
+      const theta = thetaByLevel[level.order]!
+      const stopReason =
+        index < 5
+          ? Prisma.AdaptivePracticeQuizStopReason.CLASSIFIED
+          : index < 10
+            ? Prisma.AdaptivePracticeQuizStopReason.TOTAL_QUESTION_CAP
+            : Prisma.AdaptivePracticeQuizStopReason.POOL_EXHAUSTED
+      const resultStatus =
+        index < 5
+          ? Prisma.AdaptiveResultStatus.CLASSIFIED
+          : index < 10
+            ? Prisma.AdaptiveResultStatus.INSUFFICIENT_EVIDENCE
+            : Prisma.AdaptiveResultStatus.POOL_LIMITED
+
+      return {
+        id: `ad000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+        participantId,
+        participationId: participation.id,
+        level,
+        theta,
+        stopReason,
+        resultStatus,
+      }
+    })
+
+    await tx.adaptivePracticeQuizAttempt.createMany({
+      data: attempts.map((attempt, index) => ({
+        id: attempt.id,
+        status: Prisma.AdaptivePracticeQuizAttemptStatus.COMPLETED,
+        stopReason: attempt.stopReason,
+        currentTheta: attempt.theta,
+        currentStandardError: 0.2,
+        finalTheta: attempt.theta,
+        finalStandardError: 0.2,
+        finalLevelId: attempt.level.id,
+        finalScaleLevelId: scale.levels.find(
+          ({ sourceLevelId }) => sourceLevelId === attempt.level.id
+        )!.id,
+        resultStatus: attempt.resultStatus,
+        elapsedSeconds: 240 + index * 10,
+        configId: adaptiveConfig.id,
+        competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+        publicationId: publication.id,
+        scaleVersionId: scale.id,
+        measurementVersion: Prisma.AdaptiveMeasurementVersion.IRT_V1,
+        estimatorImplementationVersion: ADAPTIVE_LEGACY_ESTIMATOR_VERSION,
+        classificationPolicyVersion: 1,
+        calibrationPolicyVersion: 1,
+        practiceQuizId: ADAPTIVE_PRACTICE_QUIZ_ID_TEST,
+        courseId: COURSE_ID_TEST,
+        participantId: attempt.participantId,
+        participationId: attempt.participationId,
+        completedAt: new Date(Date.UTC(2026, 6, 12, 12, 0, index)),
+      })),
+    })
+    await tx.adaptivePracticeQuizEstimate.createMany({
+      data: attempts.flatMap((attempt) => [
+        {
+          attemptId: attempt.id,
+          configId: adaptiveConfig.id,
+          competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          nodeKind: Prisma.AdaptiveEstimateNodeKind.OVERALL,
+          nodeId: null,
+          theta: attempt.theta,
+          standardError: 0.2,
+          responseCount: 5,
+          stopReason: attempt.stopReason,
+          resultStatus: attempt.resultStatus,
+          levelId: attempt.level.id,
+        },
+        ...nodes.map((node) => ({
+          attemptId: attempt.id,
+          configId: adaptiveConfig.id,
+          competenceTreeId: ADAPTIVE_COMPETENCE_TREE_ID_TEST,
+          nodeKind:
+            node.kind === Prisma.AdaptiveNodeKind.COMPETENCE
+              ? Prisma.AdaptiveEstimateNodeKind.COMPETENCE
+              : Prisma.AdaptiveEstimateNodeKind.SUBCOMPETENCE,
+          nodeId: node.id,
+          theta: attempt.theta,
+          standardError: 0.2,
+          responseCount: 5,
+          stopReason: attempt.stopReason,
+          resultStatus: attempt.resultStatus,
+          levelId: attempt.level.id,
+        })),
+      ]),
+    })
+  })
+
+  await recomputeDerivedPermissions(
+    {
+      practiceQuizId: ADAPTIVE_PRACTICE_QUIZ_ID_TEST,
+      userId: USER_ID_TEST,
+    },
+    prisma
+  )
+}
+
+function adaptiveChoiceCount(
+  type: (typeof ADAPTIVE_PRACTICE_QUIZ_SUPPORTED_TYPES)[number],
+  options: Prisma.Prisma.JsonValue
+) {
+  if (
+    type !== Prisma.ElementType.SC &&
+    type !== Prisma.ElementType.MC &&
+    type !== Prisma.ElementType.KPRIM
+  ) {
+    return null
+  }
+  return (options as { choices?: unknown[] }).choices?.length ?? null
+}
+
+function adaptiveSeedChecksum(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}

--- a/packages/prisma-data/src/data/seedTEST.ts
+++ b/packages/prisma-data/src/data/seedTEST.ts
@@ -32,6 +32,7 @@ import {
 } from './helpers.js'
 import { seedAccounts } from './seedAccounts.js'
 import { seedAchievements } from './seedAchievements.js'
+import { seedAdaptivePracticeQuizV2 } from './seedAdaptiveLearning.js'
 import { seedChatbots } from './seedChatbots.js'
 import { seedCompetencyTree } from './seedCompetencyTree.js'
 import { seedEmailTemplates } from './seedEmailTemplates.js'
@@ -255,6 +256,7 @@ async function seedTest(prisma: Prisma.PrismaClient) {
       description: 'Das ist ein Testkurs. Hier wird getestet. Viel Spass!',
       isGamificationEnabled: true,
       isAssessmentEnabled: false,
+      isAdaptiveLearningEnabled: true,
       ownerId: USER_ID_TEST,
       color: '#016272',
       pinCode: 123456789,
@@ -856,6 +858,8 @@ async function seedTest(prisma: Prisma.PrismaClient) {
       })
     })
   )
+
+  await seedAdaptivePracticeQuizV2(prisma, PARTICIPANT_IDS)
 
   // add participants 30 to 35 to single groups
   const PARTICIPANT_GROUP_IDS_SINGLE = [

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -68,7 +68,9 @@
     "prisma:studio": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:studio:raw",
     "prisma:studio:prod": "../../util/_run_with_infisical.sh --env prd pnpm run prisma:studio:raw",
     "prisma:studio:qa": "../../util/_run_with_infisical.sh --env stg pnpm run prisma:studio:raw",
-    "prisma:studio:raw": "prisma studio"
+    "prisma:studio:raw": "prisma studio",
+    "verify:adaptive-irt-v2-migration": "tsx src/scripts/verifyAdaptiveIrtV2Migration.ts",
+    "verify:adaptive-migration": "tsx src/scripts/verifyAdaptivePhase10Migration.ts"
   },
   "engines": {
     "node": "=24"

--- a/packages/prisma/src/prisma/audits/adaptive-learning-legacy.sql
+++ b/packages/prisma/src/prisma/audits/adaptive-learning-legacy.sql
@@ -1,0 +1,109 @@
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+
+SET LOCAL statement_timeout = '30s';
+SET LOCAL lock_timeout = '2s';
+
+WITH constants AS (
+  SELECT 'f0186f1d-3ec8-48a4-bd58-5f968db52f48'::uuid AS seed_assessment_id
+),
+counts AS (
+  SELECT 'AdaptiveAssessment' AS metric, count(*)::bigint AS value
+  FROM "AdaptiveAssessment"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentLevel', count(*) FROM "AdaptiveAssessmentLevel"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentCompetence', count(*)
+  FROM "AdaptiveAssessmentCompetence"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentSubCompetence', count(*)
+  FROM "AdaptiveAssessmentSubCompetence"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentElement', count(*)
+  FROM "AdaptiveAssessmentElement"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentAttempt', count(*)
+  FROM "AdaptiveAssessmentAttempt"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentResponse', count(*)
+  FROM "AdaptiveAssessmentResponse"
+  UNION ALL
+  SELECT 'AdaptiveAssessmentResultMessage', count(*)
+  FROM "AdaptiveAssessmentResultMessage"
+),
+classification AS (
+  SELECT
+    count(*) FILTER (WHERE assessment.id = constants.seed_assessment_id)::bigint
+      AS seed_assessments,
+    count(*) FILTER (WHERE assessment.id <> constants.seed_assessment_id)::bigint
+      AS non_seed_assessments
+  FROM "AdaptiveAssessment" assessment
+  CROSS JOIN constants
+),
+attempts AS (
+  SELECT
+    count(*) FILTER (WHERE attempt.status = 'IN_PROGRESS')::bigint AS in_progress,
+    count(*) FILTER (WHERE attempt.status = 'COMPLETED')::bigint AS completed,
+    count(*) FILTER (WHERE attempt.status = 'ABANDONED')::bigint AS abandoned,
+    count(DISTINCT attempt."participantId")::bigint AS distinct_participants,
+    count(*) FILTER (
+      WHERE attempt."assessmentId" <> constants.seed_assessment_id
+    )::bigint AS non_seed_attempts
+  FROM "AdaptiveAssessmentAttempt" attempt
+  CROSS JOIN constants
+),
+responses AS (
+  SELECT
+    count(*) FILTER (
+      WHERE attempt."assessmentId" <> constants.seed_assessment_id
+    )::bigint AS non_seed_responses,
+    count(*) FILTER (
+      WHERE attempt."assessmentId" <> element."assessmentId"
+    )::bigint AS cross_assessment_responses
+  FROM "AdaptiveAssessmentResponse" response
+  JOIN "AdaptiveAssessmentAttempt" attempt
+    ON attempt.id = response."attemptId"
+  JOIN "AdaptiveAssessmentElement" element
+    ON element.id = response."adaptiveElementId"
+  CROSS JOIN constants
+),
+decision AS (
+  SELECT CASE
+    WHEN (SELECT coalesce(sum(value), 0) FROM counts) = 0
+      THEN 'CLEANUP_CANDIDATE'
+    WHEN classification.non_seed_assessments = 0
+      AND attempts.non_seed_attempts = 0
+      AND responses.non_seed_responses = 0
+      THEN 'SEED_ONLY_MANUAL_REVIEW'
+    ELSE 'MIGRATION_DECISION_REQUIRED'
+  END AS value
+  FROM classification, attempts, responses
+),
+report AS (
+  SELECT 10 AS ordering, metric, value::text FROM counts
+  UNION ALL
+  SELECT 20, 'seed_assessments', seed_assessments::text FROM classification
+  UNION ALL
+  SELECT 21, 'non_seed_assessments', non_seed_assessments::text FROM classification
+  UNION ALL
+  SELECT 30, 'attempts_in_progress', in_progress::text FROM attempts
+  UNION ALL
+  SELECT 31, 'attempts_completed', completed::text FROM attempts
+  UNION ALL
+  SELECT 32, 'attempts_abandoned', abandoned::text FROM attempts
+  UNION ALL
+  SELECT 33, 'distinct_participants', distinct_participants::text FROM attempts
+  UNION ALL
+  SELECT 34, 'non_seed_attempts', non_seed_attempts::text FROM attempts
+  UNION ALL
+  SELECT 40, 'non_seed_responses', non_seed_responses::text FROM responses
+  UNION ALL
+  SELECT 41, 'cross_assessment_responses', cross_assessment_responses::text
+  FROM responses
+  UNION ALL
+  SELECT 99, 'decision', value FROM decision
+)
+SELECT metric, value
+FROM report
+ORDER BY ordering, metric;
+
+ROLLBACK;

--- a/packages/prisma/src/prisma/audits/adaptive-learning-phase10-preflight.sql
+++ b/packages/prisma/src/prisma/audits/adaptive-learning-phase10-preflight.sql
@@ -1,0 +1,138 @@
+\set ON_ERROR_STOP on
+\pset pager off
+
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '2min';
+
+-- Aggregate-only preflight for the forward runtime-repair and retention
+-- migrations. Zero invalid_* counts are required. repairable_* counts are
+-- expected to be changed deterministically by migration 20260713210000.
+SELECT
+  COUNT(*) AS total_attempts,
+  COUNT(*) FILTER (
+    WHERE "status" = 'IN_PROGRESS'
+      AND "nextPoolItemId" IS NULL
+  ) AS repairable_unresumable_attempts,
+  COUNT(*) FILTER (
+    WHERE (
+      "status" = 'IN_PROGRESS'
+      AND "nextPoolItemId" IS NOT NULL
+      AND ("stopReason" IS NOT NULL OR "completedAt" IS NOT NULL)
+    ) OR (
+      "status" IN ('COMPLETED', 'ABANDONED')
+      AND (
+        "nextPoolItemId" IS NOT NULL
+        OR "completedAt" IS NULL
+        OR "stopReason" IS NULL
+      )
+    )
+  ) AS repairable_lifecycle_rows,
+  COUNT(*) FILTER (
+    WHERE NOT (
+      "currentTheta" BETWEEN -10 AND 10
+      AND ("currentStandardError" IS NULL OR "currentStandardError" > 0)
+      AND ("finalTheta" IS NULL OR "finalTheta" BETWEEN -10 AND 10)
+      AND ("finalStandardError" IS NULL OR "finalStandardError" > 0)
+      AND ("elapsedSeconds" IS NULL OR "elapsedSeconds" >= 0)
+    )
+  ) AS invalid_attempt_runtime_values
+FROM "AdaptivePracticeQuizAttempt";
+
+WITH response_health AS (
+  SELECT
+    result.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY result."attemptId"
+      ORDER BY result."order", result."id"
+    ) AS expected_order,
+    EXISTS (
+      SELECT 1
+      FROM "PracticeQuizAdaptivePoolItem" AS pool
+      WHERE pool."configId" = result."configId"
+        AND pool."sourceAssignmentId" = result."assignmentId"
+        AND pool."elementId" = result."elementId"
+    ) AS has_matching_pool_item
+  FROM "AdaptivePracticeQuizResponse" AS result
+)
+SELECT
+  COUNT(*) AS total_responses,
+  COUNT(*) FILTER (
+    WHERE "poolItemId" IS NULL AND has_matching_pool_item
+  ) AS repairable_missing_pool_items,
+  COUNT(*) FILTER (
+    WHERE "elementSnapshot" IS NULL
+      AND ("poolItemId" IS NOT NULL OR has_matching_pool_item)
+  ) AS repairable_missing_snapshots,
+  COUNT(*) FILTER (
+    WHERE "poolItemId" IS NULL AND NOT has_matching_pool_item
+  ) AS invalid_unresolvable_pool_items,
+  COUNT(*) FILTER (
+    WHERE "order" <> expected_order
+  ) AS invalid_noncontiguous_response_orders,
+  COUNT(*) FILTER (
+    WHERE NOT (
+      "order" > 0
+      AND "score" BETWEEN 0 AND 1
+      AND "correct" = ("score" = 1)
+      AND ("overallThetaBefore" IS NULL OR "overallThetaBefore" BETWEEN -10 AND 10)
+      AND ("overallThetaAfter" IS NULL OR "overallThetaAfter" BETWEEN -10 AND 10)
+      AND (
+        "overallStandardErrorAfter" IS NULL
+        OR "overallStandardErrorAfter" > 0
+      )
+      AND ("elapsedSeconds" IS NULL OR "elapsedSeconds" >= 0)
+    )
+  ) AS invalid_response_runtime_values
+FROM response_health;
+
+SELECT
+  COUNT(*) AS total_estimates,
+  COUNT(*) FILTER (
+    WHERE NOT (
+      ("theta" IS NULL OR "theta" BETWEEN -10 AND 10)
+      AND ("standardError" IS NULL OR "standardError" > 0)
+      AND "responseCount" >= 0
+      AND (
+        (
+          "nodeKind" = 'OVERALL'
+          AND (
+            ("theta" IS NULL AND "standardError" IS NULL)
+            OR ("theta" IS NOT NULL AND "standardError" IS NOT NULL)
+          )
+        )
+        OR (
+          "nodeKind" <> 'OVERALL'
+          AND (
+            (
+              "responseCount" = 0
+              AND "theta" IS NULL
+              AND "standardError" IS NULL
+            )
+            OR (
+              "responseCount" > 0
+              AND "theta" IS NOT NULL
+              AND "standardError" IS NOT NULL
+            )
+          )
+        )
+      )
+    )
+  ) AS invalid_estimate_runtime_values
+FROM "AdaptivePracticeQuizEstimate";
+
+SELECT
+  conname AS constraint_name,
+  convalidated AS is_validated
+FROM pg_constraint
+WHERE conname IN (
+  'apqa_runtime_state_check',
+  'apqa_runtime_values_check',
+  'apqe_runtime_values_check',
+  'apqr_element_snapshot_required_check',
+  'apqr_pool_item_required_check',
+  'apqr_runtime_values_check'
+)
+ORDER BY conname;
+
+ROLLBACK;

--- a/packages/prisma/src/prisma/fixtures/adaptive-irt-v2-pre-migration.sql
+++ b/packages/prisma/src/prisma/fixtures/adaptive-irt-v2-pre-migration.sql
@@ -1,0 +1,63 @@
+-- Additional pre-v2 scale geometry used by the adaptive IRT migration rehearsal.
+-- The Phase 10 fixture supplies the owner and a populated one-level NEAREST tree.
+INSERT INTO "CompetenceTree" (
+  "id",
+  "name",
+  "displayName",
+  "ownerId",
+  "thetaMin",
+  "thetaMax",
+  "levelMappingRule",
+  "updatedAt"
+) VALUES (
+  '92000000-0000-4000-8000-000000000001',
+  'adaptive-irt-v2-mastery-tree',
+  'Adaptive IRT v2 mastery tree',
+  '91000000-0000-4000-8000-000000000001',
+  -3,
+  3,
+  'MASTERY',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "CompetenceTreeLevel" ("id", "label", "order", "treeId") VALUES
+  (9201, 'Foundation', 0, '92000000-0000-4000-8000-000000000001'),
+  (9202, 'Developing', 1, '92000000-0000-4000-8000-000000000001'),
+  (9203, 'Independent', 2, '92000000-0000-4000-8000-000000000001');
+
+INSERT INTO "CompetenceTree" (
+  "id", "name", "displayName", "ownerId", "thetaMin", "thetaMax",
+  "levelMappingRule", "updatedAt"
+) VALUES
+  (
+    '92000000-0000-4000-8000-000000000002',
+    'adaptive-irt-v2-nearest-tree',
+    'Adaptive IRT v2 nearest tree',
+    '91000000-0000-4000-8000-000000000001',
+    -3,
+    3,
+    'NEAREST',
+    CURRENT_TIMESTAMP
+  ),
+  (
+    '92000000-0000-4000-8000-000000000003',
+    'adaptive-irt-v2-one-level-mastery-tree',
+    'Adaptive IRT v2 one-level mastery tree',
+    '91000000-0000-4000-8000-000000000001',
+    -4,
+    2,
+    'MASTERY',
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO "CompetenceTreeLevel" ("id", "label", "order", "treeId") VALUES
+  (9211, 'Basic', 0, '92000000-0000-4000-8000-000000000002'),
+  (9212, 'Independent', 1, '92000000-0000-4000-8000-000000000002'),
+  (9213, 'Advanced', 2, '92000000-0000-4000-8000-000000000002'),
+  (9221, 'Observed', 0, '92000000-0000-4000-8000-000000000003');
+
+-- The materialized pool intentionally retains element version 1 while the
+-- mutable source element has advanced to version 2.
+UPDATE "Element"
+SET version = 2, "updatedAt" = CURRENT_TIMESTAMP
+WHERE id = 9101;

--- a/packages/prisma/src/prisma/fixtures/adaptive-learning-phase10-pre-repair.sql
+++ b/packages/prisma/src/prisma/fixtures/adaptive-learning-phase10-pre-repair.sql
@@ -1,0 +1,593 @@
+-- Populated pre-repair fixture for migration 20260713210000. The three checks
+-- are re-added NOT VALID after inserting rows that emulate legacy data which
+-- predates enforcement for new writes.
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "apqa_runtime_state_check";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+DROP CONSTRAINT "apqr_pool_item_required_check";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+DROP CONSTRAINT "apqr_element_snapshot_required_check";
+
+INSERT INTO "User" (
+  "id",
+  "email",
+  "shortname",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000001',
+  'adaptive-phase10-owner@example.com',
+  'adaptive-phase10-owner',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Course" (
+  "id",
+  "name",
+  "displayName",
+  "ownerId",
+  "pinCode",
+  "startDate",
+  "endDate",
+  "groupDeadlineDate",
+  "isAdaptiveLearningEnabled",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000002',
+  'adaptive-phase10-course',
+  'Adaptive Phase 10 course',
+  '91000000-0000-4000-8000-000000000001',
+  9101,
+  '2026-01-01T00:00:00Z',
+  '2027-01-01T00:00:00Z',
+  '2026-12-01T00:00:00Z',
+  TRUE,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "CompetenceTree" (
+  "id",
+  "name",
+  "displayName",
+  "ownerId",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000003',
+  'adaptive-phase10-tree',
+  'Adaptive Phase 10 tree',
+  '91000000-0000-4000-8000-000000000001',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "CompetenceTreeLevel" (
+  "id",
+  "label",
+  "order",
+  "treeId"
+) VALUES (
+  9101,
+  'Independent',
+  0,
+  '91000000-0000-4000-8000-000000000003'
+);
+
+INSERT INTO "CompetenceTreeNode" (
+  "id",
+  "kind",
+  "name",
+  "order",
+  "depth",
+  "treeId",
+  "updatedAt"
+) VALUES
+  (
+    9101,
+    'COMPETENCE',
+    'Reading',
+    0,
+    0,
+    '91000000-0000-4000-8000-000000000003',
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO "CompetenceTreeNode" (
+  "id",
+  "kind",
+  "name",
+  "order",
+  "depth",
+  "treeId",
+  "parentId",
+  "updatedAt"
+) VALUES (
+  9102,
+  'SUBCOMPETENCE',
+  'Scanning',
+  0,
+  1,
+  '91000000-0000-4000-8000-000000000003',
+  9101,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Element" (
+  "id",
+  "name",
+  "content",
+  "options",
+  "type",
+  "ownerId",
+  "updatedAt"
+) VALUES (
+  9101,
+  'Legacy adaptive item',
+  'Legacy adaptive item',
+  '{"displayMode":"LIST","choices":[{"ix":0,"value":"A","correct":true},{"ix":1,"value":"B","correct":false}]}'::jsonb,
+  'SC',
+  '91000000-0000-4000-8000-000000000001',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Element" (
+  "id",
+  "name",
+  "content",
+  "options",
+  "type",
+  "ownerId",
+  "updatedAt"
+) VALUES (
+  9102,
+  'Legacy adaptive next item',
+  'Legacy adaptive next item',
+  '{"displayMode":"LIST","choices":[{"ix":0,"value":"A","correct":true},{"ix":1,"value":"B","correct":false}]}'::jsonb,
+  'SC',
+  '91000000-0000-4000-8000-000000000001',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "CompetenceTreeElementAssignment" (
+  "id",
+  "treeId",
+  "elementId",
+  "leafNodeId",
+  "levelId",
+  "updatedAt"
+) VALUES (
+  9101,
+  '91000000-0000-4000-8000-000000000003',
+  9101,
+  9102,
+  9101,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "CompetenceTreeElementAssignment" (
+  "id",
+  "treeId",
+  "elementId",
+  "leafNodeId",
+  "levelId",
+  "updatedAt"
+) VALUES (
+  9102,
+  '91000000-0000-4000-8000-000000000003',
+  9102,
+  9102,
+  9101,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "PracticeQuiz" (
+  "id",
+  "name",
+  "displayName",
+  "mode",
+  "status",
+  "pointsMultiplier",
+  "ownerId",
+  "courseId",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000004',
+  'adaptive-phase10-quiz',
+  'Adaptive Phase 10 quiz',
+  'ADAPTIVE',
+  'PUBLISHED',
+  0,
+  '91000000-0000-4000-8000-000000000001',
+  '91000000-0000-4000-8000-000000000002',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "PracticeQuizAdaptiveConfig" (
+  "id",
+  "practiceQuizId",
+  "competenceTreeId",
+  "poolPublishedAt",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000004',
+  '91000000-0000-4000-8000-000000000003',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "PracticeQuizAdaptivePoolItem" (
+  "id",
+  "configId",
+  "competenceTreeId",
+  "sourceAssignmentId",
+  "elementId",
+  "elementVersion",
+  "elementType",
+  "elementName",
+  "elementData",
+  "leafNodeId",
+  "nodePath",
+  "nodeNamePath",
+  "levelId",
+  "levelLabel",
+  "levelOrder",
+  "discrimination",
+  "difficulty",
+  "guessing"
+) VALUES (
+  9101,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  9101,
+  9101,
+  1,
+  'SC',
+  'Legacy adaptive item',
+  '{"id":"9101-v1","elementId":9101,"type":"SC","name":"Legacy adaptive item","content":"Legacy adaptive item","pointsMultiplier":1,"options":{"displayMode":"LIST","choices":[{"ix":0,"value":"A","correct":true},{"ix":1,"value":"B","correct":false}]}}'::jsonb,
+  9102,
+  ARRAY[9101, 9102],
+  ARRAY['Reading', 'Scanning'],
+  9101,
+  'Independent',
+  0,
+  1.2,
+  0.0,
+  0.5
+);
+
+INSERT INTO "PracticeQuizAdaptivePoolItem" (
+  "id",
+  "configId",
+  "competenceTreeId",
+  "sourceAssignmentId",
+  "elementId",
+  "elementVersion",
+  "elementType",
+  "elementName",
+  "elementData",
+  "leafNodeId",
+  "nodePath",
+  "nodeNamePath",
+  "levelId",
+  "levelLabel",
+  "levelOrder",
+  "discrimination",
+  "difficulty",
+  "guessing"
+) VALUES (
+  9102,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  9102,
+  9102,
+  1,
+  'SC',
+  'Legacy adaptive next item',
+  '{"id":"9102-v1","elementId":9102,"type":"SC","name":"Legacy adaptive next item","content":"Legacy adaptive next item","pointsMultiplier":1,"options":{"displayMode":"LIST","choices":[{"ix":0,"value":"A","correct":true},{"ix":1,"value":"B","correct":false}]}}'::jsonb,
+  9102,
+  ARRAY[9101, 9102],
+  ARRAY['Reading', 'Scanning'],
+  9101,
+  'Independent',
+  0,
+  1.2,
+  1.0,
+  0.5
+);
+
+INSERT INTO "Participant" (
+  "id",
+  "username",
+  "password",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000006',
+  'adaptive-phase10-participant',
+  'test',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Participant" (
+  "id",
+  "username",
+  "password",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000010',
+  'adaptive-phase10-active-participant',
+  'test',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Participation" (
+  "id",
+  "courseId",
+  "participantId",
+  "updatedAt"
+) VALUES (
+  9101,
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000006',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "Participation" (
+  "id",
+  "courseId",
+  "participantId",
+  "updatedAt"
+) VALUES (
+  9102,
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000010',
+  CURRENT_TIMESTAMP
+);
+
+-- Unresumable legacy state: the forward migration preserves it as abandoned.
+INSERT INTO "AdaptivePracticeQuizAttempt" (
+  "id",
+  "status",
+  "currentTheta",
+  "currentStandardError",
+  "configId",
+  "competenceTreeId",
+  "practiceQuizId",
+  "courseId",
+  "participantId",
+  "participationId",
+  "nextPoolItemId",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000007',
+  'IN_PROGRESS',
+  0.0,
+  1.0,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  '91000000-0000-4000-8000-000000000004',
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000006',
+  9101,
+  NULL,
+  CURRENT_TIMESTAMP
+);
+
+-- Resumable answered state: the non-null immutable next pointer must survive.
+INSERT INTO "AdaptivePracticeQuizAttempt" (
+  "id",
+  "status",
+  "currentTheta",
+  "currentStandardError",
+  "configId",
+  "competenceTreeId",
+  "practiceQuizId",
+  "courseId",
+  "participantId",
+  "participationId",
+  "nextPoolItemId",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000009',
+  'IN_PROGRESS',
+  0.1,
+  0.9,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  '91000000-0000-4000-8000-000000000004',
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000010',
+  9102,
+  9102,
+  CURRENT_TIMESTAMP
+);
+
+-- Legacy terminal state and response: completion metadata, immutable pool
+-- identity, and the delivered element snapshot all need deterministic repair.
+INSERT INTO "AdaptivePracticeQuizAttempt" (
+  "id",
+  "status",
+  "currentTheta",
+  "currentStandardError",
+  "finalTheta",
+  "finalStandardError",
+  "finalLevelId",
+  "configId",
+  "competenceTreeId",
+  "practiceQuizId",
+  "courseId",
+  "participantId",
+  "participationId",
+  "nextPoolItemId",
+  "stopReason",
+  "completedAt",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000008',
+  'COMPLETED',
+  0.0,
+  1.0,
+  0.0,
+  1.0,
+  9101,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  '91000000-0000-4000-8000-000000000004',
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000006',
+  9101,
+  NULL,
+  NULL,
+  NULL,
+  CURRENT_TIMESTAMP
+);
+
+-- Existing canonical abandoned rows remain unchanged and valid.
+INSERT INTO "AdaptivePracticeQuizAttempt" (
+  "id",
+  "status",
+  "stopReason",
+  "currentTheta",
+  "currentStandardError",
+  "configId",
+  "competenceTreeId",
+  "practiceQuizId",
+  "courseId",
+  "participantId",
+  "participationId",
+  "nextPoolItemId",
+  "completedAt",
+  "updatedAt"
+) VALUES (
+  '91000000-0000-4000-8000-000000000011',
+  'ABANDONED',
+  'ABANDONED',
+  -0.2,
+  1.1,
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  '91000000-0000-4000-8000-000000000004',
+  '91000000-0000-4000-8000-000000000002',
+  '91000000-0000-4000-8000-000000000006',
+  9101,
+  NULL,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO "AdaptivePracticeQuizResponse" (
+  "id",
+  "order",
+  "response",
+  "normalizedResponse",
+  "score",
+  "correct",
+  "attemptId",
+  "configId",
+  "assignmentId",
+  "poolItemId",
+  "elementId",
+  "elementSnapshot"
+) VALUES (
+  9101,
+  1,
+  '{"choiceIndices":[0]}'::jsonb,
+  '{"choiceIndices":[0]}'::jsonb,
+  1.0,
+  TRUE,
+  '91000000-0000-4000-8000-000000000008',
+  '91000000-0000-4000-8000-000000000005',
+  9101,
+  NULL,
+  9101,
+  NULL
+);
+
+INSERT INTO "AdaptivePracticeQuizResponse" (
+  "id",
+  "order",
+  "response",
+  "normalizedResponse",
+  "score",
+  "correct",
+  "attemptId",
+  "configId",
+  "assignmentId",
+  "poolItemId",
+  "elementId",
+  "elementSnapshot",
+  "overallThetaBefore",
+  "overallThetaAfter",
+  "overallStandardErrorAfter"
+) VALUES (
+  9102,
+  1,
+  '{"choiceIndices":[0]}'::jsonb,
+  '{"choiceIndices":[0]}'::jsonb,
+  1.0,
+  TRUE,
+  '91000000-0000-4000-8000-000000000009',
+  '91000000-0000-4000-8000-000000000005',
+  9101,
+  9101,
+  9101,
+  '{"id":"9101-v1","elementId":9101,"type":"SC","name":"Legacy adaptive item","content":"Legacy adaptive item","pointsMultiplier":1,"options":{"displayMode":"LIST","choices":[{"ix":0,"value":"A","correct":true},{"ix":1,"value":"B","correct":false}]}}'::jsonb,
+  0.0,
+  0.1,
+  0.9
+);
+
+INSERT INTO "AdaptivePracticeQuizEstimate" (
+  "id",
+  "nodeKind",
+  "theta",
+  "standardError",
+  "responseCount",
+  "stopReason",
+  "attemptId",
+  "configId",
+  "competenceTreeId",
+  "levelId"
+) VALUES (
+  9101,
+  'OVERALL',
+  0.0,
+  1.0,
+  1,
+  'CLASSIFIED',
+  '91000000-0000-4000-8000-000000000008',
+  '91000000-0000-4000-8000-000000000005',
+  '91000000-0000-4000-8000-000000000003',
+  9101
+);
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "apqa_runtime_state_check"
+CHECK (
+  (
+    "status" = 'IN_PROGRESS'
+    AND "nextPoolItemId" IS NOT NULL
+    AND "stopReason" IS NULL
+    AND "completedAt" IS NULL
+  )
+  OR (
+    "status" = 'COMPLETED'
+    AND "nextPoolItemId" IS NULL
+    AND "stopReason" IS NOT NULL
+    AND "stopReason" <> 'ABANDONED'
+    AND "completedAt" IS NOT NULL
+  )
+  OR (
+    "status" = 'ABANDONED'
+    AND "nextPoolItemId" IS NULL
+    AND "stopReason" = 'ABANDONED'
+    AND "completedAt" IS NOT NULL
+  )
+) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "apqr_pool_item_required_check"
+CHECK ("poolItemId" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "apqr_element_snapshot_required_check"
+CHECK ("elementSnapshot" IS NOT NULL) NOT VALID;

--- a/packages/prisma/src/prisma/schema/adaptive.prisma
+++ b/packages/prisma/src/prisma/schema/adaptive.prisma
@@ -1,0 +1,220 @@
+// LEGACY standalone adaptive assessment schema.
+// New adaptive learning work targets competence trees and PracticeQuizMode.ADAPTIVE
+// in competence.prisma / quiz.prisma. Do not expose these models through new
+// GraphQL or UI surfaces; remove them after the no-data or migration decision.
+
+enum AdaptiveAssessmentAttemptStatus {
+  IN_PROGRESS
+  COMPLETED
+  ABANDONED
+}
+
+model AdaptiveAssessment {
+  id String @id @default(uuid()) @db.Uuid
+
+  name        String
+  displayName String
+  description String?
+  status      PublicationStatus @default(DRAFT)
+  isDeleted   Boolean           @default(false)
+
+  thetaMin               Float @default(-3)
+  thetaMax               Float @default(3)
+  discrimination         Float @default(1.5)
+  standardErrorThreshold Float @default(0.4)
+  questionThreshold      Int   @default(50)
+  topInformationRatio    Float @default(0.8)
+
+  showTimer           Boolean @default(true)
+  showCompetenceNames Boolean @default(true)
+  showFinalResult     Boolean @default(true)
+  showSolutions       Boolean @default(false)
+
+  levels         AdaptiveAssessmentLevel[]
+  competences    AdaptiveAssessmentCompetence[]
+  subCompetences AdaptiveAssessmentSubCompetence[]
+  elements       AdaptiveAssessmentElement[]
+  attempts       AdaptiveAssessmentAttempt[]
+  resultMessages AdaptiveAssessmentResultMessage[]
+
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([courseId])
+  @@index([ownerId])
+  @@index([status])
+}
+
+model AdaptiveAssessmentLevel {
+  id Int @id @default(autoincrement())
+
+  label String
+  order Int
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  elements       AdaptiveAssessmentElement[]
+  resultMessages AdaptiveAssessmentResultMessage[]
+
+  @@unique([assessmentId, label])
+  @@unique([assessmentId, order])
+}
+
+model AdaptiveAssessmentCompetence {
+  id Int @id @default(autoincrement())
+
+  name                   String
+  tagName                String?
+  enabled                Boolean @default(true)
+  order                  Int
+  weight                 Float   @default(1)
+  questionThreshold      Int?
+  standardErrorThreshold Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  subCompetences AdaptiveAssessmentSubCompetence[]
+  elements       AdaptiveAssessmentElement[]
+
+  @@unique([assessmentId, name])
+  @@unique([assessmentId, order])
+}
+
+model AdaptiveAssessmentSubCompetence {
+  id Int @id @default(autoincrement())
+
+  name                   String
+  tagName                String?
+  enabled                Boolean @default(true)
+  order                  Int
+  questionThreshold      Int?
+  standardErrorThreshold Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  competence   AdaptiveAssessmentCompetence @relation(fields: [competenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  competenceId Int
+
+  elements AdaptiveAssessmentElement[]
+
+  @@unique([assessmentId, competenceId, name])
+  @@unique([assessmentId, competenceId, order])
+}
+
+model AdaptiveAssessmentElement {
+  id Int @id @default(autoincrement())
+
+  enabled        Boolean @default(true)
+  exposure       Int     @default(0)
+  discrimination Float?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int
+
+  competence   AdaptiveAssessmentCompetence @relation(fields: [competenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  competenceId Int
+
+  subCompetence   AdaptiveAssessmentSubCompetence @relation(fields: [subCompetenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  subCompetenceId Int
+
+  level   AdaptiveAssessmentLevel @relation(fields: [levelId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  levelId Int
+
+  responses AdaptiveAssessmentResponse[]
+
+  @@unique([assessmentId, elementId, competenceId, subCompetenceId, levelId])
+  @@index([elementId])
+  @@index([assessmentId, enabled])
+}
+
+model AdaptiveAssessmentAttempt {
+  id String @id @default(uuid()) @db.Uuid
+
+  status               AdaptiveAssessmentAttemptStatus @default(IN_PROGRESS)
+  currentTheta         Float                           @default(0)
+  currentStandardError Float?
+  finalTheta           Float?
+  finalStandardError   Float?
+  finalLevelLabel      String?
+  elapsedSeconds       Int?
+  thetaHistory         Json?
+  standardErrorHistory Json?
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participantId String      @db.Uuid
+
+  participation   Participation @relation(fields: [participationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participationId Int
+
+  responses AdaptiveAssessmentResponse[]
+
+  startedAt   DateTime  @default(now())
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([assessmentId, participantId, status])
+  @@index([participationId])
+}
+
+model AdaptiveAssessmentResponse {
+  id Int @id @default(autoincrement())
+
+  order              Int
+  response           Json
+  correct            Boolean
+  thetaBefore        Float
+  thetaAfter         Float
+  standardErrorAfter Float
+  elapsedSeconds     Int?
+
+  attempt   AdaptiveAssessmentAttempt @relation(fields: [attemptId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  attemptId String                    @db.Uuid
+
+  adaptiveElement   AdaptiveAssessmentElement @relation(fields: [adaptiveElementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  adaptiveElementId Int
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, order])
+  @@index([attemptId])
+  @@index([adaptiveElementId])
+  @@index([elementId])
+}
+
+model AdaptiveAssessmentResultMessage {
+  id Int @id @default(autoincrement())
+
+  order      Int
+  message    String
+  minTheta   Float?
+  maxTheta   Float?
+  isFallback Boolean @default(false)
+
+  assessment   AdaptiveAssessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assessmentId String             @db.Uuid
+
+  level   AdaptiveAssessmentLevel? @relation(fields: [levelId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  levelId Int?
+
+  @@unique([assessmentId, order])
+  @@index([assessmentId, isFallback])
+}

--- a/packages/prisma/src/prisma/schema/adaptivePracticeQuiz.prisma
+++ b/packages/prisma/src/prisma/schema/adaptivePracticeQuiz.prisma
@@ -1,0 +1,559 @@
+model PracticeQuizAdaptiveConfig {
+  id String @id @default(uuid()) @db.Uuid
+
+  practiceQuiz   PracticeQuiz @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String       @unique(map: "pqac_practice_quiz_key") @db.Uuid
+
+  competenceTree   CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  measurementVersion       AdaptiveMeasurementVersion @default(IRT_V1)
+  calibrationPolicyVersion Int?
+
+  scaleVersion   CompetenceTreeScaleVersion? @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String?                     @db.Uuid
+
+  preset                 AdaptivePracticeQuizPreset     @default(DIAGNOSTIC)
+  attemptSelectionPolicy AdaptiveAttemptSelectionPolicy @default(LATEST_COMPLETED)
+
+  totalQuestionCap      Int                      @default(50)
+  perLeafQuestionCap    Int?
+  minQuestionsPerLeaf   Int                      @default(2)
+  classificationZ       Float                    @default(1.28)
+  topInformationRatio   Float                    @default(0.8)
+  defaultDiscrimination Float                    @default(1.2)
+  levelMappingRule      AdaptiveLevelMappingRule @default(NEAREST)
+
+  showTimer Boolean @default(true)
+
+  nodeOverrides        PracticeQuizAdaptiveNodeOverride[]
+  elementOverrides     PracticeQuizAdaptiveElementOverride[]
+  publishedPool        PracticeQuizAdaptivePoolItem[]
+  attempts             AdaptivePracticeQuizAttempt[]
+  cohortSnapshots      AdaptivePracticeQuizCohortSnapshot[]
+  publications         PracticeQuizAdaptivePublication[]
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+
+  poolPublishedAt DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([id, competenceTreeId], map: "pqac_id_tree_key")
+  @@unique([id, practiceQuizId], map: "pqac_id_quiz_key")
+  @@unique([id, practiceQuizId, competenceTreeId], map: "pqac_id_quiz_tree_key")
+  @@index([competenceTreeId], map: "pqac_tree_idx")
+}
+
+model PracticeQuizAdaptivePublication {
+  id String @id @default(uuid()) @db.Uuid
+
+  version Int
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  tree             CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "pqap_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  measurementVersion             AdaptiveMeasurementVersion
+  preset                         AdaptivePracticeQuizPreset
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+
+  /// [PrismaAdaptiveCutScoreSnapshot]
+  cutScoreSnapshot Json
+
+  priorMean              Float
+  priorStandardDeviation Float
+  gridMin                Float
+  gridMax                Float
+  gridStep               Float
+
+  classificationProbabilityThreshold Float?
+
+  /// [PrismaAdaptiveHierarchicalWeightSnapshot]
+  hierarchicalWeightSnapshot Json
+
+  /// [PrismaAdaptiveEvidenceMinimumSnapshot]
+  evidenceMinimumSnapshot Json
+
+  totalQuestionCap Int
+  showTimer        Boolean
+
+  /// [PrismaAdaptiveQuestionCapSnapshot]
+  questionCapSnapshot Json
+
+  candidateSetPolicyVersion  String
+  randomizationPolicyVersion String
+  exposureCeiling            Float
+  overlapPolicyVersion       String
+  retakePolicy               AdaptiveAttemptSelectionPolicy
+  retakeCooldownDays         Int
+
+  /// [PrismaAdaptiveResearchAllocationPolicy]
+  researchAllocationPolicy Json?
+
+  stoppingPolicyVersion String
+  rolloutPolicyVersion  Int
+
+  empiricalValidation   AdaptivePracticeQuizEmpiricalValidation? @relation(fields: [empiricalValidationId, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], references: [id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], onDelete: Restrict, onUpdate: Cascade)
+  empiricalValidationId String?                                  @db.Uuid
+
+  publishedBy   User?   @relation("PracticeQuizAdaptivePublicationPublishedBy", fields: [publishedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  publishedById String? @db.Uuid
+
+  poolItems       PracticeQuizAdaptivePoolItem[]
+  attempts        AdaptivePracticeQuizAttempt[]
+  exposures       AdaptivePracticeQuizItemExposure[]
+  cohortSnapshots AdaptivePracticeQuizCohortSnapshot[]
+
+  publishedAt   DateTime  @default(now())
+  sealedAt      DateTime?
+  supersededAt  DateTime?
+  unpublishedAt DateTime?
+  createdAt     DateTime  @default(now())
+
+  @@unique([configId, version], map: "pqap_config_version_key")
+  @@unique([configId, id], map: "pqap_config_id_key")
+  @@unique([competenceTreeId, id], map: "pqap_tree_id_key")
+  @@unique([id, scaleVersionId, measurementVersion], map: "pqap_id_scale_measurement_key")
+  @@unique([id, configId, competenceTreeId], map: "pqap_id_config_tree_key")
+  @@unique([id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], map: "pqap_dispatch_identity_key")
+  @@index([scaleVersionId], map: "pqap_scale_idx")
+  @@index([empiricalValidationId], map: "pqap_validation_idx")
+  @@index([publishedById], map: "pqap_published_by_idx")
+}
+
+model AdaptiveCalibrationExportRequest {
+  id String @id @default(uuid()) @db.Uuid
+
+  status   AdaptiveCalibrationExportStatus @default(REQUESTED)
+  runToken String?                         @db.Uuid
+
+  datasetVersion     String
+  splitPolicyVersion String @default("HMAC_80_20_V1")
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  requestedBy   User?   @relation("AdaptiveCalibrationExportRequestedBy", fields: [requestedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  requestedById String? @db.Uuid
+
+  artifactKey      String?
+  artifactChecksum String?
+  rowCount         Int?
+
+  manifestArtifactKey String?
+  manifestChecksum    String?
+
+  holdoutArtifactKey      String?
+  holdoutArtifactChecksum String?
+  holdoutRowCount         Int?
+
+  criterionArtifactKey      String?
+  criterionArtifactChecksum String?
+
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+
+  failureCode String?
+
+  createdAt   DateTime  @default(now())
+  startedAt   DateTime?
+  completedAt DateTime?
+  expiresAt   DateTime
+  updatedAt   DateTime  @updatedAt
+
+  @@index([treeId, scaleVersionId, status], map: "acer_tree_scale_status_idx")
+  @@index([requestedById, createdAt], map: "acer_requester_created_idx")
+  @@index([status, expiresAt], map: "acer_status_expiry_idx")
+}
+
+model AdaptivePracticeQuizEmpiricalValidation {
+  id String @id @default(uuid()) @db.Uuid
+
+  status AdaptiveEmpiricalValidationStatus @default(SUBMITTED)
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  tree             CompetenceTree @relation(fields: [competenceTreeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  competenceTreeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "apqev_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  exportRequest   AdaptiveCalibrationExportRequest @relation(fields: [exportRequestId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  exportRequestId String                           @db.Uuid
+
+  bankFingerprint   String
+  configFingerprint String
+
+  measurementVersion             AdaptiveMeasurementVersion
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+  validationProtocolVersion      String
+  approvedProbabilityThreshold   Float
+
+  calibrationDatasetVersion  String
+  calibrationDatasetChecksum String
+  holdoutDatasetVersion      String
+  holdoutDatasetChecksum     String
+  disjointSplitProofChecksum String
+  criterionArtifactChecksum  String
+
+  /// [PrismaAdaptiveValidationMetrics]
+  aggregateMetrics Json
+
+  /// [PrismaAdaptiveValidationStratumMetrics]
+  stratumMetrics Json
+
+  artifactChecksum String
+  artifactKey      String
+
+  submittedBy   User?   @relation("AdaptiveEmpiricalValidationSubmittedBy", fields: [submittedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  submittedById String? @db.Uuid
+
+  approvedBy   User?   @relation("AdaptiveEmpiricalValidationApprovedBy", fields: [approvedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  approvedById String? @db.Uuid
+
+  publications PracticeQuizAdaptivePublication[]
+
+  submittedAt DateTime  @default(now())
+  reviewedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], map: "apqev_publication_identity_key")
+  @@unique([configId, bankFingerprint, configFingerprint, scaleVersionId, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion, validationProtocolVersion, approvedProbabilityThreshold, exportRequestId, criterionArtifactChecksum], map: "apqev_evidence_identity_key")
+  @@index([configId, status], map: "apqev_config_status_idx")
+  @@index([scaleVersionId], map: "apqev_scale_idx")
+  @@index([exportRequestId], map: "apqev_export_request_idx")
+  @@index([submittedById], map: "apqev_submitted_by_idx")
+  @@index([approvedById], map: "apqev_approved_by_idx")
+}
+
+model AdaptivePracticeQuizItemExposure {
+  id Int @id @default(autoincrement())
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  publicationId String                          @db.Uuid
+
+  poolItem   PracticeQuizAdaptivePoolItem @relation(fields: [publicationId, poolItemId], references: [publicationId, id], onDelete: Cascade, onUpdate: Cascade)
+  poolItemId Int
+
+  servedCount   BigInt   @default(0)
+  answeredCount BigInt   @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([publicationId, poolItemId], map: "apqie_publication_pool_key")
+  @@index([publicationId, servedCount], map: "apqie_publication_served_idx")
+}
+
+model PracticeQuizAdaptiveNodeOverride {
+  id Int @id @default(autoincrement())
+
+  enabled     Boolean @default(true)
+  weight      Float?
+  questionCap Int?
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Cascade, onUpdate: Cascade, map: "pqan_config_tree_same_tree_fkey")
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  node   CompetenceTreeNode @relation(fields: [competenceTreeId, nodeId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade, map: "pqan_node_same_tree_fkey")
+  nodeId Int
+
+  @@unique([configId, nodeId], map: "pqan_config_node_key")
+  @@index([competenceTreeId, nodeId], map: "pqan_tree_node_idx")
+}
+
+model PracticeQuizAdaptiveElementOverride {
+  id Int @id @default(autoincrement())
+
+  enabled        Boolean @default(true)
+  discrimination Float?
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId, competenceTreeId], references: [id, competenceTreeId], onDelete: Cascade, onUpdate: Cascade, map: "pqae_config_tree_same_tree_fkey")
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [competenceTreeId, assignmentId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade, map: "pqae_assignment_same_tree_fkey")
+  assignmentId Int
+
+  @@unique([configId, assignmentId], map: "pqae_config_assignment_key")
+  @@index([competenceTreeId, assignmentId], map: "pqae_tree_assignment_idx")
+}
+
+model PracticeQuizAdaptivePoolItem {
+  id Int @id @default(autoincrement())
+
+  config   PracticeQuizAdaptiveConfig @relation(fields: [configId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  configId String                     @db.Uuid
+
+  competenceTreeId String @db.Uuid
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId, configId, competenceTreeId], references: [id, configId, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  publicationId String                          @db.Uuid
+
+  scaleVersionId String @db.Uuid
+
+  calibration   AdaptiveItemCalibration @relation(fields: [competenceTreeId, scaleVersionId, calibrationId, sourceAssignmentId, elementId, elementVersion], references: [treeId, scaleVersionId, id, assignmentId, elementId, elementVersion], onDelete: Restrict, onUpdate: Cascade)
+  calibrationId String                  @db.Uuid
+
+  sourceAssignment   CompetenceTreeElementAssignment @relation(fields: [sourceAssignmentId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  sourceAssignmentId Int
+
+  elementId      Int
+  elementVersion Int
+  elementType    ElementType
+  elementName    String
+
+  /// [PrismaElementData]
+  elementData Json
+
+  leafNodeId   Int
+  nodePath     Int[]
+  nodeNamePath String[]
+
+  levelId    Int
+  levelLabel String
+  levelOrder Int
+
+  discrimination             Float
+  difficulty                 Float
+  guessing                   Float
+  measurementVersion         AdaptiveMeasurementVersion
+  calibrationVersion         Int
+  calibrationStatus          AdaptiveItemCalibrationStatus
+  itemModel                  AdaptiveItemModel
+  modelImplementationVersion String
+  role                       AdaptivePoolItemRole          @default(SCORING)
+  contributesToEstimate      Boolean                       @default(true)
+  enablePercentInput         Boolean                       @default(false)
+
+  nextAttempts AdaptivePracticeQuizAttempt[]     @relation("AdaptivePracticeQuizAttemptNextPoolItem")
+  responses    AdaptivePracticeQuizResponse[]
+  exposure     AdaptivePracticeQuizItemExposure?
+
+  createdAt DateTime @default(now())
+
+  @@unique([publicationId, sourceAssignmentId], map: "pqapi_publication_assignment_key")
+  @@unique([publicationId, id], map: "pqapi_publication_id_key")
+  @@unique([publicationId, id, sourceAssignmentId, elementId], map: "pqapi_publication_response_key")
+  @@unique([configId, id], map: "pqapi_config_id_key")
+  @@unique([configId, id, sourceAssignmentId, elementId], map: "pqapi_response_identity_key")
+  @@index([publicationId, leafNodeId, levelId], map: "pqapi_publication_leaf_level_idx")
+  @@index([elementId, elementVersion], map: "pqapi_element_version_idx")
+  @@index([calibrationId], map: "pqapi_calibration_idx")
+}
+
+model AdaptivePracticeQuizAttempt {
+  id String @id @default(uuid()) @db.Uuid
+
+  status                        AdaptivePracticeQuizAttemptStatus @default(IN_PROGRESS)
+  stopReason                    AdaptivePracticeQuizStopReason?
+  currentTheta                  Float                             @default(0)
+  currentStandardError          Float?
+  finalTheta                    Float?
+  finalStandardError            Float?
+  finalLevelId                  Int?
+  finalScaleLevelId             Int?
+  elapsedSeconds                Int?
+  nextPoolItemId                Int?
+  nextAdministrationProbability Float?
+  nextCollectionDesignVersion   String?
+  nextRandomizationVersion      String?
+  nextRandomDraw                BigInt?
+  nextCandidateSetHash          String?
+  nextItemRole                  AdaptivePoolItemRole?
+  resultStatus                  AdaptiveResultStatus?
+  finalBandProbability          Float?
+  credibleLower                 Float?
+  credibleUpper                 Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  bandProbabilities Json?
+
+  config           PracticeQuizAdaptiveConfig @relation(fields: [configId, practiceQuizId, competenceTreeId], references: [id, practiceQuizId, competenceTreeId], onDelete: Restrict, onUpdate: Cascade)
+  configId         String                     @db.Uuid
+  competenceTreeId String                     @db.Uuid
+
+  publication   PracticeQuizAdaptivePublication @relation(fields: [publicationId, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], references: [id, configId, competenceTreeId, scaleVersionId, measurementVersion, estimatorImplementationVersion, classificationPolicyVersion, calibrationPolicyVersion], onDelete: Restrict, onUpdate: Cascade, map: "apqa_publication_dispatch_fkey")
+  publicationId String                          @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [competenceTreeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade, map: "apqa_scale_version_fkey")
+  scaleVersionId String                     @db.Uuid
+
+  measurementVersion             AdaptiveMeasurementVersion
+  estimatorImplementationVersion String
+  classificationPolicyVersion    Int
+  calibrationPolicyVersion       Int
+
+  practiceQuiz   PracticeQuiz @relation(fields: [practiceQuizId, courseId], references: [id, courseId], onDelete: Restrict, onUpdate: Cascade)
+  practiceQuizId String       @db.Uuid
+
+  course   Course @relation("AdaptivePracticeQuizAttemptCourse", fields: [courseId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  participantId String      @db.Uuid
+
+  participation   Participation @relation(fields: [participationId, participantId, courseId], references: [id, participantId, courseId], onDelete: Cascade, onUpdate: Cascade)
+  participationId Int
+
+  finalLevel CompetenceTreeLevel? @relation("AdaptivePracticeQuizAttemptFinalLevel", fields: [competenceTreeId, finalLevelId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+
+  finalScaleLevel CompetenceTreeScaleLevel? @relation("AdaptivePracticeQuizAttemptFinalScaleLevel", fields: [competenceTreeId, scaleVersionId, finalScaleLevelId], references: [treeId, scaleVersionId, id], onDelete: NoAction, onUpdate: Cascade, map: "apqa_final_scale_level_fkey")
+
+  nextPoolItem PracticeQuizAdaptivePoolItem? @relation("AdaptivePracticeQuizAttemptNextPoolItem", fields: [publicationId, nextPoolItemId], references: [publicationId, id], onDelete: NoAction, onUpdate: Cascade)
+
+  responses AdaptivePracticeQuizResponse[]
+  estimates AdaptivePracticeQuizEstimate[]
+
+  startedAt   DateTime  @default(now())
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([id, configId], map: "apqa_id_config_key")
+  @@unique([id, configId, competenceTreeId], map: "apqa_id_config_tree_key")
+  @@unique([id, configId, publicationId], map: "apqa_id_config_publication_key")
+  @@index([practiceQuizId, participantId, status], map: "apqa_quiz_participant_status_idx")
+  @@index([participationId, practiceQuizId], map: "apqa_participation_quiz_idx")
+  @@index([finalLevelId], map: "apqa_final_level_idx")
+  @@index([nextPoolItemId], map: "apqa_next_pool_item_idx")
+  @@index([configId, practiceQuizId], map: "apqa_config_quiz_idx")
+  @@index([practiceQuizId, status, completedAt, id], map: "apqa_quiz_status_completed_idx")
+  @@index([practiceQuizId, participantId, status, completedAt, id], map: "apqa_quiz_participant_completed_idx")
+  @@index([courseId], map: "apqa_course_retention_idx")
+  @@index([participationId, participantId, courseId], map: "apqa_participation_identity_idx")
+  @@index([configId, nextPoolItemId], map: "apqa_config_next_pool_idx")
+  @@index([publicationId, nextPoolItemId], map: "apqa_publication_next_pool_idx")
+  @@index([scaleVersionId], map: "apqa_scale_version_idx")
+}
+
+model AdaptivePracticeQuizResponse {
+  id Int @id @default(autoincrement())
+
+  order                     Int
+  response                  Json
+  normalizedResponse        Json
+  score                     Float
+  correct                   Boolean
+  overallThetaBefore        Float?
+  overallThetaAfter         Float?
+  overallStandardErrorAfter Float?
+  overallCredibleLowerAfter Float?
+  overallCredibleUpperAfter Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  overallBandProbabilitiesAfter Json?
+
+  administrationProbability Float?
+  collectionDesignVersion   String?
+  randomizationVersion      String?
+  randomDraw                BigInt?
+  candidateSetHash          String?
+  itemRole                  AdaptivePoolItemRole @default(SCORING)
+  isCalibrationAnchor       Boolean              @default(false)
+  elapsedSeconds            Int?
+
+  attempt       AdaptivePracticeQuizAttempt @relation(fields: [attemptId, configId, publicationId], references: [id, configId, publicationId], onDelete: Cascade, onUpdate: Cascade)
+  attemptId     String                      @db.Uuid
+  configId      String                      @db.Uuid
+  publicationId String                      @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [assignmentId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  assignmentId Int
+
+  poolItem   PracticeQuizAdaptivePoolItem? @relation(fields: [publicationId, poolItemId, assignmentId, elementId], references: [publicationId, id, sourceAssignmentId, elementId], onDelete: NoAction, onUpdate: Cascade)
+  poolItemId Int?
+
+  elementId       Int
+  elementSnapshot Json?
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, order], map: "apqr_attempt_order_key")
+  @@unique([attemptId, assignmentId], map: "apqr_attempt_assignment_key")
+  @@index([assignmentId], map: "apqr_assignment_idx")
+  @@index([poolItemId], map: "apqr_pool_item_idx")
+  @@index([configId, poolItemId], map: "apqr_config_pool_idx")
+  @@index([configId, poolItemId, attemptId], map: "apqr_config_pool_attempt_idx")
+  @@index([publicationId, poolItemId, attemptId], map: "apqr_publication_pool_attempt_idx")
+}
+
+model AdaptivePracticeQuizEstimate {
+  id Int @id @default(autoincrement())
+
+  nodeKind                  AdaptiveEstimateNodeKind
+  theta                     Float?
+  standardError             Float?
+  responseCount             Int
+  stopReason                AdaptivePracticeQuizStopReason?
+  resultStatus              AdaptiveResultStatus?
+  classificationProbability Float?
+  credibleLower             Float?
+  credibleUpper             Float?
+
+  /// [PrismaAdaptiveBandProbabilities]
+  bandProbabilities Json?
+
+  attempt          AdaptivePracticeQuizAttempt @relation(fields: [attemptId, configId, competenceTreeId], references: [id, configId, competenceTreeId], onDelete: Cascade, onUpdate: Cascade)
+  attemptId        String                      @db.Uuid
+  configId         String                      @db.Uuid
+  competenceTreeId String                      @db.Uuid
+
+  node   CompetenceTreeNode? @relation(fields: [competenceTreeId, nodeId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+  nodeId Int?
+
+  level   CompetenceTreeLevel? @relation(fields: [competenceTreeId, levelId], references: [treeId, id], onDelete: NoAction, onUpdate: Cascade)
+  levelId Int?
+
+  createdAt DateTime @default(now())
+
+  @@unique([attemptId, nodeKind, nodeId], map: "apqe_attempt_kind_node_key")
+  @@index([attemptId, nodeKind, nodeId, levelId], map: "apqe_attempt_node_level_idx")
+  @@index([nodeKind, levelId], map: "apqe_kind_level_idx")
+  @@index([configId, competenceTreeId], map: "apqe_config_tree_idx")
+}
+
+model AdaptivePracticeQuizCohortSnapshot {
+  id String @id @default(uuid()) @db.Uuid
+
+  config         PracticeQuizAdaptiveConfig @relation(fields: [configId, practiceQuizId], references: [id, practiceQuizId], onDelete: Restrict, onUpdate: Cascade)
+  configId       String                     @db.Uuid
+  practiceQuizId String                     @db.Uuid
+
+  publication        PracticeQuizAdaptivePublication @relation(fields: [publicationId, scaleVersionId, measurementVersion], references: [id, scaleVersionId, measurementVersion], onDelete: Restrict, onUpdate: Cascade)
+  publicationId      String                          @db.Uuid
+  scaleVersionId     String                          @db.Uuid
+  measurementVersion AdaptiveMeasurementVersion
+
+  releaseSize            Int
+  releaseWatermark       DateTime
+  policyVersion          Int                            @default(1)
+  attemptSelectionPolicy AdaptiveAttemptSelectionPolicy
+
+  /// [PrismaAdaptivePracticeQuizCohortSnapshot]
+  aggregate Json
+
+  invalidatedAt DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@unique([publicationId, releaseSize, policyVersion, attemptSelectionPolicy], map: "apqcs_publication_release_policy_key")
+  @@index([configId, invalidatedAt, releaseSize], map: "apqcs_config_valid_release_idx")
+  @@index([practiceQuizId], map: "apqcs_quiz_retention_idx")
+}

--- a/packages/prisma/src/prisma/schema/competence.prisma
+++ b/packages/prisma/src/prisma/schema/competence.prisma
@@ -1,0 +1,271 @@
+enum PracticeQuizMode {
+  STANDARD
+  ADAPTIVE
+}
+
+enum AdaptivePracticeQuizPreset {
+  PLACEMENT
+  DIAGNOSTIC
+  RESEARCH
+}
+
+enum AdaptiveAttemptSelectionPolicy {
+  FIRST_COMPLETED
+  LATEST_COMPLETED
+}
+
+enum AdaptiveLevelMappingRule {
+  NEAREST
+  MASTERY
+}
+
+enum AdaptiveNodeKind {
+  COMPETENCE
+  SUBCOMPETENCE
+}
+
+enum AdaptiveEstimateNodeKind {
+  OVERALL
+  COMPETENCE
+  SUBCOMPETENCE
+}
+
+enum AdaptivePracticeQuizAttemptStatus {
+  IN_PROGRESS
+  COMPLETED
+  ABANDONED
+}
+
+enum AdaptivePracticeQuizStopReason {
+  CLASSIFIED
+  ALL_ROOTS_CLASSIFIED
+  TOTAL_QUESTION_CAP
+  NODE_QUESTION_CAP
+  POOL_EXHAUSTED
+  INSUFFICIENT_DATA
+  ABANDONED
+}
+
+enum AdaptiveMeasurementVersion {
+  IRT_V1
+  IRT_V2_EAP_GRID_1
+}
+
+enum AdaptiveScaleVersionStatus {
+  DRAFT
+  IN_REVIEW
+  APPROVED
+  ACTIVE
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveScaleLinkStatus {
+  DRAFT
+  IN_REVIEW
+  APPROVED
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveItemCalibrationStatus {
+  PROVISIONAL
+  PILOT
+  CALIBRATED
+  FLAGGED
+  RETIRED
+}
+
+enum AdaptiveItemModel {
+  TWO_PL
+  THREE_PL_FIXED_C
+}
+
+enum AdaptiveCalibrationExportStatus {
+  REQUESTED
+  RUNNING
+  READY
+  FAILED
+  EXPIRED
+}
+
+enum AdaptiveEmpiricalValidationStatus {
+  SUBMITTED
+  APPROVED
+  REJECTED
+  SUPERSEDED
+}
+
+enum AdaptiveResultStatus {
+  CLASSIFIED
+  BETWEEN_LEVELS
+  INSUFFICIENT_EVIDENCE
+  POOL_LIMITED
+  RESEARCH_ONLY
+}
+
+enum AdaptivePoolItemRole {
+  SCORING
+  ANCHOR
+  FIELD_TEST
+}
+
+model CompetenceTree {
+  id String @id @default(uuid()) @db.Uuid
+
+  name        String
+  displayName String
+  description String?
+  isDeleted   Boolean @default(false)
+  isArchived  Boolean @default(false)
+
+  maxDepth Int   @default(5)
+  thetaMin Float @default(-3)
+  thetaMax Float @default(3)
+
+  defaultDiscrimination Float                    @default(1.2)
+  levelMappingRule      AdaptiveLevelMappingRule @default(NEAREST)
+
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  ownerId String @db.Uuid
+
+  courseLinks                 CompetenceTreeCourse[]
+  levels                      CompetenceTreeLevel[]
+  nodes                       CompetenceTreeNode[]
+  levelCoverages              CompetenceTreeLeafLevelCoverage[]
+  elementAssignments          CompetenceTreeElementAssignment[]
+  adaptivePracticeQuizConfigs PracticeQuizAdaptiveConfig[]
+  scaleVersions               CompetenceTreeScaleVersion[]
+  scaleLinks                  CompetenceTreeScaleLink[]
+  itemCalibrations            AdaptiveItemCalibration[]
+  adaptivePublications        PracticeQuizAdaptivePublication[]
+  calibrationExportRequests   AdaptiveCalibrationExportRequest[]
+  empiricalValidations        AdaptivePracticeQuizEmpiricalValidation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([ownerId], map: "ct_owner_idx")
+}
+
+model CompetenceTreeCourse {
+  id Int @id @default(autoincrement())
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String @db.Uuid
+
+  linkedBy   User?   @relation("CompetenceTreeCourseLinkedBy", fields: [linkedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  linkedById String? @db.Uuid
+
+  createdAt DateTime @default(now())
+
+  @@unique([treeId, courseId], map: "ctc_tree_course_key")
+  @@index([courseId], map: "ctc_course_idx")
+  @@index([linkedById], map: "ctc_linked_by_idx")
+}
+
+model CompetenceTreeLevel {
+  id Int @id @default(autoincrement())
+
+  label String
+  order Int
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  elementAssignments CompetenceTreeElementAssignment[]
+  levelCoverages     CompetenceTreeLeafLevelCoverage[]
+  estimates          AdaptivePracticeQuizEstimate[]
+
+  finalAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptFinalLevel")
+  scaleLevels   CompetenceTreeScaleLevel[]
+
+  @@unique([treeId, label], map: "ctl_tree_label_key")
+  @@unique([treeId, order], map: "ctl_tree_order_key")
+  @@unique([treeId, id], map: "ctl_tree_id_key")
+}
+
+model CompetenceTreeNode {
+  id Int @id @default(autoincrement())
+
+  kind        AdaptiveNodeKind
+  name        String
+  description String?
+  order       Int
+  depth       Int
+  weight      Float            @default(1)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  parent   CompetenceTreeNode?  @relation("CompetenceTreeNodeChildren", fields: [parentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  parentId Int?
+  children CompetenceTreeNode[] @relation("CompetenceTreeNodeChildren")
+
+  elementAssignments CompetenceTreeElementAssignment[]
+  levelCoverages     CompetenceTreeLeafLevelCoverage[]
+  quizNodeOverrides  PracticeQuizAdaptiveNodeOverride[]
+  estimates          AdaptivePracticeQuizEstimate[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, parentId, order], map: "ctn_tree_parent_order_key")
+  @@unique([treeId, id], map: "ctn_tree_id_key")
+  @@index([treeId, order], map: "ctn_tree_order_idx")
+  @@index([treeId, parentId], map: "ctn_tree_parent_idx")
+}
+
+model CompetenceTreeLeafLevelCoverage {
+  id Int @id @default(autoincrement())
+
+  targetItemCount Int     @default(5)
+  enabled         Boolean @default(true)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  leafNode   CompetenceTreeNode @relation(fields: [leafNodeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  leafNodeId Int
+
+  level   CompetenceTreeLevel @relation(fields: [levelId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  levelId Int
+
+  @@unique([treeId, leafNodeId, levelId], map: "ctlc_tree_leaf_level_key")
+}
+
+model CompetenceTreeElementAssignment {
+  id Int @id @default(autoincrement())
+
+  enabled            Boolean @default(true)
+  discrimination     Float?
+  enablePercentInput Boolean @default(false)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  element   Element @relation(fields: [elementId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  elementId Int
+
+  leafNode   CompetenceTreeNode @relation(fields: [leafNodeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  leafNodeId Int
+
+  level   CompetenceTreeLevel @relation(fields: [levelId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  levelId Int
+
+  quizElementOverrides PracticeQuizAdaptiveElementOverride[]
+  publishedPoolItems   PracticeQuizAdaptivePoolItem[]
+  responses            AdaptivePracticeQuizResponse[]
+  calibrations         AdaptiveItemCalibration[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, elementId], map: "ctea_tree_element_key")
+  @@unique([treeId, id], map: "ctea_tree_id_key")
+  @@index([elementId], map: "ctea_element_idx")
+  @@index([treeId, leafNodeId, enabled], map: "ctea_tree_leaf_enabled_idx")
+}

--- a/packages/prisma/src/prisma/schema/competenceScale.prisma
+++ b/packages/prisma/src/prisma/schema/competenceScale.prisma
@@ -1,0 +1,226 @@
+model CompetenceTreeScaleVersion {
+  id String @id @default(uuid()) @db.Uuid
+
+  version                     Int
+  status                      AdaptiveScaleVersionStatus @default(DRAFT)
+  priorMean                   Float                      @default(0)
+  priorStandardDeviation      Float                      @default(1)
+  gridMin                     Float                      @default(-6)
+  gridMax                     Float                      @default(6)
+  gridStep                    Float                      @default(0.1)
+  classificationPolicyVersion Int                        @default(1)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  supersedesVersion    CompetenceTreeScaleVersion?  @relation("CompetenceTreeScaleVersionSupersession", fields: [supersedesVersionId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  supersedesVersionId  String?                      @db.Uuid
+  supersededByVersions CompetenceTreeScaleVersion[] @relation("CompetenceTreeScaleVersionSupersession")
+
+  createdBy   User?   @relation("CompetenceTreeScaleVersionCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  levels               CompetenceTreeScaleLevel[]
+  approvals            CompetenceTreeScaleApproval[]
+  calibrations         AdaptiveItemCalibration[]
+  sourceScaleLinks     CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkFrom")
+  targetScaleLinks     CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkTo")
+  adaptiveConfigs      PracticeQuizAdaptiveConfig[]
+  publications         PracticeQuizAdaptivePublication[]
+  exportRequests       AdaptiveCalibrationExportRequest[]
+  empiricalValidations AdaptivePracticeQuizEmpiricalValidation[]
+  attempts             AdaptivePracticeQuizAttempt[]
+
+  submittedForReviewAt DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@unique([treeId, version], map: "ctsv_tree_version_key")
+  @@unique([treeId, id], map: "ctsv_tree_id_key")
+  @@index([treeId, status], map: "ctsv_tree_status_idx")
+  @@index([createdById], map: "ctsv_created_by_idx")
+}
+
+model CompetenceTreeScaleLevel {
+  id Int @id @default(autoincrement())
+
+  order               Int
+  label               String
+  lowerBound          Float?
+  itemDifficultyPrior Float
+
+  treeId String @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Cascade, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  sourceLevel   CompetenceTreeLevel? @relation(fields: [treeId, sourceLevelId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  sourceLevelId Int?
+
+  finalAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptFinalScaleLevel")
+
+  @@unique([scaleVersionId, order], map: "ctsl_scale_order_key")
+  @@unique([scaleVersionId, id], map: "ctsl_scale_id_key")
+  @@unique([treeId, scaleVersionId, id], map: "ctsl_tree_scale_id_key")
+  @@index([treeId, sourceLevelId], map: "ctsl_tree_source_level_idx")
+}
+
+model CompetenceTreeScaleApproval {
+  id String @id @default(uuid()) @db.Uuid
+
+  treeId String @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  method              String
+  methodVersion       String
+  panelSize           Int
+  standardSettingDate DateTime
+
+  /// [PrismaAdaptiveCutRationale]
+  cutRationale Json
+
+  artifactChecksum String
+  artifactKey      String
+  decision         AdaptiveScaleVersionStatus?
+
+  submittedBy   User?   @relation("CompetenceTreeScaleApprovalSubmittedBy", fields: [submittedById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  submittedById String? @db.Uuid
+
+  reviewer   User?   @relation("CompetenceTreeScaleApprovalReviewer", fields: [reviewerId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  reviewerId String? @db.Uuid
+
+  reviewedAt DateTime?
+  createdAt  DateTime  @default(now())
+
+  @@index([treeId, scaleVersionId], map: "ctsa_tree_scale_idx")
+  @@index([submittedById], map: "ctsa_submitted_by_idx")
+  @@index([reviewerId], map: "ctsa_reviewer_idx")
+}
+
+model CompetenceTreeScaleLink {
+  id String @id @default(uuid()) @db.Uuid
+
+  status AdaptiveScaleLinkStatus @default(DRAFT)
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  fromScaleVersion   CompetenceTreeScaleVersion @relation("CompetenceTreeScaleLinkFrom", fields: [treeId, fromScaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  fromScaleVersionId String                     @db.Uuid
+
+  toScaleVersion   CompetenceTreeScaleVersion @relation("CompetenceTreeScaleLinkTo", fields: [treeId, toScaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  toScaleVersionId String                     @db.Uuid
+
+  method                String
+  implementationVersion String
+
+  /// [PrismaAdaptiveScaleLinkMetrics]
+  fitMetrics Json
+
+  /// [PrismaAdaptiveScaleLinkMetrics]
+  uncertaintyMetrics Json
+
+  artifactChecksum String
+  artifactKey      String
+
+  createdBy   User?   @relation("CompetenceTreeScaleLinkCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  reviewedBy   User?   @relation("CompetenceTreeScaleLinkReviewedBy", fields: [reviewedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  reviewedById String? @db.Uuid
+
+  anchors CompetenceTreeScaleLinkAnchor[]
+
+  submittedForReviewAt DateTime?
+  reviewedAt           DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@unique([treeId, fromScaleVersionId, toScaleVersionId], map: "ctslk_tree_versions_key")
+  @@index([createdById], map: "ctslk_created_by_idx")
+  @@index([reviewedById], map: "ctslk_reviewed_by_idx")
+}
+
+model CompetenceTreeScaleLinkAnchor {
+  id Int @id @default(autoincrement())
+
+  scaleLink   CompetenceTreeScaleLink @relation(fields: [scaleLinkId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  scaleLinkId String                  @db.Uuid
+
+  fromCalibration   AdaptiveItemCalibration @relation("CompetenceTreeScaleLinkAnchorFrom", fields: [fromCalibrationId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  fromCalibrationId String                  @db.Uuid
+
+  toCalibration   AdaptiveItemCalibration @relation("CompetenceTreeScaleLinkAnchorTo", fields: [toCalibrationId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  toCalibrationId String                  @db.Uuid
+
+  order Int
+
+  @@unique([scaleLinkId, order], map: "ctsla_link_order_key")
+  @@unique([scaleLinkId, fromCalibrationId], map: "ctsla_link_from_key")
+  @@unique([scaleLinkId, toCalibrationId], map: "ctsla_link_to_key")
+  @@index([fromCalibrationId], map: "ctsla_from_calibration_idx")
+  @@index([toCalibrationId], map: "ctsla_to_calibration_idx")
+}
+
+model AdaptiveItemCalibration {
+  id String @id @default(uuid()) @db.Uuid
+
+  version Int
+  model   AdaptiveItemModel
+  status  AdaptiveItemCalibrationStatus @default(PROVISIONAL)
+
+  discrimination Float
+  difficulty     Float
+  guessing       Float
+
+  /// [PrismaAdaptiveParameterUncertainty]
+  parameterUncertainty Json
+
+  responseCount    Int @default(0)
+  participantCount Int @default(0)
+
+  /// [PrismaAdaptiveCalibrationDiagnostics]
+  diagnostics Json
+
+  datasetVersion             String
+  datasetChecksum            String
+  calibrationJobId           String?
+  modelImplementationVersion String
+  elementContentChecksum     String
+
+  tree   CompetenceTree @relation(fields: [treeId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  treeId String         @db.Uuid
+
+  scaleVersion   CompetenceTreeScaleVersion @relation(fields: [treeId, scaleVersionId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  scaleVersionId String                     @db.Uuid
+
+  assignment   CompetenceTreeElementAssignment @relation(fields: [treeId, assignmentId], references: [treeId, id], onDelete: Restrict, onUpdate: Cascade)
+  assignmentId Int
+
+  element        Element @relation(fields: [elementId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  elementId      Int
+  elementVersion Int
+
+  createdBy   User?   @relation("AdaptiveItemCalibrationCreatedBy", fields: [createdById], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdById String? @db.Uuid
+
+  approvedBy   User?     @relation("AdaptiveItemCalibrationApprovedBy", fields: [approvedById], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  approvedById String?   @db.Uuid
+  approvedAt   DateTime?
+
+  poolItems         PracticeQuizAdaptivePoolItem[]
+  sourceLinkAnchors CompetenceTreeScaleLinkAnchor[] @relation("CompetenceTreeScaleLinkAnchorFrom")
+  targetLinkAnchors CompetenceTreeScaleLinkAnchor[] @relation("CompetenceTreeScaleLinkAnchorTo")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([treeId, scaleVersionId, assignmentId, elementId, elementVersion, version], map: "aic_measurement_version_key")
+  @@unique([treeId, scaleVersionId, id], map: "aic_tree_scale_id_key")
+  @@unique([treeId, scaleVersionId, id, assignmentId, elementId, elementVersion], map: "aic_pool_identity_key")
+  @@index([assignmentId, elementId, elementVersion], map: "aic_assignment_element_version_idx")
+  @@index([scaleVersionId, status], map: "aic_scale_status_idx")
+  @@index([approvedById], map: "aic_approved_by_idx")
+}

--- a/packages/prisma/src/prisma/schema/course.prisma
+++ b/packages/prisma/src/prisma/schema/course.prisma
@@ -20,47 +20,52 @@ model Course {
   authType CourseAuthType @default(PIN)
   pinCode  Int?           @unique
 
-  isGamificationEnabled  Boolean @default(true)
-  isGroupCreationEnabled Boolean @default(true)
-  isAssessmentEnabled    Boolean @default(false)
+  isGamificationEnabled                Boolean @default(true)
+  isGroupCreationEnabled               Boolean @default(true)
+  isAssessmentEnabled                  Boolean @default(false)
+  isAdaptiveLearningEnabled            Boolean @default(false)
+  isAdaptiveLearningCalibrationEnabled Boolean @default(false)
 
   groupDeadlineDate         DateTime
   preferredGroupSize        Int      @default(3)
   maxGroupSize              Int      @default(5)
   randomAssignmentFinalized Boolean  @default(false)
 
-  elementStacks              ElementStack[]
-  practiceQuizzes            PracticeQuiz[]
-  groupActivities            GroupActivity[]
-  leaderboard                LeaderboardEntry[]
-  awards                     AwardEntry[]
-  classAchievements          ClassAchievementInstance[]
-  achievements               Achievement[]
-  titles                     Title[]
-  participations             Participation[]
-  subscriptions              PushSubscription[]
-  participantGroups          ParticipantGroup[]
-  microLearnings             MicroLearning[]
-  liveQuizzes                LiveQuiz[]
-  participantAnalytics       ParticipantAnalytics[]
-  aggregatedAnalytics        AggregatedAnalytics[]
-  aggregatedCourseAnalytics  AggregatedCourseAnalytics?
-  participantCourseAnalytics ParticipantCourseAnalytics[]
-  participantPerformances    ParticipantPerformance[]
-  instancePerformances       InstancePerformance[]
-  activityPerformances       ActivityPerformance[]
-  activityProgresses         ActivityProgress[]
-  responses                  QuestionResponse[]
-  groupAssignmentPoolEntries GroupAssignmentPoolEntry[]
-  timelineEntries            TimelineEntry[]
-  chatbots                   Chatbot[]
-  participantInvitations     ParticipantInvitation[]
+  elementStacks                ElementStack[]
+  practiceQuizzes              PracticeQuiz[]
+  groupActivities              GroupActivity[]
+  leaderboard                  LeaderboardEntry[]
+  awards                       AwardEntry[]
+  classAchievements            ClassAchievementInstance[]
+  achievements                 Achievement[]
+  titles                       Title[]
+  participations               Participation[]
+  subscriptions                PushSubscription[]
+  participantGroups            ParticipantGroup[]
+  microLearnings               MicroLearning[]
+  liveQuizzes                  LiveQuiz[]
+  participantAnalytics         ParticipantAnalytics[]
+  aggregatedAnalytics          AggregatedAnalytics[]
+  aggregatedCourseAnalytics    AggregatedCourseAnalytics?
+  participantCourseAnalytics   ParticipantCourseAnalytics[]
+  participantPerformances      ParticipantPerformance[]
+  instancePerformances         InstancePerformance[]
+  activityPerformances         ActivityPerformance[]
+  activityProgresses           ActivityProgress[]
+  responses                    QuestionResponse[]
+  groupAssignmentPoolEntries   GroupAssignmentPoolEntry[]
+  timelineEntries              TimelineEntry[]
+  chatbots                     Chatbot[]
+  participantInvitations       ParticipantInvitation[]
+  adaptiveAssessments          AdaptiveAssessment[]
+  adaptivePracticeQuizAttempts AdaptivePracticeQuizAttempt[] @relation("AdaptivePracticeQuizAttemptCourse")
+  competenceTreeLinks          CompetenceTreeCourse[]
 
-  directPermissions  Permission[]
-  permissions        DerivedPermission[]
-  accessRequests     AccessRequest[]
-  catalogAssignments CatalogCollectionAssignment[]
-  activityLog        ActivityLogEntry[]
+  directPermissions   Permission[]
+  permissions         DerivedPermission[]
+  accessRequests      AccessRequest[]
+  catalogAssignments  CatalogCollectionAssignment[]
+  activityLog         ActivityLogEntry[]
   verificationRecords VerifiableCredential[]
 
   competencyTree   CompetencyTree? @relation(fields: [competencyTreeId], references: [id], onDelete: SetNull, onUpdate: Cascade)

--- a/packages/prisma/src/prisma/schema/element.prisma
+++ b/packages/prisma/src/prisma/schema/element.prisma
@@ -24,6 +24,9 @@ model Element {
   version    Int     @default(1) // used to track question versions, incremented on each update
   originalId String?
 
+  creationRequestId          String? @unique(map: "element_creation_request_key") @db.Uuid
+  creationRequestFingerprint String? @db.VarChar(64)
+
   isArchived Boolean @default(false)
   isDeleted  Boolean @default(false)
 
@@ -42,8 +45,12 @@ model Element {
 
   tags Tag[]
 
-  elementInstances ElementInstance[]
-  feedbacks        ElementFeedback[]
+  elementInstances            ElementInstance[]
+  feedbacks                   ElementFeedback[]
+  adaptiveAssessmentElements  AdaptiveAssessmentElement[]
+  adaptiveAssessmentResponses AdaptiveAssessmentResponse[]
+  competenceTreeAssignments   CompetenceTreeElementAssignment[]
+  adaptiveItemCalibrations    AdaptiveItemCalibration[]
 
   answerCollectionItems AnswerCollectionEntry[] @relation("ElementAnswerCollectionUsedItems")
   answerCollection      AnswerCollection?       @relation(fields: [answerCollectionId], references: [id], onDelete: SetNull, onUpdate: Cascade)

--- a/packages/prisma/src/prisma/schema/migrations/20260601104500_adaptive_assessments/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260601104500_adaptive_assessments/migration.sql
@@ -1,0 +1,178 @@
+-- CreateEnum
+CREATE TYPE "AdaptiveAssessmentAttemptStatus" AS ENUM ('IN_PROGRESS', 'COMPLETED', 'ABANDONED');
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessment" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "thetaMin" DOUBLE PRECISION NOT NULL DEFAULT -3,
+    "thetaMax" DOUBLE PRECISION NOT NULL DEFAULT 3,
+    "discrimination" DOUBLE PRECISION NOT NULL DEFAULT 1.5,
+    "standardErrorThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0.4,
+    "questionThreshold" INTEGER NOT NULL DEFAULT 50,
+    "topInformationRatio" DOUBLE PRECISION NOT NULL DEFAULT 0.8,
+    "showTimer" BOOLEAN NOT NULL DEFAULT true,
+    "showCompetenceNames" BOOLEAN NOT NULL DEFAULT true,
+    "showFinalResult" BOOLEAN NOT NULL DEFAULT true,
+    "courseId" UUID NOT NULL,
+    "ownerId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentLevel" (
+    "id" SERIAL NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "assessmentId" UUID NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessmentLevel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentCompetence" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "tagName" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "order" INTEGER NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL DEFAULT 1,
+    "assessmentId" UUID NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessmentCompetence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentSubCompetence" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "tagName" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "order" INTEGER NOT NULL,
+    "questionThreshold" INTEGER,
+    "standardErrorThreshold" DOUBLE PRECISION,
+    "assessmentId" UUID NOT NULL,
+    "competenceId" INTEGER NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessmentSubCompetence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentElement" (
+    "id" SERIAL NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "exposure" INTEGER NOT NULL DEFAULT 0,
+    "discrimination" DOUBLE PRECISION,
+    "assessmentId" UUID NOT NULL,
+    "elementId" INTEGER NOT NULL,
+    "competenceId" INTEGER NOT NULL,
+    "subCompetenceId" INTEGER NOT NULL,
+    "levelId" INTEGER NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessmentElement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentAttempt" (
+    "id" UUID NOT NULL,
+    "status" "AdaptiveAssessmentAttemptStatus" NOT NULL DEFAULT 'IN_PROGRESS',
+    "currentTheta" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "currentStandardError" DOUBLE PRECISION,
+    "finalTheta" DOUBLE PRECISION,
+    "finalStandardError" DOUBLE PRECISION,
+    "finalLevelLabel" TEXT,
+    "elapsedSeconds" INTEGER,
+    "thetaHistory" JSONB,
+    "standardErrorHistory" JSONB,
+    "assessmentId" UUID NOT NULL,
+    "participantId" UUID NOT NULL,
+    "participationId" INTEGER NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdaptiveAssessmentAttempt_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentResponse" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "response" JSONB NOT NULL,
+    "correct" BOOLEAN NOT NULL,
+    "thetaBefore" DOUBLE PRECISION NOT NULL,
+    "thetaAfter" DOUBLE PRECISION NOT NULL,
+    "standardErrorAfter" DOUBLE PRECISION NOT NULL,
+    "elapsedSeconds" INTEGER,
+    "attemptId" UUID NOT NULL,
+    "adaptiveElementId" INTEGER NOT NULL,
+    "elementId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdaptiveAssessmentResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptiveAssessmentResultMessage" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "message" TEXT NOT NULL,
+    "minTheta" DOUBLE PRECISION,
+    "maxTheta" DOUBLE PRECISION,
+    "isFallback" BOOLEAN NOT NULL DEFAULT false,
+    "assessmentId" UUID NOT NULL,
+    "levelId" INTEGER,
+
+    CONSTRAINT "AdaptiveAssessmentResultMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdaptiveAssessment_courseId_idx" ON "AdaptiveAssessment"("courseId");
+CREATE INDEX "AdaptiveAssessment_ownerId_idx" ON "AdaptiveAssessment"("ownerId");
+CREATE INDEX "AdaptiveAssessment_status_idx" ON "AdaptiveAssessment"("status");
+CREATE UNIQUE INDEX "AdaptiveAssessmentLevel_assessmentId_label_key" ON "AdaptiveAssessmentLevel"("assessmentId", "label");
+CREATE UNIQUE INDEX "AdaptiveAssessmentLevel_assessmentId_order_key" ON "AdaptiveAssessmentLevel"("assessmentId", "order");
+CREATE UNIQUE INDEX "AdaptiveAssessmentCompetence_assessmentId_name_key" ON "AdaptiveAssessmentCompetence"("assessmentId", "name");
+CREATE UNIQUE INDEX "AdaptiveAssessmentCompetence_assessmentId_order_key" ON "AdaptiveAssessmentCompetence"("assessmentId", "order");
+CREATE UNIQUE INDEX "AdaptiveAssessmentSubCompetence_assessmentId_competenceId_name_key" ON "AdaptiveAssessmentSubCompetence"("assessmentId", "competenceId", "name");
+CREATE UNIQUE INDEX "AdaptiveAssessmentSubCompetence_assessmentId_competenceId_order_key" ON "AdaptiveAssessmentSubCompetence"("assessmentId", "competenceId", "order");
+CREATE UNIQUE INDEX "AdaptiveAssessmentElement_assessmentId_elementId_competenceId_subCompetenceId_levelId_key" ON "AdaptiveAssessmentElement"("assessmentId", "elementId", "competenceId", "subCompetenceId", "levelId");
+CREATE INDEX "AdaptiveAssessmentElement_elementId_idx" ON "AdaptiveAssessmentElement"("elementId");
+CREATE INDEX "AdaptiveAssessmentElement_assessmentId_enabled_idx" ON "AdaptiveAssessmentElement"("assessmentId", "enabled");
+CREATE INDEX "AdaptiveAssessmentAttempt_assessmentId_participantId_status_idx" ON "AdaptiveAssessmentAttempt"("assessmentId", "participantId", "status");
+CREATE INDEX "AdaptiveAssessmentAttempt_participationId_idx" ON "AdaptiveAssessmentAttempt"("participationId");
+CREATE UNIQUE INDEX "AdaptiveAssessmentResponse_attemptId_order_key" ON "AdaptiveAssessmentResponse"("attemptId", "order");
+CREATE INDEX "AdaptiveAssessmentResponse_attemptId_idx" ON "AdaptiveAssessmentResponse"("attemptId");
+CREATE INDEX "AdaptiveAssessmentResponse_adaptiveElementId_idx" ON "AdaptiveAssessmentResponse"("adaptiveElementId");
+CREATE INDEX "AdaptiveAssessmentResponse_elementId_idx" ON "AdaptiveAssessmentResponse"("elementId");
+CREATE UNIQUE INDEX "AdaptiveAssessmentResultMessage_assessmentId_order_key" ON "AdaptiveAssessmentResultMessage"("assessmentId", "order");
+CREATE INDEX "AdaptiveAssessmentResultMessage_assessmentId_isFallback_idx" ON "AdaptiveAssessmentResultMessage"("assessmentId", "isFallback");
+
+-- AddForeignKey
+ALTER TABLE "AdaptiveAssessment" ADD CONSTRAINT "AdaptiveAssessment_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessment" ADD CONSTRAINT "AdaptiveAssessment_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentLevel" ADD CONSTRAINT "AdaptiveAssessmentLevel_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentCompetence" ADD CONSTRAINT "AdaptiveAssessmentCompetence_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentSubCompetence" ADD CONSTRAINT "AdaptiveAssessmentSubCompetence_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentSubCompetence" ADD CONSTRAINT "AdaptiveAssessmentSubCompetence_competenceId_fkey" FOREIGN KEY ("competenceId") REFERENCES "AdaptiveAssessmentCompetence"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentElement" ADD CONSTRAINT "AdaptiveAssessmentElement_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentElement" ADD CONSTRAINT "AdaptiveAssessmentElement_elementId_fkey" FOREIGN KEY ("elementId") REFERENCES "Element"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentElement" ADD CONSTRAINT "AdaptiveAssessmentElement_competenceId_fkey" FOREIGN KEY ("competenceId") REFERENCES "AdaptiveAssessmentCompetence"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentElement" ADD CONSTRAINT "AdaptiveAssessmentElement_subCompetenceId_fkey" FOREIGN KEY ("subCompetenceId") REFERENCES "AdaptiveAssessmentSubCompetence"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentElement" ADD CONSTRAINT "AdaptiveAssessmentElement_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "AdaptiveAssessmentLevel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentAttempt" ADD CONSTRAINT "AdaptiveAssessmentAttempt_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentAttempt" ADD CONSTRAINT "AdaptiveAssessmentAttempt_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentAttempt" ADD CONSTRAINT "AdaptiveAssessmentAttempt_participationId_fkey" FOREIGN KEY ("participationId") REFERENCES "Participation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentResponse" ADD CONSTRAINT "AdaptiveAssessmentResponse_attemptId_fkey" FOREIGN KEY ("attemptId") REFERENCES "AdaptiveAssessmentAttempt"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentResponse" ADD CONSTRAINT "AdaptiveAssessmentResponse_adaptiveElementId_fkey" FOREIGN KEY ("adaptiveElementId") REFERENCES "AdaptiveAssessmentElement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentResponse" ADD CONSTRAINT "AdaptiveAssessmentResponse_elementId_fkey" FOREIGN KEY ("elementId") REFERENCES "Element"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentResultMessage" ADD CONSTRAINT "AdaptiveAssessmentResultMessage_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "AdaptiveAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptiveAssessmentResultMessage" ADD CONSTRAINT "AdaptiveAssessmentResultMessage_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "AdaptiveAssessmentLevel"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/src/prisma/schema/migrations/20260602120000_adaptive_show_solutions/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260602120000_adaptive_show_solutions/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "AdaptiveAssessment" ADD COLUMN "showSolutions" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/src/prisma/schema/migrations/20260603110000_adaptive_competence_thresholds/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260603110000_adaptive_competence_thresholds/migration.sql
@@ -1,0 +1,4 @@
+-- Add optional competence-level adaptive stopping rules.
+ALTER TABLE "AdaptiveAssessmentCompetence"
+  ADD COLUMN "questionThreshold" INTEGER,
+  ADD COLUMN "standardErrorThreshold" DOUBLE PRECISION;

--- a/packages/prisma/src/prisma/schema/migrations/20260707120000_adaptive_practice_quiz_competence_trees/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260707120000_adaptive_practice_quiz_competence_trees/migration.sql
@@ -1,0 +1,265 @@
+-- CreateEnum
+CREATE TYPE "PracticeQuizMode" AS ENUM ('STANDARD', 'ADAPTIVE');
+CREATE TYPE "AdaptiveLevelMappingRule" AS ENUM ('NEAREST', 'MASTERY');
+CREATE TYPE "AdaptiveNodeKind" AS ENUM ('COMPETENCE', 'SUBCOMPETENCE');
+CREATE TYPE "AdaptiveEstimateNodeKind" AS ENUM ('OVERALL', 'COMPETENCE', 'SUBCOMPETENCE');
+CREATE TYPE "AdaptivePracticeQuizAttemptStatus" AS ENUM ('IN_PROGRESS', 'COMPLETED', 'ABANDONED');
+
+-- AlterTable
+ALTER TABLE "PracticeQuiz" ADD COLUMN "mode" "PracticeQuizMode" NOT NULL DEFAULT 'STANDARD';
+
+-- CreateTable
+CREATE TABLE "CompetenceTree" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "maxDepth" INTEGER NOT NULL DEFAULT 5,
+    "thetaMin" DOUBLE PRECISION NOT NULL DEFAULT -3,
+    "thetaMax" DOUBLE PRECISION NOT NULL DEFAULT 3,
+    "defaultDiscrimination" DOUBLE PRECISION NOT NULL DEFAULT 1.2,
+    "levelMappingRule" "AdaptiveLevelMappingRule" NOT NULL DEFAULT 'NEAREST',
+    "ownerId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CompetenceTree_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CompetenceTreeCourse" (
+    "id" SERIAL NOT NULL,
+    "treeId" UUID NOT NULL,
+    "courseId" UUID NOT NULL,
+    "linkedById" UUID,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CompetenceTreeCourse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CompetenceTreeLevel" (
+    "id" SERIAL NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "treeId" UUID NOT NULL,
+
+    CONSTRAINT "CompetenceTreeLevel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CompetenceTreeNode" (
+    "id" SERIAL NOT NULL,
+    "kind" "AdaptiveNodeKind" NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "order" INTEGER NOT NULL,
+    "depth" INTEGER NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL DEFAULT 1,
+    "treeId" UUID NOT NULL,
+    "parentId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CompetenceTreeNode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CompetenceTreeLeafLevelCoverage" (
+    "id" SERIAL NOT NULL,
+    "targetItemCount" INTEGER NOT NULL DEFAULT 5,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "treeId" UUID NOT NULL,
+    "leafNodeId" INTEGER NOT NULL,
+    "levelId" INTEGER NOT NULL,
+
+    CONSTRAINT "CompetenceTreeLeafLevelCoverage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CompetenceTreeElementAssignment" (
+    "id" SERIAL NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "discrimination" DOUBLE PRECISION,
+    "enablePercentInput" BOOLEAN NOT NULL DEFAULT false,
+    "treeId" UUID NOT NULL,
+    "elementId" INTEGER NOT NULL,
+    "leafNodeId" INTEGER NOT NULL,
+    "levelId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CompetenceTreeElementAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PracticeQuizAdaptiveConfig" (
+    "id" UUID NOT NULL,
+    "practiceQuizId" UUID NOT NULL,
+    "competenceTreeId" UUID NOT NULL,
+    "totalQuestionCap" INTEGER NOT NULL DEFAULT 50,
+    "perLeafQuestionCap" INTEGER,
+    "minQuestionsPerLeaf" INTEGER NOT NULL DEFAULT 2,
+    "classificationZ" DOUBLE PRECISION NOT NULL DEFAULT 1.28,
+    "standardErrorThreshold" DOUBLE PRECISION,
+    "topInformationRatio" DOUBLE PRECISION NOT NULL DEFAULT 0.8,
+    "defaultDiscrimination" DOUBLE PRECISION NOT NULL DEFAULT 1.2,
+    "levelMappingRule" "AdaptiveLevelMappingRule" NOT NULL DEFAULT 'NEAREST',
+    "showTimer" BOOLEAN NOT NULL DEFAULT true,
+    "showFinalResult" BOOLEAN NOT NULL DEFAULT true,
+    "showLiveEstimate" BOOLEAN NOT NULL DEFAULT false,
+    "enableSelfAssessmentWarmup" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PracticeQuizAdaptiveConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PracticeQuizAdaptiveNodeOverride" (
+    "id" SERIAL NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "weight" DOUBLE PRECISION,
+    "questionCap" INTEGER,
+    "configId" UUID NOT NULL,
+    "nodeId" INTEGER NOT NULL,
+
+    CONSTRAINT "PracticeQuizAdaptiveNodeOverride_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PracticeQuizAdaptiveElementOverride" (
+    "id" SERIAL NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "discrimination" DOUBLE PRECISION,
+    "configId" UUID NOT NULL,
+    "assignmentId" INTEGER NOT NULL,
+
+    CONSTRAINT "PracticeQuizAdaptiveElementOverride_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptivePracticeQuizAttempt" (
+    "id" UUID NOT NULL,
+    "status" "AdaptivePracticeQuizAttemptStatus" NOT NULL DEFAULT 'IN_PROGRESS',
+    "currentTheta" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "currentStandardError" DOUBLE PRECISION,
+    "finalTheta" DOUBLE PRECISION,
+    "finalStandardError" DOUBLE PRECISION,
+    "finalLevelId" INTEGER,
+    "elapsedSeconds" INTEGER,
+    "nextAssignmentId" INTEGER,
+    "thetaHistory" JSONB,
+    "standardErrorHistory" JSONB,
+    "configId" UUID NOT NULL,
+    "practiceQuizId" UUID NOT NULL,
+    "participantId" UUID NOT NULL,
+    "participationId" INTEGER NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdaptivePracticeQuizAttempt_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptivePracticeQuizResponse" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "response" JSONB NOT NULL,
+    "normalizedResponse" JSONB,
+    "correct" BOOLEAN NOT NULL,
+    "thetaBefore" DOUBLE PRECISION NOT NULL,
+    "thetaAfter" DOUBLE PRECISION NOT NULL,
+    "standardErrorAfter" DOUBLE PRECISION NOT NULL,
+    "elapsedSeconds" INTEGER,
+    "attemptId" UUID NOT NULL,
+    "assignmentId" INTEGER NOT NULL,
+    "elementId" INTEGER NOT NULL,
+    "elementSnapshot" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdaptivePracticeQuizResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdaptivePracticeQuizEstimate" (
+    "id" SERIAL NOT NULL,
+    "nodeKind" "AdaptiveEstimateNodeKind" NOT NULL,
+    "theta" DOUBLE PRECISION NOT NULL,
+    "standardError" DOUBLE PRECISION,
+    "responseCount" INTEGER NOT NULL,
+    "stopReason" TEXT,
+    "attemptId" UUID NOT NULL,
+    "nodeId" INTEGER,
+    "levelId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdaptivePracticeQuizEstimate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ct_owner_idx" ON "CompetenceTree"("ownerId");
+CREATE UNIQUE INDEX "ctc_tree_course_key" ON "CompetenceTreeCourse"("treeId", "courseId");
+CREATE INDEX "ctc_course_idx" ON "CompetenceTreeCourse"("courseId");
+CREATE INDEX "ctc_linked_by_idx" ON "CompetenceTreeCourse"("linkedById");
+CREATE UNIQUE INDEX "ctl_tree_label_key" ON "CompetenceTreeLevel"("treeId", "label");
+CREATE UNIQUE INDEX "ctl_tree_order_key" ON "CompetenceTreeLevel"("treeId", "order");
+CREATE UNIQUE INDEX "ctn_tree_parent_order_key" ON "CompetenceTreeNode"("treeId", "parentId", "order");
+CREATE UNIQUE INDEX "ctn_tree_root_order_key" ON "CompetenceTreeNode"("treeId", "order") WHERE "parentId" IS NULL;
+CREATE INDEX "ctn_tree_order_idx" ON "CompetenceTreeNode"("treeId", "order");
+CREATE INDEX "ctn_tree_parent_idx" ON "CompetenceTreeNode"("treeId", "parentId");
+CREATE UNIQUE INDEX "ctlc_tree_leaf_level_key" ON "CompetenceTreeLeafLevelCoverage"("treeId", "leafNodeId", "levelId");
+CREATE UNIQUE INDEX "ctea_tree_element_key" ON "CompetenceTreeElementAssignment"("treeId", "elementId");
+CREATE INDEX "ctea_element_idx" ON "CompetenceTreeElementAssignment"("elementId");
+CREATE INDEX "ctea_tree_leaf_enabled_idx" ON "CompetenceTreeElementAssignment"("treeId", "leafNodeId", "enabled");
+CREATE UNIQUE INDEX "pqac_practice_quiz_key" ON "PracticeQuizAdaptiveConfig"("practiceQuizId");
+CREATE INDEX "pqac_tree_idx" ON "PracticeQuizAdaptiveConfig"("competenceTreeId");
+CREATE UNIQUE INDEX "pqan_config_node_key" ON "PracticeQuizAdaptiveNodeOverride"("configId", "nodeId");
+CREATE UNIQUE INDEX "pqae_config_assignment_key" ON "PracticeQuizAdaptiveElementOverride"("configId", "assignmentId");
+CREATE INDEX "apqa_quiz_participant_status_idx" ON "AdaptivePracticeQuizAttempt"("practiceQuizId", "participantId", "status");
+CREATE INDEX "apqa_participation_quiz_idx" ON "AdaptivePracticeQuizAttempt"("participationId", "practiceQuizId");
+CREATE INDEX "apqa_final_level_idx" ON "AdaptivePracticeQuizAttempt"("finalLevelId");
+CREATE INDEX "apqa_next_assignment_idx" ON "AdaptivePracticeQuizAttempt"("nextAssignmentId");
+CREATE UNIQUE INDEX "apqa_one_in_progress_key" ON "AdaptivePracticeQuizAttempt"("practiceQuizId", "participantId") WHERE "status" = 'IN_PROGRESS';
+CREATE UNIQUE INDEX "apqr_attempt_order_key" ON "AdaptivePracticeQuizResponse"("attemptId", "order");
+CREATE UNIQUE INDEX "apqr_attempt_assignment_key" ON "AdaptivePracticeQuizResponse"("attemptId", "assignmentId");
+CREATE INDEX "apqr_assignment_idx" ON "AdaptivePracticeQuizResponse"("assignmentId");
+CREATE UNIQUE INDEX "apqe_attempt_kind_node_key" ON "AdaptivePracticeQuizEstimate"("attemptId", "nodeKind", "nodeId");
+CREATE UNIQUE INDEX "apqe_attempt_kind_overall_key" ON "AdaptivePracticeQuizEstimate"("attemptId", "nodeKind") WHERE "nodeId" IS NULL;
+CREATE INDEX "apqe_kind_level_idx" ON "AdaptivePracticeQuizEstimate"("nodeKind", "levelId");
+
+-- AddForeignKey
+ALTER TABLE "CompetenceTree" ADD CONSTRAINT "CompetenceTree_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeCourse" ADD CONSTRAINT "CompetenceTreeCourse_treeId_fkey" FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeCourse" ADD CONSTRAINT "CompetenceTreeCourse_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeCourse" ADD CONSTRAINT "CompetenceTreeCourse_linkedById_fkey" FOREIGN KEY ("linkedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeLevel" ADD CONSTRAINT "CompetenceTreeLevel_treeId_fkey" FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeNode" ADD CONSTRAINT "CompetenceTreeNode_treeId_fkey" FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeNode" ADD CONSTRAINT "CompetenceTreeNode_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "CompetenceTreeNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeLeafLevelCoverage" ADD CONSTRAINT "CompetenceTreeLeafLevelCoverage_treeId_fkey" FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeLeafLevelCoverage" ADD CONSTRAINT "CompetenceTreeLeafLevelCoverage_leafNodeId_fkey" FOREIGN KEY ("leafNodeId") REFERENCES "CompetenceTreeNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeLeafLevelCoverage" ADD CONSTRAINT "CompetenceTreeLeafLevelCoverage_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "CompetenceTreeLevel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeElementAssignment" ADD CONSTRAINT "CompetenceTreeElementAssignment_treeId_fkey" FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeElementAssignment" ADD CONSTRAINT "CompetenceTreeElementAssignment_elementId_fkey" FOREIGN KEY ("elementId") REFERENCES "Element"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeElementAssignment" ADD CONSTRAINT "CompetenceTreeElementAssignment_leafNodeId_fkey" FOREIGN KEY ("leafNodeId") REFERENCES "CompetenceTreeNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CompetenceTreeElementAssignment" ADD CONSTRAINT "CompetenceTreeElementAssignment_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "CompetenceTreeLevel"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveConfig" ADD CONSTRAINT "PracticeQuizAdaptiveConfig_practiceQuizId_fkey" FOREIGN KEY ("practiceQuizId") REFERENCES "PracticeQuiz"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveConfig" ADD CONSTRAINT "PracticeQuizAdaptiveConfig_competenceTreeId_fkey" FOREIGN KEY ("competenceTreeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride" ADD CONSTRAINT "PracticeQuizAdaptiveNodeOverride_configId_fkey" FOREIGN KEY ("configId") REFERENCES "PracticeQuizAdaptiveConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride" ADD CONSTRAINT "PracticeQuizAdaptiveNodeOverride_nodeId_fkey" FOREIGN KEY ("nodeId") REFERENCES "CompetenceTreeNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveElementOverride" ADD CONSTRAINT "PracticeQuizAdaptiveElementOverride_configId_fkey" FOREIGN KEY ("configId") REFERENCES "PracticeQuizAdaptiveConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PracticeQuizAdaptiveElementOverride" ADD CONSTRAINT "PracticeQuizAdaptiveElementOverride_assignmentId_fkey" FOREIGN KEY ("assignmentId") REFERENCES "CompetenceTreeElementAssignment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_configId_fkey" FOREIGN KEY ("configId") REFERENCES "PracticeQuizAdaptiveConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuizId_fkey" FOREIGN KEY ("practiceQuizId") REFERENCES "PracticeQuiz"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_participationId_fkey" FOREIGN KEY ("participationId") REFERENCES "Participation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_finalLevelId_fkey" FOREIGN KEY ("finalLevelId") REFERENCES "CompetenceTreeLevel"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizAttempt" ADD CONSTRAINT "AdaptivePracticeQuizAttempt_nextAssignmentId_fkey" FOREIGN KEY ("nextAssignmentId") REFERENCES "CompetenceTreeElementAssignment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizResponse" ADD CONSTRAINT "AdaptivePracticeQuizResponse_attemptId_fkey" FOREIGN KEY ("attemptId") REFERENCES "AdaptivePracticeQuizAttempt"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizResponse" ADD CONSTRAINT "AdaptivePracticeQuizResponse_assignmentId_fkey" FOREIGN KEY ("assignmentId") REFERENCES "CompetenceTreeElementAssignment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizEstimate" ADD CONSTRAINT "AdaptivePracticeQuizEstimate_attemptId_fkey" FOREIGN KEY ("attemptId") REFERENCES "AdaptivePracticeQuizAttempt"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizEstimate" ADD CONSTRAINT "AdaptivePracticeQuizEstimate_nodeId_fkey" FOREIGN KEY ("nodeId") REFERENCES "CompetenceTreeNode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AdaptivePracticeQuizEstimate" ADD CONSTRAINT "AdaptivePracticeQuizEstimate_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "CompetenceTreeLevel"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/src/prisma/schema/migrations/20260710152000_adaptive_tree_integrity/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260710152000_adaptive_tree_integrity/migration.sql
@@ -1,0 +1,49 @@
+-- Composite keys support same-tree foreign keys for hierarchical references.
+-- The original single-column foreign keys intentionally remain because Prisma
+-- models those relations for client navigation. These composite constraints add
+-- tree identity at the database boundary; integration tests cover the layering.
+CREATE UNIQUE INDEX "ctl_tree_id_key"
+ON "CompetenceTreeLevel" ("treeId", "id");
+
+CREATE UNIQUE INDEX "ctn_tree_id_key"
+ON "CompetenceTreeNode" ("treeId", "id");
+
+ALTER TABLE "CompetenceTreeNode"
+ADD CONSTRAINT "ctn_parent_same_tree_fkey"
+FOREIGN KEY ("treeId", "parentId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "CompetenceTreeLeafLevelCoverage"
+ADD CONSTRAINT "ctlc_leaf_same_tree_fkey"
+FOREIGN KEY ("treeId", "leafNodeId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "CompetenceTreeLeafLevelCoverage"
+ADD CONSTRAINT "ctlc_level_same_tree_fkey"
+FOREIGN KEY ("treeId", "levelId")
+REFERENCES "CompetenceTreeLevel" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "CompetenceTreeElementAssignment"
+ADD CONSTRAINT "ctea_leaf_same_tree_fkey"
+FOREIGN KEY ("treeId", "leafNodeId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "CompetenceTreeElementAssignment"
+ADD CONSTRAINT "ctea_level_same_tree_fkey"
+FOREIGN KEY ("treeId", "levelId")
+REFERENCES "CompetenceTreeLevel" ("treeId", "id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- The original migration already enforces one NULL-node estimate per kind.
+-- Constrain which kinds may use a NULL node.
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD CONSTRAINT "apqe_node_kind_node_check"
+CHECK (
+  ("nodeKind" = 'OVERALL' AND "nodeId" IS NULL)
+  OR
+  ("nodeKind" IN ('COMPETENCE', 'SUBCOMPETENCE') AND "nodeId" IS NOT NULL)
+);

--- a/packages/prisma/src/prisma/schema/migrations/20260710190000_adaptive_practice_quiz_configuration/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260710190000_adaptive_practice_quiz_configuration/migration.sql
@@ -1,0 +1,466 @@
+-- Persist product semantics instead of inferring them from mutable defaults.
+CREATE TYPE "AdaptivePracticeQuizPreset" AS ENUM (
+  'PLACEMENT',
+  'DIAGNOSTIC',
+  'RESEARCH'
+);
+
+CREATE TYPE "AdaptiveAttemptSelectionPolicy" AS ENUM (
+  'FIRST_COMPLETED',
+  'LATEST_COMPLETED'
+);
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD COLUMN "preset" "AdaptivePracticeQuizPreset" NOT NULL DEFAULT 'DIAGNOSTIC',
+ADD COLUMN "attemptSelectionPolicy" "AdaptiveAttemptSelectionPolicy" NOT NULL DEFAULT 'LATEST_COMPLETED',
+ADD COLUMN "poolPublishedAt" TIMESTAMP(3);
+
+-- Preserve pre-existing advanced settings by classifying those rows as
+-- research configurations. Normal presets receive only their stable policy.
+UPDATE "PracticeQuizAdaptiveConfig" AS config
+SET
+  "preset" = CASE
+    WHEN
+      config."showLiveEstimate" = false
+      AND config."topInformationRatio" = 0.8
+      AND config."defaultDiscrimination" = 1.2
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "CompetenceTree" AS tree
+        WHERE tree."id" = config."competenceTreeId"
+          AND tree."defaultDiscrimination" <> 1.2
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "CompetenceTreeElementAssignment" AS tree_assignment
+        WHERE tree_assignment."treeId" = config."competenceTreeId"
+          AND tree_assignment."discrimination" IS NOT NULL
+          AND tree_assignment."discrimination" <> 1.2
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "PracticeQuizAdaptiveElementOverride" AS element_override
+        WHERE element_override."configId" = config."id"
+          AND element_override."discrimination" IS NOT NULL
+      )
+    THEN CASE
+      WHEN config."levelMappingRule" = 'MASTERY'
+        THEN 'PLACEMENT'::"AdaptivePracticeQuizPreset"
+      ELSE 'DIAGNOSTIC'::"AdaptivePracticeQuizPreset"
+    END
+    ELSE 'RESEARCH'::"AdaptivePracticeQuizPreset"
+  END,
+  "attemptSelectionPolicy" = CASE
+    WHEN config."levelMappingRule" = 'MASTERY' THEN 'FIRST_COMPLETED'::"AdaptiveAttemptSelectionPolicy"
+    ELSE 'LATEST_COMPLETED'::"AdaptiveAttemptSelectionPolicy"
+  END,
+  "showFinalResult" = true,
+  "enableSelfAssessmentWarmup" = false;
+
+UPDATE "PracticeQuiz" AS quiz
+SET "mode" = 'ADAPTIVE'
+FROM "PracticeQuizAdaptiveConfig" AS config
+WHERE config."practiceQuizId" = quiz."id";
+
+UPDATE "PracticeQuiz"
+SET
+  "pointsMultiplier" = 0,
+  "isGamificationEnabled" = false,
+  "isAssessmentEnabled" = false
+WHERE "mode" = 'ADAPTIVE';
+
+-- Phase 2 deliberately supports immediate adaptive publication only. Any
+-- experimental scheduled row is returned to draft; an already-created stale
+-- task observes DRAFT with a null task id and exits idempotently.
+UPDATE "PracticeQuiz"
+SET
+  "status" = 'DRAFT',
+  "availableFrom" = NULL,
+  "scheduledPublicationTaskId" = NULL
+WHERE "mode" = 'ADAPTIVE'
+  AND "status" = 'SCHEDULED';
+
+-- Repeat tree identity on override rows so PostgreSQL can reject cross-tree ids.
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride"
+ADD COLUMN "competenceTreeId" UUID;
+
+ALTER TABLE "PracticeQuizAdaptiveElementOverride"
+ADD COLUMN "competenceTreeId" UUID;
+
+UPDATE "PracticeQuizAdaptiveNodeOverride" AS override
+SET "competenceTreeId" = config."competenceTreeId"
+FROM "PracticeQuizAdaptiveConfig" AS config
+WHERE config."id" = override."configId";
+
+UPDATE "PracticeQuizAdaptiveElementOverride" AS override
+SET "competenceTreeId" = config."competenceTreeId"
+FROM "PracticeQuizAdaptiveConfig" AS config
+WHERE config."id" = override."configId";
+
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride"
+ALTER COLUMN "competenceTreeId" SET NOT NULL;
+
+ALTER TABLE "PracticeQuizAdaptiveElementOverride"
+ALTER COLUMN "competenceTreeId" SET NOT NULL;
+
+-- Immutable source for adaptive delivery. Runtime never reads mutable Element data.
+CREATE TABLE "PracticeQuizAdaptivePoolItem" (
+  "id" SERIAL NOT NULL,
+  "configId" UUID NOT NULL,
+  "competenceTreeId" UUID NOT NULL,
+  "sourceAssignmentId" INTEGER NOT NULL,
+  "elementId" INTEGER NOT NULL,
+  "elementVersion" INTEGER NOT NULL,
+  "elementType" "ElementType" NOT NULL,
+  "elementName" TEXT NOT NULL,
+  "elementData" JSONB NOT NULL,
+  "leafNodeId" INTEGER NOT NULL,
+  "nodePath" INTEGER[] NOT NULL,
+  "nodeNamePath" TEXT[] NOT NULL,
+  "levelId" INTEGER NOT NULL,
+  "levelLabel" TEXT NOT NULL,
+  "levelOrder" INTEGER NOT NULL,
+  "discrimination" DOUBLE PRECISION NOT NULL,
+  "difficulty" DOUBLE PRECISION NOT NULL,
+  "guessing" DOUBLE PRECISION NOT NULL,
+  "enablePercentInput" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "PracticeQuizAdaptivePoolItem_pkey" PRIMARY KEY ("id")
+);
+
+-- Transitional nullable references preserve experimental rows. A NOT VALID
+-- check below still requires every newly inserted response to use the pool.
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD COLUMN "nextPoolItemId" INTEGER,
+ADD COLUMN "courseId" UUID;
+
+UPDATE "AdaptivePracticeQuizAttempt" AS attempt
+SET "courseId" = quiz."courseId"
+FROM "PracticeQuiz" AS quiz
+WHERE quiz."id" = attempt."practiceQuizId";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ALTER COLUMN "courseId" SET NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD COLUMN "poolItemId" INTEGER,
+ADD COLUMN "configId" UUID;
+
+UPDATE "AdaptivePracticeQuizResponse" AS response
+SET "configId" = attempt."configId"
+FROM "AdaptivePracticeQuizAttempt" AS attempt
+WHERE attempt."id" = response."attemptId";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ALTER COLUMN "configId" SET NOT NULL;
+
+CREATE UNIQUE INDEX "ctea_tree_id_key"
+ON "CompetenceTreeElementAssignment" ("treeId", "id");
+
+CREATE UNIQUE INDEX "pqac_id_tree_key"
+ON "PracticeQuizAdaptiveConfig" ("id", "competenceTreeId");
+
+CREATE UNIQUE INDEX "pqac_id_quiz_key"
+ON "PracticeQuizAdaptiveConfig" ("id", "practiceQuizId");
+
+CREATE UNIQUE INDEX "practice_quiz_id_course_key"
+ON "PracticeQuiz" ("id", "courseId");
+
+CREATE UNIQUE INDEX "participation_identity_key"
+ON "Participation" ("id", "participantId", "courseId");
+
+CREATE UNIQUE INDEX "pqapi_config_assignment_key"
+ON "PracticeQuizAdaptivePoolItem" ("configId", "sourceAssignmentId");
+
+CREATE UNIQUE INDEX "pqapi_config_id_key"
+ON "PracticeQuizAdaptivePoolItem" ("configId", "id");
+
+CREATE UNIQUE INDEX "pqapi_response_identity_key"
+ON "PracticeQuizAdaptivePoolItem" ("configId", "id", "sourceAssignmentId", "elementId");
+
+CREATE UNIQUE INDEX "apqa_id_config_key"
+ON "AdaptivePracticeQuizAttempt" ("id", "configId");
+
+CREATE INDEX "pqapi_config_leaf_level_idx"
+ON "PracticeQuizAdaptivePoolItem" ("configId", "leafNodeId", "levelId");
+
+CREATE INDEX "pqapi_element_version_idx"
+ON "PracticeQuizAdaptivePoolItem" ("elementId", "elementVersion");
+
+CREATE INDEX "pqapi_tree_assignment_idx"
+ON "PracticeQuizAdaptivePoolItem" ("competenceTreeId", "sourceAssignmentId");
+
+CREATE INDEX "pqan_tree_node_idx"
+ON "PracticeQuizAdaptiveNodeOverride" ("competenceTreeId", "nodeId");
+
+CREATE INDEX "pqae_tree_assignment_idx"
+ON "PracticeQuizAdaptiveElementOverride" ("competenceTreeId", "assignmentId");
+
+CREATE INDEX "apqa_next_pool_item_idx"
+ON "AdaptivePracticeQuizAttempt" ("nextPoolItemId");
+
+CREATE INDEX "apqa_config_quiz_idx"
+ON "AdaptivePracticeQuizAttempt" ("configId", "practiceQuizId");
+
+CREATE INDEX "apqa_participation_identity_idx"
+ON "AdaptivePracticeQuizAttempt" ("participationId", "participantId", "courseId");
+
+CREATE INDEX "apqa_config_next_pool_idx"
+ON "AdaptivePracticeQuizAttempt" ("configId", "nextPoolItemId");
+
+CREATE INDEX "apqr_pool_item_idx"
+ON "AdaptivePracticeQuizResponse" ("poolItemId");
+
+CREATE INDEX "apqr_config_pool_idx"
+ON "AdaptivePracticeQuizResponse" ("configId", "poolItemId");
+
+-- Stop with an actionable error instead of silently rewriting invalid
+-- experimental values that cannot satisfy the production contract.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptiveConfig"
+    WHERE NOT (
+      "totalQuestionCap" BETWEEN 1 AND 1000
+      AND ("perLeafQuestionCap" IS NULL OR "perLeafQuestionCap" BETWEEN 1 AND "totalQuestionCap")
+      AND "minQuestionsPerLeaf" BETWEEN 1 AND "totalQuestionCap"
+      AND "classificationZ" > 0 AND "classificationZ" <= 5
+      AND ("standardErrorThreshold" IS NULL OR "standardErrorThreshold" > 0)
+      AND "topInformationRatio" > 0 AND "topInformationRatio" <= 1
+      AND "defaultDiscrimination" > 0 AND "defaultDiscrimination" <= 10
+    )
+  ) THEN
+    RAISE EXCEPTION 'Adaptive configuration contains values outside the Phase 2 production bounds; review the affected row before migrating.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptiveNodeOverride"
+    WHERE ("weight" IS NOT NULL AND "weight" < 0)
+      OR ("questionCap" IS NOT NULL AND "questionCap" NOT BETWEEN 1 AND 1000)
+  ) THEN
+    RAISE EXCEPTION 'Adaptive node override contains values outside the Phase 2 production bounds; review the affected row before migrating.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptiveElementOverride"
+    WHERE "discrimination" IS NOT NULL
+      AND NOT ("discrimination" > 0 AND "discrimination" <= 10)
+  ) THEN
+    RAISE EXCEPTION 'Adaptive element override contains values outside the Phase 2 production bounds; review the affected row before migrating.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "AdaptivePracticeQuizAttempt" AS attempt
+    JOIN "PracticeQuizAdaptiveConfig" AS config
+      ON config."id" = attempt."configId"
+    WHERE attempt."practiceQuizId" <> config."practiceQuizId"
+  ) THEN
+    RAISE EXCEPTION 'Adaptive attempt references a config owned by another practice quiz; repair the affected row before migrating.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "AdaptivePracticeQuizAttempt" AS attempt
+    JOIN "Participation" AS participation
+      ON participation."id" = attempt."participationId"
+    WHERE participation."participantId" <> attempt."participantId"
+      OR participation."courseId" <> attempt."courseId"
+  ) THEN
+    RAISE EXCEPTION 'Adaptive attempt participant/course does not match its participation; repair the affected row before migrating.';
+  END IF;
+END $$;
+
+-- Product and numerical invariants remain valid even for direct database writes.
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD CONSTRAINT "pqac_numeric_bounds_check"
+CHECK (
+  "totalQuestionCap" BETWEEN 1 AND 1000
+  AND ("perLeafQuestionCap" IS NULL OR "perLeafQuestionCap" BETWEEN 1 AND "totalQuestionCap")
+  AND "minQuestionsPerLeaf" BETWEEN 1 AND "totalQuestionCap"
+  AND "classificationZ" > 0 AND "classificationZ" <= 5
+  AND ("standardErrorThreshold" IS NULL OR "standardErrorThreshold" > 0)
+  AND "topInformationRatio" > 0 AND "topInformationRatio" <= 1
+  AND "defaultDiscrimination" > 0 AND "defaultDiscrimination" <= 10
+);
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD CONSTRAINT "pqac_preset_semantics_check"
+CHECK (
+  (
+    "preset" = 'PLACEMENT'
+    AND "levelMappingRule" = 'MASTERY'
+    AND "attemptSelectionPolicy" = 'FIRST_COMPLETED'
+    AND "showLiveEstimate" = false
+    AND "topInformationRatio" = 0.8
+    AND "defaultDiscrimination" = 1.2
+  )
+  OR (
+    "preset" = 'DIAGNOSTIC'
+    AND "levelMappingRule" = 'NEAREST'
+    AND "attemptSelectionPolicy" = 'LATEST_COMPLETED'
+    AND "showLiveEstimate" = false
+    AND "topInformationRatio" = 0.8
+    AND "defaultDiscrimination" = 1.2
+  )
+  OR "preset" = 'RESEARCH'
+);
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD CONSTRAINT "pqac_final_result_required_check"
+CHECK ("showFinalResult" = true);
+
+ALTER TABLE "PracticeQuiz"
+ADD CONSTRAINT "practice_quiz_adaptive_no_gamification_check"
+CHECK (
+  "mode" <> 'ADAPTIVE'
+  OR (
+    "pointsMultiplier" = 0
+    AND "isGamificationEnabled" = false
+    AND "isAssessmentEnabled" = false
+  )
+);
+
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride"
+ADD CONSTRAINT "pqan_values_check"
+CHECK (
+  ("weight" IS NULL OR "weight" >= 0)
+  AND ("questionCap" IS NULL OR "questionCap" BETWEEN 1 AND 1000)
+);
+
+ALTER TABLE "PracticeQuizAdaptiveElementOverride"
+ADD CONSTRAINT "pqae_discrimination_check"
+CHECK (
+  "discrimination" IS NULL
+  OR ("discrimination" > 0 AND "discrimination" <= 10)
+);
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "pqapi_values_check"
+CHECK (
+  "elementVersion" > 0
+  AND "levelOrder" >= 0
+  AND "discrimination" > 0 AND "discrimination" <= 10
+  AND "difficulty" BETWEEN -10 AND 10
+  AND "guessing" >= 0 AND "guessing" < 1
+  AND cardinality("nodePath") > 0
+  AND cardinality("nodePath") = cardinality("nodeNamePath")
+);
+
+-- Override navigation keeps its existing single-column relations; these
+-- composite constraints add the missing same-tree guarantees.
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride"
+ADD CONSTRAINT "pqan_config_tree_same_tree_fkey"
+FOREIGN KEY ("configId", "competenceTreeId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "competenceTreeId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptiveNodeOverride"
+ADD CONSTRAINT "pqan_node_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "nodeId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptiveElementOverride"
+ADD CONSTRAINT "pqae_config_tree_same_tree_fkey"
+FOREIGN KEY ("configId", "competenceTreeId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "competenceTreeId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptiveElementOverride"
+ADD CONSTRAINT "pqae_assignment_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "assignmentId")
+REFERENCES "CompetenceTreeElementAssignment" ("treeId", "id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "PracticeQuizAdaptivePoolItem_configId_fkey"
+FOREIGN KEY ("configId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "PracticeQuizAdaptivePoolItem_sourceAssignmentId_fkey"
+FOREIGN KEY ("sourceAssignmentId")
+REFERENCES "CompetenceTreeElementAssignment" ("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "pqapi_config_tree_same_tree_fkey"
+FOREIGN KEY ("configId", "competenceTreeId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "competenceTreeId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "pqapi_assignment_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "sourceAssignmentId")
+REFERENCES "CompetenceTreeElementAssignment" ("treeId", "id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "pqapi_leaf_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "leafNodeId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+ADD CONSTRAINT "pqapi_level_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "levelId")
+REFERENCES "CompetenceTreeLevel" ("treeId", "id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_configId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "apqr_pool_item_required_check"
+CHECK ("poolItemId" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+DROP CONSTRAINT "AdaptivePracticeQuizResponse_attemptId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuizId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_participationId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_configId_practiceQuizId_fkey"
+FOREIGN KEY ("configId", "practiceQuizId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "practiceQuizId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuizId_courseId_fkey"
+FOREIGN KEY ("practiceQuizId", "courseId")
+REFERENCES "PracticeQuiz" ("id", "courseId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_participationId_participantId_courseId_fkey"
+FOREIGN KEY ("participationId", "participantId", "courseId")
+REFERENCES "Participation" ("id", "participantId", "courseId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "AdaptivePracticeQuizResponse_attemptId_configId_fkey"
+FOREIGN KEY ("attemptId", "configId")
+REFERENCES "AdaptivePracticeQuizAttempt" ("id", "configId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_configId_nextPoolItemId_fkey"
+FOREIGN KEY ("configId", "nextPoolItemId")
+REFERENCES "PracticeQuizAdaptivePoolItem" ("configId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "AdaptivePracticeQuizResponse_configId_poolItemId_assignmentId_elementId_fkey"
+FOREIGN KEY ("configId", "poolItemId", "assignmentId", "elementId")
+REFERENCES "PracticeQuizAdaptivePoolItem" ("configId", "id", "sourceAssignmentId", "elementId")
+ON DELETE NO ACTION ON UPDATE CASCADE;

--- a/packages/prisma/src/prisma/schema/migrations/20260710210000_adaptive_practice_quiz_runtime/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260710210000_adaptive_practice_quiz_runtime/migration.sql
@@ -1,0 +1,336 @@
+-- Phase 3 makes ordered response rows the canonical trajectory and removes the
+-- transitional live-tree pointer that predates immutable publication pools.
+CREATE TYPE "AdaptivePracticeQuizStopReason" AS ENUM (
+  'CLASSIFIED',
+  'ALL_ROOTS_CLASSIFIED',
+  'TOTAL_QUESTION_CAP',
+  'NODE_QUESTION_CAP',
+  'POOL_EXHAUSTED',
+  'INSUFFICIENT_DATA',
+  'ABANDONED'
+);
+
+DO $$
+DECLARE
+  invalid_attempt_id UUID;
+  invalid_estimate_id INTEGER;
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "AdaptivePracticeQuizAttempt"
+    WHERE "nextAssignmentId" IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'Adaptive attempts still reference live competence-tree assignments; migrate or abandon those experimental attempts before applying the Phase 3 runtime migration.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "AdaptivePracticeQuizEstimate"
+    WHERE "stopReason" IS NOT NULL
+      AND "stopReason" NOT IN (
+        'CLASSIFIED',
+        'ALL_ROOTS_CLASSIFIED',
+        'TOTAL_QUESTION_CAP',
+        'NODE_QUESTION_CAP',
+        'POOL_EXHAUSTED',
+        'INSUFFICIENT_DATA',
+        'ABANDONED'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Adaptive estimates contain unknown stop reasons; review those experimental rows before applying the Phase 3 runtime migration.';
+  END IF;
+
+  SELECT attempt."id"
+  INTO invalid_attempt_id
+  FROM "AdaptivePracticeQuizAttempt" AS attempt
+  JOIN "PracticeQuizAdaptiveConfig" AS config
+    ON config."id" = attempt."configId"
+  JOIN "CompetenceTreeLevel" AS level
+    ON level."id" = attempt."finalLevelId"
+  WHERE level."treeId" <> config."competenceTreeId"
+  ORDER BY attempt."id"
+  LIMIT 1;
+
+  IF invalid_attempt_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive attempt % has a final level from another competence tree; clear or migrate that experimental result before applying the Phase 3 runtime migration.', invalid_attempt_id;
+  END IF;
+
+  SELECT estimate."id"
+  INTO invalid_estimate_id
+  FROM "AdaptivePracticeQuizEstimate" AS estimate
+  JOIN "AdaptivePracticeQuizAttempt" AS attempt
+    ON attempt."id" = estimate."attemptId"
+  JOIN "PracticeQuizAdaptiveConfig" AS config
+    ON config."id" = attempt."configId"
+  JOIN "CompetenceTreeNode" AS node
+    ON node."id" = estimate."nodeId"
+  WHERE node."treeId" <> config."competenceTreeId"
+  ORDER BY estimate."id"
+  LIMIT 1;
+
+  IF invalid_estimate_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive estimate % references a node from another competence tree; clear or migrate that experimental result before applying the Phase 3 runtime migration.', invalid_estimate_id;
+  END IF;
+
+  SELECT estimate."id"
+  INTO invalid_estimate_id
+  FROM "AdaptivePracticeQuizEstimate" AS estimate
+  JOIN "AdaptivePracticeQuizAttempt" AS attempt
+    ON attempt."id" = estimate."attemptId"
+  JOIN "PracticeQuizAdaptiveConfig" AS config
+    ON config."id" = attempt."configId"
+  JOIN "CompetenceTreeLevel" AS level
+    ON level."id" = estimate."levelId"
+  WHERE level."treeId" <> config."competenceTreeId"
+  ORDER BY estimate."id"
+  LIMIT 1;
+
+  IF invalid_estimate_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive estimate % references a level from another competence tree; clear or migrate that experimental result before applying the Phase 3 runtime migration.', invalid_estimate_id;
+  END IF;
+END $$;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD COLUMN "stopReason" "AdaptivePracticeQuizStopReason",
+ADD COLUMN "competenceTreeId" UUID;
+
+UPDATE "AdaptivePracticeQuizAttempt" AS attempt
+SET "competenceTreeId" = config."competenceTreeId"
+FROM "PracticeQuizAdaptiveConfig" AS config
+WHERE attempt."configId" = config."id";
+
+-- Preserve the terminal reason for pre-runtime attempts. Prefer the canonical
+-- overall estimate and use deterministic fallbacks for older experimental rows.
+UPDATE "AdaptivePracticeQuizAttempt" AS attempt
+SET "stopReason" = CASE
+  WHEN attempt."status" = 'ABANDONED' THEN
+    'ABANDONED'::"AdaptivePracticeQuizStopReason"
+  WHEN attempt."status" = 'COMPLETED' THEN
+    COALESCE(
+      (
+        SELECT estimate."stopReason"::"AdaptivePracticeQuizStopReason"
+        FROM "AdaptivePracticeQuizEstimate" AS estimate
+        WHERE estimate."attemptId" = attempt."id"
+          AND estimate."nodeKind" = 'OVERALL'
+          AND estimate."nodeId" IS NULL
+        ORDER BY estimate."id" DESC
+        LIMIT 1
+      ),
+      CASE
+        WHEN attempt."finalLevelId" IS NOT NULL THEN
+          'CLASSIFIED'::"AdaptivePracticeQuizStopReason"
+        ELSE
+          'INSUFFICIENT_DATA'::"AdaptivePracticeQuizStopReason"
+      END
+    )
+  ELSE NULL
+END
+WHERE attempt."status" <> 'IN_PROGRESS';
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ALTER COLUMN "competenceTreeId" SET NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD COLUMN "configId" UUID,
+ADD COLUMN "competenceTreeId" UUID;
+
+UPDATE "AdaptivePracticeQuizEstimate" AS estimate
+SET
+  "configId" = attempt."configId",
+  "competenceTreeId" = attempt."competenceTreeId"
+FROM "AdaptivePracticeQuizAttempt" AS attempt
+WHERE estimate."attemptId" = attempt."id";
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ALTER COLUMN "configId" SET NOT NULL,
+ALTER COLUMN "competenceTreeId" SET NOT NULL,
+ALTER COLUMN "theta" DROP NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ALTER COLUMN "stopReason" TYPE "AdaptivePracticeQuizStopReason"
+USING "stopReason"::"AdaptivePracticeQuizStopReason";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+RENAME COLUMN "thetaBefore" TO "overallThetaBefore";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+RENAME COLUMN "thetaAfter" TO "overallThetaAfter";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+RENAME COLUMN "standardErrorAfter" TO "overallStandardErrorAfter";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ALTER COLUMN "overallThetaBefore" DROP NOT NULL,
+ALTER COLUMN "overallThetaAfter" DROP NOT NULL,
+ALTER COLUMN "overallStandardErrorAfter" DROP NOT NULL,
+ADD COLUMN "score" DOUBLE PRECISION;
+
+-- Existing experimental rows retain their original binary outcome as score
+-- and response JSON as the normalized audit value. New runtime rows always
+-- write the type-specific canonical normalization explicitly.
+UPDATE "AdaptivePracticeQuizResponse"
+SET
+  "normalizedResponse" = COALESCE("normalizedResponse", "response"),
+  "score" = CASE WHEN "correct" THEN 1.0 ELSE 0.0 END;
+
+UPDATE "AdaptivePracticeQuizResponse" AS response
+SET "elementSnapshot" = pool."elementData"
+FROM "PracticeQuizAdaptivePoolItem" AS pool
+WHERE response."elementSnapshot" IS NULL
+  AND response."poolItemId" = pool."id"
+  AND response."configId" = pool."configId";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ALTER COLUMN "normalizedResponse" SET NOT NULL,
+ALTER COLUMN "score" SET NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_nextAssignmentId_fkey";
+
+DROP INDEX "apqa_next_assignment_idx";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP COLUMN "nextAssignmentId",
+DROP COLUMN "thetaHistory",
+DROP COLUMN "standardErrorHistory";
+
+CREATE UNIQUE INDEX "pqac_id_quiz_tree_key"
+ON "PracticeQuizAdaptiveConfig" ("id", "practiceQuizId", "competenceTreeId");
+
+CREATE UNIQUE INDEX "apqa_id_config_tree_key"
+ON "AdaptivePracticeQuizAttempt" ("id", "configId", "competenceTreeId");
+
+CREATE INDEX "apqe_config_tree_idx"
+ON "AdaptivePracticeQuizEstimate" ("configId", "competenceTreeId");
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_configId_practiceQuizId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_finalLevelId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+DROP CONSTRAINT "AdaptivePracticeQuizEstimate_attemptId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+DROP CONSTRAINT "AdaptivePracticeQuizEstimate_nodeId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+DROP CONSTRAINT "AdaptivePracticeQuizEstimate_levelId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_config_quiz_tree_fkey"
+FOREIGN KEY ("configId", "practiceQuizId", "competenceTreeId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "practiceQuizId", "competenceTreeId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_final_level_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "finalLevelId")
+REFERENCES "CompetenceTreeLevel" ("treeId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD CONSTRAINT "AdaptivePracticeQuizEstimate_attempt_config_tree_fkey"
+FOREIGN KEY ("attemptId", "configId", "competenceTreeId")
+REFERENCES "AdaptivePracticeQuizAttempt" ("id", "configId", "competenceTreeId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD CONSTRAINT "AdaptivePracticeQuizEstimate_node_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "nodeId")
+REFERENCES "CompetenceTreeNode" ("treeId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD CONSTRAINT "AdaptivePracticeQuizEstimate_level_same_tree_fkey"
+FOREIGN KEY ("competenceTreeId", "levelId")
+REFERENCES "CompetenceTreeLevel" ("treeId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- NOT VALID preserves readable experimental history while enforcing the full
+-- Phase 3 contract for every new or updated row.
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "apqa_runtime_state_check"
+CHECK (
+  (
+    "status" = 'IN_PROGRESS'
+    AND "nextPoolItemId" IS NOT NULL
+    AND "stopReason" IS NULL
+    AND "completedAt" IS NULL
+  )
+  OR (
+    "status" = 'COMPLETED'
+    AND "nextPoolItemId" IS NULL
+    AND "stopReason" IS NOT NULL
+    AND "stopReason" <> 'ABANDONED'
+    AND "completedAt" IS NOT NULL
+  )
+  OR (
+    "status" = 'ABANDONED'
+    AND "nextPoolItemId" IS NULL
+    AND "stopReason" = 'ABANDONED'
+    AND "completedAt" IS NOT NULL
+  )
+) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "apqa_runtime_values_check"
+CHECK (
+  "currentTheta" BETWEEN -10 AND 10
+  AND ("currentStandardError" IS NULL OR "currentStandardError" > 0)
+  AND ("finalTheta" IS NULL OR "finalTheta" BETWEEN -10 AND 10)
+  AND ("finalStandardError" IS NULL OR "finalStandardError" > 0)
+  AND ("elapsedSeconds" IS NULL OR "elapsedSeconds" >= 0)
+) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "apqr_runtime_values_check"
+CHECK (
+  "order" > 0
+  AND "score" BETWEEN 0 AND 1
+  AND "correct" = ("score" = 1)
+  AND ("overallThetaBefore" IS NULL OR "overallThetaBefore" BETWEEN -10 AND 10)
+  AND ("overallThetaAfter" IS NULL OR "overallThetaAfter" BETWEEN -10 AND 10)
+  AND (
+    "overallStandardErrorAfter" IS NULL
+    OR "overallStandardErrorAfter" > 0
+  )
+  AND ("elapsedSeconds" IS NULL OR "elapsedSeconds" >= 0)
+) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+ADD CONSTRAINT "apqr_element_snapshot_required_check"
+CHECK ("elementSnapshot" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+ADD CONSTRAINT "apqe_runtime_values_check"
+CHECK (
+  ("theta" IS NULL OR "theta" BETWEEN -10 AND 10)
+  AND ("standardError" IS NULL OR "standardError" > 0)
+  AND "responseCount" >= 0
+  AND (
+    (
+      "nodeKind" = 'OVERALL'
+      AND (
+        ("theta" IS NULL AND "standardError" IS NULL)
+        OR ("theta" IS NOT NULL AND "standardError" IS NOT NULL)
+      )
+    )
+    OR (
+      "nodeKind" <> 'OVERALL'
+      AND (
+        (
+          "responseCount" = 0
+          AND "theta" IS NULL
+          AND "standardError" IS NULL
+        )
+        OR (
+          "responseCount" > 0
+          AND "theta" IS NOT NULL
+          AND "standardError" IS NOT NULL
+        )
+      )
+    )
+  )
+) NOT VALID;

--- a/packages/prisma/src/prisma/schema/migrations/20260712120000_competence_tree_archive_state/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260712120000_competence_tree_archive_state/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "CompetenceTree"
+ADD COLUMN "isArchived" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/src/prisma/schema/migrations/20260713100504_course_adaptive_learning_rollout/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260713100504_course_adaptive_learning_rollout/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."Course"
+ADD COLUMN "isAdaptiveLearningEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/src/prisma/schema/migrations/20260713210000_adaptive_runtime_constraint_validation/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260713210000_adaptive_runtime_constraint_validation/migration.sql
@@ -1,0 +1,264 @@
+-- Repair deterministic Phase 3 runtime-state gaps and validate every adaptive
+-- runtime check that was introduced as NOT VALID. Numeric or trajectory
+-- corruption is not guessed: the migration aborts with the first offending ID.
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '15min';
+
+DO $$
+DECLARE
+  invalid_attempt_id UUID;
+  invalid_response_id INTEGER;
+  invalid_estimate_id INTEGER;
+BEGIN
+  SELECT attempt."id"
+  INTO invalid_attempt_id
+  FROM "AdaptivePracticeQuizAttempt" AS attempt
+  WHERE NOT (
+    attempt."currentTheta" BETWEEN -10 AND 10
+    AND (
+      attempt."currentStandardError" IS NULL
+      OR attempt."currentStandardError" > 0
+    )
+    AND (
+      attempt."finalTheta" IS NULL
+      OR attempt."finalTheta" BETWEEN -10 AND 10
+    )
+    AND (
+      attempt."finalStandardError" IS NULL
+      OR attempt."finalStandardError" > 0
+    )
+    AND (
+      attempt."elapsedSeconds" IS NULL
+      OR attempt."elapsedSeconds" >= 0
+    )
+  )
+  ORDER BY attempt."id"
+  LIMIT 1;
+
+  IF invalid_attempt_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive attempt % has invalid psychometric or elapsed-time values. Correct it before retrying migration 20260713210000.', invalid_attempt_id;
+  END IF;
+
+  SELECT result."id"
+  INTO invalid_response_id
+  FROM "AdaptivePracticeQuizResponse" AS result
+  WHERE NOT (
+    result."order" > 0
+    AND result."score" BETWEEN 0 AND 1
+    AND result."correct" = (result."score" = 1)
+    AND (
+      result."overallThetaBefore" IS NULL
+      OR result."overallThetaBefore" BETWEEN -10 AND 10
+    )
+    AND (
+      result."overallThetaAfter" IS NULL
+      OR result."overallThetaAfter" BETWEEN -10 AND 10
+    )
+    AND (
+      result."overallStandardErrorAfter" IS NULL
+      OR result."overallStandardErrorAfter" > 0
+    )
+    AND (
+      result."elapsedSeconds" IS NULL
+      OR result."elapsedSeconds" >= 0
+    )
+  )
+  ORDER BY result."id"
+  LIMIT 1;
+
+  IF invalid_response_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive response % has invalid score, psychometric, or elapsed-time values. Correct it before retrying migration 20260713210000.', invalid_response_id;
+  END IF;
+
+  SELECT estimate."id"
+  INTO invalid_estimate_id
+  FROM "AdaptivePracticeQuizEstimate" AS estimate
+  WHERE NOT (
+    (
+      estimate."theta" IS NULL
+      OR estimate."theta" BETWEEN -10 AND 10
+    )
+    AND (
+      estimate."standardError" IS NULL
+      OR estimate."standardError" > 0
+    )
+    AND estimate."responseCount" >= 0
+    AND (
+      (
+        estimate."nodeKind" = 'OVERALL'
+        AND (
+          (
+            estimate."theta" IS NULL
+            AND estimate."standardError" IS NULL
+          )
+          OR (
+            estimate."theta" IS NOT NULL
+            AND estimate."standardError" IS NOT NULL
+          )
+        )
+      )
+      OR (
+        estimate."nodeKind" <> 'OVERALL'
+        AND (
+          (
+            estimate."responseCount" = 0
+            AND estimate."theta" IS NULL
+            AND estimate."standardError" IS NULL
+          )
+          OR (
+            estimate."responseCount" > 0
+            AND estimate."theta" IS NOT NULL
+            AND estimate."standardError" IS NOT NULL
+          )
+        )
+      )
+    )
+  )
+  ORDER BY estimate."id"
+  LIMIT 1;
+
+  IF invalid_estimate_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive estimate % has invalid psychometric state. Correct it before retrying migration 20260713210000.', invalid_estimate_id;
+  END IF;
+
+  WITH ordered_responses AS (
+    SELECT
+      result."id",
+      result."order",
+      ROW_NUMBER() OVER (
+        PARTITION BY result."attemptId"
+        ORDER BY result."order", result."id"
+      ) AS expected_order
+    FROM "AdaptivePracticeQuizResponse" AS result
+  )
+  SELECT ordered."id"
+  INTO invalid_response_id
+  FROM ordered_responses AS ordered
+  WHERE ordered."order" <> ordered.expected_order
+  ORDER BY ordered."id"
+  LIMIT 1;
+
+  IF invalid_response_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive response % is part of a non-contiguous attempt trajectory. Repair the response order before retrying migration 20260713210000.', invalid_response_id;
+  END IF;
+
+  SELECT result."id"
+  INTO invalid_response_id
+  FROM "AdaptivePracticeQuizResponse" AS result
+  WHERE result."poolItemId" IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "PracticeQuizAdaptivePoolItem" AS pool
+      WHERE pool."configId" = result."configId"
+        AND pool."sourceAssignmentId" = result."assignmentId"
+        AND pool."elementId" = result."elementId"
+    )
+  ORDER BY result."id"
+  LIMIT 1;
+
+  IF invalid_response_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Adaptive response % cannot be linked unambiguously to its immutable publication-pool item. Restore the pool row or archive the experimental response before retrying migration 20260713210000.', invalid_response_id;
+  END IF;
+END $$;
+
+UPDATE "AdaptivePracticeQuizResponse" AS result
+SET
+  "poolItemId" = pool."id",
+  "elementSnapshot" = COALESCE(result."elementSnapshot", pool."elementData")
+FROM "PracticeQuizAdaptivePoolItem" AS pool
+WHERE result."poolItemId" IS NULL
+  AND pool."configId" = result."configId"
+  AND pool."sourceAssignmentId" = result."assignmentId"
+  AND pool."elementId" = result."elementId";
+
+UPDATE "AdaptivePracticeQuizResponse" AS result
+SET "elementSnapshot" = pool."elementData"
+FROM "PracticeQuizAdaptivePoolItem" AS pool
+WHERE result."elementSnapshot" IS NULL
+  AND pool."id" = result."poolItemId"
+  AND pool."configId" = result."configId"
+  AND pool."sourceAssignmentId" = result."assignmentId"
+  AND pool."elementId" = result."elementId";
+
+-- An in-progress row without a next immutable item cannot be resumed safely.
+-- Preserve it as an abandoned result rather than inventing a new trajectory.
+UPDATE "AdaptivePracticeQuizAttempt"
+SET
+  "status" = 'ABANDONED',
+  "stopReason" = 'ABANDONED',
+  "nextPoolItemId" = NULL,
+  "completedAt" = COALESCE(
+    "completedAt",
+    "updatedAt",
+    "startedAt",
+    "createdAt",
+    CURRENT_TIMESTAMP
+  )
+WHERE "status" = 'IN_PROGRESS'
+  AND "nextPoolItemId" IS NULL;
+
+UPDATE "AdaptivePracticeQuizAttempt"
+SET
+  "stopReason" = NULL,
+  "completedAt" = NULL
+WHERE "status" = 'IN_PROGRESS'
+  AND "nextPoolItemId" IS NOT NULL
+  AND (
+    "stopReason" IS NOT NULL
+    OR "completedAt" IS NOT NULL
+  );
+
+UPDATE "AdaptivePracticeQuizAttempt"
+SET
+  "nextPoolItemId" = NULL,
+  "stopReason" = CASE
+    WHEN "stopReason" IS NULL OR "stopReason" = 'ABANDONED' THEN
+      CASE
+        WHEN "finalLevelId" IS NOT NULL THEN 'CLASSIFIED'::"AdaptivePracticeQuizStopReason"
+        ELSE 'INSUFFICIENT_DATA'::"AdaptivePracticeQuizStopReason"
+      END
+    ELSE "stopReason"
+  END,
+  "completedAt" = COALESCE(
+    "completedAt",
+    "updatedAt",
+    "startedAt",
+    "createdAt",
+    CURRENT_TIMESTAMP
+  )
+WHERE "status" = 'COMPLETED';
+
+UPDATE "AdaptivePracticeQuizAttempt"
+SET
+  "nextPoolItemId" = NULL,
+  "stopReason" = 'ABANDONED',
+  "completedAt" = COALESCE(
+    "completedAt",
+    "updatedAt",
+    "startedAt",
+    "createdAt",
+    CURRENT_TIMESTAMP
+  )
+WHERE "status" = 'ABANDONED';
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+VALIDATE CONSTRAINT "apqr_pool_item_required_check";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+VALIDATE CONSTRAINT "apqr_element_snapshot_required_check";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+VALIDATE CONSTRAINT "apqr_runtime_values_check";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+VALIDATE CONSTRAINT "apqa_runtime_state_check";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+VALIDATE CONSTRAINT "apqa_runtime_values_check";
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+VALIDATE CONSTRAINT "apqe_runtime_values_check";
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260713212000_adaptive_competence_tree_audit_type/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260713212000_adaptive_competence_tree_audit_type/migration.sql
@@ -1,0 +1,3 @@
+-- Competence-tree ownership transfers are operational account-closure events.
+-- Keep the value internal until generic sharing supports competence trees.
+ALTER TYPE "ObjectType" ADD VALUE IF NOT EXISTS 'COMPETENCE_TREE';

--- a/packages/prisma/src/prisma/schema/migrations/20260713213000_adaptive_history_retention/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260713213000_adaptive_history_retention/migration.sql
@@ -1,0 +1,73 @@
+-- Preserve adaptive attempt history when owners, quizzes, configs, or courses
+-- are removed. Participant and participation cascades deliberately remain so
+-- participant erasure can still delete the learner's adaptive history.
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '15min';
+
+ALTER TABLE "CompetenceTree"
+ADD CONSTRAINT "CompetenceTree_ownerId_restrict_fkey"
+FOREIGN KEY ("ownerId")
+REFERENCES "User" ("id")
+ON DELETE RESTRICT ON UPDATE CASCADE
+NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_config_quiz_tree_restrict_fkey"
+FOREIGN KEY ("configId", "practiceQuizId", "competenceTreeId")
+REFERENCES "PracticeQuizAdaptiveConfig" ("id", "practiceQuizId", "competenceTreeId")
+ON DELETE RESTRICT ON UPDATE CASCADE
+NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuiz_course_restrict_fkey"
+FOREIGN KEY ("practiceQuizId", "courseId")
+REFERENCES "PracticeQuiz" ("id", "courseId")
+ON DELETE RESTRICT ON UPDATE CASCADE
+NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+ADD CONSTRAINT "AdaptivePracticeQuizAttempt_courseId_fkey"
+FOREIGN KEY ("courseId")
+REFERENCES "Course" ("id")
+ON DELETE RESTRICT ON UPDATE CASCADE
+NOT VALID;
+
+ALTER TABLE "CompetenceTree"
+VALIDATE CONSTRAINT "CompetenceTree_ownerId_restrict_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+VALIDATE CONSTRAINT "AdaptivePracticeQuizAttempt_config_quiz_tree_restrict_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+VALIDATE CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuiz_course_restrict_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+VALIDATE CONSTRAINT "AdaptivePracticeQuizAttempt_courseId_fkey";
+
+ALTER TABLE "CompetenceTree"
+DROP CONSTRAINT "CompetenceTree_ownerId_fkey";
+
+ALTER TABLE "CompetenceTree"
+RENAME CONSTRAINT "CompetenceTree_ownerId_restrict_fkey"
+TO "CompetenceTree_ownerId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_config_quiz_tree_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+RENAME CONSTRAINT "AdaptivePracticeQuizAttempt_config_quiz_tree_restrict_fkey"
+TO "AdaptivePracticeQuizAttempt_config_quiz_tree_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+DROP CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuizId_courseId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+RENAME CONSTRAINT "AdaptivePracticeQuizAttempt_practiceQuiz_course_restrict_fkey"
+TO "AdaptivePracticeQuizAttempt_practiceQuizId_courseId_fkey";
+
+CREATE INDEX "apqa_course_retention_idx"
+ON "AdaptivePracticeQuizAttempt" ("courseId");
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260713220000_adaptive_remove_inert_settings/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260713220000_adaptive_remove_inert_settings/migration.sql
@@ -1,0 +1,50 @@
+-- Remove adaptive settings that never affect participant delivery. Completion
+-- results remain mandatory product behavior, not a configurable database flag.
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+DROP CONSTRAINT "pqac_numeric_bounds_check",
+DROP CONSTRAINT "pqac_preset_semantics_check",
+DROP CONSTRAINT "pqac_final_result_required_check";
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+DROP COLUMN "standardErrorThreshold",
+DROP COLUMN "showFinalResult",
+DROP COLUMN "showLiveEstimate",
+DROP COLUMN "enableSelfAssessmentWarmup";
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD CONSTRAINT "pqac_numeric_bounds_check"
+CHECK (
+  "totalQuestionCap" BETWEEN 1 AND 1000
+  AND ("perLeafQuestionCap" IS NULL OR "perLeafQuestionCap" BETWEEN 1 AND "totalQuestionCap")
+  AND "minQuestionsPerLeaf" BETWEEN 1 AND "totalQuestionCap"
+  AND "classificationZ" > 0 AND "classificationZ" <= 5
+  AND "topInformationRatio" > 0 AND "topInformationRatio" <= 1
+  AND "defaultDiscrimination" > 0 AND "defaultDiscrimination" <= 10
+);
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+ADD CONSTRAINT "pqac_preset_semantics_check"
+CHECK (
+  (
+    "preset" = 'PLACEMENT'
+    AND "levelMappingRule" = 'MASTERY'
+    AND "attemptSelectionPolicy" = 'FIRST_COMPLETED'
+    AND "topInformationRatio" = 0.8
+    AND "defaultDiscrimination" = 1.2
+  )
+  OR (
+    "preset" = 'DIAGNOSTIC'
+    AND "levelMappingRule" = 'NEAREST'
+    AND "attemptSelectionPolicy" = 'LATEST_COMPLETED'
+    AND "topInformationRatio" = 0.8
+    AND "defaultDiscrimination" = 1.2
+  )
+  OR "preset" = 'RESEARCH'
+);
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260714075147_adaptive_cohort_snapshots/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260714075147_adaptive_cohort_snapshots/migration.sql
@@ -1,0 +1,90 @@
+-- Persist only privacy-reviewed cohort aggregates at fixed release boundaries.
+CREATE TABLE "AdaptivePracticeQuizCohortSnapshot" (
+    "id" UUID NOT NULL,
+    "configId" UUID NOT NULL,
+    "practiceQuizId" UUID NOT NULL,
+    "releaseSize" INTEGER NOT NULL,
+    "releaseWatermark" TIMESTAMP(3) NOT NULL,
+    "policyVersion" INTEGER NOT NULL DEFAULT 1,
+    "attemptSelectionPolicy" "AdaptiveAttemptSelectionPolicy" NOT NULL,
+    "aggregate" JSONB NOT NULL,
+    "invalidatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdaptivePracticeQuizCohortSnapshot_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "apqcs_release_size_check" CHECK (
+      "releaseSize" >= 5 AND "releaseSize" % 5 = 0
+    ),
+    CONSTRAINT "apqcs_policy_version_check" CHECK ("policyVersion" > 0),
+    CONSTRAINT "apqcs_aggregate_schema_check" CHECK (
+      jsonb_typeof("aggregate") = 'object'
+      AND "aggregate" ->> 'schemaVersion' = '1'
+    )
+);
+
+CREATE INDEX "apqcs_config_valid_release_idx"
+  ON "AdaptivePracticeQuizCohortSnapshot"("configId", "invalidatedAt", "releaseSize");
+
+CREATE INDEX "apqcs_quiz_retention_idx"
+  ON "AdaptivePracticeQuizCohortSnapshot"("practiceQuizId");
+
+CREATE UNIQUE INDEX "apqcs_release_policy_key"
+  ON "AdaptivePracticeQuizCohortSnapshot"(
+    "configId",
+    "releaseSize",
+    "policyVersion",
+    "attemptSelectionPolicy"
+  );
+
+CREATE INDEX "apqa_quiz_status_completed_idx"
+  ON "AdaptivePracticeQuizAttempt"("practiceQuizId", "status", "completedAt", "id");
+
+CREATE INDEX "apqa_quiz_participant_completed_idx"
+  ON "AdaptivePracticeQuizAttempt"(
+    "practiceQuizId",
+    "participantId",
+    "status",
+    "completedAt",
+    "id"
+  );
+
+CREATE INDEX "apqe_attempt_node_level_idx"
+  ON "AdaptivePracticeQuizEstimate"("attemptId", "nodeKind", "nodeId", "levelId");
+
+CREATE INDEX "apqr_config_pool_attempt_idx"
+  ON "AdaptivePracticeQuizResponse"("configId", "poolItemId", "attemptId");
+
+ALTER TABLE "AdaptivePracticeQuizCohortSnapshot"
+  ADD CONSTRAINT "AdaptivePracticeQuizCohortSnapshot_configId_practiceQuizId_fkey"
+  FOREIGN KEY ("configId", "practiceQuizId")
+  REFERENCES "PracticeQuizAdaptiveConfig"("id", "practiceQuizId")
+  ON DELETE RESTRICT
+  ON UPDATE CASCADE;
+
+-- Participant erasure cascades through attempts. Any aggregate that may contain
+-- the erased participant's contribution is withheld until it is recomputed at
+-- a fresh complete release boundary.
+CREATE FUNCTION invalidate_adaptive_cohort_snapshots_on_attempt_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE "AdaptivePracticeQuizCohortSnapshot"
+  SET
+    "invalidatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP
+  WHERE "configId" IN (
+    SELECT DISTINCT "configId"
+    FROM deleted_adaptive_attempts
+  );
+
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER "apqa_invalidate_cohort_snapshots_after_delete"
+AFTER DELETE ON "AdaptivePracticeQuizAttempt"
+REFERENCING OLD TABLE AS deleted_adaptive_attempts
+FOR EACH STATEMENT
+EXECUTE FUNCTION invalidate_adaptive_cohort_snapshots_on_attempt_delete();

--- a/packages/prisma/src/prisma/schema/migrations/20260731120000_adaptive_irt_v2_records/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260731120000_adaptive_irt_v2_records/migration.sql
@@ -1,0 +1,358 @@
+-- Expand the adaptive-learning persistence model without rewriting legacy rows.
+-- References that depend on backfilled identities are added in the contract migration.
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+CREATE TYPE "AdaptiveMeasurementVersion" AS ENUM ('IRT_V1', 'IRT_V2_EAP_GRID_1');
+CREATE TYPE "AdaptiveScaleVersionStatus" AS ENUM ('DRAFT', 'IN_REVIEW', 'APPROVED', 'ACTIVE', 'REJECTED', 'SUPERSEDED');
+CREATE TYPE "AdaptiveScaleLinkStatus" AS ENUM ('DRAFT', 'IN_REVIEW', 'APPROVED', 'REJECTED', 'SUPERSEDED');
+CREATE TYPE "AdaptiveItemCalibrationStatus" AS ENUM ('PROVISIONAL', 'PILOT', 'CALIBRATED', 'FLAGGED', 'RETIRED');
+CREATE TYPE "AdaptiveItemModel" AS ENUM ('TWO_PL', 'THREE_PL_FIXED_C');
+CREATE TYPE "AdaptiveCalibrationExportStatus" AS ENUM ('REQUESTED', 'RUNNING', 'READY', 'FAILED', 'EXPIRED');
+CREATE TYPE "AdaptiveEmpiricalValidationStatus" AS ENUM ('SUBMITTED', 'APPROVED', 'REJECTED', 'SUPERSEDED');
+CREATE TYPE "AdaptiveResultStatus" AS ENUM ('CLASSIFIED', 'BETWEEN_LEVELS', 'INSUFFICIENT_EVIDENCE', 'POOL_LIMITED', 'RESEARCH_ONLY');
+CREATE TYPE "AdaptivePoolItemRole" AS ENUM ('SCORING', 'ANCHOR', 'FIELD_TEST');
+
+ALTER TABLE "Course"
+  ADD COLUMN "isAdaptiveLearningCalibrationEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+  ADD COLUMN "measurementVersion" "AdaptiveMeasurementVersion" NOT NULL DEFAULT 'IRT_V1',
+  ADD COLUMN "calibrationPolicyVersion" INTEGER,
+  ADD COLUMN "scaleVersionId" UUID;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ADD COLUMN "publicationId" UUID,
+  ADD COLUMN "scaleVersionId" UUID,
+  ADD COLUMN "calibrationId" UUID,
+  ADD COLUMN "measurementVersion" "AdaptiveMeasurementVersion",
+  ADD COLUMN "calibrationVersion" INTEGER,
+  ADD COLUMN "calibrationStatus" "AdaptiveItemCalibrationStatus",
+  ADD COLUMN "itemModel" "AdaptiveItemModel",
+  ADD COLUMN "modelImplementationVersion" TEXT,
+  ADD COLUMN "role" "AdaptivePoolItemRole" NOT NULL DEFAULT 'SCORING',
+  ADD COLUMN "contributesToEstimate" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+  ADD COLUMN "publicationId" UUID,
+  ADD COLUMN "scaleVersionId" UUID,
+  ADD COLUMN "measurementVersion" "AdaptiveMeasurementVersion",
+  ADD COLUMN "estimatorImplementationVersion" TEXT,
+  ADD COLUMN "classificationPolicyVersion" INTEGER,
+  ADD COLUMN "calibrationPolicyVersion" INTEGER,
+  ADD COLUMN "finalScaleLevelId" INTEGER,
+  ADD COLUMN "nextAdministrationProbability" DOUBLE PRECISION,
+  ADD COLUMN "nextCollectionDesignVersion" TEXT,
+  ADD COLUMN "nextRandomizationVersion" TEXT,
+  ADD COLUMN "nextRandomDraw" BIGINT,
+  ADD COLUMN "nextCandidateSetHash" TEXT,
+  ADD COLUMN "nextItemRole" "AdaptivePoolItemRole",
+  ADD COLUMN "resultStatus" "AdaptiveResultStatus",
+  ADD COLUMN "finalBandProbability" DOUBLE PRECISION,
+  ADD COLUMN "credibleLower" DOUBLE PRECISION,
+  ADD COLUMN "credibleUpper" DOUBLE PRECISION,
+  ADD COLUMN "bandProbabilities" JSONB;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+  ADD COLUMN "publicationId" UUID,
+  ADD COLUMN "overallCredibleLowerAfter" DOUBLE PRECISION,
+  ADD COLUMN "overallCredibleUpperAfter" DOUBLE PRECISION,
+  ADD COLUMN "overallBandProbabilitiesAfter" JSONB,
+  ADD COLUMN "administrationProbability" DOUBLE PRECISION,
+  ADD COLUMN "collectionDesignVersion" TEXT,
+  ADD COLUMN "randomizationVersion" TEXT,
+  ADD COLUMN "randomDraw" BIGINT,
+  ADD COLUMN "candidateSetHash" TEXT,
+  ADD COLUMN "itemRole" "AdaptivePoolItemRole" NOT NULL DEFAULT 'SCORING',
+  ADD COLUMN "isCalibrationAnchor" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+  ADD COLUMN "resultStatus" "AdaptiveResultStatus",
+  ADD COLUMN "classificationProbability" DOUBLE PRECISION,
+  ADD COLUMN "credibleLower" DOUBLE PRECISION,
+  ADD COLUMN "credibleUpper" DOUBLE PRECISION,
+  ADD COLUMN "bandProbabilities" JSONB;
+
+CREATE TABLE "CompetenceTreeScaleVersion" (
+  "id" UUID NOT NULL,
+  "version" INTEGER NOT NULL,
+  "status" "AdaptiveScaleVersionStatus" NOT NULL DEFAULT 'DRAFT',
+  "priorMean" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "priorStandardDeviation" DOUBLE PRECISION NOT NULL DEFAULT 1,
+  "gridMin" DOUBLE PRECISION NOT NULL DEFAULT -6,
+  "gridMax" DOUBLE PRECISION NOT NULL DEFAULT 6,
+  "gridStep" DOUBLE PRECISION NOT NULL DEFAULT 0.1,
+  "classificationPolicyVersion" INTEGER NOT NULL DEFAULT 1,
+  "treeId" UUID NOT NULL,
+  "supersedesVersionId" UUID,
+  "createdById" UUID,
+  "submittedForReviewAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "CompetenceTreeScaleVersion_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CompetenceTreeScaleLevel" (
+  "id" SERIAL NOT NULL,
+  "order" INTEGER NOT NULL,
+  "label" TEXT NOT NULL,
+  "lowerBound" DOUBLE PRECISION,
+  "itemDifficultyPrior" DOUBLE PRECISION NOT NULL,
+  "treeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "sourceLevelId" INTEGER,
+  CONSTRAINT "CompetenceTreeScaleLevel_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CompetenceTreeScaleApproval" (
+  "id" UUID NOT NULL,
+  "treeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "method" TEXT NOT NULL,
+  "methodVersion" TEXT NOT NULL,
+  "panelSize" INTEGER NOT NULL,
+  "standardSettingDate" TIMESTAMP(3) NOT NULL,
+  "cutRationale" JSONB NOT NULL,
+  "artifactChecksum" TEXT NOT NULL,
+  "artifactKey" TEXT NOT NULL,
+  "decision" "AdaptiveScaleVersionStatus",
+  "submittedById" UUID,
+  "reviewerId" UUID,
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "CompetenceTreeScaleApproval_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CompetenceTreeScaleLink" (
+  "id" UUID NOT NULL,
+  "status" "AdaptiveScaleLinkStatus" NOT NULL DEFAULT 'DRAFT',
+  "treeId" UUID NOT NULL,
+  "fromScaleVersionId" UUID NOT NULL,
+  "toScaleVersionId" UUID NOT NULL,
+  "method" TEXT NOT NULL,
+  "implementationVersion" TEXT NOT NULL,
+  "fitMetrics" JSONB NOT NULL,
+  "uncertaintyMetrics" JSONB NOT NULL,
+  "artifactChecksum" TEXT NOT NULL,
+  "artifactKey" TEXT NOT NULL,
+  "createdById" UUID,
+  "reviewedById" UUID,
+  "submittedForReviewAt" TIMESTAMP(3),
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "CompetenceTreeScaleLink_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CompetenceTreeScaleLinkAnchor" (
+  "id" SERIAL NOT NULL,
+  "scaleLinkId" UUID NOT NULL,
+  "fromCalibrationId" UUID NOT NULL,
+  "toCalibrationId" UUID NOT NULL,
+  "order" INTEGER NOT NULL,
+  CONSTRAINT "CompetenceTreeScaleLinkAnchor_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AdaptiveItemCalibration" (
+  "id" UUID NOT NULL,
+  "version" INTEGER NOT NULL,
+  "model" "AdaptiveItemModel" NOT NULL,
+  "status" "AdaptiveItemCalibrationStatus" NOT NULL DEFAULT 'PROVISIONAL',
+  "discrimination" DOUBLE PRECISION NOT NULL,
+  "difficulty" DOUBLE PRECISION NOT NULL,
+  "guessing" DOUBLE PRECISION NOT NULL,
+  "parameterUncertainty" JSONB NOT NULL,
+  "responseCount" INTEGER NOT NULL DEFAULT 0,
+  "participantCount" INTEGER NOT NULL DEFAULT 0,
+  "diagnostics" JSONB NOT NULL,
+  "datasetVersion" TEXT NOT NULL,
+  "datasetChecksum" TEXT NOT NULL,
+  "calibrationJobId" TEXT,
+  "modelImplementationVersion" TEXT NOT NULL,
+  "elementContentChecksum" TEXT NOT NULL,
+  "treeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "assignmentId" INTEGER NOT NULL,
+  "elementId" INTEGER NOT NULL,
+  "elementVersion" INTEGER NOT NULL,
+  "createdById" UUID,
+  "approvedById" UUID,
+  "approvedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AdaptiveItemCalibration_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PracticeQuizAdaptivePublication" (
+  "id" UUID NOT NULL,
+  "version" INTEGER NOT NULL,
+  "configId" UUID NOT NULL,
+  "competenceTreeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "measurementVersion" "AdaptiveMeasurementVersion" NOT NULL,
+  "preset" "AdaptivePracticeQuizPreset" NOT NULL,
+  "estimatorImplementationVersion" TEXT NOT NULL,
+  "classificationPolicyVersion" INTEGER NOT NULL,
+  "calibrationPolicyVersion" INTEGER NOT NULL,
+  "cutScoreSnapshot" JSONB NOT NULL,
+  "priorMean" DOUBLE PRECISION NOT NULL,
+  "priorStandardDeviation" DOUBLE PRECISION NOT NULL,
+  "gridMin" DOUBLE PRECISION NOT NULL,
+  "gridMax" DOUBLE PRECISION NOT NULL,
+  "gridStep" DOUBLE PRECISION NOT NULL,
+  "classificationProbabilityThreshold" DOUBLE PRECISION,
+  "hierarchicalWeightSnapshot" JSONB NOT NULL,
+  "evidenceMinimumSnapshot" JSONB NOT NULL,
+  "totalQuestionCap" INTEGER NOT NULL,
+  "showTimer" BOOLEAN NOT NULL,
+  "questionCapSnapshot" JSONB NOT NULL,
+  "candidateSetPolicyVersion" TEXT NOT NULL,
+  "randomizationPolicyVersion" TEXT NOT NULL,
+  "exposureCeiling" DOUBLE PRECISION NOT NULL,
+  "overlapPolicyVersion" TEXT NOT NULL,
+  "retakePolicy" "AdaptiveAttemptSelectionPolicy" NOT NULL,
+  "retakeCooldownDays" INTEGER NOT NULL,
+  "researchAllocationPolicy" JSONB,
+  "stoppingPolicyVersion" TEXT NOT NULL,
+  "rolloutPolicyVersion" INTEGER NOT NULL,
+  "empiricalValidationId" UUID,
+  "publishedById" UUID,
+  "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "sealedAt" TIMESTAMP(3),
+  "supersededAt" TIMESTAMP(3),
+  "unpublishedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PracticeQuizAdaptivePublication_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "AdaptivePracticeQuizCohortSnapshot"
+  ADD COLUMN "publicationId" UUID,
+  ADD COLUMN "scaleVersionId" UUID,
+  ADD COLUMN "measurementVersion" "AdaptiveMeasurementVersion";
+
+CREATE TABLE "AdaptiveCalibrationExportRequest" (
+  "id" UUID NOT NULL,
+  "status" "AdaptiveCalibrationExportStatus" NOT NULL DEFAULT 'REQUESTED',
+  "treeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "requestedById" UUID,
+  "artifactKey" TEXT,
+  "artifactChecksum" TEXT,
+  "rowCount" INTEGER,
+  "failureCode" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "startedAt" TIMESTAMP(3),
+  "completedAt" TIMESTAMP(3),
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AdaptiveCalibrationExportRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AdaptivePracticeQuizEmpiricalValidation" (
+  "id" UUID NOT NULL,
+  "status" "AdaptiveEmpiricalValidationStatus" NOT NULL DEFAULT 'SUBMITTED',
+  "configId" UUID NOT NULL,
+  "competenceTreeId" UUID NOT NULL,
+  "scaleVersionId" UUID NOT NULL,
+  "exportRequestId" UUID NOT NULL,
+  "bankFingerprint" TEXT NOT NULL,
+  "configFingerprint" TEXT NOT NULL,
+  "measurementVersion" "AdaptiveMeasurementVersion" NOT NULL,
+  "estimatorImplementationVersion" TEXT NOT NULL,
+  "classificationPolicyVersion" INTEGER NOT NULL,
+  "calibrationPolicyVersion" INTEGER NOT NULL,
+  "validationProtocolVersion" TEXT NOT NULL,
+  "approvedProbabilityThreshold" DOUBLE PRECISION NOT NULL,
+  "calibrationDatasetVersion" TEXT NOT NULL,
+  "calibrationDatasetChecksum" TEXT NOT NULL,
+  "holdoutDatasetVersion" TEXT NOT NULL,
+  "holdoutDatasetChecksum" TEXT NOT NULL,
+  "disjointSplitProofChecksum" TEXT NOT NULL,
+  "criterionArtifactChecksum" TEXT NOT NULL,
+  "aggregateMetrics" JSONB NOT NULL,
+  "stratumMetrics" JSONB NOT NULL,
+  "artifactChecksum" TEXT NOT NULL,
+  "artifactKey" TEXT NOT NULL,
+  "submittedById" UUID,
+  "approvedById" UUID,
+  "submittedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AdaptivePracticeQuizItemExposure" (
+  "id" SERIAL NOT NULL,
+  "publicationId" UUID NOT NULL,
+  "poolItemId" INTEGER NOT NULL,
+  "servedCount" BIGINT NOT NULL DEFAULT 0,
+  "answeredCount" BIGINT NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AdaptivePracticeQuizItemExposure_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ctsv_tree_status_idx" ON "CompetenceTreeScaleVersion"("treeId", "status");
+CREATE INDEX "ctsv_created_by_idx" ON "CompetenceTreeScaleVersion"("createdById");
+CREATE UNIQUE INDEX "ctsv_tree_version_key" ON "CompetenceTreeScaleVersion"("treeId", "version");
+CREATE UNIQUE INDEX "ctsv_tree_id_key" ON "CompetenceTreeScaleVersion"("treeId", "id");
+CREATE INDEX "ctsl_tree_source_level_idx" ON "CompetenceTreeScaleLevel"("treeId", "sourceLevelId");
+CREATE UNIQUE INDEX "ctsl_scale_order_key" ON "CompetenceTreeScaleLevel"("scaleVersionId", "order");
+CREATE UNIQUE INDEX "ctsl_scale_id_key" ON "CompetenceTreeScaleLevel"("scaleVersionId", "id");
+CREATE UNIQUE INDEX "ctsl_tree_scale_id_key" ON "CompetenceTreeScaleLevel"("treeId", "scaleVersionId", "id");
+CREATE INDEX "ctsa_tree_scale_idx" ON "CompetenceTreeScaleApproval"("treeId", "scaleVersionId");
+CREATE INDEX "ctsa_submitted_by_idx" ON "CompetenceTreeScaleApproval"("submittedById");
+CREATE INDEX "ctsa_reviewer_idx" ON "CompetenceTreeScaleApproval"("reviewerId");
+CREATE INDEX "ctslk_created_by_idx" ON "CompetenceTreeScaleLink"("createdById");
+CREATE INDEX "ctslk_reviewed_by_idx" ON "CompetenceTreeScaleLink"("reviewedById");
+CREATE UNIQUE INDEX "ctslk_tree_versions_key" ON "CompetenceTreeScaleLink"("treeId", "fromScaleVersionId", "toScaleVersionId");
+CREATE INDEX "ctsla_from_calibration_idx" ON "CompetenceTreeScaleLinkAnchor"("fromCalibrationId");
+CREATE INDEX "ctsla_to_calibration_idx" ON "CompetenceTreeScaleLinkAnchor"("toCalibrationId");
+CREATE UNIQUE INDEX "ctsla_link_order_key" ON "CompetenceTreeScaleLinkAnchor"("scaleLinkId", "order");
+CREATE UNIQUE INDEX "ctsla_link_pair_key" ON "CompetenceTreeScaleLinkAnchor"("scaleLinkId", "fromCalibrationId", "toCalibrationId");
+CREATE INDEX "aic_assignment_element_version_idx" ON "AdaptiveItemCalibration"("assignmentId", "elementId", "elementVersion");
+CREATE INDEX "aic_scale_status_idx" ON "AdaptiveItemCalibration"("scaleVersionId", "status");
+CREATE INDEX "aic_approved_by_idx" ON "AdaptiveItemCalibration"("approvedById");
+CREATE UNIQUE INDEX "aic_measurement_version_key" ON "AdaptiveItemCalibration"("treeId", "scaleVersionId", "assignmentId", "elementId", "elementVersion", "version");
+CREATE UNIQUE INDEX "aic_tree_scale_id_key" ON "AdaptiveItemCalibration"("treeId", "scaleVersionId", "id");
+CREATE UNIQUE INDEX "aic_pool_identity_key" ON "AdaptiveItemCalibration"("treeId", "scaleVersionId", "id", "assignmentId", "elementId", "elementVersion");
+CREATE INDEX "pqap_scale_idx" ON "PracticeQuizAdaptivePublication"("scaleVersionId");
+CREATE INDEX "pqap_validation_idx" ON "PracticeQuizAdaptivePublication"("empiricalValidationId");
+CREATE INDEX "pqap_published_by_idx" ON "PracticeQuizAdaptivePublication"("publishedById");
+CREATE UNIQUE INDEX "pqap_config_version_key" ON "PracticeQuizAdaptivePublication"("configId", "version");
+CREATE UNIQUE INDEX "pqap_config_id_key" ON "PracticeQuizAdaptivePublication"("configId", "id");
+CREATE UNIQUE INDEX "pqap_tree_id_key" ON "PracticeQuizAdaptivePublication"("competenceTreeId", "id");
+CREATE UNIQUE INDEX "pqap_id_scale_measurement_key" ON "PracticeQuizAdaptivePublication"("id", "scaleVersionId", "measurementVersion");
+CREATE UNIQUE INDEX "pqap_id_config_tree_key" ON "PracticeQuizAdaptivePublication"("id", "configId", "competenceTreeId");
+CREATE UNIQUE INDEX "pqap_dispatch_identity_key" ON "PracticeQuizAdaptivePublication"("id", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion");
+
+DROP INDEX "apqcs_release_policy_key";
+CREATE UNIQUE INDEX "apqcs_publication_release_policy_key"
+  ON "AdaptivePracticeQuizCohortSnapshot"("publicationId", "releaseSize", "policyVersion", "attemptSelectionPolicy");
+CREATE INDEX "acer_tree_scale_status_idx" ON "AdaptiveCalibrationExportRequest"("treeId", "scaleVersionId", "status");
+CREATE INDEX "acer_requester_created_idx" ON "AdaptiveCalibrationExportRequest"("requestedById", "createdAt");
+CREATE INDEX "acer_status_expiry_idx" ON "AdaptiveCalibrationExportRequest"("status", "expiresAt");
+CREATE INDEX "apqev_config_status_idx" ON "AdaptivePracticeQuizEmpiricalValidation"("configId", "status");
+CREATE INDEX "apqev_scale_idx" ON "AdaptivePracticeQuizEmpiricalValidation"("scaleVersionId");
+CREATE INDEX "apqev_export_request_idx" ON "AdaptivePracticeQuizEmpiricalValidation"("exportRequestId");
+CREATE INDEX "apqev_submitted_by_idx" ON "AdaptivePracticeQuizEmpiricalValidation"("submittedById");
+CREATE INDEX "apqev_approved_by_idx" ON "AdaptivePracticeQuizEmpiricalValidation"("approvedById");
+CREATE UNIQUE INDEX "apqev_publication_identity_key" ON "AdaptivePracticeQuizEmpiricalValidation"("id", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion");
+CREATE UNIQUE INDEX "apqev_evidence_identity_key" ON "AdaptivePracticeQuizEmpiricalValidation"("configId", "bankFingerprint", "configFingerprint", "scaleVersionId", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion", "validationProtocolVersion", "approvedProbabilityThreshold", "exportRequestId", "criterionArtifactChecksum");
+CREATE INDEX "apqie_publication_served_idx" ON "AdaptivePracticeQuizItemExposure"("publicationId", "servedCount");
+CREATE UNIQUE INDEX "apqie_publication_pool_key" ON "AdaptivePracticeQuizItemExposure"("publicationId", "poolItemId");
+
+CREATE INDEX "apqa_publication_next_pool_idx" ON "AdaptivePracticeQuizAttempt"("publicationId", "nextPoolItemId");
+CREATE INDEX "apqa_scale_version_idx" ON "AdaptivePracticeQuizAttempt"("scaleVersionId");
+CREATE UNIQUE INDEX "apqa_id_config_publication_key" ON "AdaptivePracticeQuizAttempt"("id", "configId", "publicationId");
+CREATE INDEX "apqr_publication_pool_attempt_idx" ON "AdaptivePracticeQuizResponse"("publicationId", "poolItemId", "attemptId");
+CREATE INDEX "pqapi_publication_leaf_level_idx" ON "PracticeQuizAdaptivePoolItem"("publicationId", "leafNodeId", "levelId");
+CREATE INDEX "pqapi_calibration_idx" ON "PracticeQuizAdaptivePoolItem"("calibrationId");
+CREATE UNIQUE INDEX "pqapi_publication_assignment_key" ON "PracticeQuizAdaptivePoolItem"("publicationId", "sourceAssignmentId");
+CREATE UNIQUE INDEX "pqapi_publication_id_key" ON "PracticeQuizAdaptivePoolItem"("publicationId", "id");
+CREATE UNIQUE INDEX "pqapi_publication_response_key" ON "PracticeQuizAdaptivePoolItem"("publicationId", "id", "sourceAssignmentId", "elementId");
+CREATE UNIQUE INDEX "ctea_tree_id_element_key" ON "CompetenceTreeElementAssignment"("treeId", "id", "elementId");
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260731121000_adaptive_irt_v2_backfill/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260731121000_adaptive_irt_v2_backfill/migration.sql
@@ -1,0 +1,560 @@
+-- Guard and migrate legacy adaptive-learning rows into immutable v1 records.
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "CompetenceTree"
+    WHERE "thetaMin"::text IN ('NaN', 'Infinity', '-Infinity')
+       OR "thetaMax"::text IN ('NaN', 'Infinity', '-Infinity')
+       OR "defaultDiscrimination"::text IN ('NaN', 'Infinity', '-Infinity')
+       OR "thetaMin" >= "thetaMax"
+       OR "defaultDiscrimination" <= 0
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 backfill rejected invalid competence-tree geometry';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "CompetenceTreeLevel"
+    GROUP BY "treeId"
+    HAVING min("order") <> 0
+       OR max("order") <> count(*) - 1
+       OR count(DISTINCT "order") <> count(*)
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 backfill requires contiguous zero-based level orders';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "CompetenceTreeElementAssignment" assignment
+    JOIN "Element" element ON element.id = assignment."elementId"
+    WHERE element.version IS NULL OR element.version < 1
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 backfill requires positive element versions';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptivePoolItem"
+    GROUP BY "configId", "sourceAssignmentId"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 backfill found duplicate active pool assignments';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptivePoolItem" pool
+    JOIN "PracticeQuizAdaptiveConfig" config ON config.id = pool."configId"
+    JOIN "CompetenceTreeElementAssignment" assignment ON assignment.id = pool."sourceAssignmentId"
+    JOIN "Element" element ON element.id = assignment."elementId"
+    WHERE pool."competenceTreeId" <> config."competenceTreeId"
+       OR assignment."treeId" <> config."competenceTreeId"
+       OR pool."elementId" <> assignment."elementId"
+       OR pool."elementVersion" < 1
+       OR pool."elementVersion" > element.version
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 backfill found an inconsistent legacy publication pool';
+  END IF;
+END $$;
+
+INSERT INTO "CompetenceTreeScaleVersion" (
+  "id",
+  "version",
+  "status",
+  "priorMean",
+  "priorStandardDeviation",
+  "gridMin",
+  "gridMax",
+  "gridStep",
+  "classificationPolicyVersion",
+  "treeId",
+  "createdById",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  md5('adaptive-scale:' || tree.id::text)::uuid,
+  1,
+  'DRAFT'::"AdaptiveScaleVersionStatus",
+  0,
+  1,
+  least(-6, tree."thetaMin"),
+  greatest(6, tree."thetaMax"),
+  0.1,
+  1,
+  tree.id,
+  tree."ownerId",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM "CompetenceTree" tree;
+
+WITH ordered_levels AS (
+  SELECT
+    level.id,
+    level."treeId",
+    level.label,
+    level."order",
+    tree."thetaMin",
+    tree."thetaMax",
+    tree."levelMappingRule",
+    count(*) OVER (PARTITION BY level."treeId")::double precision AS level_count
+  FROM "CompetenceTreeLevel" level
+  JOIN "CompetenceTree" tree ON tree.id = level."treeId"
+), anchored_levels AS (
+  SELECT
+    *,
+    CASE
+      WHEN level_count = 1 THEN ("thetaMin" + "thetaMax") / 2
+      WHEN "levelMappingRule" = 'NEAREST'::"AdaptiveLevelMappingRule"
+        THEN "thetaMin" + ("thetaMax" - "thetaMin") * "order" / (level_count - 1)
+      ELSE "thetaMin" + ("thetaMax" - "thetaMin") * "order" / level_count
+    END AS anchor
+  FROM ordered_levels
+)
+INSERT INTO "CompetenceTreeScaleLevel" (
+  "order",
+  "label",
+  "lowerBound",
+  "itemDifficultyPrior",
+  "treeId",
+  "scaleVersionId",
+  "sourceLevelId"
+)
+SELECT
+  "order",
+  label,
+  CASE
+    WHEN "order" = 0 THEN NULL
+    WHEN "levelMappingRule" = 'NEAREST'::"AdaptiveLevelMappingRule"
+      THEN (lag(anchor) OVER (PARTITION BY "treeId" ORDER BY "order") + anchor) / 2
+    ELSE anchor
+  END,
+  anchor,
+  "treeId",
+  md5('adaptive-scale:' || "treeId"::text)::uuid,
+  id
+FROM anchored_levels;
+
+WITH legacy_item_sources AS (
+  SELECT
+    assignment.id AS assignment_id,
+    assignment."treeId" AS tree_id,
+    assignment."elementId" AS element_id,
+    element.version AS element_version,
+    element.type AS element_type,
+    element.content || ':' || element.options::text AS content_payload,
+    coalesce(assignment.discrimination, tree."defaultDiscrimination") AS discrimination,
+    scale_level."itemDifficultyPrior" AS difficulty,
+    coalesce(
+      (
+        SELECT pool.guessing
+        FROM "PracticeQuizAdaptivePoolItem" pool
+        WHERE pool."sourceAssignmentId" = assignment.id
+          AND pool."elementVersion" = element.version
+        ORDER BY pool.id
+        LIMIT 1
+      ),
+      CASE element.type
+        WHEN 'SC'::"ElementType" THEN 1.0 / greatest(
+          CASE WHEN jsonb_typeof(element.options -> 'choices') = 'array'
+            THEN jsonb_array_length(element.options -> 'choices') ELSE 4 END,
+          2
+        )
+        WHEN 'MC'::"ElementType" THEN 1.0 / greatest(
+          power(2, CASE WHEN jsonb_typeof(element.options -> 'choices') = 'array'
+            THEN jsonb_array_length(element.options -> 'choices') ELSE 4 END) - 1,
+          1
+        )
+        WHEN 'KPRIM'::"ElementType" THEN 1.0 / power(
+          2,
+          CASE WHEN jsonb_typeof(element.options -> 'choices') = 'array'
+            THEN jsonb_array_length(element.options -> 'choices') ELSE 4 END
+        )
+        ELSE 0
+      END
+    ) AS guessing,
+    1 AS source_priority
+  FROM "CompetenceTreeElementAssignment" assignment
+  JOIN "CompetenceTree" tree ON tree.id = assignment."treeId"
+  JOIN "Element" element ON element.id = assignment."elementId"
+  JOIN "CompetenceTreeScaleLevel" scale_level
+    ON scale_level."treeId" = assignment."treeId"
+   AND scale_level."sourceLevelId" = assignment."levelId"
+  UNION ALL
+  SELECT
+    pool."sourceAssignmentId",
+    pool."competenceTreeId",
+    pool."elementId",
+    pool."elementVersion",
+    pool."elementType",
+    pool."elementData"::text,
+    pool.discrimination,
+    pool.difficulty,
+    pool.guessing,
+    0
+  FROM "PracticeQuizAdaptivePoolItem" pool
+), legacy_item_parameters AS (
+  SELECT DISTINCT ON (assignment_id, element_version)
+    assignment_id,
+    tree_id,
+    element_id,
+    element_version,
+    element_type,
+    content_payload,
+    discrimination,
+    difficulty,
+    guessing
+  FROM legacy_item_sources
+  ORDER BY assignment_id, element_version, source_priority
+)
+INSERT INTO "AdaptiveItemCalibration" (
+  "id",
+  "version",
+  "model",
+  "status",
+  "discrimination",
+  "difficulty",
+  "guessing",
+  "parameterUncertainty",
+  "responseCount",
+  "participantCount",
+  "diagnostics",
+  "datasetVersion",
+  "datasetChecksum",
+  "modelImplementationVersion",
+  "elementContentChecksum",
+  "treeId",
+  "scaleVersionId",
+  "assignmentId",
+  "elementId",
+  "elementVersion",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  md5('adaptive-calibration:' || assignment_id::text || ':' || element_version::text || ':1')::uuid,
+  1,
+  CASE
+    WHEN element_type IN ('NUMERICAL'::"ElementType", 'FREE_TEXT'::"ElementType")
+      THEN 'TWO_PL'::"AdaptiveItemModel"
+    ELSE 'THREE_PL_FIXED_C'::"AdaptiveItemModel"
+  END,
+  'PROVISIONAL'::"AdaptiveItemCalibrationStatus",
+  discrimination,
+  difficulty,
+  guessing,
+  jsonb_build_object(
+    'discriminationStandardError', NULL,
+    'difficultyStandardError', NULL,
+    'guessingStandardError', NULL,
+    'discriminationInterval', NULL,
+    'difficultyInterval', NULL,
+    'guessingInterval', NULL
+  ),
+  0,
+  0,
+  jsonb_build_object(
+    'fitStatus', 'WARN',
+    'difStatus', 'WARN',
+    'driftStatus', 'WARN',
+    'fitStatistics', '{}'::jsonb,
+    'warningCodes', jsonb_build_array('LEGACY_AUTHOR_PRIOR_NOT_EMPIRICALLY_CALIBRATED'),
+    'dif', '{}'::jsonb,
+    'drift', '{}'::jsonb
+  ),
+  'legacy-author-prior-v1',
+  'legacy-md5:' || md5(tree_id::text || ':' || assignment_id::text || ':' || element_version::text),
+  'irt-v1-author-prior',
+  'legacy-md5:' || md5(
+    element_id::text || ':' || element_version::text || ':' || content_payload
+  ),
+  tree_id,
+  md5('adaptive-scale:' || tree_id::text)::uuid,
+  assignment_id,
+  element_id,
+  element_version,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM legacy_item_parameters;
+
+INSERT INTO "PracticeQuizAdaptivePublication" (
+  "id",
+  "version",
+  "configId",
+  "competenceTreeId",
+  "scaleVersionId",
+  "measurementVersion",
+  "preset",
+  "estimatorImplementationVersion",
+  "classificationPolicyVersion",
+  "calibrationPolicyVersion",
+  "cutScoreSnapshot",
+  "priorMean",
+  "priorStandardDeviation",
+  "gridMin",
+  "gridMax",
+  "gridStep",
+  "classificationProbabilityThreshold",
+  "hierarchicalWeightSnapshot",
+  "evidenceMinimumSnapshot",
+  "totalQuestionCap",
+  "showTimer",
+  "questionCapSnapshot",
+  "candidateSetPolicyVersion",
+  "randomizationPolicyVersion",
+  "exposureCeiling",
+  "overlapPolicyVersion",
+  "retakePolicy",
+  "retakeCooldownDays",
+  "researchAllocationPolicy",
+  "stoppingPolicyVersion",
+  "rolloutPolicyVersion",
+  "publishedAt",
+  "unpublishedAt",
+  "createdAt"
+)
+SELECT
+  md5('adaptive-publication:' || config.id::text || ':1')::uuid,
+  1,
+  config.id,
+  config."competenceTreeId",
+  md5('adaptive-scale:' || config."competenceTreeId"::text)::uuid,
+  'IRT_V1'::"AdaptiveMeasurementVersion",
+  config.preset,
+  'irt-v1-legacy',
+  1,
+  1,
+  coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+      'scaleLevelId', scale_level.id,
+      'sourceLevelId', scale_level."sourceLevelId",
+      'order', scale_level."order",
+      'label', scale_level.label,
+      'lowerBound', scale_level."lowerBound",
+      'itemDifficultyPrior', scale_level."itemDifficultyPrior"
+    ) ORDER BY scale_level."order")
+    FROM "CompetenceTreeScaleLevel" scale_level
+    WHERE scale_level."scaleVersionId" = md5('adaptive-scale:' || config."competenceTreeId"::text)::uuid
+  ), '[]'::jsonb),
+  0,
+  1,
+  least(-6, tree."thetaMin"),
+  greatest(6, tree."thetaMax"),
+  0.1,
+  NULL,
+  coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+      'nodeId', hierarchy.id,
+      'name', hierarchy.name,
+      'parentId', hierarchy."parentId",
+      'kind', hierarchy.kind,
+      'depth', hierarchy.depth,
+      'order', hierarchy."order",
+      'nodePath', hierarchy.node_path,
+      'enabled', hierarchy.enabled,
+      'normalizedWeight', hierarchy.normalized_weight,
+      'effectiveLeafWeight', CASE WHEN hierarchy.is_leaf THEN hierarchy.effective_weight ELSE NULL END
+    ) ORDER BY hierarchy.node_path)
+    FROM (
+      WITH RECURSIVE effective_nodes AS (
+        SELECT
+          node.id,
+          node.name,
+          node."parentId",
+          node.kind,
+          node.depth,
+          node."order",
+          coalesce(override.enabled, true) AS enabled,
+          coalesce(override.weight, node.weight) AS weight
+        FROM "CompetenceTreeNode" node
+        LEFT JOIN "PracticeQuizAdaptiveNodeOverride" override
+          ON override."configId" = config.id AND override."nodeId" = node.id
+        WHERE node."treeId" = config."competenceTreeId"
+      ), hierarchy AS (
+        SELECT
+          node.id,
+          node.name,
+          node."parentId",
+          node.kind,
+          node.depth,
+          node."order",
+          ARRAY[node.id] AS node_path,
+          node.enabled,
+          CASE WHEN node.enabled THEN node.weight / NULLIF(sum(node.weight) FILTER (WHERE node.enabled) OVER (), 0) ELSE 0 END AS normalized_weight,
+          CASE WHEN node.enabled THEN node.weight / NULLIF(sum(node.weight) FILTER (WHERE node.enabled) OVER (), 0) ELSE 0 END AS effective_weight
+        FROM effective_nodes node
+        WHERE node."parentId" IS NULL
+
+        UNION ALL
+
+        SELECT
+          child.id,
+          child.name,
+          child."parentId",
+          child.kind,
+          child.depth,
+          child."order",
+          parent.node_path || child.id,
+          parent.enabled AND child.enabled,
+          CASE
+            WHEN parent.enabled AND child.enabled THEN child.weight / NULLIF((
+              SELECT sum(sibling.weight) FROM effective_nodes sibling
+              WHERE sibling."parentId" = child."parentId" AND sibling.enabled
+            ), 0)
+            ELSE 0
+          END,
+          parent.effective_weight * CASE
+            WHEN parent.enabled AND child.enabled THEN child.weight / NULLIF((
+              SELECT sum(sibling.weight) FROM effective_nodes sibling
+              WHERE sibling."parentId" = child."parentId" AND sibling.enabled
+            ), 0)
+            ELSE 0
+          END
+        FROM effective_nodes child
+        JOIN hierarchy parent ON parent.id = child."parentId"
+      )
+      SELECT
+        hierarchy.*,
+        NOT EXISTS (SELECT 1 FROM effective_nodes child WHERE child."parentId" = hierarchy.id) AS is_leaf
+      FROM hierarchy
+    ) hierarchy
+  ), '[]'::jsonb),
+  jsonb_build_object(
+    'minimumResponsesPerLeaf', config."minQuestionsPerLeaf",
+    'minimumResponsesPerRoot', config."minQuestionsPerLeaf",
+    'classificationZ', config."classificationZ",
+    'topInformationRatio', config."topInformationRatio",
+    'levelMappingRule', config."levelMappingRule",
+    'thetaMin', tree."thetaMin",
+    'thetaMax', tree."thetaMax",
+    'requiredRootIds', coalesce((
+      SELECT jsonb_agg(node.id ORDER BY node."order", node.id)
+      FROM "CompetenceTreeNode" node
+      LEFT JOIN "PracticeQuizAdaptiveNodeOverride" override
+        ON override."configId" = config.id AND override."nodeId" = node.id
+      WHERE node."treeId" = config."competenceTreeId"
+        AND node."parentId" IS NULL
+        AND coalesce(override.enabled, true)
+    ), '[]'::jsonb)
+  ),
+  config."totalQuestionCap",
+  config."showTimer",
+  jsonb_build_object(
+    'root', coalesce((
+      SELECT jsonb_object_agg(node.id::text, override."questionCap" ORDER BY node.id)
+      FROM "CompetenceTreeNode" node
+      LEFT JOIN "PracticeQuizAdaptiveNodeOverride" override
+        ON override."configId" = config.id AND override."nodeId" = node.id
+      WHERE node."treeId" = config."competenceTreeId" AND node."parentId" IS NULL
+    ), '{}'::jsonb),
+    'node', coalesce((
+      SELECT jsonb_object_agg(node.id::text, override."questionCap" ORDER BY node.id)
+      FROM "CompetenceTreeNode" node
+      LEFT JOIN "PracticeQuizAdaptiveNodeOverride" override
+        ON override."configId" = config.id AND override."nodeId" = node.id
+      WHERE node."treeId" = config."competenceTreeId"
+    ), '{}'::jsonb),
+    'leaf', coalesce((
+      SELECT jsonb_object_agg(node.id::text, config."perLeafQuestionCap" ORDER BY node.id)
+      FROM "CompetenceTreeNode" node
+      WHERE node."treeId" = config."competenceTreeId"
+        AND NOT EXISTS (
+          SELECT 1 FROM "CompetenceTreeNode" child
+          WHERE child."treeId" = node."treeId" AND child."parentId" = node.id
+        )
+    ), '{}'::jsonb)
+  ),
+  'irt-v1-max-information',
+  'irt-v1-deterministic',
+  1,
+  'irt-v1-no-exposure-control',
+  config."attemptSelectionPolicy",
+  quiz."resetTimeDays",
+  NULL,
+  'irt-v1-z-interval',
+  1,
+  coalesce(config."poolPublishedAt", config."createdAt"),
+  CASE WHEN EXISTS (
+    SELECT 1 FROM "PracticeQuizAdaptivePoolItem" pool WHERE pool."configId" = config.id
+  ) THEN NULL ELSE CURRENT_TIMESTAMP END,
+  CURRENT_TIMESTAMP
+FROM "PracticeQuizAdaptiveConfig" config
+JOIN "CompetenceTree" tree ON tree.id = config."competenceTreeId"
+JOIN "PracticeQuiz" quiz ON quiz.id = config."practiceQuizId"
+WHERE EXISTS (
+  SELECT 1 FROM "PracticeQuizAdaptivePoolItem" pool WHERE pool."configId" = config.id
+) OR EXISTS (
+  SELECT 1 FROM "AdaptivePracticeQuizAttempt" attempt WHERE attempt."configId" = config.id
+);
+
+UPDATE "AdaptivePracticeQuizCohortSnapshot" snapshot
+SET
+  "publicationId" = publication.id,
+  "scaleVersionId" = publication."scaleVersionId",
+  "measurementVersion" = publication."measurementVersion"
+FROM "PracticeQuizAdaptivePublication" publication
+WHERE publication."configId" = snapshot."configId"
+  AND publication.version = 1;
+
+UPDATE "PracticeQuizAdaptiveConfig" config
+SET
+  "measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion",
+  "calibrationPolicyVersion" = 1,
+  "scaleVersionId" = md5('adaptive-scale:' || config."competenceTreeId"::text)::uuid;
+
+UPDATE "PracticeQuizAdaptivePoolItem" pool
+SET
+  "publicationId" = md5('adaptive-publication:' || pool."configId"::text || ':1')::uuid,
+  "scaleVersionId" = md5('adaptive-scale:' || pool."competenceTreeId"::text)::uuid,
+  "calibrationId" = calibration.id,
+  "measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion",
+  "calibrationVersion" = calibration.version,
+  "calibrationStatus" = calibration.status,
+  "itemModel" = calibration.model,
+  "modelImplementationVersion" = calibration."modelImplementationVersion",
+  "role" = 'SCORING'::"AdaptivePoolItemRole",
+  "contributesToEstimate" = true
+FROM "AdaptiveItemCalibration" calibration
+WHERE calibration."assignmentId" = pool."sourceAssignmentId"
+  AND calibration."elementId" = pool."elementId"
+  AND calibration."elementVersion" = pool."elementVersion"
+  AND calibration.version = 1;
+
+UPDATE "AdaptivePracticeQuizAttempt" attempt
+SET
+  "publicationId" = md5('adaptive-publication:' || attempt."configId"::text || ':1')::uuid,
+  "scaleVersionId" = md5('adaptive-scale:' || attempt."competenceTreeId"::text)::uuid,
+  "measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion",
+  "estimatorImplementationVersion" = 'irt-v1-legacy',
+  "classificationPolicyVersion" = 1,
+  "calibrationPolicyVersion" = 1,
+  "finalScaleLevelId" = scale_level.id
+FROM "CompetenceTreeScaleLevel" scale_level
+WHERE scale_level."treeId" = attempt."competenceTreeId"
+  AND scale_level."sourceLevelId" = attempt."finalLevelId";
+
+UPDATE "AdaptivePracticeQuizAttempt" attempt
+SET
+  "publicationId" = md5('adaptive-publication:' || attempt."configId"::text || ':1')::uuid,
+  "scaleVersionId" = md5('adaptive-scale:' || attempt."competenceTreeId"::text)::uuid,
+  "measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion",
+  "estimatorImplementationVersion" = 'irt-v1-legacy',
+  "classificationPolicyVersion" = 1,
+  "calibrationPolicyVersion" = 1
+WHERE attempt."publicationId" IS NULL;
+
+UPDATE "AdaptivePracticeQuizResponse" response
+SET "publicationId" = attempt."publicationId"
+FROM "AdaptivePracticeQuizAttempt" attempt
+WHERE attempt.id = response."attemptId";
+
+UPDATE "PracticeQuizAdaptivePublication"
+SET "sealedAt" = CURRENT_TIMESTAMP
+WHERE "sealedAt" IS NULL;
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260731122000_adaptive_irt_v2_constraints/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260731122000_adaptive_irt_v2_constraints/migration.sql
@@ -1,0 +1,1225 @@
+-- Contract the adaptive-learning schema after every legacy identity is materialized.
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "PracticeQuizAdaptivePoolItem"
+    WHERE "publicationId" IS NULL
+       OR "scaleVersionId" IS NULL
+       OR "calibrationId" IS NULL
+       OR "measurementVersion" IS NULL
+       OR "calibrationVersion" IS NULL
+       OR "calibrationStatus" IS NULL
+       OR "itemModel" IS NULL
+       OR "modelImplementationVersion" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 contract found an unversioned publication-pool row';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "AdaptivePracticeQuizAttempt"
+    WHERE "publicationId" IS NULL
+       OR "scaleVersionId" IS NULL
+       OR "measurementVersion" IS NULL
+       OR "estimatorImplementationVersion" IS NULL
+       OR "classificationPolicyVersion" IS NULL
+       OR "calibrationPolicyVersion" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 contract found an unversioned attempt';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM "AdaptivePracticeQuizResponse" WHERE "publicationId" IS NULL) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 contract found an unversioned response';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PracticeQuizAdaptivePoolItem" pool
+    JOIN "PracticeQuizAdaptivePublication" publication ON publication.id = pool."publicationId"
+    JOIN "AdaptiveItemCalibration" calibration ON calibration.id = pool."calibrationId"
+    WHERE publication."configId" <> pool."configId"
+       OR publication."competenceTreeId" <> pool."competenceTreeId"
+       OR publication."scaleVersionId" <> pool."scaleVersionId"
+       OR calibration."treeId" <> pool."competenceTreeId"
+       OR calibration."scaleVersionId" <> pool."scaleVersionId"
+       OR calibration."assignmentId" <> pool."sourceAssignmentId"
+       OR calibration."elementId" <> pool."elementId"
+       OR calibration."elementVersion" <> pool."elementVersion"
+  ) THEN
+    RAISE EXCEPTION 'Adaptive IRT v2 contract found inconsistent pool publication or calibration identity';
+  END IF;
+END $$;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ALTER COLUMN "publicationId" SET NOT NULL,
+  ALTER COLUMN "scaleVersionId" SET NOT NULL,
+  ALTER COLUMN "calibrationId" SET NOT NULL,
+  ALTER COLUMN "measurementVersion" SET NOT NULL,
+  ALTER COLUMN "calibrationVersion" SET NOT NULL,
+  ALTER COLUMN "calibrationStatus" SET NOT NULL,
+  ALTER COLUMN "itemModel" SET NOT NULL,
+  ALTER COLUMN "modelImplementationVersion" SET NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+  ALTER COLUMN "publicationId" SET NOT NULL,
+  ALTER COLUMN "scaleVersionId" SET NOT NULL,
+  ALTER COLUMN "measurementVersion" SET NOT NULL,
+  ALTER COLUMN "estimatorImplementationVersion" SET NOT NULL,
+  ALTER COLUMN "classificationPolicyVersion" SET NOT NULL,
+  ALTER COLUMN "calibrationPolicyVersion" SET NOT NULL;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+  ALTER COLUMN "publicationId" SET NOT NULL;
+
+DROP INDEX "pqapi_config_assignment_key";
+DROP INDEX "pqapi_config_leaf_level_idx";
+DROP INDEX "pqapi_tree_assignment_idx";
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  DROP CONSTRAINT "PracticeQuizAdaptivePoolItem_configId_fkey",
+  DROP CONSTRAINT "pqapi_config_tree_same_tree_fkey";
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ADD CONSTRAINT "PracticeQuizAdaptivePoolItem_configId_fkey"
+  FOREIGN KEY ("configId") REFERENCES "PracticeQuizAdaptiveConfig"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ADD CONSTRAINT "pqapi_config_tree_same_tree_fkey"
+  FOREIGN KEY ("configId", "competenceTreeId") REFERENCES "PracticeQuizAdaptiveConfig"("id", "competenceTreeId")
+  ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+  DROP CONSTRAINT "AdaptivePracticeQuizAttempt_configId_nextPoolItemId_fkey";
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+  DROP CONSTRAINT "AdaptivePracticeQuizResponse_attemptId_configId_fkey",
+  DROP CONSTRAINT "AdaptivePracticeQuizResponse_configId_poolItemId_assignmentId_e";
+
+ALTER TABLE "CompetenceTreeScaleVersion"
+  ADD CONSTRAINT "CompetenceTreeScaleVersion_treeId_fkey"
+    FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleVersion_supersedesVersionId_fkey"
+    FOREIGN KEY ("supersedesVersionId") REFERENCES "CompetenceTreeScaleVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleVersion_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLevel"
+  ADD CONSTRAINT "CompetenceTreeScaleLevel_treeId_scaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLevel_treeId_sourceLevelId_fkey"
+    FOREIGN KEY ("treeId", "sourceLevelId") REFERENCES "CompetenceTreeLevel"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleApproval"
+  ADD CONSTRAINT "CompetenceTreeScaleApproval_treeId_scaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleApproval_submittedById_fkey"
+    FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleApproval_reviewerId_fkey"
+    FOREIGN KEY ("reviewerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLink"
+  ADD CONSTRAINT "CompetenceTreeScaleLink_treeId_fkey"
+    FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLink_treeId_fromScaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "fromScaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLink_treeId_toScaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "toScaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLink_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLink_reviewedById_fkey"
+    FOREIGN KEY ("reviewedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLinkAnchor"
+  ADD CONSTRAINT "CompetenceTreeScaleLinkAnchor_scaleLinkId_fkey"
+    FOREIGN KEY ("scaleLinkId") REFERENCES "CompetenceTreeScaleLink"("id") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLinkAnchor_fromCalibrationId_fkey"
+    FOREIGN KEY ("fromCalibrationId") REFERENCES "AdaptiveItemCalibration"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "CompetenceTreeScaleLinkAnchor_toCalibrationId_fkey"
+    FOREIGN KEY ("toCalibrationId") REFERENCES "AdaptiveItemCalibration"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptiveItemCalibration"
+  ADD CONSTRAINT "AdaptiveItemCalibration_treeId_fkey"
+    FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveItemCalibration_treeId_scaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveItemCalibration_treeId_assignmentId_fkey"
+    FOREIGN KEY ("treeId", "assignmentId") REFERENCES "CompetenceTreeElementAssignment"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "aic_assignment_element_identity_fkey"
+    FOREIGN KEY ("treeId", "assignmentId", "elementId") REFERENCES "CompetenceTreeElementAssignment"("treeId", "id", "elementId") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveItemCalibration_elementId_fkey"
+    FOREIGN KEY ("elementId") REFERENCES "Element"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveItemCalibration_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveItemCalibration_approvedById_fkey"
+    FOREIGN KEY ("approvedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptiveConfig"
+  ADD CONSTRAINT "PracticeQuizAdaptiveConfig_competenceTreeId_scaleVersionId_fkey"
+  FOREIGN KEY ("competenceTreeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePublication"
+  ADD CONSTRAINT "PracticeQuizAdaptivePublication_configId_competenceTreeId_fkey"
+    FOREIGN KEY ("configId", "competenceTreeId") REFERENCES "PracticeQuizAdaptiveConfig"("id", "competenceTreeId") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "PracticeQuizAdaptivePublication_competenceTreeId_fkey"
+    FOREIGN KEY ("competenceTreeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "pqap_scale_version_fkey"
+    FOREIGN KEY ("competenceTreeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "PracticeQuizAdaptivePublication_empiricalValidationId_conf_fkey"
+    FOREIGN KEY ("empiricalValidationId", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion")
+    REFERENCES "AdaptivePracticeQuizEmpiricalValidation"("id", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion")
+    ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "PracticeQuizAdaptivePublication_publishedById_fkey"
+    FOREIGN KEY ("publishedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizCohortSnapshot"
+  ALTER COLUMN "publicationId" SET NOT NULL,
+  ALTER COLUMN "scaleVersionId" SET NOT NULL,
+  ALTER COLUMN "measurementVersion" SET NOT NULL,
+  ADD CONSTRAINT "AdaptivePracticeQuizCohortSnapshot_publication_fkey"
+    FOREIGN KEY ("publicationId", "scaleVersionId", "measurementVersion")
+    REFERENCES "PracticeQuizAdaptivePublication"("id", "scaleVersionId", "measurementVersion")
+    ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizCohortSnapshot"
+  DROP CONSTRAINT "apqcs_aggregate_schema_check",
+  ADD CONSTRAINT "apqcs_aggregate_schema_check" CHECK (
+    jsonb_typeof("aggregate") = 'object'
+    AND "aggregate" ->> 'schemaVersion' IN ('1', '2')
+  );
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ADD CONSTRAINT "AdaptiveCalibrationExportRequest_treeId_fkey"
+    FOREIGN KEY ("treeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveCalibrationExportRequest_treeId_scaleVersionId_fkey"
+    FOREIGN KEY ("treeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptiveCalibrationExportRequest_requestedById_fkey"
+    FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizEmpiricalValidation"
+  ADD CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_configId_competenc_fkey"
+    FOREIGN KEY ("configId", "competenceTreeId") REFERENCES "PracticeQuizAdaptiveConfig"("id", "competenceTreeId") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_competenceTreeId_fkey"
+    FOREIGN KEY ("competenceTreeId") REFERENCES "CompetenceTree"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "apqev_scale_version_fkey"
+    FOREIGN KEY ("competenceTreeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_exportRequestId_fkey"
+    FOREIGN KEY ("exportRequestId") REFERENCES "AdaptiveCalibrationExportRequest"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_submittedById_fkey"
+    FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizEmpiricalValidation_approvedById_fkey"
+    FOREIGN KEY ("approvedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizItemExposure"
+  ADD CONSTRAINT "AdaptivePracticeQuizItemExposure_publicationId_fkey"
+    FOREIGN KEY ("publicationId") REFERENCES "PracticeQuizAdaptivePublication"("id") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizItemExposure_publicationId_poolItemId_fkey"
+    FOREIGN KEY ("publicationId", "poolItemId") REFERENCES "PracticeQuizAdaptivePoolItem"("publicationId", "id") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ADD CONSTRAINT "PracticeQuizAdaptivePoolItem_publicationId_configId_compet_fkey"
+    FOREIGN KEY ("publicationId", "configId", "competenceTreeId") REFERENCES "PracticeQuizAdaptivePublication"("id", "configId", "competenceTreeId") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "PracticeQuizAdaptivePoolItem_competenceTreeId_scaleVersion_fkey"
+    FOREIGN KEY ("competenceTreeId", "scaleVersionId", "calibrationId", "sourceAssignmentId", "elementId", "elementVersion") REFERENCES "AdaptiveItemCalibration"("treeId", "scaleVersionId", "id", "assignmentId", "elementId", "elementVersion") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+  ADD CONSTRAINT "apqa_publication_dispatch_fkey"
+    FOREIGN KEY ("publicationId", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion")
+    REFERENCES "PracticeQuizAdaptivePublication"("id", "configId", "competenceTreeId", "scaleVersionId", "measurementVersion", "estimatorImplementationVersion", "classificationPolicyVersion", "calibrationPolicyVersion") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "apqa_scale_version_fkey"
+    FOREIGN KEY ("competenceTreeId", "scaleVersionId") REFERENCES "CompetenceTreeScaleVersion"("treeId", "id") ON DELETE RESTRICT ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "apqa_final_scale_level_fkey"
+    FOREIGN KEY ("competenceTreeId", "scaleVersionId", "finalScaleLevelId") REFERENCES "CompetenceTreeScaleLevel"("treeId", "scaleVersionId", "id") ON DELETE NO ACTION ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizAttempt_publicationId_nextPoolItemId_fkey"
+    FOREIGN KEY ("publicationId", "nextPoolItemId") REFERENCES "PracticeQuizAdaptivePoolItem"("publicationId", "id") ON DELETE NO ACTION ON UPDATE CASCADE NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+  ADD CONSTRAINT "AdaptivePracticeQuizResponse_attemptId_configId_publicatio_fkey"
+    FOREIGN KEY ("attemptId", "configId", "publicationId") REFERENCES "AdaptivePracticeQuizAttempt"("id", "configId", "publicationId") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID,
+  ADD CONSTRAINT "AdaptivePracticeQuizResponse_publicationId_poolItemId_assi_fkey"
+    FOREIGN KEY ("publicationId", "poolItemId", "assignmentId", "elementId") REFERENCES "PracticeQuizAdaptivePoolItem"("publicationId", "id", "sourceAssignmentId", "elementId") ON DELETE NO ACTION ON UPDATE CASCADE NOT VALID;
+
+DO $$
+DECLARE
+  item record;
+BEGIN
+  FOR item IN
+    SELECT * FROM (VALUES
+      ('"PracticeQuizAdaptivePoolItem"', 'PracticeQuizAdaptivePoolItem_configId_fkey'),
+      ('"PracticeQuizAdaptivePoolItem"', 'pqapi_config_tree_same_tree_fkey'),
+      ('"CompetenceTreeScaleVersion"', 'CompetenceTreeScaleVersion_treeId_fkey'),
+      ('"CompetenceTreeScaleVersion"', 'CompetenceTreeScaleVersion_supersedesVersionId_fkey'),
+      ('"CompetenceTreeScaleVersion"', 'CompetenceTreeScaleVersion_createdById_fkey'),
+      ('"CompetenceTreeScaleLevel"', 'CompetenceTreeScaleLevel_treeId_scaleVersionId_fkey'),
+      ('"CompetenceTreeScaleLevel"', 'CompetenceTreeScaleLevel_treeId_sourceLevelId_fkey'),
+      ('"CompetenceTreeScaleApproval"', 'CompetenceTreeScaleApproval_treeId_scaleVersionId_fkey'),
+      ('"CompetenceTreeScaleApproval"', 'CompetenceTreeScaleApproval_submittedById_fkey'),
+      ('"CompetenceTreeScaleApproval"', 'CompetenceTreeScaleApproval_reviewerId_fkey'),
+      ('"CompetenceTreeScaleLink"', 'CompetenceTreeScaleLink_treeId_fkey'),
+      ('"CompetenceTreeScaleLink"', 'CompetenceTreeScaleLink_treeId_fromScaleVersionId_fkey'),
+      ('"CompetenceTreeScaleLink"', 'CompetenceTreeScaleLink_treeId_toScaleVersionId_fkey'),
+      ('"CompetenceTreeScaleLink"', 'CompetenceTreeScaleLink_createdById_fkey'),
+      ('"CompetenceTreeScaleLink"', 'CompetenceTreeScaleLink_reviewedById_fkey'),
+      ('"CompetenceTreeScaleLinkAnchor"', 'CompetenceTreeScaleLinkAnchor_scaleLinkId_fkey'),
+      ('"CompetenceTreeScaleLinkAnchor"', 'CompetenceTreeScaleLinkAnchor_fromCalibrationId_fkey'),
+      ('"CompetenceTreeScaleLinkAnchor"', 'CompetenceTreeScaleLinkAnchor_toCalibrationId_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_treeId_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_treeId_scaleVersionId_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_treeId_assignmentId_fkey'),
+      ('"AdaptiveItemCalibration"', 'aic_assignment_element_identity_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_elementId_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_createdById_fkey'),
+      ('"AdaptiveItemCalibration"', 'AdaptiveItemCalibration_approvedById_fkey'),
+      ('"PracticeQuizAdaptiveConfig"', 'PracticeQuizAdaptiveConfig_competenceTreeId_scaleVersionId_fkey'),
+      ('"PracticeQuizAdaptivePublication"', 'PracticeQuizAdaptivePublication_configId_competenceTreeId_fkey'),
+      ('"PracticeQuizAdaptivePublication"', 'PracticeQuizAdaptivePublication_competenceTreeId_fkey'),
+      ('"PracticeQuizAdaptivePublication"', 'pqap_scale_version_fkey'),
+      ('"PracticeQuizAdaptivePublication"', 'PracticeQuizAdaptivePublication_empiricalValidationId_conf_fkey'),
+      ('"PracticeQuizAdaptivePublication"', 'PracticeQuizAdaptivePublication_publishedById_fkey'),
+      ('"AdaptivePracticeQuizCohortSnapshot"', 'AdaptivePracticeQuizCohortSnapshot_publication_fkey'),
+      ('"AdaptiveCalibrationExportRequest"', 'AdaptiveCalibrationExportRequest_treeId_fkey'),
+      ('"AdaptiveCalibrationExportRequest"', 'AdaptiveCalibrationExportRequest_treeId_scaleVersionId_fkey'),
+      ('"AdaptiveCalibrationExportRequest"', 'AdaptiveCalibrationExportRequest_requestedById_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'AdaptivePracticeQuizEmpiricalValidation_configId_competenc_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'AdaptivePracticeQuizEmpiricalValidation_competenceTreeId_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'apqev_scale_version_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'AdaptivePracticeQuizEmpiricalValidation_exportRequestId_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'AdaptivePracticeQuizEmpiricalValidation_submittedById_fkey'),
+      ('"AdaptivePracticeQuizEmpiricalValidation"', 'AdaptivePracticeQuizEmpiricalValidation_approvedById_fkey'),
+      ('"AdaptivePracticeQuizItemExposure"', 'AdaptivePracticeQuizItemExposure_publicationId_fkey'),
+      ('"AdaptivePracticeQuizItemExposure"', 'AdaptivePracticeQuizItemExposure_publicationId_poolItemId_fkey'),
+      ('"PracticeQuizAdaptivePoolItem"', 'PracticeQuizAdaptivePoolItem_publicationId_configId_compet_fkey'),
+      ('"PracticeQuizAdaptivePoolItem"', 'PracticeQuizAdaptivePoolItem_competenceTreeId_scaleVersion_fkey'),
+      ('"AdaptivePracticeQuizAttempt"', 'apqa_publication_dispatch_fkey'),
+      ('"AdaptivePracticeQuizAttempt"', 'apqa_scale_version_fkey'),
+      ('"AdaptivePracticeQuizAttempt"', 'apqa_final_scale_level_fkey'),
+      ('"AdaptivePracticeQuizAttempt"', 'AdaptivePracticeQuizAttempt_publicationId_nextPoolItemId_fkey'),
+      ('"AdaptivePracticeQuizResponse"', 'AdaptivePracticeQuizResponse_attemptId_configId_publicatio_fkey'),
+      ('"AdaptivePracticeQuizResponse"', 'AdaptivePracticeQuizResponse_publicationId_poolItemId_assi_fkey')
+    ) AS expected(table_name, conname)
+  LOOP
+    EXECUTE format('ALTER TABLE %s VALIDATE CONSTRAINT %I', item.table_name, item.conname);
+  END LOOP;
+END $$;
+
+ALTER TABLE "CompetenceTreeScaleVersion"
+  ADD CONSTRAINT "ctsv_numeric_check" CHECK (
+    "version" > 0
+    AND "classificationPolicyVersion" > 0
+    AND "priorMean"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "priorStandardDeviation"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "priorStandardDeviation" > 0
+    AND "gridMin"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridMax"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridStep"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridMin" < "gridMax"
+    AND "gridStep" > 0
+  ) NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLevel"
+  ADD CONSTRAINT "ctsl_numeric_check" CHECK (
+    "order" >= 0
+    AND ("lowerBound" IS NULL OR "lowerBound"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND "itemDifficultyPrior"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+  ) NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleApproval"
+  ADD CONSTRAINT "ctsa_evidence_check" CHECK (
+    "panelSize" > 0
+    AND ("decision" IS NULL OR "decision" IN ('APPROVED'::"AdaptiveScaleVersionStatus", 'REJECTED'::"AdaptiveScaleVersionStatus"))
+    AND ("decision" IS NULL) = ("reviewerId" IS NULL)
+    AND ("decision" IS NULL) = ("reviewedAt" IS NULL)
+    AND length("method") > 0
+    AND length("methodVersion") > 0
+    AND length("artifactChecksum") > 0
+    AND length("artifactKey") > 0
+  ) NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLink"
+  ADD CONSTRAINT "ctslk_versions_check" CHECK (
+    "fromScaleVersionId" <> "toScaleVersionId"
+    AND ("reviewedById" IS NULL) = ("reviewedAt" IS NULL)
+  ) NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleLinkAnchor"
+  ADD CONSTRAINT "ctsla_order_check" CHECK ("order" >= 0) NOT VALID;
+
+ALTER TABLE "AdaptiveItemCalibration"
+  ADD CONSTRAINT "aic_parameters_check" CHECK (
+    "version" > 0
+    AND "elementVersion" > 0
+    AND "discrimination"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "difficulty"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "guessing"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "discrimination" > 0
+    AND "guessing" >= 0
+    AND "guessing" < 1
+    AND "responseCount" >= 0
+    AND "participantCount" >= 0
+    AND ("approvedById" IS NULL) = ("approvedAt" IS NULL)
+    AND (
+      "status" <> 'CALIBRATED'::"AdaptiveItemCalibrationStatus"
+      OR ("approvedById" IS NOT NULL AND "approvedAt" IS NOT NULL)
+    )
+  ) NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePublication"
+  ADD CONSTRAINT "pqap_policy_check" CHECK (
+    "version" > 0
+    AND "classificationPolicyVersion" > 0
+    AND "calibrationPolicyVersion" > 0
+    AND "rolloutPolicyVersion" > 0
+    AND "priorMean"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "priorStandardDeviation"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "priorStandardDeviation" > 0
+    AND "gridMin"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridMax"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridStep"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "gridMin" < "gridMax"
+    AND "gridStep" > 0
+    AND "totalQuestionCap" > 0
+    AND "retakeCooldownDays" >= 0
+    AND "exposureCeiling"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "exposureCeiling" > 0
+    AND "exposureCeiling" <= 1
+    AND (
+      ("measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion" AND "classificationProbabilityThreshold" IS NULL)
+      OR (
+        "measurementVersion" = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion"
+        AND "classificationProbabilityThreshold" >= 0.8
+        AND "classificationProbabilityThreshold" < 1
+        AND "classificationProbabilityThreshold"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+      )
+    )
+  ) NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePublication"
+  ADD CONSTRAINT "pqap_lifecycle_timestamps_check" CHECK (
+    ("sealedAt" IS NULL OR "sealedAt" >= "publishedAt")
+    AND ("supersededAt" IS NULL OR ("sealedAt" IS NOT NULL AND "supersededAt" >= "sealedAt"))
+    AND ("unpublishedAt" IS NULL OR ("sealedAt" IS NOT NULL AND "unpublishedAt" >= "sealedAt"))
+  ) NOT VALID;
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ADD CONSTRAINT "acer_state_check" CHECK (
+    ("rowCount" IS NULL OR "rowCount" >= 0)
+    AND "expiresAt" > "createdAt"
+    AND ("status" <> 'READY'::"AdaptiveCalibrationExportStatus" OR ("artifactKey" IS NOT NULL AND "artifactChecksum" IS NOT NULL AND "rowCount" IS NOT NULL AND "completedAt" IS NOT NULL))
+    AND ("status" <> 'FAILED'::"AdaptiveCalibrationExportStatus" OR ("failureCode" IS NOT NULL AND "completedAt" IS NOT NULL))
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizEmpiricalValidation"
+  ADD CONSTRAINT "apqev_evidence_check" CHECK (
+    "classificationPolicyVersion" > 0
+    AND "calibrationPolicyVersion" > 0
+    AND length("validationProtocolVersion") BETWEEN 1 AND 160
+    AND "criterionArtifactChecksum" ~ '^[a-f0-9]{64}$'
+    AND "approvedProbabilityThreshold"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "approvedProbabilityThreshold" >= 0.8
+    AND "approvedProbabilityThreshold" < 1
+    AND "calibrationDatasetVersion" <> "holdoutDatasetVersion"
+    AND "calibrationDatasetChecksum" <> "holdoutDatasetChecksum"
+    AND (
+      (
+        "status" = 'SUBMITTED'::"AdaptiveEmpiricalValidationStatus"
+        AND "approvedById" IS NULL
+        AND "reviewedAt" IS NULL
+      )
+      OR (
+        "status" = 'REJECTED'::"AdaptiveEmpiricalValidationStatus"
+        AND (("approvedById" IS NULL) = ("reviewedAt" IS NULL))
+      )
+      OR (
+        "status" IN (
+          'APPROVED'::"AdaptiveEmpiricalValidationStatus",
+          'SUPERSEDED'::"AdaptiveEmpiricalValidationStatus"
+        )
+        AND "approvedById" IS NOT NULL
+        AND "reviewedAt" IS NOT NULL
+      )
+    )
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizItemExposure"
+  ADD CONSTRAINT "apqie_counts_check" CHECK (
+    "servedCount" >= 0 AND "answeredCount" >= 0 AND "answeredCount" <= "servedCount"
+  ) NOT VALID;
+
+ALTER TABLE "PracticeQuizAdaptivePoolItem"
+  ADD CONSTRAINT "pqapi_snapshot_check" CHECK (
+    "elementVersion" > 0
+    AND "calibrationVersion" > 0
+    AND "discrimination"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "difficulty"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "guessing"::text NOT IN ('NaN', 'Infinity', '-Infinity')
+    AND "discrimination" > 0
+    AND "guessing" >= 0
+    AND "guessing" < 1
+    AND (
+      ("role" = 'FIELD_TEST'::"AdaptivePoolItemRole" AND NOT "contributesToEstimate")
+      OR ("role" IN ('SCORING'::"AdaptivePoolItemRole", 'ANCHOR'::"AdaptivePoolItemRole") AND "contributesToEstimate")
+    )
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizAttempt"
+  ADD CONSTRAINT "apqa_result_check" CHECK (
+    "classificationPolicyVersion" > 0
+    AND "calibrationPolicyVersion" > 0
+    AND ("finalBandProbability" IS NULL OR ("finalBandProbability" >= 0 AND "finalBandProbability" <= 1 AND "finalBandProbability"::text NOT IN ('NaN', 'Infinity', '-Infinity')))
+    AND ("credibleLower" IS NULL OR "credibleLower"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("credibleUpper" IS NULL OR "credibleUpper"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("credibleLower" IS NULL OR "credibleUpper" IS NULL OR "credibleLower" <= "credibleUpper")
+    AND ("nextAdministrationProbability" IS NULL OR ("nextAdministrationProbability" > 0 AND "nextAdministrationProbability" <= 1 AND "nextAdministrationProbability"::text NOT IN ('NaN', 'Infinity', '-Infinity')))
+    AND ("nextRandomDraw" IS NULL OR ("nextRandomDraw" >= 0 AND "nextRandomDraw" <= 4294967295))
+    AND (
+      (
+        "measurementVersion" = 'IRT_V1'::"AdaptiveMeasurementVersion"
+        AND "nextAdministrationProbability" IS NULL
+        AND "nextCollectionDesignVersion" IS NULL
+        AND "nextRandomizationVersion" IS NULL
+        AND "nextRandomDraw" IS NULL
+        AND "nextCandidateSetHash" IS NULL
+        AND "nextItemRole" IS NULL
+      )
+      OR (
+        "measurementVersion" = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion"
+        AND (
+          (
+            "nextPoolItemId" IS NULL
+            AND "nextAdministrationProbability" IS NULL
+            AND "nextCollectionDesignVersion" IS NULL
+            AND "nextRandomizationVersion" IS NULL
+            AND "nextRandomDraw" IS NULL
+            AND "nextCandidateSetHash" IS NULL
+            AND "nextItemRole" IS NULL
+          )
+          OR (
+            "nextPoolItemId" IS NOT NULL
+            AND "nextAdministrationProbability" IS NOT NULL
+            AND "nextRandomizationVersion" IS NOT NULL
+            AND "nextRandomDraw" IS NOT NULL
+            AND "nextCandidateSetHash" IS NOT NULL
+            AND "nextItemRole" IS NOT NULL
+          )
+        )
+      )
+    )
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizResponse"
+  ADD CONSTRAINT "apqr_design_check" CHECK (
+    ("administrationProbability" IS NULL OR ("administrationProbability" > 0 AND "administrationProbability" <= 1 AND "administrationProbability"::text NOT IN ('NaN', 'Infinity', '-Infinity')))
+    AND ("randomDraw" IS NULL OR ("randomDraw" >= 0 AND "randomDraw" <= 4294967295))
+    AND "isCalibrationAnchor" = ("itemRole" = 'ANCHOR'::"AdaptivePoolItemRole")
+    AND ("overallCredibleLowerAfter" IS NULL OR "overallCredibleLowerAfter"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("overallCredibleUpperAfter" IS NULL OR "overallCredibleUpperAfter"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("overallCredibleLowerAfter" IS NULL OR "overallCredibleUpperAfter" IS NULL OR "overallCredibleLowerAfter" <= "overallCredibleUpperAfter")
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+  DROP CONSTRAINT "apqe_runtime_values_check",
+  ADD CONSTRAINT "apqe_runtime_values_check" CHECK (
+    ("theta" IS NULL OR "theta" BETWEEN -10 AND 10)
+    AND ("standardError" IS NULL OR "standardError" > 0)
+    AND "responseCount" >= 0
+    AND (
+      ("theta" IS NULL AND "standardError" IS NULL)
+      OR ("theta" IS NOT NULL AND "standardError" IS NOT NULL)
+    )
+  ) NOT VALID;
+
+ALTER TABLE "AdaptivePracticeQuizEstimate"
+  ADD CONSTRAINT "apqe_result_check" CHECK (
+    ("classificationProbability" IS NULL OR ("classificationProbability" >= 0 AND "classificationProbability" <= 1 AND "classificationProbability"::text NOT IN ('NaN', 'Infinity', '-Infinity')))
+    AND ("credibleLower" IS NULL OR "credibleLower"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("credibleUpper" IS NULL OR "credibleUpper"::text NOT IN ('NaN', 'Infinity', '-Infinity'))
+    AND ("credibleLower" IS NULL OR "credibleUpper" IS NULL OR "credibleLower" <= "credibleUpper")
+  ) NOT VALID;
+
+ALTER TABLE "CompetenceTreeScaleVersion" VALIDATE CONSTRAINT "ctsv_numeric_check";
+ALTER TABLE "CompetenceTreeScaleLevel" VALIDATE CONSTRAINT "ctsl_numeric_check";
+ALTER TABLE "CompetenceTreeScaleApproval" VALIDATE CONSTRAINT "ctsa_evidence_check";
+ALTER TABLE "CompetenceTreeScaleLink" VALIDATE CONSTRAINT "ctslk_versions_check";
+ALTER TABLE "CompetenceTreeScaleLinkAnchor" VALIDATE CONSTRAINT "ctsla_order_check";
+ALTER TABLE "AdaptiveItemCalibration" VALIDATE CONSTRAINT "aic_parameters_check";
+ALTER TABLE "PracticeQuizAdaptivePublication" VALIDATE CONSTRAINT "pqap_policy_check";
+ALTER TABLE "PracticeQuizAdaptivePublication" VALIDATE CONSTRAINT "pqap_lifecycle_timestamps_check";
+ALTER TABLE "AdaptiveCalibrationExportRequest" VALIDATE CONSTRAINT "acer_state_check";
+ALTER TABLE "AdaptivePracticeQuizEmpiricalValidation" VALIDATE CONSTRAINT "apqev_evidence_check";
+ALTER TABLE "AdaptivePracticeQuizItemExposure" VALIDATE CONSTRAINT "apqie_counts_check";
+ALTER TABLE "PracticeQuizAdaptivePoolItem" VALIDATE CONSTRAINT "pqapi_snapshot_check";
+ALTER TABLE "AdaptivePracticeQuizAttempt" VALIDATE CONSTRAINT "apqa_result_check";
+ALTER TABLE "AdaptivePracticeQuizResponse" VALIDATE CONSTRAINT "apqr_design_check";
+ALTER TABLE "AdaptivePracticeQuizEstimate" VALIDATE CONSTRAINT "apqe_runtime_values_check";
+ALTER TABLE "AdaptivePracticeQuizEstimate" VALIDATE CONSTRAINT "apqe_result_check";
+
+CREATE UNIQUE INDEX "ctsv_one_active_per_tree_key"
+  ON "CompetenceTreeScaleVersion"("treeId")
+  WHERE "status" = 'ACTIVE'::"AdaptiveScaleVersionStatus";
+
+CREATE UNIQUE INDEX "pqap_one_active_per_config_key"
+  ON "PracticeQuizAdaptivePublication"("configId")
+  WHERE "sealedAt" IS NOT NULL AND "supersededAt" IS NULL AND "unpublishedAt" IS NULL;
+
+CREATE OR REPLACE FUNCTION adaptive_assert_scale_geometry(scale_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  scale_record record;
+  level_count integer;
+  minimum_order integer;
+  maximum_order integer;
+  distinct_order_count integer;
+BEGIN
+  SELECT "gridMin", "gridMax" INTO scale_record
+  FROM "CompetenceTreeScaleVersion"
+  WHERE id = scale_id;
+
+  SELECT count(*), min("order"), max("order"), count(DISTINCT "order")
+  INTO level_count, minimum_order, maximum_order, distinct_order_count
+  FROM "CompetenceTreeScaleLevel"
+  WHERE "scaleVersionId" = scale_id;
+
+  IF level_count = 0
+     OR minimum_order <> 0
+     OR maximum_order <> level_count - 1
+     OR distinct_order_count <> level_count THEN
+    RAISE EXCEPTION 'A reviewed scale requires non-empty contiguous zero-based levels';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT
+        "order",
+        "lowerBound",
+        "itemDifficultyPrior",
+        lag("itemDifficultyPrior") OVER (ORDER BY "order") AS previous_prior,
+        lag("lowerBound") OVER (ORDER BY "order") AS previous_lower
+      FROM "CompetenceTreeScaleLevel"
+      WHERE "scaleVersionId" = scale_id
+    ) level
+    WHERE (level."order" = 0 AND level."lowerBound" IS NOT NULL)
+       OR (level."order" > 0 AND level."lowerBound" IS NULL)
+       OR level."itemDifficultyPrior" < scale_record."gridMin"
+       OR level."itemDifficultyPrior" > scale_record."gridMax"
+       OR (level."lowerBound" IS NOT NULL AND (level."lowerBound" < scale_record."gridMin" OR level."lowerBound" > scale_record."gridMax"))
+       OR (level."order" > 0 AND level."itemDifficultyPrior" <= level.previous_prior)
+       OR (level."order" > 1 AND level."lowerBound" <= level.previous_lower)
+       OR (level."order" > 0 AND (level."lowerBound" <= level.previous_prior OR level."lowerBound" > level."itemDifficultyPrior"))
+  ) THEN
+    RAISE EXCEPTION 'Scale cuts and item-difficulty priors must be finite, ordered, and inside the scale grid';
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION adaptive_scale_version_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  previous_scale record;
+BEGIN
+  IF NEW."supersedesVersionId" IS NOT NULL THEN
+    SELECT "treeId", "version" INTO previous_scale
+    FROM "CompetenceTreeScaleVersion"
+    WHERE id = NEW."supersedesVersionId";
+
+    IF previous_scale."treeId" IS DISTINCT FROM NEW."treeId" OR previous_scale."version" >= NEW."version" THEN
+      RAISE EXCEPTION 'A scale can only supersede an older version of the same tree';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' AND NEW.status <> 'DRAFT'::"AdaptiveScaleVersionStatus" THEN
+    RAISE EXCEPTION 'A scale version must be created in DRAFT';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NOT (
+      (OLD.status = 'DRAFT'::"AdaptiveScaleVersionStatus" AND NEW.status = 'IN_REVIEW'::"AdaptiveScaleVersionStatus")
+      OR (OLD.status = 'IN_REVIEW'::"AdaptiveScaleVersionStatus" AND NEW.status IN ('APPROVED'::"AdaptiveScaleVersionStatus", 'REJECTED'::"AdaptiveScaleVersionStatus"))
+      OR (OLD.status = 'APPROVED'::"AdaptiveScaleVersionStatus" AND NEW.status = 'ACTIVE'::"AdaptiveScaleVersionStatus")
+      OR (OLD.status = 'ACTIVE'::"AdaptiveScaleVersionStatus" AND NEW.status = 'SUPERSEDED'::"AdaptiveScaleVersionStatus")
+    ) THEN
+      RAISE EXCEPTION 'Invalid scale-version lifecycle transition: % -> %', OLD.status, NEW.status;
+    END IF;
+
+    IF NEW.status IN ('APPROVED'::"AdaptiveScaleVersionStatus", 'REJECTED'::"AdaptiveScaleVersionStatus")
+       AND NOT EXISTS (
+         SELECT 1 FROM "CompetenceTreeScaleApproval" approval
+         WHERE approval."scaleVersionId" = NEW.id AND approval.decision = NEW.status
+       ) THEN
+      RAISE EXCEPTION 'Scale review evidence is required before a review decision';
+    END IF;
+
+    IF NEW.status = 'IN_REVIEW'::"AdaptiveScaleVersionStatus"
+       AND NOT EXISTS (
+         SELECT 1 FROM "CompetenceTreeScaleApproval" approval
+         WHERE approval."scaleVersionId" = NEW.id AND approval.decision IS NULL
+       ) THEN
+      RAISE EXCEPTION 'Standard-setting evidence is required before scale review';
+    END IF;
+
+    IF NEW.status IN ('IN_REVIEW'::"AdaptiveScaleVersionStatus", 'ACTIVE'::"AdaptiveScaleVersionStatus") THEN
+      PERFORM adaptive_assert_scale_geometry(NEW.id);
+    END IF;
+
+    IF NEW.status = 'ACTIVE'::"AdaptiveScaleVersionStatus"
+       AND NEW."supersedesVersionId" IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM "CompetenceTreeScaleLink" link
+         WHERE link."treeId" = NEW."treeId"
+           AND link."fromScaleVersionId" = NEW."supersedesVersionId"
+           AND link."toScaleVersionId" = NEW.id
+           AND link.status = 'APPROVED'::"AdaptiveScaleLinkStatus"
+       ) THEN
+      RAISE EXCEPTION 'An approved scale link is required before activating a superseding scale';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND OLD.status <> 'DRAFT'::"AdaptiveScaleVersionStatus"
+     AND (
+       to_jsonb(NEW) - ARRAY['status', 'submittedForReviewAt', 'updatedAt']::text[]
+       IS DISTINCT FROM
+       to_jsonb(OLD) - ARRAY['status', 'submittedForReviewAt', 'updatedAt']::text[]
+     ) THEN
+    RAISE EXCEPTION 'Reviewed scale definitions are immutable';
+  END IF;
+
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctsv_lifecycle_guard"
+BEFORE INSERT OR UPDATE ON "CompetenceTreeScaleVersion"
+FOR EACH ROW EXECUTE FUNCTION adaptive_scale_version_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_scale_level_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  scale_status "AdaptiveScaleVersionStatus";
+BEGIN
+  SELECT status INTO scale_status
+  FROM "CompetenceTreeScaleVersion"
+  WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD."scaleVersionId" ELSE NEW."scaleVersionId" END;
+
+  IF scale_status IS DISTINCT FROM 'DRAFT'::"AdaptiveScaleVersionStatus" THEN
+    RAISE EXCEPTION 'Scale levels are immutable after review submission';
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctsl_lifecycle_guard"
+BEFORE INSERT OR UPDATE OR DELETE ON "CompetenceTreeScaleLevel"
+FOR EACH ROW EXECUTE FUNCTION adaptive_scale_level_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_independent_review_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  creator_id uuid;
+BEGIN
+  IF TG_TABLE_NAME = 'CompetenceTreeScaleApproval' THEN
+    SELECT "createdById" INTO creator_id FROM "CompetenceTreeScaleVersion" WHERE id = NEW."scaleVersionId";
+    IF NEW."reviewerId" IS NOT NULL AND creator_id IS NOT NULL AND creator_id = NEW."reviewerId" THEN
+      RAISE EXCEPTION 'A scale creator cannot review their own scale';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'CompetenceTreeScaleLink' THEN
+    IF NEW."reviewedById" IS NOT NULL AND NEW."createdById" IS NOT NULL AND NEW."reviewedById" = NEW."createdById" THEN
+      RAISE EXCEPTION 'A scale-link creator cannot review their own link';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'AdaptiveItemCalibration' THEN
+    IF NEW."approvedById" IS NOT NULL AND NEW."createdById" IS NOT NULL AND NEW."approvedById" = NEW."createdById" THEN
+      RAISE EXCEPTION 'A calibration creator cannot approve their own calibration';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'AdaptivePracticeQuizEmpiricalValidation' THEN
+    IF TG_OP = 'INSERT' AND NOT (
+      (
+        NEW.status = 'SUBMITTED'::"AdaptiveEmpiricalValidationStatus"
+        AND NEW."approvedById" IS NULL
+        AND NEW."reviewedAt" IS NULL
+      )
+      OR (
+        NEW.status = 'REJECTED'::"AdaptiveEmpiricalValidationStatus"
+        AND NEW."approvedById" IS NULL
+        AND NEW."reviewedAt" IS NULL
+      )
+    ) THEN
+      RAISE EXCEPTION 'Empirical-validation evidence must enter an unreviewed lifecycle state';
+    END IF;
+    IF NEW."approvedById" IS NOT NULL AND NEW."submittedById" IS NOT NULL AND NEW."approvedById" = NEW."submittedById" THEN
+      RAISE EXCEPTION 'A validation submitter cannot approve their own evidence';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctsa_independent_reviewer"
+BEFORE INSERT OR UPDATE ON "CompetenceTreeScaleApproval"
+FOR EACH ROW EXECUTE FUNCTION adaptive_independent_review_guard();
+CREATE TRIGGER "ctslk_independent_reviewer"
+BEFORE INSERT OR UPDATE ON "CompetenceTreeScaleLink"
+FOR EACH ROW EXECUTE FUNCTION adaptive_independent_review_guard();
+CREATE TRIGGER "aic_independent_reviewer"
+BEFORE INSERT OR UPDATE ON "AdaptiveItemCalibration"
+FOR EACH ROW EXECUTE FUNCTION adaptive_independent_review_guard();
+CREATE TRIGGER "apqev_independent_reviewer"
+BEFORE INSERT OR UPDATE ON "AdaptivePracticeQuizEmpiricalValidation"
+FOR EACH ROW EXECUTE FUNCTION adaptive_independent_review_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_review_evidence_immutability_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Adaptive review evidence cannot be deleted';
+  END IF;
+
+  IF TG_TABLE_NAME = 'CompetenceTreeScaleApproval'
+     AND to_jsonb(NEW) - ARRAY['decision', 'reviewerId', 'reviewedAt']::text[]
+         IS DISTINCT FROM
+         to_jsonb(OLD) - ARRAY['decision', 'reviewerId', 'reviewedAt']::text[] THEN
+    RAISE EXCEPTION 'Submitted standard-setting evidence is immutable';
+  END IF;
+
+  IF TG_TABLE_NAME = 'AdaptivePracticeQuizEmpiricalValidation' THEN
+    IF to_jsonb(NEW) - ARRAY['status', 'approvedById', 'reviewedAt', 'updatedAt']::text[]
+       IS DISTINCT FROM
+       to_jsonb(OLD) - ARRAY['status', 'approvedById', 'reviewedAt', 'updatedAt']::text[] THEN
+      RAISE EXCEPTION 'Submitted empirical-validation evidence is immutable';
+    END IF;
+
+    IF NEW.status = OLD.status THEN
+      IF NEW."approvedById" IS DISTINCT FROM OLD."approvedById"
+         OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt" THEN
+        RAISE EXCEPTION 'Empirical-validation review identity is immutable';
+      END IF;
+    ELSIF OLD.status = 'SUBMITTED'::"AdaptiveEmpiricalValidationStatus"
+          AND NEW.status IN (
+            'APPROVED'::"AdaptiveEmpiricalValidationStatus",
+            'REJECTED'::"AdaptiveEmpiricalValidationStatus"
+          ) THEN
+      IF NEW."approvedById" IS NULL OR NEW."reviewedAt" IS NULL THEN
+        RAISE EXCEPTION 'Empirical-validation review requires a reviewer and timestamp';
+      END IF;
+    ELSIF OLD.status = 'APPROVED'::"AdaptiveEmpiricalValidationStatus"
+          AND NEW.status = 'SUPERSEDED'::"AdaptiveEmpiricalValidationStatus" THEN
+      IF NEW."approvedById" IS DISTINCT FROM OLD."approvedById"
+         OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt" THEN
+        RAISE EXCEPTION 'Empirical-validation review identity is immutable';
+      END IF;
+      IF EXISTS (
+        SELECT 1
+        FROM "PracticeQuizAdaptivePublication" publication
+        WHERE publication."empiricalValidationId" = OLD.id
+          AND publication."supersededAt" IS NULL
+          AND publication."unpublishedAt" IS NULL
+      ) THEN
+        RAISE EXCEPTION 'Active adaptive publications must be invalidated before validation supersession';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'Illegal empirical-validation status transition';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctsa_evidence_immutability_guard"
+BEFORE UPDATE OR DELETE ON "CompetenceTreeScaleApproval"
+FOR EACH ROW EXECUTE FUNCTION adaptive_review_evidence_immutability_guard();
+CREATE TRIGGER "apqev_evidence_immutability_guard"
+BEFORE UPDATE OR DELETE ON "AdaptivePracticeQuizEmpiricalValidation"
+FOR EACH ROW EXECUTE FUNCTION adaptive_review_evidence_immutability_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_scale_link_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  from_version integer;
+  to_version integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status <> 'DRAFT'::"AdaptiveScaleLinkStatus" THEN
+      RAISE EXCEPTION 'Reviewed scale-link evidence cannot be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  SELECT version INTO from_version FROM "CompetenceTreeScaleVersion" WHERE id = NEW."fromScaleVersionId";
+  SELECT version INTO to_version FROM "CompetenceTreeScaleVersion" WHERE id = NEW."toScaleVersionId";
+  IF from_version >= to_version THEN
+    RAISE EXCEPTION 'Scale links must point from an older to a newer scale';
+  END IF;
+
+  IF TG_OP = 'INSERT' AND NEW.status <> 'DRAFT'::"AdaptiveScaleLinkStatus" THEN
+    RAISE EXCEPTION 'A scale link must be created in DRAFT';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NOT (
+      (OLD.status = 'DRAFT'::"AdaptiveScaleLinkStatus" AND NEW.status = 'IN_REVIEW'::"AdaptiveScaleLinkStatus")
+      OR (OLD.status = 'IN_REVIEW'::"AdaptiveScaleLinkStatus" AND NEW.status IN ('APPROVED'::"AdaptiveScaleLinkStatus", 'REJECTED'::"AdaptiveScaleLinkStatus"))
+      OR (OLD.status = 'APPROVED'::"AdaptiveScaleLinkStatus" AND NEW.status = 'SUPERSEDED'::"AdaptiveScaleLinkStatus")
+    ) THEN
+      RAISE EXCEPTION 'Invalid scale-link lifecycle transition: % -> %', OLD.status, NEW.status;
+    END IF;
+    IF NEW.status IN ('APPROVED'::"AdaptiveScaleLinkStatus", 'REJECTED'::"AdaptiveScaleLinkStatus")
+       AND (NEW."reviewedById" IS NULL OR NEW."reviewedAt" IS NULL) THEN
+      RAISE EXCEPTION 'Scale-link review identity is required for a review decision';
+    END IF;
+    IF NEW.status = 'APPROVED'::"AdaptiveScaleLinkStatus"
+       AND NOT EXISTS (SELECT 1 FROM "CompetenceTreeScaleLinkAnchor" anchor WHERE anchor."scaleLinkId" = NEW.id) THEN
+      RAISE EXCEPTION 'At least one exact anchor pair is required to approve a scale link';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND OLD.status <> 'DRAFT'::"AdaptiveScaleLinkStatus"
+     AND to_jsonb(NEW) - ARRAY['status', 'reviewedById', 'reviewedAt', 'updatedAt']::text[]
+         IS DISTINCT FROM
+         to_jsonb(OLD) - ARRAY['status', 'reviewedById', 'reviewedAt', 'updatedAt']::text[] THEN
+    RAISE EXCEPTION 'Reviewed scale-link evidence is immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctslk_lifecycle_guard"
+BEFORE INSERT OR UPDATE OR DELETE ON "CompetenceTreeScaleLink"
+FOR EACH ROW EXECUTE FUNCTION adaptive_scale_link_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_scale_link_anchor_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  link_record record;
+  from_record record;
+  to_record record;
+BEGIN
+  SELECT "treeId", "fromScaleVersionId", "toScaleVersionId", status INTO link_record
+  FROM "CompetenceTreeScaleLink"
+  WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD."scaleLinkId" ELSE NEW."scaleLinkId" END;
+
+  IF link_record.status IS DISTINCT FROM 'DRAFT'::"AdaptiveScaleLinkStatus" THEN
+    RAISE EXCEPTION 'Scale-link anchors are immutable after review submission';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT "treeId", "scaleVersionId", "assignmentId", "elementId", "elementVersion" INTO from_record
+  FROM "AdaptiveItemCalibration" WHERE id = NEW."fromCalibrationId";
+  SELECT "treeId", "scaleVersionId", "assignmentId", "elementId", "elementVersion" INTO to_record
+  FROM "AdaptiveItemCalibration" WHERE id = NEW."toCalibrationId";
+
+  IF from_record."treeId" IS DISTINCT FROM link_record."treeId"
+     OR to_record."treeId" IS DISTINCT FROM link_record."treeId"
+     OR from_record."scaleVersionId" IS DISTINCT FROM link_record."fromScaleVersionId"
+     OR to_record."scaleVersionId" IS DISTINCT FROM link_record."toScaleVersionId"
+     OR from_record."assignmentId" IS DISTINCT FROM to_record."assignmentId"
+     OR from_record."elementId" IS DISTINCT FROM to_record."elementId"
+     OR from_record."elementVersion" IS DISTINCT FROM to_record."elementVersion" THEN
+    RAISE EXCEPTION 'Scale-link anchors must pair the same item identity across the linked scales';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "ctsla_identity_guard"
+BEFORE INSERT OR UPDATE OR DELETE ON "CompetenceTreeScaleLinkAnchor"
+FOR EACH ROW EXECUTE FUNCTION adaptive_scale_link_anchor_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_publication_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  quiz_preset "AdaptivePracticeQuizPreset";
+  validation_status "AdaptiveEmpiricalValidationStatus";
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD."sealedAt" IS NOT NULL AND (
+      OLD."unpublishedAt" IS NULL
+      OR EXISTS (
+        SELECT 1 FROM "AdaptivePracticeQuizAttempt" attempt
+        WHERE attempt."publicationId" = OLD.id
+      )
+    ) THEN
+      RAISE EXCEPTION 'Active adaptive publications and publications with attempts cannot be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND (
+    to_jsonb(NEW) - ARRAY['sealedAt', 'supersededAt', 'unpublishedAt']::text[]
+    IS DISTINCT FROM
+    to_jsonb(OLD) - ARRAY['sealedAt', 'supersededAt', 'unpublishedAt']::text[]
+  ) THEN
+    RAISE EXCEPTION 'Published adaptive measurement snapshots are immutable';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD."sealedAt" IS NOT NULL AND NEW."sealedAt" IS DISTINCT FROM OLD."sealedAt" THEN
+    RAISE EXCEPTION 'Adaptive publications cannot be unsealed or resealed';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND OLD."supersededAt" IS NOT NULL
+     AND NEW."supersededAt" IS DISTINCT FROM OLD."supersededAt" THEN
+    RAISE EXCEPTION 'Adaptive publication supersession is monotonic';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND OLD."unpublishedAt" IS NOT NULL
+     AND NEW."unpublishedAt" IS DISTINCT FROM OLD."unpublishedAt" THEN
+    RAISE EXCEPTION 'Adaptive publication withdrawal is monotonic';
+  END IF;
+
+  IF NEW."sealedAt" IS NOT NULL
+     AND (TG_OP = 'INSERT' OR OLD."sealedAt" IS NULL)
+     AND NOT EXISTS (
+       SELECT 1 FROM "PracticeQuizAdaptivePoolItem" pool WHERE pool."publicationId" = NEW.id
+     ) THEN
+    RAISE EXCEPTION 'An adaptive publication cannot be sealed with an empty pool';
+  END IF;
+
+  IF NEW."empiricalValidationId" IS NOT NULL THEN
+    SELECT status INTO validation_status
+    FROM "AdaptivePracticeQuizEmpiricalValidation"
+    WHERE id = NEW."empiricalValidationId";
+    IF validation_status IS DISTINCT FROM 'APPROVED'::"AdaptiveEmpiricalValidationStatus" THEN
+      RAISE EXCEPTION 'Only approved empirical validation may be attached to a publication';
+    END IF;
+  END IF;
+
+  IF NEW."measurementVersion" = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion" THEN
+    SELECT preset INTO quiz_preset FROM "PracticeQuizAdaptiveConfig" WHERE id = NEW."configId";
+    IF quiz_preset = 'DIAGNOSTIC'::"AdaptivePracticeQuizPreset" AND NEW."empiricalValidationId" IS NULL THEN
+      RAISE EXCEPTION 'Diagnostic IRT v2 publication requires approved holdout validation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "pqap_publication_guard"
+BEFORE INSERT OR UPDATE OR DELETE ON "PracticeQuizAdaptivePublication"
+FOR EACH ROW EXECUTE FUNCTION adaptive_publication_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_pool_snapshot_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  publication_record record;
+  calibration_record record;
+BEGIN
+  SELECT "scaleVersionId", "measurementVersion", "sealedAt", "unpublishedAt" INTO publication_record
+  FROM "PracticeQuizAdaptivePublication"
+  WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD."publicationId" ELSE NEW."publicationId" END;
+
+  IF TG_OP = 'UPDATE' AND publication_record."sealedAt" IS NOT NULL THEN
+    RAISE EXCEPTION 'Sealed adaptive pool rows are immutable';
+  END IF;
+  IF TG_OP = 'DELETE' AND publication_record."sealedAt" IS NOT NULL
+     AND (
+       publication_record."unpublishedAt" IS NULL
+       OR EXISTS (
+         SELECT 1 FROM "AdaptivePracticeQuizAttempt" attempt
+         WHERE attempt."publicationId" = OLD."publicationId"
+       )
+     ) THEN
+    RAISE EXCEPTION 'Active adaptive pool rows and pools with attempts cannot be deleted';
+  END IF;
+  IF TG_OP = 'INSERT' AND publication_record."sealedAt" IS NOT NULL THEN
+    RAISE EXCEPTION 'Items cannot be added to a sealed adaptive pool';
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT version, status, model, "modelImplementationVersion", discrimination, difficulty, guessing
+  INTO calibration_record
+  FROM "AdaptiveItemCalibration" WHERE id = NEW."calibrationId";
+
+  IF publication_record."scaleVersionId" IS DISTINCT FROM NEW."scaleVersionId"
+     OR publication_record."measurementVersion" IS DISTINCT FROM NEW."measurementVersion"
+     OR calibration_record.version IS DISTINCT FROM NEW."calibrationVersion"
+     OR calibration_record.status IS DISTINCT FROM NEW."calibrationStatus"
+     OR calibration_record.model IS DISTINCT FROM NEW."itemModel"
+     OR calibration_record."modelImplementationVersion" IS DISTINCT FROM NEW."modelImplementationVersion" THEN
+    RAISE EXCEPTION 'Adaptive pool snapshots must match their publication and calibration identities';
+  END IF;
+
+  IF NEW."measurementVersion" = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion"
+     AND (
+       (NEW.role IN ('SCORING'::"AdaptivePoolItemRole", 'ANCHOR'::"AdaptivePoolItemRole")
+        AND calibration_record.status <> 'CALIBRATED'::"AdaptiveItemCalibrationStatus")
+       OR (NEW.role = 'FIELD_TEST'::"AdaptivePoolItemRole"
+           AND calibration_record.status NOT IN (
+             'PROVISIONAL'::"AdaptiveItemCalibrationStatus",
+             'PILOT'::"AdaptiveItemCalibrationStatus"
+           ))
+       OR calibration_record.discrimination IS DISTINCT FROM NEW.discrimination
+       OR calibration_record.difficulty IS DISTINCT FROM NEW.difficulty
+       OR calibration_record.guessing IS DISTINCT FROM NEW.guessing
+     ) THEN
+    RAISE EXCEPTION 'IRT v2 scoring pools require exact approved calibration parameters';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "pqapi_snapshot_guard"
+BEFORE INSERT OR UPDATE OR DELETE ON "PracticeQuizAdaptivePoolItem"
+FOR EACH ROW EXECUTE FUNCTION adaptive_pool_snapshot_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_attempt_publication_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  publication_measurement "AdaptiveMeasurementVersion";
+  pool_role "AdaptivePoolItemRole";
+BEGIN
+  SELECT publication."measurementVersion"
+  INTO publication_measurement
+  FROM "PracticeQuizAdaptivePublication" publication
+  WHERE publication.id = NEW."publicationId" AND publication."sealedAt" IS NOT NULL;
+
+  IF publication_measurement IS NULL THEN
+    RAISE EXCEPTION 'Adaptive attempts require a sealed publication';
+  END IF;
+  IF publication_measurement IS DISTINCT FROM NEW."measurementVersion" THEN
+    RAISE EXCEPTION 'Adaptive attempt estimator identity must match its publication';
+  END IF;
+  IF NEW."nextPoolItemId" IS NOT NULL THEN
+    SELECT role INTO pool_role
+    FROM "PracticeQuizAdaptivePoolItem"
+    WHERE "publicationId" = NEW."publicationId" AND id = NEW."nextPoolItemId";
+    IF pool_role IS NULL THEN
+      RAISE EXCEPTION 'Adaptive attempt next item must belong to its publication';
+    END IF;
+    IF publication_measurement = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion"
+       AND pool_role IS DISTINCT FROM NEW."nextItemRole" THEN
+      RAISE EXCEPTION 'Adaptive attempt delivery identity must match its next pool item';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "apqa_sealed_publication_guard"
+BEFORE INSERT OR UPDATE ON "AdaptivePracticeQuizAttempt"
+FOR EACH ROW EXECUTE FUNCTION adaptive_attempt_publication_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_response_design_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  pool_role "AdaptivePoolItemRole";
+  attempt_record RECORD;
+BEGIN
+  IF NEW."poolItemId" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT role INTO pool_role
+  FROM "PracticeQuizAdaptivePoolItem"
+  WHERE "publicationId" = NEW."publicationId" AND id = NEW."poolItemId";
+
+  IF pool_role IS DISTINCT FROM NEW."itemRole"
+     OR NEW."isCalibrationAnchor" IS DISTINCT FROM (pool_role = 'ANCHOR'::"AdaptivePoolItemRole") THEN
+    RAISE EXCEPTION 'Adaptive response design identity must match the served pool item';
+  END IF;
+  SELECT
+    "measurementVersion",
+    "nextPoolItemId",
+    "nextAdministrationProbability",
+    "nextCollectionDesignVersion",
+    "nextRandomizationVersion",
+    "nextRandomDraw",
+    "nextCandidateSetHash",
+    "nextItemRole"
+  INTO attempt_record
+  FROM "AdaptivePracticeQuizAttempt"
+  WHERE id = NEW."attemptId";
+
+  IF attempt_record."measurementVersion" = 'IRT_V2_EAP_GRID_1'::"AdaptiveMeasurementVersion"
+     AND (
+       attempt_record."nextPoolItemId" IS DISTINCT FROM NEW."poolItemId"
+       OR attempt_record."nextAdministrationProbability" IS DISTINCT FROM NEW."administrationProbability"
+       OR attempt_record."nextCollectionDesignVersion" IS DISTINCT FROM NEW."collectionDesignVersion"
+       OR attempt_record."nextRandomizationVersion" IS DISTINCT FROM NEW."randomizationVersion"
+       OR attempt_record."nextRandomDraw" IS DISTINCT FROM NEW."randomDraw"
+       OR attempt_record."nextCandidateSetHash" IS DISTINCT FROM NEW."candidateSetHash"
+       OR attempt_record."nextItemRole" IS DISTINCT FROM NEW."itemRole"
+     ) THEN
+    RAISE EXCEPTION 'Adaptive response audit identity must match the served delivery';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "apqr_design_identity_guard"
+BEFORE INSERT OR UPDATE ON "AdaptivePracticeQuizResponse"
+FOR EACH ROW EXECUTE FUNCTION adaptive_response_design_guard();
+
+CREATE OR REPLACE FUNCTION adaptive_calibration_immutability_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Calibration records cannot be deleted';
+  END IF;
+  IF to_jsonb(NEW) - ARRAY['status', 'approvedById', 'approvedAt', 'updatedAt']::text[]
+     IS DISTINCT FROM
+     to_jsonb(OLD) - ARRAY['status', 'approvedById', 'approvedAt', 'updatedAt']::text[] THEN
+    RAISE EXCEPTION 'Calibration parameters are immutable; create a new calibration version';
+  END IF;
+  IF NEW.status IS DISTINCT FROM OLD.status
+     AND NOT (
+       (OLD.status = 'PROVISIONAL'::"AdaptiveItemCalibrationStatus" AND NEW.status IN (
+         'PILOT'::"AdaptiveItemCalibrationStatus",
+         'FLAGGED'::"AdaptiveItemCalibrationStatus",
+         'RETIRED'::"AdaptiveItemCalibrationStatus"
+       ))
+       OR (OLD.status = 'PILOT'::"AdaptiveItemCalibrationStatus" AND NEW.status IN (
+         'CALIBRATED'::"AdaptiveItemCalibrationStatus",
+         'FLAGGED'::"AdaptiveItemCalibrationStatus",
+         'RETIRED'::"AdaptiveItemCalibrationStatus"
+       ))
+       OR (OLD.status = 'CALIBRATED'::"AdaptiveItemCalibrationStatus" AND NEW.status IN (
+         'FLAGGED'::"AdaptiveItemCalibrationStatus",
+         'RETIRED'::"AdaptiveItemCalibrationStatus"
+       ))
+       OR (OLD.status = 'FLAGGED'::"AdaptiveItemCalibrationStatus" AND NEW.status IN (
+         'CALIBRATED'::"AdaptiveItemCalibrationStatus",
+         'RETIRED'::"AdaptiveItemCalibrationStatus"
+       ))
+     ) THEN
+    RAISE EXCEPTION 'Invalid adaptive calibration status transition';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "aic_immutability_guard"
+BEFORE UPDATE OR DELETE ON "AdaptiveItemCalibration"
+FOR EACH ROW EXECUTE FUNCTION adaptive_calibration_immutability_guard();
+
+COMMENT ON TABLE "CompetenceTreeScaleVersion" IS 'Versioned latent scale; activation requires independent standard-setting evidence.';
+COMMENT ON TABLE "AdaptiveItemCalibration" IS 'Immutable item-parameter version for an exact tree, scale, assignment, element, and element-version identity.';
+COMMENT ON TABLE "PracticeQuizAdaptivePublication" IS 'Immutable estimator, policy, scale, and cut-score snapshot for one materialized adaptive pool.';
+COMMENT ON TABLE "AdaptivePracticeQuizItemExposure" IS 'Mutable aggregate exposure counters without participant identity.';
+COMMENT ON COLUMN "AdaptiveCalibrationExportRequest"."artifactKey" IS 'Worker-only opaque storage key; never expose through public GraphQL.';
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260731123000_adaptive_irt_v2_export_artifacts/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260731123000_adaptive_irt_v2_export_artifacts/migration.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ADD COLUMN "datasetVersion" TEXT NOT NULL DEFAULT 'legacy-v1',
+  ADD COLUMN "splitPolicyVersion" TEXT NOT NULL DEFAULT 'HMAC_80_20_V1',
+  ADD COLUMN "manifestArtifactKey" TEXT,
+  ADD COLUMN "manifestChecksum" TEXT,
+  ADD COLUMN "holdoutArtifactKey" TEXT,
+  ADD COLUMN "holdoutArtifactChecksum" TEXT,
+  ADD COLUMN "holdoutRowCount" INTEGER,
+  ADD COLUMN "criterionArtifactKey" TEXT,
+  ADD COLUMN "criterionArtifactChecksum" TEXT;
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ALTER COLUMN "datasetVersion" DROP DEFAULT,
+  DROP CONSTRAINT "acer_state_check",
+  ADD CONSTRAINT "acer_state_check" CHECK (
+    length("datasetVersion") BETWEEN 1 AND 160
+    AND length("splitPolicyVersion") BETWEEN 1 AND 160
+    AND ("rowCount" IS NULL OR "rowCount" >= 0)
+    AND ("holdoutRowCount" IS NULL OR "holdoutRowCount" >= 0)
+    AND (("criterionArtifactKey" IS NULL) = ("criterionArtifactChecksum" IS NULL))
+    AND ("criterionArtifactChecksum" IS NULL OR "criterionArtifactChecksum" ~ '^[a-f0-9]{64}$')
+    AND "expiresAt" > "createdAt"
+    AND (
+      "status" <> 'READY'::"AdaptiveCalibrationExportStatus"
+      OR (
+        "artifactKey" IS NOT NULL
+        AND "artifactChecksum" ~ '^[a-f0-9]{64}$'
+        AND "rowCount" IS NOT NULL
+        AND "manifestArtifactKey" IS NOT NULL
+        AND "manifestChecksum" ~ '^[a-f0-9]{64}$'
+        AND "holdoutArtifactKey" IS NOT NULL
+        AND "holdoutArtifactChecksum" ~ '^[a-f0-9]{64}$'
+        AND "holdoutRowCount" IS NOT NULL
+        AND "completedAt" IS NOT NULL
+      )
+    )
+    AND (
+      "status" <> 'FAILED'::"AdaptiveCalibrationExportStatus"
+      OR ("failureCode" IS NOT NULL AND "completedAt" IS NOT NULL)
+    )
+  ) NOT VALID;
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  VALIDATE CONSTRAINT "acer_state_check";
+
+COMMENT ON COLUMN "AdaptiveCalibrationExportRequest"."manifestArtifactKey" IS
+  'Worker-only opaque storage key; never expose through public GraphQL.';
+COMMENT ON COLUMN "AdaptiveCalibrationExportRequest"."holdoutArtifactKey" IS
+  'Sealed worker/reviewer-only storage key; never expose to the tree owner.';
+COMMENT ON COLUMN "AdaptiveCalibrationExportRequest"."criterionArtifactKey" IS
+  'Sealed reviewer-provided criterion key; retained only until validation succeeds or the export expires.';
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260801120000_adaptive_operation_fencing/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260801120000_adaptive_operation_fencing/migration.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE "Element"
+  ADD COLUMN "creationRequestId" UUID,
+  ADD COLUMN "creationRequestFingerprint" VARCHAR(64);
+
+CREATE UNIQUE INDEX "element_creation_request_key"
+  ON "Element"("creationRequestId");
+
+ALTER TABLE "Element"
+  ADD CONSTRAINT "element_creation_request_identity_check" CHECK (
+    ("creationRequestId" IS NULL AND "creationRequestFingerprint" IS NULL)
+    OR (
+      "creationRequestId" IS NOT NULL
+      AND "creationRequestFingerprint" IS NOT NULL
+      AND "creationRequestFingerprint" ~ '^[0-9a-f]{64}$'
+    )
+  ) NOT VALID;
+
+ALTER TABLE "Element"
+  VALIDATE CONSTRAINT "element_creation_request_identity_check";
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ADD COLUMN "runToken" UUID;
+
+UPDATE "AdaptiveCalibrationExportRequest"
+SET "runToken" = gen_random_uuid()
+WHERE "status" = 'RUNNING'::"AdaptiveCalibrationExportStatus";
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  ADD CONSTRAINT "acer_running_lease_check" CHECK (
+    ("status" = 'RUNNING'::"AdaptiveCalibrationExportStatus")
+    = ("runToken" IS NOT NULL)
+  ) NOT VALID;
+
+ALTER TABLE "AdaptiveCalibrationExportRequest"
+  VALIDATE CONSTRAINT "acer_running_lease_check";
+
+COMMENT ON COLUMN "Element"."creationRequestId" IS
+  'Durable idempotency token for atomic first-save element creation and assignment.';
+COMMENT ON COLUMN "Element"."creationRequestFingerprint" IS
+  'SHA-256 fingerprint of the immutable first-save element and assignment request.';
+COMMENT ON COLUMN "AdaptiveCalibrationExportRequest"."runToken" IS
+  'Lease token fencing terminal updates and artifacts to one export worker run.';
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260801130000_adaptive_scale_link_anchor_uniqueness/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260801130000_adaptive_scale_link_anchor_uniqueness/migration.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+
+DROP INDEX "ctsla_link_pair_key";
+
+CREATE UNIQUE INDEX "ctsla_link_from_key"
+  ON "CompetenceTreeScaleLinkAnchor"("scaleLinkId", "fromCalibrationId");
+
+CREATE UNIQUE INDEX "ctsla_link_to_key"
+  ON "CompetenceTreeScaleLinkAnchor"("scaleLinkId", "toCalibrationId");
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/participant.prisma
+++ b/packages/prisma/src/prisma/schema/participant.prisma
@@ -93,6 +93,8 @@ model Participant {
   invitations                     ParticipantInvitation[]
   pointCorrections                PointCorrection[]
   individualPointCorrections      PointCorrection[]                @relation("PointCorrectionParticipants")
+  adaptiveAssessmentAttempts      AdaptiveAssessmentAttempt[]
+  adaptivePracticeQuizAttempts    AdaptivePracticeQuizAttempt[]
   verificationRecords             VerifiableCredential[]
 
   createdAt DateTime @default(now())
@@ -161,16 +163,19 @@ model Participation {
   sessionLeaderboards LeaderboardEntry[] @relation("SessionLeaderboards")
   timelineEntries     TimelineEntry[]
 
-  responses               QuestionResponse[]
-  detailResponses         QuestionResponseDetail[]
-  subscriptions           PushSubscription[]
-  completedMicroLearnings String[]
-  bookmarkedElementStacks ElementStack[]
+  responses                    QuestionResponse[]
+  detailResponses              QuestionResponseDetail[]
+  subscriptions                PushSubscription[]
+  completedMicroLearnings      String[]
+  bookmarkedElementStacks      ElementStack[]
+  adaptiveAssessmentAttempts   AdaptiveAssessmentAttempt[]
+  adaptivePracticeQuizAttempts AdaptivePracticeQuizAttempt[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@unique([courseId, participantId])
+  @@unique([id, participantId, courseId], map: "participation_identity_key")
 }
 
 model GroupAssignmentPoolEntry {

--- a/packages/prisma/src/prisma/schema/quiz.prisma
+++ b/packages/prisma/src/prisma/schema/quiz.prisma
@@ -29,6 +29,7 @@ model PracticeQuiz {
   pointsMultiplier Int               @default(1)
   resetTimeDays    Int               @default(6)
   orderType        ElementOrderType  @default(SPACED_REPETITION)
+  mode             PracticeQuizMode  @default(STANDARD)
   status           PublicationStatus @default(DRAFT)
 
   availableFrom              DateTime?
@@ -41,6 +42,9 @@ model PracticeQuiz {
   isDeleted             Boolean @default(false)
 
   stacks ElementStack[]
+
+  adaptiveConfig   PracticeQuizAdaptiveConfig?
+  adaptiveAttempts AdaptivePracticeQuizAttempt[]
 
   responses               QuestionResponse[]
   responseDetails         QuestionResponseDetail[]
@@ -68,6 +72,8 @@ model PracticeQuiz {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([id, courseId], map: "practice_quiz_id_course_key")
 }
 
 // #endregion

--- a/packages/prisma/src/prisma/schema/sharing.prisma
+++ b/packages/prisma/src/prisma/schema/sharing.prisma
@@ -1,170 +1,170 @@
 // ----- SHARING & PERMISSIONS -----
 // #region
 enum PermissionLevel {
-    READ // read access (no modifications, no deletion, no sharing)
-    WRITE // edit access (no deletion, no sharing)
-    EXECUTE // e.g. for live quizzes: only inspect evaluation
-    ADMIN // e.g. admins can not only edit (= WRITE) but also change access rights
-    OWNER // (derived permissions only)
+  READ // read access (no modifications, no deletion, no sharing)
+  WRITE // edit access (no deletion, no sharing)
+  EXECUTE // e.g. for live quizzes: only inspect evaluation
+  ADMIN // e.g. admins can not only edit (= WRITE) but also change access rights
+  OWNER // (derived permissions only)
 }
 
 model UserGroup {
-    id   Int    @id @default(autoincrement())
-    name String
+  id   Int    @id @default(autoincrement())
+  name String
 
-    members User[] @relation("UserGroupMembers") // can view / edit / admin shared objects according to permissions
-    admins  User[] @relation("UserGroupAdmins") // member + can add & remove members and provide & remove admin access
+  members User[] @relation("UserGroupMembers") // can view / edit / admin shared objects according to permissions
+  admins  User[] @relation("UserGroupAdmins") // member + can add & remove members and provide & remove admin access
 
-    permissions Permission[]
+  permissions Permission[]
 
-    owner   User   @relation(name: "UserGroupOwner", fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    ownerId String @db.Uuid
+  owner   User   @relation(name: "UserGroupOwner", fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    @@unique([ownerId, name])
+  @@unique([ownerId, name])
 }
 
 // explicitly granted permissions for a user or user group to access an object
 model Permission {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // user or user group requesting access
-    user   User?   @relation("DirectlySharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String? @db.Uuid
+  // user or user group requesting access
+  user   User?   @relation("DirectlySharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String? @db.Uuid
 
-    userGroup   UserGroup? @relation(fields: [userGroupId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userGroupId Int?
+  userGroup   UserGroup? @relation(fields: [userGroupId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userGroupId Int?
 
-    // define if only minimal permissions should be propagated or if the explicitly granted
-    // permission level should be propagated according to the permission scheme
-    // & link all permissions that are derived from this permission to it
-    propagation        Boolean             @default(false)
-    derivedPermissions DerivedPermission[]
+  // define if only minimal permissions should be propagated or if the explicitly granted
+  // permission level should be propagated according to the permission scheme
+  // & link all permissions that are derived from this permission to it
+  propagation        Boolean             @default(false)
+  derivedPermissions DerivedPermission[]
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one permission per object and user / user group
-    @@unique([catalogCollectionId, userId])
-    @@unique([answerCollectionId, userId])
-    @@unique([elementId, userId])
-    @@unique([courseId, userId])
-    @@unique([liveQuizId, userId])
-    @@unique([practiceQuizId, userId])
-    @@unique([microLearningId, userId])
-    @@unique([groupActivityId, userId])
-    @@unique([catalogCollectionId, userGroupId])
-    @@unique([answerCollectionId, userGroupId])
-    @@unique([elementId, userGroupId])
-    @@unique([courseId, userGroupId])
-    @@unique([liveQuizId, userGroupId])
-    @@unique([practiceQuizId, userGroupId])
-    @@unique([microLearningId, userGroupId])
-    @@unique([groupActivityId, userGroupId])
+  // only one permission per object and user / user group
+  @@unique([catalogCollectionId, userId])
+  @@unique([answerCollectionId, userId])
+  @@unique([elementId, userId])
+  @@unique([courseId, userId])
+  @@unique([liveQuizId, userId])
+  @@unique([practiceQuizId, userId])
+  @@unique([microLearningId, userId])
+  @@unique([groupActivityId, userId])
+  @@unique([catalogCollectionId, userGroupId])
+  @@unique([answerCollectionId, userGroupId])
+  @@unique([elementId, userGroupId])
+  @@unique([courseId, userGroupId])
+  @@unique([liveQuizId, userGroupId])
+  @@unique([practiceQuizId, userGroupId])
+  @@unique([microLearningId, userGroupId])
+  @@unique([groupActivityId, userGroupId])
 }
 
 // permissions requested by a user (default: READ, after granting higher access level can be requested)
 // to avoid the need for a separate table of derived access requests, duplicates are stored for every object owner / admin
 model AccessRequest {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // user requesting access
-    user   User   @relation("RequestedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String @db.Uuid
+  // user requesting access
+  user   User   @relation("RequestedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String @db.Uuid
 
-    // user id of owner / admin to which the request is sent
-    objectAdminOrOwner   User   @relation("PendingRequests", fields: [objectAdminOrOwnerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    objectAdminOrOwnerId String @db.Uuid
+  // user id of owner / admin to which the request is sent
+  objectAdminOrOwner   User   @relation("PendingRequests", fields: [objectAdminOrOwnerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  objectAdminOrOwnerId String @db.Uuid
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one access request per object and user (duplicates for every owner / admin; upsert when creating a new request)
-    @@unique([catalogCollectionId, userId, objectAdminOrOwnerId])
-    @@unique([answerCollectionId, userId, objectAdminOrOwnerId])
-    @@unique([elementId, userId, objectAdminOrOwnerId])
-    @@unique([courseId, userId, objectAdminOrOwnerId])
-    @@unique([liveQuizId, userId, objectAdminOrOwnerId])
-    @@unique([practiceQuizId, userId, objectAdminOrOwnerId])
-    @@unique([microLearningId, userId, objectAdminOrOwnerId])
-    @@unique([groupActivityId, userId, objectAdminOrOwnerId])
-    // indices to efficiently query all access requests for a user or object admin / owner
-    @@index([userId])
-    @@index([objectAdminOrOwnerId])
-    // indices to efficiently query all instances of an object request for a specific user
-    // -> efficiently delete entries when access is granted / rejected or the user withdrew the request
-    @@index([catalogCollectionId, userId])
-    @@index([answerCollectionId, userId])
-    @@index([elementId, userId])
-    @@index([courseId, userId])
-    @@index([liveQuizId, userId])
-    @@index([practiceQuizId, userId])
-    @@index([microLearningId, userId])
-    @@index([groupActivityId, userId])
-    // indices to efficiently query all object requests for a specific object and object admin / owner
-    // -> efficiently delete entries when admin access is revoked / ownership is transferred
-    @@index([catalogCollectionId, objectAdminOrOwnerId])
-    @@index([answerCollectionId, objectAdminOrOwnerId])
-    @@index([elementId, objectAdminOrOwnerId])
-    @@index([courseId, objectAdminOrOwnerId])
-    @@index([liveQuizId, objectAdminOrOwnerId])
-    @@index([practiceQuizId, objectAdminOrOwnerId])
-    @@index([microLearningId, objectAdminOrOwnerId])
-    @@index([groupActivityId, objectAdminOrOwnerId])
+  // only one access request per object and user (duplicates for every owner / admin; upsert when creating a new request)
+  @@unique([catalogCollectionId, userId, objectAdminOrOwnerId])
+  @@unique([answerCollectionId, userId, objectAdminOrOwnerId])
+  @@unique([elementId, userId, objectAdminOrOwnerId])
+  @@unique([courseId, userId, objectAdminOrOwnerId])
+  @@unique([liveQuizId, userId, objectAdminOrOwnerId])
+  @@unique([practiceQuizId, userId, objectAdminOrOwnerId])
+  @@unique([microLearningId, userId, objectAdminOrOwnerId])
+  @@unique([groupActivityId, userId, objectAdminOrOwnerId])
+  // indices to efficiently query all access requests for a user or object admin / owner
+  @@index([userId])
+  @@index([objectAdminOrOwnerId])
+  // indices to efficiently query all instances of an object request for a specific user
+  // -> efficiently delete entries when access is granted / rejected or the user withdrew the request
+  @@index([catalogCollectionId, userId])
+  @@index([answerCollectionId, userId])
+  @@index([elementId, userId])
+  @@index([courseId, userId])
+  @@index([liveQuizId, userId])
+  @@index([practiceQuizId, userId])
+  @@index([microLearningId, userId])
+  @@index([groupActivityId, userId])
+  // indices to efficiently query all object requests for a specific object and object admin / owner
+  // -> efficiently delete entries when admin access is revoked / ownership is transferred
+  @@index([catalogCollectionId, objectAdminOrOwnerId])
+  @@index([answerCollectionId, objectAdminOrOwnerId])
+  @@index([elementId, objectAdminOrOwnerId])
+  @@index([courseId, objectAdminOrOwnerId])
+  @@index([liveQuizId, objectAdminOrOwnerId])
+  @@index([practiceQuizId, objectAdminOrOwnerId])
+  @@index([microLearningId, objectAdminOrOwnerId])
+  @@index([groupActivityId, objectAdminOrOwnerId])
 }
 
 // derived permissions that have been computed based on the user's direct permissions on parent objects or user group permissions
@@ -172,66 +172,66 @@ model AccessRequest {
 // for every user only the highest available access level is stored here for efficient querying
 // direct permissions are also copied to the derived permissions table for more efficient access (and deduplication)
 model DerivedPermission {
-    id              Int             @id @default(autoincrement())
-    permissionLevel PermissionLevel
+  id              Int             @id @default(autoincrement())
+  permissionLevel PermissionLevel
 
-    // permission from which this derived permission was created (not required to allow storing owner permission also as derived permission)
-    directPermission   Permission? @relation(fields: [directPermissionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    directPermissionId Int?
+  // permission from which this derived permission was created (not required to allow storing owner permission also as derived permission)
+  directPermission   Permission? @relation(fields: [directPermissionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  directPermissionId Int?
 
-    // true if the permission is not based on a direct permission (user or user group), but derived from another object (e.g. element -> answer collection)
-    derived Boolean @default(false)
+  // true if the permission is not based on a direct permission (user or user group), but derived from another object (e.g. element -> answer collection)
+  derived Boolean @default(false)
 
-    // user or user group requesting access
-    user   User   @relation("SharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    userId String @db.Uuid
+  // user or user group requesting access
+  user   User   @relation("SharedObjects", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String @db.Uuid
 
-    // shared objects
-    catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String?            @db.Uuid
+  // shared objects
+  catalogCollection   CatalogCollection? @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String?            @db.Uuid
 
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // only one access request per object and user (upsert when creating a new request)
-    @@unique([catalogCollectionId, userId])
-    @@unique([answerCollectionId, userId])
-    @@unique([elementId, userId])
-    @@unique([courseId, userId])
-    @@unique([liveQuizId, userId])
-    @@unique([practiceQuizId, userId])
-    @@unique([microLearningId, userId])
-    @@unique([groupActivityId, userId])
-    // index on permission level and object id to efficiently retrieve all users with a specific access level to the object
-    @@index([catalogCollectionId, permissionLevel])
-    @@index([answerCollectionId, permissionLevel])
-    @@index([elementId, permissionLevel])
-    @@index([courseId, permissionLevel])
-    @@index([liveQuizId, permissionLevel])
-    @@index([practiceQuizId, permissionLevel])
-    @@index([microLearningId, permissionLevel])
-    @@index([groupActivityId, permissionLevel])
+  // only one access request per object and user (upsert when creating a new request)
+  @@unique([catalogCollectionId, userId])
+  @@unique([answerCollectionId, userId])
+  @@unique([elementId, userId])
+  @@unique([courseId, userId])
+  @@unique([liveQuizId, userId])
+  @@unique([practiceQuizId, userId])
+  @@unique([microLearningId, userId])
+  @@unique([groupActivityId, userId])
+  // index on permission level and object id to efficiently retrieve all users with a specific access level to the object
+  @@index([catalogCollectionId, permissionLevel])
+  @@index([answerCollectionId, permissionLevel])
+  @@index([elementId, permissionLevel])
+  @@index([courseId, permissionLevel])
+  @@index([liveQuizId, permissionLevel])
+  @@index([practiceQuizId, permissionLevel])
+  @@index([microLearningId, permissionLevel])
+  @@index([groupActivityId, permissionLevel])
 }
 
 // #endregion
@@ -239,28 +239,28 @@ model DerivedPermission {
 // ----- ACTIVITY TEMPLATES -----
 // #region
 model ActivityTemplate {
-    id String @id @default(uuid()) @db.Uuid
+  id String @id @default(uuid()) @db.Uuid
 
-    description  String // description of the activity template (to be shown in the catalog)
-    instructions String // instructions for the user (to be shown in the template editor)
+  description  String // description of the activity template (to be shown in the catalog)
+  instructions String // instructions for the user (to be shown in the template editor)
 
-    // link to at least one activity for which this template is used
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @unique @db.Uuid
+  // link to at least one activity for which this template is used
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @unique @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @unique @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @unique @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @unique @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @unique @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @unique @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @unique @db.Uuid
 
-    // optional link to answer collections, if any question in the activity is based on these collections
-    answerCollections     AnswerCollection[]      @relation("TemplateAnswerCollectionUsages")
-    // optional link to answer collection items, if any question in the activity is based on these items
-    answerCollectionItems AnswerCollectionEntry[] @relation("TemplateAnswerCollectionUsedItems")
+  // optional link to answer collections, if any question in the activity is based on these collections
+  answerCollections     AnswerCollection[]      @relation("TemplateAnswerCollectionUsages")
+  // optional link to answer collection items, if any question in the activity is based on these items
+  answerCollectionItems AnswerCollectionEntry[] @relation("TemplateAnswerCollectionUsedItems")
 }
 
 // #endregion
@@ -268,80 +268,80 @@ model ActivityTemplate {
 // ----- CATALOG -----
 // #region
 enum ObjectAccess {
-    RESTRICTED
-    PUBLIC
+  RESTRICTED
+  PUBLIC
 }
 
 // many-to-many join table between catalog collection and shared object with access information
 model CatalogCollectionAssignment {
-    id Int @id @default(autoincrement())
+  id Int @id @default(autoincrement())
 
-    // access level for this specific assignment
-    access ObjectAccess @default(RESTRICTED)
+  // access level for this specific assignment
+  access ObjectAccess @default(RESTRICTED)
 
-    // catalog collection assignment
-    catalogCollection   CatalogCollection @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    catalogCollectionId String            @db.Uuid
+  // catalog collection assignment
+  catalogCollection   CatalogCollection @relation(fields: [catalogCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  catalogCollectionId String            @db.Uuid
 
-    // object in the catalog collection
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  // object in the catalog collection
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    // for each assignment of an object to a catalog collection there is only allowed to be one entry
-    @@unique([answerCollectionId, catalogCollectionId])
-    @@unique([elementId, catalogCollectionId])
-    @@unique([courseId, catalogCollectionId])
-    @@unique([liveQuizId, catalogCollectionId])
-    @@unique([practiceQuizId, catalogCollectionId])
-    @@unique([microLearningId, catalogCollectionId])
-    @@unique([groupActivityId, catalogCollectionId])
+  // for each assignment of an object to a catalog collection there is only allowed to be one entry
+  @@unique([answerCollectionId, catalogCollectionId])
+  @@unique([elementId, catalogCollectionId])
+  @@unique([courseId, catalogCollectionId])
+  @@unique([liveQuizId, catalogCollectionId])
+  @@unique([practiceQuizId, catalogCollectionId])
+  @@unique([microLearningId, catalogCollectionId])
+  @@unique([groupActivityId, catalogCollectionId])
 }
 
 model CatalogCollection {
-    id          String  @id @default(uuid()) @db.Uuid
-    name        String
-    description String?
+  id          String  @id @default(uuid()) @db.Uuid
+  name        String
+  description String?
 
-    // access level determines who can browse a collection's content (public = everyone, restricted = only users with access)
-    access ObjectAccess @default(RESTRICTED)
+  // access level determines who can browse a collection's content (public = everyone, restricted = only users with access)
+  access ObjectAccess @default(RESTRICTED)
 
-    // users / user groups that are allowed to import / request elements from this collection (read access)
-    // users / user groups that are allowed to add elements to this collection (write access)
-    // users / user groups that are allowed to edit the access rights of other users / user groups (admin access)
-    directPermissions Permission[]
-    permissions       DerivedPermission[]
-    accessRequests    AccessRequest[]
+  // users / user groups that are allowed to import / request elements from this collection (read access)
+  // users / user groups that are allowed to add elements to this collection (write access)
+  // users / user groups that are allowed to edit the access rights of other users / user groups (admin access)
+  directPermissions Permission[]
+  permissions       DerivedPermission[]
+  accessRequests    AccessRequest[]
 
-    // link to the join-table containing all associated objects
-    objectAssignments CatalogCollectionAssignment[]
+  // link to the join-table containing all associated objects
+  objectAssignments CatalogCollectionAssignment[]
 
-    // owner connection needs to remain optional for the top-level catalog collection to work as expected
-    owner   User?   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    ownerId String? @db.Uuid
+  // owner connection needs to remain optional for the top-level catalog collection to work as expected
+  owner   User?   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId String? @db.Uuid
 
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // #endregion
@@ -349,110 +349,111 @@ model CatalogCollection {
 // ----- AUDIT LOG -----
 // #region
 enum AuditLogType {
-    PERMISSION_GRANTED // granted direct permission
-    PERMISSION_REVOKED // revoked direct permission (by owner / admin)
-    PERMISSION_REMOVED // removed direct permission (by user himself)
-    PERMISSION_MODIFIED // modified direct permission
-    OWNER_TRANSFERRED // ownership of an object was transferred
-    REQUEST_CREATED // created object access request
-    REQUEST_CANCELLED // cancelled object access request
-    REQUEST_RESOLVED // resolved object access request
-    CATALOG_ASSIGNMENT_CREATED // created catalog assignment
-    CATALOG_ASSIGNMENT_DELETED // deleted catalog assignment
-    CATALOG_ASSIGNMENT_MODIFIED // created catalog collection
-    USER_GROUP_CREATED // created user group
-    USER_GROUP_MODIFIED // modified user group
-    USER_GROUP_DELETED // deleted user group
-    USER_GROUP_USER_ADDED // added user to user group
-    USER_GROUP_USER_REMOVED // removed user from user group
-    USER_GROUP_USER_MODIFIED // modified user in user group (promotion / demotion)
+  PERMISSION_GRANTED // granted direct permission
+  PERMISSION_REVOKED // revoked direct permission (by owner / admin)
+  PERMISSION_REMOVED // removed direct permission (by user himself)
+  PERMISSION_MODIFIED // modified direct permission
+  OWNER_TRANSFERRED // ownership of an object was transferred
+  REQUEST_CREATED // created object access request
+  REQUEST_CANCELLED // cancelled object access request
+  REQUEST_RESOLVED // resolved object access request
+  CATALOG_ASSIGNMENT_CREATED // created catalog assignment
+  CATALOG_ASSIGNMENT_DELETED // deleted catalog assignment
+  CATALOG_ASSIGNMENT_MODIFIED // created catalog collection
+  USER_GROUP_CREATED // created user group
+  USER_GROUP_MODIFIED // modified user group
+  USER_GROUP_DELETED // deleted user group
+  USER_GROUP_USER_ADDED // added user to user group
+  USER_GROUP_USER_REMOVED // removed user from user group
+  USER_GROUP_USER_MODIFIED // modified user in user group (promotion / demotion)
 }
 
 enum ObjectType {
-    USER_GROUP
-    CATALOG_COLLECTION
-    ANSWER_COLLECTION
-    ELEMENT
-    COURSE
-    LIVE_QUIZ
-    PRACTICE_QUIZ
-    MICRO_LEARNING
-    GROUP_ACTIVITY
+  USER_GROUP
+  CATALOG_COLLECTION
+  ANSWER_COLLECTION
+  ELEMENT
+  COURSE
+  LIVE_QUIZ
+  PRACTICE_QUIZ
+  MICRO_LEARNING
+  GROUP_ACTIVITY
+  COMPETENCE_TREE
 }
 
 model AuditLogEntry {
-    id   Int          @id @default(autoincrement())
-    type AuditLogType // type of the audit log entry
+  id   Int          @id @default(autoincrement())
+  type AuditLogType // type of the audit log entry
 
-    // object information
-    objectType ObjectType
-    objectId   String
+  // object information
+  objectType ObjectType
+  objectId   String
 
-    // users / user groups involved in the action
-    sourceUserId      String  @db.Uuid // id of the user who performed the action
-    targetUserId      String? @db.Uuid // id of the user who was affected by the action (can be the same as sourceUserId)
-    targetUserGroupId Int? // id of the user group who was affected by the action (can include the source user)
+  // users / user groups involved in the action
+  sourceUserId      String  @db.Uuid // id of the user who performed the action
+  targetUserId      String? @db.Uuid // id of the user who was affected by the action (can be the same as sourceUserId)
+  targetUserGroupId Int? // id of the user group who was affected by the action (can include the source user)
 
-    // generic message containing more information on the action
-    message String
+  // generic message containing more information on the action
+  message String
 
-    // timestamp of the action
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  // timestamp of the action
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 enum ActivityLogType {
-    MESSAGE // message sent by one of the users with access to the object
-    MODIFICATION // modification of the object (field modified, etc.)
-    CREATION // creation of the object
-    SHARING // sharing of the object
+  MESSAGE // message sent by one of the users with access to the object
+  MODIFICATION // modification of the object (field modified, etc.)
+  CREATION // creation of the object
+  SHARING // sharing of the object
 }
 
 model ActivityLogEntry {
-    id         Int             @id @default(autoincrement())
-    type       ActivityLogType // type of the change log entry
-    objectType ObjectType // type of the object
+  id         Int             @id @default(autoincrement())
+  type       ActivityLogType // type of the change log entry
+  objectType ObjectType // type of the object
 
-    // generic message containing more information on the action
-    message String?
+  // generic message containing more information on the action
+  message String?
 
-    // structured data about modifications (for type MODIFICATION)
-    /// [PrismaActivityLogModificationDetails]
-    modificationDetails Json?
+  // structured data about modifications (for type MODIFICATION)
+  /// [PrismaActivityLogModificationDetails]
+  modificationDetails Json?
 
-    // whether the entry has been resolved (for type MESSAGE)
-    resolved   Boolean   @default(false)
-    resolvedAt DateTime?
+  // whether the entry has been resolved (for type MESSAGE)
+  resolved   Boolean   @default(false)
+  resolvedAt DateTime?
 
-    // user who performed the action
-    user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-    userId String? @db.Uuid
+  // user who performed the action
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  userId String? @db.Uuid
 
-    // object in affected by the change
-    answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    answerCollectionId Int?
+  // object in affected by the change
+  answerCollection   AnswerCollection? @relation(fields: [answerCollectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  answerCollectionId Int?
 
-    element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    elementId Int?
+  element   Element? @relation(fields: [elementId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  elementId Int?
 
-    course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    courseId String? @db.Uuid
+  course   Course? @relation(fields: [courseId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  courseId String? @db.Uuid
 
-    liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    liveQuizId String?   @db.Uuid
+  liveQuiz   LiveQuiz? @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String?   @db.Uuid
 
-    practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    practiceQuizId String?       @db.Uuid
+  practiceQuiz   PracticeQuiz? @relation(fields: [practiceQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practiceQuizId String?       @db.Uuid
 
-    microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    microLearningId String?        @db.Uuid
+  microLearning   MicroLearning? @relation(fields: [microLearningId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  microLearningId String?        @db.Uuid
 
-    groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-    groupActivityId String?        @db.Uuid
+  groupActivity   GroupActivity? @relation(fields: [groupActivityId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  groupActivityId String?        @db.Uuid
 
-    // timestamps for the creation and modification of the entry
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  // timestamps for the creation and modification of the entry
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // #endregion

--- a/packages/prisma/src/prisma/schema/user.prisma
+++ b/packages/prisma/src/prisma/schema/user.prisma
@@ -110,23 +110,37 @@ model User {
   publicPreview  Boolean @default(false)
   privatePreview Boolean @default(false)
 
-  logins                     UserLogin[]
-  session                    Session[]
-  accounts                   Account[]
-  courses                    Course[]
-  questions                  Element[]
-  mediaFiles                 MediaFile[]
-  tags                       Tag[]
-  groupActivities            GroupActivity[]
-  elementInstances           ElementInstance[]
-  practiceQuizzes            PracticeQuiz[]
-  microLearnings             MicroLearning[]
-  liveQuizzes                LiveQuiz[]
-  competencyTrees            CompetencyTree[]
-  answerCollections          AnswerCollection[]
-  chatbots                   Chatbot[]
-  chatbotDisclaimers         ChatbotDisclaimer[]
-  revokedVerificationRecords VerifiableCredential[] @relation("RevokedVerifiableCredentials")
+  logins                          UserLogin[]
+  session                         Session[]
+  accounts                        Account[]
+  courses                         Course[]
+  questions                       Element[]
+  mediaFiles                      MediaFile[]
+  tags                            Tag[]
+  groupActivities                 GroupActivity[]
+  elementInstances                ElementInstance[]
+  practiceQuizzes                 PracticeQuiz[]
+  microLearnings                  MicroLearning[]
+  liveQuizzes                     LiveQuiz[]
+  competencyTrees                 CompetencyTree[]
+  answerCollections               AnswerCollection[]
+  chatbots                        Chatbot[]
+  chatbotDisclaimers              ChatbotDisclaimer[]
+  adaptiveAssessments             AdaptiveAssessment[]
+  competenceTrees                 CompetenceTree[]
+  linkedCompetenceTreeCourses     CompetenceTreeCourse[]                    @relation("CompetenceTreeCourseLinkedBy")
+  adaptiveScaleVersionsCreated    CompetenceTreeScaleVersion[]              @relation("CompetenceTreeScaleVersionCreatedBy")
+  adaptiveScaleApprovalsSubmitted CompetenceTreeScaleApproval[]             @relation("CompetenceTreeScaleApprovalSubmittedBy")
+  adaptiveScaleApprovals          CompetenceTreeScaleApproval[]             @relation("CompetenceTreeScaleApprovalReviewer")
+  adaptiveScaleLinksCreated       CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkCreatedBy")
+  adaptiveScaleLinksReviewed      CompetenceTreeScaleLink[]                 @relation("CompetenceTreeScaleLinkReviewedBy")
+  adaptiveCalibrationsCreated     AdaptiveItemCalibration[]                 @relation("AdaptiveItemCalibrationCreatedBy")
+  adaptiveCalibrationsApproved    AdaptiveItemCalibration[]                 @relation("AdaptiveItemCalibrationApprovedBy")
+  adaptivePublications            PracticeQuizAdaptivePublication[]         @relation("PracticeQuizAdaptivePublicationPublishedBy")
+  adaptiveExportRequests          AdaptiveCalibrationExportRequest[]        @relation("AdaptiveCalibrationExportRequestedBy")
+  adaptiveValidationsSubmitted    AdaptivePracticeQuizEmpiricalValidation[] @relation("AdaptiveEmpiricalValidationSubmittedBy")
+  adaptiveValidationsApproved     AdaptivePracticeQuizEmpiricalValidation[] @relation("AdaptiveEmpiricalValidationApprovedBy")
+  revokedVerificationRecords      VerifiableCredential[]                    @relation("RevokedVerifiableCredentials")
 
   userGroups                UserGroup[]         @relation("UserGroupMembers")
   adminUserGroups           UserGroup[]         @relation("UserGroupAdmins")

--- a/packages/prisma/src/scripts/verifyAdaptiveIrtV2Migration.ts
+++ b/packages/prisma/src/scripts/verifyAdaptiveIrtV2Migration.ts
@@ -1,0 +1,833 @@
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { Client, type DatabaseError } from 'pg'
+
+const PHASE_10_FIRST_MIGRATION =
+  '20260713210000_adaptive_runtime_constraint_validation'
+const IRT_V2_MIGRATIONS = [
+  '20260731120000_adaptive_irt_v2_records',
+  '20260731121000_adaptive_irt_v2_backfill',
+  '20260731122000_adaptive_irt_v2_constraints',
+  '20260731123000_adaptive_irt_v2_export_artifacts',
+] as const
+const IRT_V2_FIRST_MIGRATION = IRT_V2_MIGRATIONS[0]
+const IRT_V2_LAST_MIGRATION = IRT_V2_MIGRATIONS.at(-1)!
+
+const migrationsPath = fileURLToPath(
+  new URL('../prisma/schema/migrations/', import.meta.url)
+)
+const phase10FixturePath = fileURLToPath(
+  new URL(
+    '../prisma/fixtures/adaptive-learning-phase10-pre-repair.sql',
+    import.meta.url
+  )
+)
+const irtV2FixturePath = fileURLToPath(
+  new URL(
+    '../prisma/fixtures/adaptive-irt-v2-pre-migration.sql',
+    import.meta.url
+  )
+)
+
+async function main() {
+  const sourceDatabaseUrl = process.env.DATABASE_URL
+  if (!sourceDatabaseUrl) {
+    throw new Error('DATABASE_URL is required for the migration rehearsal.')
+  }
+
+  const migrationNames = (
+    await readdir(migrationsPath, { withFileTypes: true })
+  )
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name <= IRT_V2_LAST_MIGRATION)
+    .sort()
+
+  for (const migration of IRT_V2_MIGRATIONS) {
+    assert(migrationNames.includes(migration), `Missing migration ${migration}`)
+  }
+
+  const admin = new Client({ connectionString: sourceDatabaseUrl })
+  await admin.connect()
+  try {
+    await withTemporaryDatabase(
+      admin,
+      sourceDatabaseUrl,
+      'clean',
+      async (database) => {
+        await applyMigrations(database, migrationNames)
+        await verifyCleanReplay(database)
+      }
+    )
+
+    await withTemporaryDatabase(
+      admin,
+      sourceDatabaseUrl,
+      'populated',
+      async (database) => {
+        await preparePopulatedPreIrtDatabase(database, migrationNames)
+        await applyMigrations(database, [...IRT_V2_MIGRATIONS])
+        await verifyPopulatedReplay(database)
+      }
+    )
+
+    await withTemporaryDatabase(
+      admin,
+      sourceDatabaseUrl,
+      'atomic',
+      async (database) => {
+        await preparePopulatedPreIrtDatabase(database, migrationNames)
+        await applyMigrations(database, [IRT_V2_MIGRATIONS[0]])
+        await database.query(`
+          CREATE FUNCTION fail_adaptive_calibration_insert()
+          RETURNS trigger LANGUAGE plpgsql AS $$
+          BEGIN
+            RAISE EXCEPTION 'intentional late backfill failure';
+          END $$;
+          CREATE TRIGGER fail_adaptive_calibration_insert
+          BEFORE INSERT ON "AdaptiveItemCalibration"
+          FOR EACH ROW EXECUTE FUNCTION fail_adaptive_calibration_insert();
+        `)
+        await assert.rejects(applyMigrations(database, [IRT_V2_MIGRATIONS[1]]))
+        await database.query('ROLLBACK')
+        const scales = await database.query<{ count: number }>(`
+          SELECT count(*)::integer AS count FROM "CompetenceTreeScaleVersion"
+        `)
+        assert.equal(scales.rows[0]?.count, 0)
+      }
+    )
+  } finally {
+    await admin.end()
+  }
+
+  console.log(
+    `Adaptive IRT v2 clean and populated migration rehearsals passed across ${migrationNames.length} migrations.`
+  )
+}
+
+async function withTemporaryDatabase(
+  admin: Client,
+  sourceDatabaseUrl: string,
+  suffix: string,
+  verify: (database: Client) => Promise<void>
+) {
+  const databaseName = `adaptive_irt_v2_${suffix}_${process.pid}_${Date.now()}`
+  const databaseUrl = new URL(sourceDatabaseUrl)
+  databaseUrl.pathname = `/${databaseName}`
+  const database = new Client({ connectionString: databaseUrl.href })
+
+  await admin.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`)
+  try {
+    await database.connect()
+    await verify(database)
+  } finally {
+    await database.end().catch(() => undefined)
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [databaseName]
+    )
+    await admin.query(
+      `DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`
+    )
+  }
+}
+
+async function applyMigrations(client: Client, migrationNames: string[]) {
+  for (const migrationName of migrationNames) {
+    await applySqlFile(
+      client,
+      `${migrationsPath}/${migrationName}/migration.sql`,
+      migrationName
+    )
+  }
+}
+
+async function preparePopulatedPreIrtDatabase(
+  database: Client,
+  migrationNames: string[]
+) {
+  const prePhase10 = migrationNames.filter(
+    (name) => name < PHASE_10_FIRST_MIGRATION
+  )
+  const phase10ToPreIrt = migrationNames.filter(
+    (name) => name >= PHASE_10_FIRST_MIGRATION && name < IRT_V2_FIRST_MIGRATION
+  )
+
+  await applyMigrations(database, prePhase10)
+  await applySqlFile(database, phase10FixturePath, 'Phase 10 populated fixture')
+  await applyMigrations(database, phase10ToPreIrt)
+  await applySqlFile(
+    database,
+    irtV2FixturePath,
+    'adaptive IRT v2 populated fixture'
+  )
+}
+
+async function applySqlFile(client: Client, path: string, label: string) {
+  const sql = await readFile(path, 'utf8')
+  try {
+    await client.query(sql)
+  } catch (error) {
+    throw new Error(`Failed while applying ${label}.`, { cause: error })
+  }
+}
+
+async function verifyCleanReplay(client: Client) {
+  const records = await client.query<{ relation: string | null }>(`
+    SELECT to_regclass('"CompetenceTreeScaleVersion"')::text AS relation
+    UNION ALL
+    SELECT to_regclass('"AdaptiveItemCalibration"')::text
+    UNION ALL
+    SELECT to_regclass('"PracticeQuizAdaptivePublication"')::text
+    UNION ALL
+    SELECT to_regclass('"AdaptivePracticeQuizItemExposure"')::text
+  `)
+  assert.equal(records.rowCount, 4)
+  assert(records.rows.every(({ relation }) => relation !== null))
+
+  const requiredColumns = await client.query<{ count: number }>(`
+    SELECT count(*)::integer AS count
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND (table_name, column_name) IN (
+        ('PracticeQuizAdaptivePoolItem', 'publicationId'),
+        ('AdaptivePracticeQuizAttempt', 'measurementVersion'),
+        ('AdaptivePracticeQuizResponse', 'administrationProbability'),
+        ('AdaptivePracticeQuizEstimate', 'bandProbabilities'),
+        ('AdaptiveCalibrationExportRequest', 'datasetVersion'),
+        ('AdaptiveCalibrationExportRequest', 'manifestArtifactKey'),
+        ('AdaptiveCalibrationExportRequest', 'holdoutArtifactKey'),
+        ('AdaptiveCalibrationExportRequest', 'criterionArtifactKey'),
+        ('AdaptivePracticeQuizEmpiricalValidation', 'exportRequestId'),
+        ('AdaptivePracticeQuizEmpiricalValidation', 'validationProtocolVersion'),
+        ('AdaptivePracticeQuizEmpiricalValidation', 'criterionArtifactChecksum')
+      )
+  `)
+  assert.equal(requiredColumns.rows[0]?.count, 11)
+
+  const poolCalibrationIdentity = await client.query<{ definition: string }>(`
+    SELECT pg_get_constraintdef(oid) AS definition
+    FROM pg_constraint
+    WHERE conname = 'PracticeQuizAdaptivePoolItem_competenceTreeId_scaleVersion_fkey'
+  `)
+  assert.match(
+    poolCalibrationIdentity.rows[0]?.definition ?? '',
+    /sourceAssignmentId.*elementId.*elementVersion/
+  )
+
+  const validationEvidenceIdentity = await client.query<{
+    definition: string
+  }>(`
+    SELECT indexdef AS definition
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND indexname = 'apqev_evidence_identity_key'
+  `)
+  assert.match(
+    validationEvidenceIdentity.rows[0]?.definition ?? '',
+    /exportRequestId.*criterionArtifactChecksum/
+  )
+
+  const validationLifecycleGuard = await client.query<{
+    definition: string
+  }>(`
+    SELECT pg_get_functiondef(oid) AS definition
+    FROM pg_proc
+    WHERE proname = 'adaptive_review_evidence_immutability_guard'
+      AND pg_function_is_visible(oid)
+  `)
+  assert.match(
+    validationLifecycleGuard.rows[0]?.definition ?? '',
+    /Illegal empirical-validation status transition/
+  )
+  assert.match(
+    validationLifecycleGuard.rows[0]?.definition ?? '',
+    /Active adaptive publications must be invalidated/
+  )
+
+  const validationInsertGuard = await client.query<{
+    definition: string
+  }>(`
+    SELECT pg_get_functiondef(oid) AS definition
+    FROM pg_proc
+    WHERE proname = 'adaptive_independent_review_guard'
+      AND pg_function_is_visible(oid)
+  `)
+  assert.match(
+    validationInsertGuard.rows[0]?.definition ?? '',
+    /Empirical-validation evidence must enter an unreviewed lifecycle state/
+  )
+
+  const migrationOnlyObjects = await client.query<{
+    name: string
+    kind: string
+  }>(`
+    SELECT conname AS name, 'constraint' AS kind
+    FROM pg_constraint
+    WHERE conname = 'aic_assignment_element_identity_fkey'
+    UNION ALL
+    SELECT indexname, 'index'
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND indexname IN (
+        'ctea_tree_id_element_key',
+        'ctsv_one_active_per_tree_key',
+        'pqap_one_active_per_config_key'
+      )
+    UNION ALL
+    SELECT DISTINCT trigger_name, 'trigger'
+    FROM information_schema.triggers
+    WHERE trigger_schema = current_schema()
+      AND trigger_name IN (
+        'aic_immutability_guard',
+        'apqa_sealed_publication_guard',
+        'apqr_design_identity_guard',
+        'ctsa_evidence_immutability_guard',
+        'ctsl_lifecycle_guard',
+        'ctslk_lifecycle_guard',
+        'pqap_publication_guard',
+        'pqapi_snapshot_guard'
+      )
+    ORDER BY kind, name
+  `)
+  assert.deepEqual(migrationOnlyObjects.rows, [
+    { name: 'aic_assignment_element_identity_fkey', kind: 'constraint' },
+    { name: 'ctea_tree_id_element_key', kind: 'index' },
+    { name: 'ctsv_one_active_per_tree_key', kind: 'index' },
+    { name: 'pqap_one_active_per_config_key', kind: 'index' },
+    { name: 'aic_immutability_guard', kind: 'trigger' },
+    { name: 'apqa_sealed_publication_guard', kind: 'trigger' },
+    { name: 'apqr_design_identity_guard', kind: 'trigger' },
+    { name: 'ctsa_evidence_immutability_guard', kind: 'trigger' },
+    { name: 'ctsl_lifecycle_guard', kind: 'trigger' },
+    { name: 'ctslk_lifecycle_guard', kind: 'trigger' },
+    { name: 'pqap_publication_guard', kind: 'trigger' },
+    { name: 'pqapi_snapshot_guard', kind: 'trigger' },
+  ])
+}
+
+async function verifyPopulatedReplay(client: Client) {
+  const scales = await client.query<{
+    treeId: string
+    order: number
+    lowerBound: number | null
+    itemDifficultyPrior: number
+    status: string
+  }>(`
+    SELECT
+      scale."treeId" AS "treeId",
+      level."order",
+      level."lowerBound" AS "lowerBound",
+      level."itemDifficultyPrior" AS "itemDifficultyPrior",
+      scale.status::text
+    FROM "CompetenceTreeScaleVersion" scale
+    JOIN "CompetenceTreeScaleLevel" level ON level."scaleVersionId" = scale.id
+    ORDER BY scale."treeId", level."order"
+  `)
+  assert.deepEqual(scales.rows, [
+    {
+      treeId: '91000000-0000-4000-8000-000000000003',
+      order: 0,
+      lowerBound: null,
+      itemDifficultyPrior: 0,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000001',
+      order: 0,
+      lowerBound: null,
+      itemDifficultyPrior: -3,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000001',
+      order: 1,
+      lowerBound: -1,
+      itemDifficultyPrior: -1,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000001',
+      order: 2,
+      lowerBound: 1,
+      itemDifficultyPrior: 1,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000002',
+      order: 0,
+      lowerBound: null,
+      itemDifficultyPrior: -3,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000002',
+      order: 1,
+      lowerBound: -1.5,
+      itemDifficultyPrior: 0,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000002',
+      order: 2,
+      lowerBound: 1.5,
+      itemDifficultyPrior: 3,
+      status: 'DRAFT',
+    },
+    {
+      treeId: '92000000-0000-4000-8000-000000000003',
+      order: 0,
+      lowerBound: null,
+      itemDifficultyPrior: -1,
+      status: 'DRAFT',
+    },
+  ])
+
+  const config = await client.query<{
+    measurementVersion: string
+    calibrationPolicyVersion: number
+    hasScale: boolean
+  }>(`
+    SELECT
+      "measurementVersion"::text AS "measurementVersion",
+      "calibrationPolicyVersion" AS "calibrationPolicyVersion",
+      "scaleVersionId" IS NOT NULL AS "hasScale"
+    FROM "PracticeQuizAdaptiveConfig"
+  `)
+  assert.deepEqual(config.rows, [
+    {
+      measurementVersion: 'IRT_V1',
+      calibrationPolicyVersion: 1,
+      hasScale: true,
+    },
+  ])
+
+  const publication = await client.query<{
+    measurementVersion: string
+    estimatorImplementationVersion: string
+    poolItems: number
+    attempts: number
+    validations: number
+    sealed: boolean
+  }>(`
+    SELECT
+      publication."measurementVersion"::text AS "measurementVersion",
+      publication."estimatorImplementationVersion" AS "estimatorImplementationVersion",
+      count(DISTINCT pool.id)::integer AS "poolItems",
+      count(DISTINCT attempt.id)::integer AS attempts,
+      count(DISTINCT publication."empiricalValidationId")::integer AS validations,
+      publication."sealedAt" IS NOT NULL AS sealed
+    FROM "PracticeQuizAdaptivePublication" publication
+    LEFT JOIN "PracticeQuizAdaptivePoolItem" pool ON pool."publicationId" = publication.id
+    LEFT JOIN "AdaptivePracticeQuizAttempt" attempt ON attempt."publicationId" = publication.id
+    GROUP BY publication.id
+  `)
+  assert.deepEqual(publication.rows, [
+    {
+      measurementVersion: 'IRT_V1',
+      estimatorImplementationVersion: 'irt-v1-legacy',
+      poolItems: 2,
+      attempts: 4,
+      validations: 0,
+      sealed: true,
+    },
+  ])
+
+  const snapshotShapes = await client.query<{
+    cuts: string
+    weights: string
+    evidence: string
+    caps: string
+    diagnostics: string
+    fitStatus: string
+    difStatus: string
+    driftStatus: string
+  }>(`
+    SELECT
+      jsonb_typeof(publication."cutScoreSnapshot") AS cuts,
+      jsonb_typeof(publication."hierarchicalWeightSnapshot") AS weights,
+      jsonb_typeof(publication."evidenceMinimumSnapshot") AS evidence,
+      jsonb_typeof(publication."questionCapSnapshot") AS caps,
+      jsonb_typeof(calibration.diagnostics) AS diagnostics,
+      calibration.diagnostics->>'fitStatus' AS "fitStatus",
+      calibration.diagnostics->>'difStatus' AS "difStatus",
+      calibration.diagnostics->>'driftStatus' AS "driftStatus"
+    FROM "PracticeQuizAdaptivePublication" publication
+    CROSS JOIN LATERAL (
+      SELECT diagnostics FROM "AdaptiveItemCalibration" ORDER BY id LIMIT 1
+    ) calibration
+    WHERE publication.version = 1
+  `)
+  assert.deepEqual(snapshotShapes.rows, [
+    {
+      cuts: 'array',
+      weights: 'array',
+      evidence: 'object',
+      caps: 'object',
+      diagnostics: 'object',
+      fitStatus: 'WARN',
+      difStatus: 'WARN',
+      driftStatus: 'WARN',
+    },
+  ])
+
+  const calibrations = await client.query<{
+    status: string
+    guessing: number
+    responseCount: number
+    participantCount: number
+    elementVersion: number
+  }>(`
+    SELECT
+      status::text,
+      guessing,
+      "responseCount" AS "responseCount",
+      "participantCount" AS "participantCount",
+      "elementVersion" AS "elementVersion"
+    FROM "AdaptiveItemCalibration"
+    ORDER BY "assignmentId", "elementVersion"
+  `)
+  assert.deepEqual(calibrations.rows, [
+    {
+      status: 'PROVISIONAL',
+      guessing: 0.5,
+      responseCount: 0,
+      participantCount: 0,
+      elementVersion: 1,
+    },
+    {
+      status: 'PROVISIONAL',
+      guessing: 0.5,
+      responseCount: 0,
+      participantCount: 0,
+      elementVersion: 2,
+    },
+    {
+      status: 'PROVISIONAL',
+      guessing: 0.5,
+      responseCount: 0,
+      participantCount: 0,
+      elementVersion: 1,
+    },
+  ])
+
+  const attempts = await client.query<{
+    measurementVersion: string
+    estimatorImplementationVersion: string
+    versioned: boolean
+  }>(`
+    SELECT
+      "measurementVersion"::text AS "measurementVersion",
+      "estimatorImplementationVersion" AS "estimatorImplementationVersion",
+      "publicationId" IS NOT NULL AND "scaleVersionId" IS NOT NULL AS versioned
+    FROM "AdaptivePracticeQuizAttempt"
+    ORDER BY id
+  `)
+  assert.equal(attempts.rowCount, 4)
+  assert(
+    attempts.rows.every(
+      ({ measurementVersion, estimatorImplementationVersion, versioned }) =>
+        measurementVersion === 'IRT_V1' &&
+        estimatorImplementationVersion === 'irt-v1-legacy' &&
+        versioned
+    )
+  )
+
+  const responseIdentity = await client.query<{ matches: boolean }>(`
+    SELECT bool_and(response."publicationId" = attempt."publicationId") AS matches
+    FROM "AdaptivePracticeQuizResponse" response
+    JOIN "AdaptivePracticeQuizAttempt" attempt ON attempt.id = response."attemptId"
+  `)
+  assert.equal(responseIdentity.rows[0]?.matches, true)
+
+  const expectedConstraints = [
+    'aic_parameters_check',
+    'apqcs_aggregate_schema_check',
+    'apqev_evidence_check',
+    'apqie_counts_check',
+    'apqr_design_check',
+    'ctsv_numeric_check',
+    'pqap_lifecycle_timestamps_check',
+    'pqap_policy_check',
+    'pqapi_snapshot_check',
+  ]
+  const constraints = await client.query<{
+    conname: string
+    convalidated: boolean
+  }>(
+    `
+      SELECT conname, convalidated
+      FROM pg_constraint
+      WHERE conname = ANY($1::text[])
+      ORDER BY conname
+    `,
+    [expectedConstraints]
+  )
+  assert.deepEqual(
+    constraints.rows,
+    expectedConstraints.sort().map((conname) => ({
+      conname,
+      convalidated: true,
+    }))
+  )
+
+  await assert.rejects(
+    client.query(`
+      UPDATE "CompetenceTreeScaleVersion"
+      SET "priorMean" = 'NaN'::double precision
+      WHERE "treeId" = '91000000-0000-4000-8000-000000000003'
+    `),
+    (error: DatabaseError) => error.code === '23514'
+  )
+
+  await assert.rejects(
+    client.query(`
+      INSERT INTO "CompetenceTreeScaleApproval" (
+        id, "treeId", "scaleVersionId", method, "methodVersion", "panelSize",
+        "standardSettingDate", "cutRationale", "artifactChecksum", "artifactKey",
+        decision, "submittedById", "reviewerId", "reviewedAt"
+      )
+      SELECT
+        '92000000-0000-4000-8000-000000000010', "treeId", id, 'bookmark', '1', 3,
+        CURRENT_TIMESTAMP, '{}'::jsonb, 'checksum', 'private/key', 'APPROVED',
+        "createdById", "createdById", CURRENT_TIMESTAMP
+      FROM "CompetenceTreeScaleVersion"
+      WHERE "treeId" = '91000000-0000-4000-8000-000000000003'
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await assert.rejects(
+    client.query(`
+      UPDATE "PracticeQuizAdaptivePoolItem"
+      SET "elementName" = 'mutated historical snapshot'
+      WHERE id = 9101
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await assert.rejects(
+    client.query(`
+      DELETE FROM "PracticeQuizAdaptivePoolItem"
+      WHERE id = 9101
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await assert.rejects(
+    client.query(`
+      UPDATE "AdaptivePracticeQuizAttempt"
+      SET "estimatorImplementationVersion" = 'mismatched-estimator'
+      WHERE id = '91000000-0000-4000-8000-000000000007'
+    `),
+    (error: DatabaseError) => error.code === '23503'
+  )
+
+  await assert.rejects(
+    client.query(`
+      UPDATE "AdaptivePracticeQuizResponse"
+      SET "itemRole" = 'FIELD_TEST'
+      WHERE id = 9101
+    `),
+    (error: DatabaseError) => ['P0001', '23514'].includes(error.code)
+  )
+
+  await assert.rejects(
+    client.query(`
+      INSERT INTO "PracticeQuizAdaptivePublication" (
+        id, version, "configId", "competenceTreeId", "scaleVersionId",
+        "measurementVersion", "preset", "estimatorImplementationVersion",
+        "classificationPolicyVersion", "calibrationPolicyVersion",
+        "cutScoreSnapshot", "priorMean", "priorStandardDeviation", "gridMin",
+        "gridMax", "gridStep", "classificationProbabilityThreshold",
+        "hierarchicalWeightSnapshot", "evidenceMinimumSnapshot",
+        "totalQuestionCap", "showTimer", "questionCapSnapshot", "candidateSetPolicyVersion",
+        "randomizationPolicyVersion", "exposureCeiling", "overlapPolicyVersion",
+        "retakePolicy", "retakeCooldownDays", "researchAllocationPolicy", "stoppingPolicyVersion",
+        "rolloutPolicyVersion", "publishedById", "publishedAt", "sealedAt", "createdAt"
+      )
+      SELECT
+        '92000000-0000-4000-8000-000000000019', 99, "configId",
+        "competenceTreeId", "scaleVersionId", "measurementVersion", "preset",
+        "estimatorImplementationVersion", "classificationPolicyVersion",
+        "calibrationPolicyVersion", "cutScoreSnapshot", "priorMean",
+        "priorStandardDeviation", "gridMin", "gridMax", "gridStep",
+        "classificationProbabilityThreshold", "hierarchicalWeightSnapshot",
+        "evidenceMinimumSnapshot", "totalQuestionCap", "showTimer", "questionCapSnapshot",
+        "candidateSetPolicyVersion", "randomizationPolicyVersion",
+        "exposureCeiling", "overlapPolicyVersion", "retakePolicy", "retakeCooldownDays",
+        "researchAllocationPolicy", "stoppingPolicyVersion",
+        "rolloutPolicyVersion", "publishedById", CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM "PracticeQuizAdaptivePublication"
+      WHERE version = 1
+      LIMIT 1
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await client.query(`
+    UPDATE "PracticeQuizAdaptiveConfig"
+    SET preset = 'RESEARCH'
+    WHERE id = '91000000-0000-4000-8000-000000000005';
+
+    UPDATE "AdaptiveItemCalibration"
+    SET status = 'PILOT', "updatedAt" = CURRENT_TIMESTAMP
+    WHERE "assignmentId" = 9102 AND "elementVersion" = 1;
+
+    INSERT INTO "PracticeQuizAdaptivePublication" (
+      id, version, "configId", "competenceTreeId", "scaleVersionId",
+      "measurementVersion", "preset", "estimatorImplementationVersion",
+      "classificationPolicyVersion", "calibrationPolicyVersion",
+      "cutScoreSnapshot", "priorMean", "priorStandardDeviation", "gridMin",
+      "gridMax", "gridStep", "classificationProbabilityThreshold",
+      "hierarchicalWeightSnapshot", "evidenceMinimumSnapshot",
+      "totalQuestionCap", "showTimer", "questionCapSnapshot", "candidateSetPolicyVersion",
+      "randomizationPolicyVersion", "exposureCeiling", "overlapPolicyVersion",
+      "retakePolicy", "retakeCooldownDays", "researchAllocationPolicy", "stoppingPolicyVersion",
+      "rolloutPolicyVersion", "publishedById", "publishedAt", "createdAt"
+    )
+    SELECT
+      '92000000-0000-4000-8000-000000000020', 2, "configId",
+      "competenceTreeId", "scaleVersionId", 'IRT_V2_EAP_GRID_1', 'RESEARCH',
+      'eap-grid-test', 2, 2, "cutScoreSnapshot", "priorMean",
+      "priorStandardDeviation", "gridMin", "gridMax", "gridStep", 0.8,
+      "hierarchicalWeightSnapshot", "evidenceMinimumSnapshot",
+      "totalQuestionCap", "showTimer", "questionCapSnapshot", 'candidate-test',
+      'randomization-test', 1, 'overlap-test', "retakePolicy", "retakeCooldownDays",
+      '{"anchorProbability":0,"fieldTestProbability":1,"collectionDesignVersion":"test"}'::jsonb,
+      'stopping-test', 1, '91000000-0000-4000-8000-000000000001',
+      CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    FROM "PracticeQuizAdaptivePublication"
+    WHERE version = 1;
+
+    INSERT INTO "PracticeQuizAdaptivePoolItem" (
+      "configId", "competenceTreeId", "publicationId", "scaleVersionId",
+      "calibrationId", "sourceAssignmentId", "elementId", "elementVersion",
+      "elementType", "elementName", "elementData", "leafNodeId", "nodePath",
+      "nodeNamePath", "levelId", "levelLabel", "levelOrder", discrimination,
+      difficulty, guessing, "measurementVersion", "calibrationVersion",
+      "calibrationStatus", "itemModel", "modelImplementationVersion", role,
+      "contributesToEstimate", "enablePercentInput"
+    )
+    SELECT
+      pool."configId", pool."competenceTreeId",
+      '92000000-0000-4000-8000-000000000020', pool."scaleVersionId",
+      calibration.id, pool."sourceAssignmentId", pool."elementId",
+      pool."elementVersion", pool."elementType", pool."elementName",
+      pool."elementData", pool."leafNodeId", pool."nodePath",
+      pool."nodeNamePath", pool."levelId", pool."levelLabel", pool."levelOrder",
+      calibration.discrimination, calibration.difficulty, calibration.guessing,
+      'IRT_V2_EAP_GRID_1', calibration.version, calibration.status,
+      calibration.model, calibration."modelImplementationVersion", 'FIELD_TEST',
+      false, pool."enablePercentInput"
+    FROM "PracticeQuizAdaptivePoolItem" pool
+    JOIN "AdaptiveItemCalibration" calibration
+      ON calibration."assignmentId" = pool."sourceAssignmentId"
+     AND calibration."elementVersion" = pool."elementVersion"
+    WHERE pool.id = 9102;
+
+    UPDATE "PracticeQuizAdaptivePublication"
+    SET "supersededAt" = CURRENT_TIMESTAMP
+    WHERE version = 1;
+
+    UPDATE "PracticeQuizAdaptivePublication"
+    SET "sealedAt" = CURRENT_TIMESTAMP
+    WHERE id = '92000000-0000-4000-8000-000000000020';
+  `)
+
+  const fieldTestPool = await client.query<{
+    role: string
+    contributesToEstimate: boolean
+    calibrationStatus: string
+    sealed: boolean
+  }>(`
+    SELECT
+      pool.role::text,
+      pool."contributesToEstimate" AS "contributesToEstimate",
+      pool."calibrationStatus"::text AS "calibrationStatus",
+      publication."sealedAt" IS NOT NULL AS sealed
+    FROM "PracticeQuizAdaptivePoolItem" pool
+    JOIN "PracticeQuizAdaptivePublication" publication ON publication.id = pool."publicationId"
+    WHERE pool."publicationId" = '92000000-0000-4000-8000-000000000020'
+  `)
+  assert.deepEqual(fieldTestPool.rows, [
+    {
+      role: 'FIELD_TEST',
+      contributesToEstimate: false,
+      calibrationStatus: 'PILOT',
+      sealed: true,
+    },
+  ])
+
+  await assert.rejects(
+    client.query(`
+      INSERT INTO "PracticeQuizAdaptivePoolItem" (
+        "configId", "competenceTreeId", "publicationId", "scaleVersionId",
+        "calibrationId", "sourceAssignmentId", "elementId", "elementVersion",
+        "elementType", "elementName", "elementData", "leafNodeId", "nodePath",
+        "nodeNamePath", "levelId", "levelLabel", "levelOrder", discrimination,
+        difficulty, guessing, "measurementVersion", "calibrationVersion",
+        "calibrationStatus", "itemModel", "modelImplementationVersion", role,
+        "contributesToEstimate", "enablePercentInput"
+      )
+      SELECT
+        "configId", "competenceTreeId", "publicationId", "scaleVersionId",
+        "calibrationId", "sourceAssignmentId", "elementId", "elementVersion",
+        "elementType", "elementName", "elementData", "leafNodeId", "nodePath",
+        "nodeNamePath", "levelId", "levelLabel", "levelOrder", discrimination,
+        difficulty, guessing, "measurementVersion", "calibrationVersion",
+        "calibrationStatus", "itemModel", "modelImplementationVersion", role,
+        "contributesToEstimate", "enablePercentInput"
+      FROM "PracticeQuizAdaptivePoolItem"
+      WHERE "publicationId" = '92000000-0000-4000-8000-000000000020'
+      LIMIT 1
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await client.query(`
+    INSERT INTO "CompetenceTreeScaleApproval" (
+      id, "treeId", "scaleVersionId", method, "methodVersion", "panelSize",
+      "standardSettingDate", "cutRationale", "artifactChecksum", "artifactKey",
+      "submittedById"
+    )
+    SELECT
+      '92000000-0000-4000-8000-000000000011', "treeId", id, 'bookmark', '1', 3,
+      CURRENT_TIMESTAMP, '[{"scaleLevelOrder":0,"codes":["PANEL"]}]'::jsonb,
+      'checksum', 'private/key', "createdById"
+    FROM "CompetenceTreeScaleVersion"
+    WHERE "treeId" = '91000000-0000-4000-8000-000000000003'
+  `)
+  await client.query(`
+    UPDATE "CompetenceTreeScaleVersion"
+    SET status = 'IN_REVIEW', "submittedForReviewAt" = CURRENT_TIMESTAMP
+    WHERE "treeId" = '91000000-0000-4000-8000-000000000003'
+  `)
+  await assert.rejects(
+    client.query(`
+      UPDATE "CompetenceTreeScaleApproval"
+      SET method = 'mutated'
+      WHERE id = '92000000-0000-4000-8000-000000000011'
+    `),
+    (error: DatabaseError) => error.code === 'P0001'
+  )
+
+  await assert.rejects(
+    client.query(`
+      DELETE FROM "PracticeQuizAdaptiveConfig"
+      WHERE id = '91000000-0000-4000-8000-000000000005'
+    `),
+    (error: DatabaseError) => error.code === '23503'
+  )
+}
+
+function quoteIdentifier(value: string) {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/prisma/src/scripts/verifyAdaptivePhase10Migration.ts
+++ b/packages/prisma/src/scripts/verifyAdaptivePhase10Migration.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { Client, type DatabaseError } from 'pg'
+
+const PHASE_10_MIGRATIONS = [
+  '20260713210000_adaptive_runtime_constraint_validation',
+  '20260713212000_adaptive_competence_tree_audit_type',
+  '20260713213000_adaptive_history_retention',
+] as const
+const FIRST_PHASE_10_MIGRATION = PHASE_10_MIGRATIONS[0]
+const migrationsPath = fileURLToPath(
+  new URL('../prisma/schema/migrations/', import.meta.url)
+)
+const fixturePath = fileURLToPath(
+  new URL(
+    '../prisma/fixtures/adaptive-learning-phase10-pre-repair.sql',
+    import.meta.url
+  )
+)
+
+async function main() {
+  const sourceDatabaseUrl = process.env.DATABASE_URL
+  if (!sourceDatabaseUrl) {
+    throw new Error('DATABASE_URL is required for the migration rehearsal.')
+  }
+
+  const databaseName = `adaptive_phase10_${process.pid}_${Date.now()}`
+  const admin = new Client({ connectionString: sourceDatabaseUrl })
+  const testDatabaseUrl = new URL(sourceDatabaseUrl)
+  testDatabaseUrl.pathname = `/${databaseName}`
+  const testDatabase = new Client({ connectionString: testDatabaseUrl.href })
+
+  await admin.connect()
+  await admin.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`)
+  try {
+    await testDatabase.connect()
+    const migrationNames = (
+      await readdir(migrationsPath, {
+        withFileTypes: true,
+      })
+    )
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+    const prePhase10Migrations = migrationNames.filter(
+      (name) => name < FIRST_PHASE_10_MIGRATION
+    )
+
+    for (const migrationName of prePhase10Migrations) {
+      await applySqlFile(
+        testDatabase,
+        `${migrationsPath}/${migrationName}/migration.sql`,
+        migrationName
+      )
+    }
+    await applySqlFile(testDatabase, fixturePath, 'Phase 10 pre-repair fixture')
+    for (const migrationName of PHASE_10_MIGRATIONS) {
+      assert(
+        migrationNames.includes(migrationName),
+        `Missing migration ${migrationName}`
+      )
+      await applySqlFile(
+        testDatabase,
+        `${migrationsPath}/${migrationName}/migration.sql`,
+        migrationName
+      )
+    }
+
+    await verifyRepairs(testDatabase)
+    await verifyConstraints(testDatabase)
+    await verifyRetentionAndErasure(testDatabase)
+    console.log(
+      `Adaptive Phase 10 migration rehearsal passed on ${prePhase10Migrations.length} prior migrations.`
+    )
+  } finally {
+    await testDatabase.end().catch(() => undefined)
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [databaseName]
+    )
+    await admin.query(
+      `DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`
+    )
+    await admin.end()
+  }
+}
+
+async function applySqlFile(
+  client: Client,
+  path: string,
+  label: string
+): Promise<void> {
+  const sql = await readFile(path, 'utf8')
+  try {
+    await client.query(sql)
+  } catch (error) {
+    throw new Error(`Failed while applying ${label}.`, { cause: error })
+  }
+}
+
+async function verifyRepairs(client: Client) {
+  const attempts = await client.query<{
+    id: string
+    status: string
+    stopReason: string | null
+    completed: boolean
+    nextPoolItemId: number | null
+  }>(`
+    SELECT
+      "id",
+      "status"::text,
+      "stopReason"::text AS "stopReason",
+      "completedAt" IS NOT NULL AS completed,
+      "nextPoolItemId" AS "nextPoolItemId"
+    FROM "AdaptivePracticeQuizAttempt"
+    ORDER BY "id"
+  `)
+  assert.deepEqual(attempts.rows, [
+    {
+      id: '91000000-0000-4000-8000-000000000007',
+      status: 'ABANDONED',
+      stopReason: 'ABANDONED',
+      completed: true,
+      nextPoolItemId: null,
+    },
+    {
+      id: '91000000-0000-4000-8000-000000000008',
+      status: 'COMPLETED',
+      stopReason: 'CLASSIFIED',
+      completed: true,
+      nextPoolItemId: null,
+    },
+    {
+      id: '91000000-0000-4000-8000-000000000009',
+      status: 'IN_PROGRESS',
+      stopReason: null,
+      completed: false,
+      nextPoolItemId: 9102,
+    },
+    {
+      id: '91000000-0000-4000-8000-000000000011',
+      status: 'ABANDONED',
+      stopReason: 'ABANDONED',
+      completed: true,
+      nextPoolItemId: null,
+    },
+  ])
+
+  const response = await client.query<{
+    poolItemId: number | null
+    hasSnapshot: boolean
+  }>(`
+    SELECT
+      "poolItemId" AS "poolItemId",
+      "elementSnapshot" IS NOT NULL AS "hasSnapshot"
+    FROM "AdaptivePracticeQuizResponse"
+    WHERE "id" = 9101
+  `)
+  assert.deepEqual(response.rows, [{ poolItemId: 9101, hasSnapshot: true }])
+}
+
+async function verifyConstraints(client: Client) {
+  const expectedConstraints = [
+    'apqa_runtime_state_check',
+    'apqa_runtime_values_check',
+    'apqe_runtime_values_check',
+    'apqr_element_snapshot_required_check',
+    'apqr_pool_item_required_check',
+    'apqr_runtime_values_check',
+  ]
+  const constraints = await client.query<{
+    conname: string
+    convalidated: boolean
+  }>(
+    `
+      SELECT conname, convalidated
+      FROM pg_constraint
+      WHERE conname = ANY($1::text[])
+      ORDER BY conname
+    `,
+    [expectedConstraints]
+  )
+  assert.deepEqual(
+    constraints.rows,
+    expectedConstraints.sort().map((conname) => ({
+      conname,
+      convalidated: true,
+    }))
+  )
+
+  const retentionConstraints = await client.query<{
+    conname: string
+    confdeltype: string
+    convalidated: boolean
+  }>(`
+    SELECT conname, confdeltype, convalidated
+    FROM pg_constraint
+    WHERE conname IN (
+      'CompetenceTree_ownerId_fkey',
+      'AdaptivePracticeQuizAttempt_config_quiz_tree_fkey',
+      'AdaptivePracticeQuizAttempt_practiceQuizId_courseId_fkey',
+      'AdaptivePracticeQuizAttempt_courseId_fkey'
+    )
+    ORDER BY conname
+  `)
+  assert.equal(retentionConstraints.rowCount, 4)
+  assert(
+    retentionConstraints.rows.every(
+      ({ confdeltype, convalidated }) =>
+        confdeltype === 'r' && convalidated === true
+    )
+  )
+
+  const auditType = await client.query<{ present: boolean }>(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_enum
+      JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+      WHERE pg_type.typname = 'ObjectType'
+        AND pg_enum.enumlabel = 'COMPETENCE_TREE'
+    ) AS present
+  `)
+  assert.equal(auditType.rows[0]?.present, true)
+}
+
+async function verifyRetentionAndErasure(client: Client) {
+  await assert.rejects(
+    client.query(`
+      DELETE FROM "PracticeQuiz"
+      WHERE "id" = '91000000-0000-4000-8000-000000000004'
+    `),
+    (error: DatabaseError) => error.code === '23503'
+  )
+  await client.query(`
+    DELETE FROM "Participant"
+    WHERE "id" IN (
+      '91000000-0000-4000-8000-000000000006',
+      '91000000-0000-4000-8000-000000000010'
+    )
+  `)
+  const attemptCount = await client.query<{ count: number }>(`
+    SELECT COUNT(*)::integer AS count
+    FROM "AdaptivePracticeQuizAttempt"
+  `)
+  assert.equal(attemptCount.rows[0]?.count, 0)
+  const quizCount = await client.query<{ count: number }>(`
+    SELECT COUNT(*)::integer AS count
+    FROM "PracticeQuiz"
+    WHERE "id" = '91000000-0000-4000-8000-000000000004'
+  `)
+  assert.equal(quizCount.rows[0]?.count, 1)
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+await main()

--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -76,11 +76,23 @@ export async function ensureDatabaseViews() {
 export async function cleanupDatabase() {
   const prisma = await getPrisma()
   try {
+    // Review evidence is immutable under normal DELETE operations. This runs
+    // only in the disposable Playwright database and clears the two adaptive
+    // aggregate roots before the generic activity cleanup below.
+    await prisma.$executeRawUnsafe(`
+      TRUNCATE TABLE
+        "PracticeQuizAdaptiveConfig",
+        "CompetenceTreeScaleVersion"
+      RESTART IDENTITY CASCADE
+    `)
+    await prisma.adaptivePracticeQuizCohortSnapshot.deleteMany()
+    await prisma.adaptivePracticeQuizAttempt.deleteMany()
     await prisma.liveQuiz.deleteMany()
     await prisma.microLearning.deleteMany()
     await prisma.practiceQuiz.deleteMany()
     await prisma.groupActivity.deleteMany()
 
+    await prisma.competenceTree.deleteMany()
     await prisma.course.deleteMany()
 
     await prisma.element.deleteMany()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2172,6 +2172,9 @@ importers:
 
   packages/prisma-data:
     devDependencies:
+      '@klicker-uzh/adaptive-learning':
+        specifier: workspace:*
+        version: link:../adaptive-learning
       '@klicker-uzh/prisma':
         specifier: workspace:*
         version: link:../prisma


### PR DESCRIPTION
## Description

Stack 2/5, based on #5289. Adds the durable domain model, forward migrations, analytics mirror, and local fixtures needed by the adaptive PracticeQuiz runtime. The next layer is #5291.

## Proposed Changes

- Persist reusable cross-course competence trees with nested subcompetences up to depth five, level coverage, weights, course links, and leaf-level element assignments.
- Add adaptive PracticeQuiz configuration, immutable publication pools, attempts, responses, estimates, cohort snapshots, calibration governance, and policy/version provenance.
- Keep competence trees outside the generic catalog-sharing GraphQL enum; they use the feature-specific ownership and course-link authorization model while the database enum remains available for audit records.
- Use forward migrations and repair/backfill steps for populated databases, including the previously failing required attempt/publication/calibration columns.
- Keep the analytics schema mirror synchronized.
- Seed a depth-five reusable tree, balanced supported elements, a published adaptive PracticeQuiz, and enough participant data for local lecturer/student workflows.
- Include the adaptive-learning package build output in Playwright artifacts so clean shard jobs can run the adaptive seed before browser tests.
- Clear adaptive aggregate roots before generic activity cleanup in disposable Playwright and Cypress databases, preserving independent CI for this layer.
- Document migration, retention, privacy, ownership, and rollout operations.

## How to Test & Verification Evidence

- [x] Frozen-lockfile validation
- [x] Prisma client generation, build, and package typecheck
- [x] Prisma-data package typecheck
- [x] Prisma-to-analytics schema sync check
- [x] GraphQL codegen/bundle followed by a fresh Manage strict typecheck and production build
- [x] Playwright and Cypress harness typechecks after adaptive cleanup ordering
- [x] Workflow/docs formatting and Biome format check

## Manual/Visual Verification

N/A. Product workflows are shown in #5292.

## Review Focus

Migration safety on populated databases, constraints and indexes, retention/erasure semantics, cross-course ownership, immutable publication snapshots, and seed determinism.
