### PR TITLE
ci(backend-docker): gate the app image build on the migrator build

### DIFF
--- a/.github/workflows/v3_backend-docker-prd.yml
+++ b/.github/workflows/v3_backend-docker-prd.yml
@@ -16,6 +16,14 @@ env:
 jobs:
   build-arm:
     if: github.event.pull_request.draft == false
+    # Gate the app image on the migrator image so the two tags can never drift
+    # apart in the dangerous direction. If the migrator build fails, this job is
+    # skipped and the backend tag stays put, leaving the migrator ahead of the
+    # app — the expand-contract state migrations must already tolerate. The
+    # reverse (app ahead of migrator) would let the PreSync hook run an old
+    # migrator, apply nothing, exit 0, and roll out code against an unmigrated
+    # schema.
+    needs: build-migrator-arm
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -56,6 +64,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
   build-amd:
     if: github.event.pull_request.draft == false
+    # See build-arm: the app image must never advance without its migrator.
+    needs: build-migrator-amd
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/v3_backend-docker-stg.yml
+++ b/.github/workflows/v3_backend-docker-stg.yml
@@ -26,6 +26,14 @@ env:
 jobs:
   build-arm:
     if: github.event.pull_request.draft == false
+    # Gate the app image on the migrator image so the two tags can never drift
+    # apart in the dangerous direction. If the migrator build fails, this job is
+    # skipped and the backend tag stays put, leaving the migrator ahead of the
+    # app — the expand-contract state migrations must already tolerate. The
+    # reverse (app ahead of migrator) would let the PreSync hook run an old
+    # migrator, apply nothing, exit 0, and roll out code against an unmigrated
+    # schema.
+    needs: build-migrator-arm
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -66,6 +74,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
   build-amd:
     if: github.event.pull_request.draft == false
+    # See build-arm: the app image must never advance without its migrator.
+    needs: build-migrator-amd
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes M8 from the PR #5183 production-readiness report.

## The problem

The four jobs in both `v3_backend-docker-{stg,prd}.yml` were fully independent — no `needs:` between them — and each pushed its own tag on its own success.

So an ordinary run where `build-migrator-arm` fails while `build-arm` succeeds advances `backend-docker-arm:v3` while `backend-docker-migrator-arm:v3` stays at the previous commit. The next stg sync then runs the **old** migrator: it applies nothing, exits 0, the ArgoCD PreSync hook reports success, and the new code rolls out against an unmigrated schema.

The failure is silent and the pipeline is green throughout — the hook exists to prevent exactly this and would not catch it.

The readiness report characterised M8 as a partial-re-run risk. That understated it: independent job failure within a single normal run is the primary path.

## The fix

`build-arm` now needs `build-migrator-arm`, and `build-amd` needs `build-migrator-amd`, in both workflows.

The direction is the point. A job with `needs:` is skipped when its dependency fails, so the migrator image is pushed **before** the app image can be, and any partial failure leaves the migrator **ahead** of the app rather than behind. Migrator-ahead means new migrations applied while the previous app version still runs — the expand-contract state every migration in this repo is already required to tolerate. Migrator-behind, the only genuinely broken direction, becomes unreachable.

## Cost

Roughly 30–40s of added critical path, from the migrator's recorded build times (amd 28s, arm 37s). The arm and amd chains still run in parallel with each other. On pull requests neither job pushes, so there the dependency costs that latency and buys nothing — kept uniform for readability.

## Verification

- Both workflows parse; every `needs:` target resolves to a real job in the same file; no cycles; arm and amd chains independent.
- `prettier --check` clean on both files.
- Not exercised end to end: proving a migrator failure actually skips the backend job needs a real failing build. The `needs:` semantics are standard GitHub Actions behaviour.

## Residual risk (accepted, not closed)

Re-running an **older** run's migrator job still pushes that commit's migrator to the floating `:v3` tag, landing behind the app. The backend image has the identical exposure today, so this is inherent to floating tags rather than a new risk. Documented rather than engineered against.

## Not included

A startup check in the backend comparing `_prisma_migrations` against its bundled migrations would catch *every* cause of code-ahead-of-schema, not just CI skew. That's a real behaviour change with a new startup failure mode — separate PR, separate decision.