### PR TITLE
fix(frontend-pwa): restore Edu-ID login for the assessment build

### DIFF
--- a/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
+++ b/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
@@ -50,10 +50,11 @@ function getAssessmentReportIssueErrorKey(error: unknown) {
 function SuspendedAssessmentResults({ courseId }: { courseId: string }) {
   const t = useTranslations()
   const locale = useLocale()
-  // `errorPolicy: 'all'` keeps a failing query (e.g. a participant without an
-  // accepted course invitation) out of the error boundary: without it the thrown
-  // error takes down the whole app instead of rendering the notification below.
-  const { data } = useSuspenseQuery(GetStudentAssessmentResultsDocument, {
+  // `errorPolicy: 'all'` returns GraphQL errors instead of throwing them (e.g. a
+  // participant without an accepted course invitation). There is no error boundary
+  // above this component, so a thrown error takes down the whole course page
+  // instead of rendering the notification below.
+  const { data, error } = useSuspenseQuery(GetStudentAssessmentResultsDocument, {
     variables: { courseId },
     fetchPolicy: 'network-only',
     errorPolicy: 'all',
@@ -63,6 +64,12 @@ function SuspendedAssessmentResults({ courseId }: { courseId: string }) {
   const [reportArtifact, setReportArtifact] =
     useState<AssessmentReportArtifact | null>(null)
   const [issueAssessmentReport] = useMutation(MIssueCredentialDocument)
+
+  // Swallowing the error above would otherwise leave no trace of why the results
+  // failed to load - this keeps the cause recoverable from the browser console.
+  useEffect(() => {
+    if (error) console.error(error)
+  }, [error])
 
   useEffect(() => {
     if (!reportArtifact) return

--- a/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
+++ b/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
@@ -54,11 +54,14 @@ function SuspendedAssessmentResults({ courseId }: { courseId: string }) {
   // participant without an accepted course invitation). There is no error boundary
   // above this component, so a thrown error takes down the whole course page
   // instead of rendering the notification below.
-  const { data, error } = useSuspenseQuery(GetStudentAssessmentResultsDocument, {
-    variables: { courseId },
-    fetchPolicy: 'network-only',
-    errorPolicy: 'all',
-  })
+  const { data, error } = useSuspenseQuery(
+    GetStudentAssessmentResultsDocument,
+    {
+      variables: { courseId },
+      fetchPolicy: 'network-only',
+      errorPolicy: 'all',
+    }
+  )
   const [isExporting, setIsExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
   const [reportArtifact, setReportArtifact] =

--- a/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
+++ b/apps/frontend-pwa/src/components/insights/assessmentResults/SuspendedAssessmentResults.tsx
@@ -50,9 +50,13 @@ function getAssessmentReportIssueErrorKey(error: unknown) {
 function SuspendedAssessmentResults({ courseId }: { courseId: string }) {
   const t = useTranslations()
   const locale = useLocale()
+  // `errorPolicy: 'all'` keeps a failing query (e.g. a participant without an
+  // accepted course invitation) out of the error boundary: without it the thrown
+  // error takes down the whole app instead of rendering the notification below.
   const { data } = useSuspenseQuery(GetStudentAssessmentResultsDocument, {
     variables: { courseId },
     fetchPolicy: 'network-only',
+    errorPolicy: 'all',
   })
   const [isExporting, setIsExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
@@ -90,7 +94,7 @@ function SuspendedAssessmentResults({ courseId }: { courseId: string }) {
     link.remove()
   }
 
-  const results = data.studentAssessmentResults
+  const results = data?.studentAssessmentResults
   const liveQuizzes = results?.liveQuizzes ?? []
   const practiceQuizzes = results?.practiceQuizzes ?? []
   const microLearnings = results?.microLearnings ?? []

--- a/apps/frontend-pwa/src/pages/login.tsx
+++ b/apps/frontend-pwa/src/pages/login.tsx
@@ -188,20 +188,23 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     : forwardedProto || 'https'
   const host = ctx.req.headers.host as string
   const requestBase = `${proto}://${host}`
-  const configuredPwaUrl = process.env.NEXT_PUBLIC_PWA_URL
-  const pwaUrl = configuredPwaUrl || requestBase
+  const isAssessment = process.env.NEXT_PUBLIC_IS_ASSESSMENT === 'true'
+  // The assessment build is served from its own origin, so both the redirect
+  // validation and the post-login target must be anchored there. Anchoring them
+  // on the regular PWA origin sends students to an app that has no Edu-ID login.
+  const configuredAppUrl = isAssessment
+    ? process.env.NEXT_PUBLIC_ASSESSMENT_URL
+    : process.env.NEXT_PUBLIC_PWA_URL
+  const appUrl = configuredAppUrl || requestBase
   const redirectPath = getSafeRedirectPath(
     ctx.query.redirect_to,
-    pwaUrl,
+    appUrl,
     process.env.NEXT_PUBLIC_CHAT_URL
   )
 
   // In assessment mode, SSR-redirect to Auth /student to avoid client-side flash
-  if (process.env.NEXT_PUBLIC_IS_ASSESSMENT === 'true') {
-    if (!configuredPwaUrl) {
-      throw new Error('NEXT_PUBLIC_PWA_URL is required in assessment mode')
-    }
-    const targetUrl = new URL(redirectPath, configuredPwaUrl).toString()
+  if (isAssessment) {
+    const targetUrl = new URL(redirectPath, appUrl).toString()
     const authBase =
       process.env.NEXT_PUBLIC_AUTH_URL || 'https://auth.klicker.uzh.ch'
 

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -2,7 +2,7 @@
 type: Auth Model
 title: Auth Model
 description: Login flows for lecturers and participants, origin-based cookie selection in the backend, JWT scopes, and LTI launch rules.
-timestamp: '2026-07-10'
+timestamp: '2026-08-04'
 tags:
   - backend
   - auth
@@ -49,9 +49,11 @@ Note the account-duplication trap: participant emails are only unique per auth m
 Manage and PWA login pages treat return targets as untrusted input:
 
 - Manage preserves the current path when an authenticated query fails (`apps/frontend-manage/src/components/Layout.tsx:Layout`). Its login page resolves `redirect_to` against `NEXT_PUBLIC_MANAGE_URL` and accepts only that exact origin. External or malformed targets fall back to the manage root before the page redirects to the auth app (`apps/frontend-manage/src/pages/login.tsx:getServerSideProps`).
-- PWA login accepts paths on the exact `NEXT_PUBLIC_PWA_URL` origin and normalizes them to relative navigation. It also accepts the exact `NEXT_PUBLIC_CHAT_URL` origin because chat login must return to a different app. Every other origin and malformed value falls back to the PWA root (`apps/frontend-pwa/src/pages/login.tsx:getSafeRedirectPath`). Local PWA targets use the Next router; chat targets use a full browser navigation after password login (`apps/frontend-pwa/src/pages/login.tsx:Login`). Assessment mode requires `NEXT_PUBLIC_PWA_URL` and resolves Auth return targets against that configured origin rather than the request `Host`.
+- PWA login accepts paths on the exact origin the build is served from and normalizes them to relative navigation. It also accepts the exact `NEXT_PUBLIC_CHAT_URL` origin because chat login must return to a different app. Every other origin and malformed value falls back to the app root (`apps/frontend-pwa/src/pages/login.tsx:getSafeRedirectPath`). Local PWA targets use the Next router; chat targets use a full browser navigation after password login (`apps/frontend-pwa/src/pages/login.tsx:Login`).
 
-The chat login-required page validates its own return target against `NEXT_PUBLIC_CHAT_URL` before passing an absolute URL to the PWA (`apps/chat/src/app/noLogin/page.tsx:getChatRedirectUrl`). Assessment login receives the same sanitized PWA target through the auth app.
+**The anchoring origin is build-specific.** The regular build anchors on `NEXT_PUBLIC_PWA_URL`, the assessment build on `NEXT_PUBLIC_ASSESSMENT_URL`, and either falls back to the request `Host` when its variable is unset (`apps/frontend-pwa/src/pages/login.tsx:getServerSideProps`). Anchoring assessment mode on `NEXT_PUBLIC_PWA_URL` is a regression, not a shortcut: the two builds run on separate origins with separate sessions, and the regular PWA offers no Edu-ID login, so students sent there after Edu-ID cannot sign in at all. The Next.js 16 upgrade (#5166) introduced exactly that regression on `v3`; production never shipped it, because prd stayed pinned to a pre-#5166 tag while staging floats `v3`.
+
+The chat login-required page validates its own return target against `NEXT_PUBLIC_CHAT_URL` before passing an absolute URL to the PWA (`apps/chat/src/app/noLogin/page.tsx:getChatRedirectUrl`). Assessment login receives the same sanitized target through the auth app.
 
 ## Where authorization happens
 

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -53,7 +53,9 @@ Manage and PWA login pages treat return targets as untrusted input:
 
 **The anchoring origin is build-specific.** The regular build anchors on `NEXT_PUBLIC_PWA_URL`, the assessment build on `NEXT_PUBLIC_ASSESSMENT_URL`, and either falls back to the request `Host` when its variable is unset (`apps/frontend-pwa/src/pages/login.tsx:getServerSideProps`). Anchoring assessment mode on `NEXT_PUBLIC_PWA_URL` is a regression, not a shortcut: the two builds run on separate origins with separate sessions, and the regular PWA offers no Edu-ID login, so students sent there after Edu-ID cannot sign in at all. The Next.js 16 upgrade (#5166) introduced exactly that regression on `v3`; production never shipped it, because prd stayed pinned to a pre-#5166 tag while staging floats `v3`.
 
-The chat login-required page validates its own return target against `NEXT_PUBLIC_CHAT_URL` before passing an absolute URL to the PWA (`apps/chat/src/app/noLogin/page.tsx:getChatRedirectUrl`). Assessment login receives the same sanitized target through the auth app.
+The chat login-required page validates its own return target against `NEXT_PUBLIC_CHAT_URL` before passing an absolute URL to the PWA (`apps/chat/src/app/noLogin/page.tsx:getChatRedirectUrl`). That page always routes through `NEXT_PUBLIC_PWA_URL/login`, so a chat target never reaches the assessment build.
+
+**The PWA-side sanitizer is not the only gate.** The auth app independently validates the `/student` `redirectTo` against `AUTH_STUDENT_ALLOWED_HOSTS` and returns `400 Invalid redirect URL` for anything outside it (`apps/auth/src/middleware.ts`). That second gate is what keeps the request-`Host` fallback above safe, and it is also what a `400` from `/student` means: the target origin is missing from that env var (`assessment.klicker.stg.df-app.ch` on stg, `assessment.klicker.uzh.ch` on prd).
 
 ## Where authorization happens
 

--- a/docs/log/2026-08-04-assessment-login-anchoring.md
+++ b/docs/log/2026-08-04-assessment-login-anchoring.md
@@ -1,0 +1,3 @@
+## 2026-08-04
+
+- **Update**: [auth-model](../auth-model.md) records that the PWA login page anchors return targets on a build-specific origin (`NEXT_PUBLIC_ASSESSMENT_URL` for the assessment build, `NEXT_PUBLIC_PWA_URL` otherwise, request `Host` as fallback), that anchoring assessment mode on the regular PWA origin is the #5166 regression that stranded students on an app without Edu-ID login, and that the auth app's `AUTH_STUDENT_ALLOWED_HOSTS` check is a second, independent gate on the `/student` return target.


### PR DESCRIPTION
## What

Two fixes in the assessment (Edu-ID) student flow, both found while verifying the migration hook (#5183) end-to-end on staging.

**1. Assessment login redirected students to the wrong app.** In assessment mode, `login.tsx` resolved both the redirect-validation origin and the post-login target against `NEXT_PUBLIC_PWA_URL`. The assessment build runs on its own origin with its own session, and the regular PWA has no Edu-ID button — so students were sent somewhere they could not sign in. Now anchored on `NEXT_PUBLIC_ASSESSMENT_URL`, with the request `Host` as fallback. The open-redirect hardening added in #5166 is kept, just validated against the correct origin.

**2. A failing assessment-results query crashed the whole PWA.** `useSuspenseQuery` rethrows, and there is no error boundary above the `Suspense` wrapper, so a participant without an accepted course invitation got Next's generic "client-side exception" page. `errorPolicy: 'all'` routes the error into the notification the component already renders for missing results.

## Why now

Regression introduced by #5166 (Next.js 16 upgrade, 2026-07-19). Production is **not** affected today only because prd is pinned to `v3.4.0-alpha.62` (pre-#5166) while staging floats `v3` — the next prd release would have shipped it.

## Verification

- Reproduced on staging: `assessment.klicker.stg.df-app.ch/login?redirect_to=…` returned `307 → auth…/student?redirectTo=https://pwa.klicker.stg.df-app.ch/…` (wrong origin); prd returns the assessment origin, and `git show v3.4.0-alpha.62:apps/frontend-pwa/src/pages/login.tsx` confirms the pre-upgrade code used the request host.
- Crash reproduced in-browser (console: `ApolloError: Active assessment participation with an accepted invitation not found` → "Application error").
- Post-merge: re-check the staging redirect and the no-invitation state once stg picks up `v3`.

## Notes

- Wiki updated: [docs/auth-model.md](docs/auth-model.md) "Login return targets" now states the anchoring origin is build-specific and records the regression.
- No unit test yet: `apps/frontend-pwa` has no test setup, and adding one (vitest, mirroring `apps/chat`) means a new devDependency plus a lockfile change. Happy to add it here or as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Assessment login redirects now return users to the correct assessment application.
  - Login routing uses configured application origins, with a safe request-origin fallback when configuration is unavailable.
  - Assessment results can display the existing failure notification when result data is unavailable, instead of failing unexpectedly.
  - Redirect validation now consistently applies to authentication and chat destinations.

- **Documentation**
  - Updated authentication guidance and added an assessment login troubleshooting record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->