### PR TITLE
ci(deploy): auto-promote merged commits to staging

### DIFF
--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -110,35 +110,45 @@ jobs:
           set -euo pipefail
           # Matched per workflow *file* via `.path`. Check-runs cannot be used: all 13
           # stg workflows name their jobs `build-arm`/`build-amd`, so the names collide.
-          gh api --paginate --slurp \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&event=push&per_page=100" \
-            | jq '[.[].workflow_runs[] | select(.head_branch == "v3")]' > runs.json
+          # Re-poll rather than giving up on the first look. This job is only ever
+          # triggered by a build completing, so if the API has not yet indexed the
+          # last run when the surviving promoter evaluates, there is no later trigger
+          # to recover -- staging would stall silently until the next merge.
+          for attempt in 1 2 3 4 5 6; do
+            gh api --paginate --slurp \
+              "/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&event=push&per_page=100" \
+              | jq '[.[].workflow_runs[] | select(.head_branch == "v3")]' > runs.json
 
-          missing=(); notgreen=()
-          # Required set derived from the checkout, so adding a 14th stg app needs no
-          # edit here -- only the trigger list above.
-          for wf in .github/workflows/v3_*-stg.yml; do
-            run=$(jq -c --arg p "$wf" \
-              '[.[] | select(.path == $p)] | sort_by(.id) | last // empty' runs.json)
-            if [ -z "$run" ]; then missing+=("$wf [no run]"); continue; fi
-            st=$(jq -r '.status'     <<<"$run")
-            cc=$(jq -r '.conclusion' <<<"$run")
-            if   [ "$st" != "completed" ]; then missing+=("$wf [$st]")
-            # `skipped` is deliberately NOT success: on push every job runs, so a
-            # skipped run means no image was published for that component.
-            elif [ "$cc" != "success"   ]; then notgreen+=("$wf [$cc]")
+            missing=(); notgreen=()
+            # Required set derived from the checkout, so adding a 14th stg app needs no
+            # edit here -- only the trigger list above.
+            for wf in .github/workflows/v3_*-stg.yml; do
+              run=$(jq -c --arg p "$wf" \
+                '[.[] | select(.path == $p)] | sort_by(.id) | last // empty' runs.json)
+              if [ -z "$run" ]; then missing+=("$wf [no run]"); continue; fi
+              st=$(jq -r '.status'     <<<"$run")
+              cc=$(jq -r '.conclusion' <<<"$run")
+              if   [ "$st" != "completed" ]; then missing+=("$wf [$st]")
+              # `skipped` is deliberately NOT success: on push every job runs, so a
+              # skipped run means no image was published for that component.
+              elif [ "$cc" != "success"   ]; then notgreen+=("$wf [$cc]")
+              fi
+            done
+
+            # A genuine failure is final -- no amount of waiting fixes it.
+            if [ ${#notgreen[@]} -gt 0 ]; then
+              echo "::notice::not promoting ${SHA}; not green: ${notgreen[*]}"
+              echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
             fi
+            if [ ${#missing[@]} -eq 0 ]; then
+              echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
+            fi
+            echo "attempt ${attempt}: waiting on ${missing[*]}"
+            [ "$attempt" -eq 6 ] || sleep 20
           done
 
-          if [ ${#notgreen[@]} -gt 0 ]; then
-            echo "::notice::not promoting ${SHA}; not green: ${notgreen[*]}"
-            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
-          fi
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "::notice::waiting on: ${missing[*]}"
-            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
-          fi
-          echo "go=true" >>"$GITHUB_OUTPUT"
+          echo "::notice::giving up on ${SHA}; still waiting on: ${missing[*]}"
+          echo "go=false" >>"$GITHUB_OUTPUT"
 
       - name: Skip if already promoted or superseded
         id: guard
@@ -151,11 +161,25 @@ jobs:
           git merge-base --is-ancestor "$SHA" origin/v3 \
             || { echo "::error::$SHA is not an ancestor of origin/v3"; exit 1; }
 
+          # Never promote a promotion. The `[skip ci]` marker in the PR title normally
+          # stops the squash-merge from rebuilding and re-firing this workflow, but that
+          # depends on the repository's `squash_merge_commit_title` setting, which lives
+          # outside this repo and is not recorded anywhere as load-bearing. This check
+          # does not depend on it, and without it a flipped setting yields a runaway loop
+          # that burns 13 image builds and a full stg rollout per iteration.
+          if git log -1 --format='%s' "$SHA" | grep -q '^chore(deploy): promote '; then
+            echo "::notice::${SHA} is itself a promotion commit"
+            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
+          fi
+
           CUR=$(sed -n "s/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release: '\(.*\)'$/\1/p" "$F" | head -1)
           # Stale-promotion guard, and the idempotence check for the 13 re-fires:
-          # `--is-ancestor` is true for equal commits. A legacy value such as
-          # `v3.4.0-alpha.64` does not resolve to a commit and correctly falls through.
-          if [ -n "$CUR" ] && git cat-file -e "${CUR}^{commit}" 2>/dev/null; then
+          # `--is-ancestor` is true for equal commits. Restricted to hex so a legacy
+          # release-tag value is not silently resolved as a commit -- `v3.4.0-alpha.64`
+          # IS a tag in this repo, and comparing against a tag newer than the target
+          # would skip a promotion that should have happened.
+          if printf '%s' "$CUR" | grep -qE '^[0-9a-f]{7,40}$' \
+             && git cat-file -e "${CUR}^{commit}" 2>/dev/null; then
             if git merge-base --is-ancestor "$SHA" "$CUR"; then
               echo "::notice::${CUR} is already promoted and is newer than or equal to ${SHA}"
               echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
@@ -199,8 +223,12 @@ jobs:
 
           # Supersede any promotion still open: with `strict: true` an older one can
           # sit un-mergeable behind a newer commit and would otherwise roll stg back.
+          # Exclude the branch we are about to create, so a re-run of a flaky build
+          # within the promotion window cannot close this SHA's own open PR.
           for n in $(gh pr list --state open --limit 100 --json number,headRefName \
-                       --jq '.[] | select(.headRefName | startswith("chore/promote-stg-")) | .number'); do
+                       | jq -r --arg b "$BRANCH" \
+                         '.[] | select(.headRefName | startswith("chore/promote-stg-"))
+                              | select(.headRefName != $b) | .number'); do
             gh pr close "$n" --delete-branch \
               --comment "Superseded by the promotion of ${SHORT}." || true
           done
@@ -232,3 +260,23 @@ jobs:
             --body-file /tmp/pr-body.md
 
           gh pr merge "$BRANCH" --squash --auto --delete-branch
+
+          # `--auto` returns immediately, so a PR that can NEVER merge would otherwise
+          # leave a green run, an open PR nobody looks at, and staging exactly as stale
+          # as before -- the silent no-op this whole workflow exists to prevent. Watch
+          # it briefly and fail loudly instead. Still pending after this is fine: that
+          # is auto-merge waiting on checks, which will complete on its own.
+          STATE=''
+          for attempt in 1 2 3 4 5 6; do
+            sleep 20
+            STATE=$(gh pr view "$BRANCH" --json state,mergeStateStatus \
+                      --jq '.state + "/" + .mergeStateStatus')
+            case "$STATE" in
+              MERGED/*)
+                echo "::notice::promotion of ${SHORT} merged"; exit 0 ;;
+              */BLOCKED | */DIRTY)
+                echo "::error::promotion PR for ${SHORT} is ${STATE} and will not merge on its own - staging will NOT update"
+                exit 1 ;;
+            esac
+          done
+          echo "::notice::promotion PR for ${SHORT} is ${STATE}; auto-merge will complete it"

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -1,0 +1,234 @@
+name: Promote to stg
+
+# Staging pulls the floating `v3` image tag, so rebuilding an image never changes
+# the rendered manifest: ArgoCD sees no drift, never syncs, and the new image is
+# only picked up whenever someone happens to restart the pods. This workflow closes
+# that gap by writing the built commit's SHA into the `rollout.klicker.uzh.ch/release`
+# pod annotations. That DOES change the pod template, so ArgoCD detects drift, runs
+# the PreSync migration hook, and rolls the pods -- in that order (see ADR-0003).
+#
+# It promotes only once every stg image for that commit exists, so the rollout can
+# never start against a half-published or stale `:v3` tag.
+#
+# INVARIANT: every `.github/workflows/v3_*-stg.yml` must (a) run unconditionally on
+# push to `v3` and (b) appear under `workflows:` below. Adding a push-level `paths:`
+# filter to any of them stalls promotion permanently -- the gate would wait forever
+# for a run that is never going to happen.
+
+on:
+  workflow_run:
+    # These are workflow *names*, not paths. A typo fails silently: GitHub simply
+    # never fires this workflow for that build. Keep in sync with `name:` in each
+    # `v3_*-stg.yml` (the gate below derives the required set from the files, so a
+    # missing entry here only costs a trigger, never a false promotion).
+    workflows:
+      - 'Build Docker image for analytics (stg)'
+      - 'Build Docker image for auth (stg)'
+      - 'Build Docker image for backend-docker (stg)'
+      - 'Build Docker image for chat (stg)'
+      - 'Build Docker image for frontend-assessment (stg)'
+      - 'Build Docker image for frontend-control (stg)'
+      - 'Build Docker image for frontend-manage (stg)'
+      - 'Build Docker image for frontend-pwa (stg)'
+      - 'Build Docker image for hatchet-worker-general (stg)'
+      - 'Build Docker image for hatchet-worker-response-processor (stg)'
+      - 'Build Docker image for lti (stg)'
+      - 'Build Docker image for olat-api (stg)'
+      - 'Build Docker image for response-api (stg)'
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA on v3 to promote (break-glass / first run)'
+        required: true
+      dry_run:
+        description: 'Evaluate and print the diff only, do not open a PR'
+        type: boolean
+        default: true
+
+# Must stay `false`: cancelling a promoter mid-publish could leave a branch pushed
+# with no PR. GitHub keeps at most one running plus one pending run per group, so
+# the 13 build completions collapse to the latest-queued one, which is what we want.
+concurrency:
+  group: promote-stg
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    # `head_branch == 'v3'` is mandatory: the stg build workflows also fire on `v3*`
+    # feature branches, which must never promote. `event == 'push'` excludes PR
+    # builds, which do not push images at all.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'v3' &&
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Require the promotion token
+        env:
+          TOKEN: ${{ secrets.STG_PROMOTE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # A PR opened with the default GITHUB_TOKEN does not trigger workflows, so
+          # its required checks would never report and auto-merge would never fire.
+          # The promotion therefore needs a token that acts as a real user/app.
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::secrets.STG_PROMOTE_TOKEN is not set - see docs/ci-and-deployment.md"
+            exit 1
+          fi
+
+      - name: Resolve target commit
+        id: target
+        env:
+          WR_SHA: ${{ github.event.workflow_run.head_sha }}
+          IN_SHA: ${{ github.event.inputs.sha }}
+        run: |
+          set -euo pipefail
+          # Must be the BUILD's head SHA, never the current tip of v3: the tip may
+          # have advanced past the commit whose images are actually green.
+          SHA="${WR_SHA:-$IN_SHA}"
+          [ -n "$SHA" ] || { echo "::error::no target SHA"; exit 1; }
+          echo "sha=$SHA" >>"$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: v3
+          fetch-depth: 0 # merge-base needs full history
+          token: ${{ secrets.STG_PROMOTE_TOKEN }}
+
+      - name: Require every stg image for this commit
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Matched per workflow *file* via `.path`. Check-runs cannot be used: all 13
+          # stg workflows name their jobs `build-arm`/`build-amd`, so the names collide.
+          gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&event=push&per_page=100" \
+            | jq '[.[].workflow_runs[] | select(.head_branch == "v3")]' > runs.json
+
+          missing=(); notgreen=()
+          # Required set derived from the checkout, so adding a 14th stg app needs no
+          # edit here -- only the trigger list above.
+          for wf in .github/workflows/v3_*-stg.yml; do
+            run=$(jq -c --arg p "$wf" \
+              '[.[] | select(.path == $p)] | sort_by(.id) | last // empty' runs.json)
+            if [ -z "$run" ]; then missing+=("$wf [no run]"); continue; fi
+            st=$(jq -r '.status'     <<<"$run")
+            cc=$(jq -r '.conclusion' <<<"$run")
+            if   [ "$st" != "completed" ]; then missing+=("$wf [$st]")
+            # `skipped` is deliberately NOT success: on push every job runs, so a
+            # skipped run means no image was published for that component.
+            elif [ "$cc" != "success"   ]; then notgreen+=("$wf [$cc]")
+            fi
+          done
+
+          if [ ${#notgreen[@]} -gt 0 ]; then
+            echo "::notice::not promoting ${SHA}; not green: ${notgreen[*]}"
+            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::notice::waiting on: ${missing[*]}"
+            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "go=true" >>"$GITHUB_OUTPUT"
+
+      - name: Skip if already promoted or superseded
+        id: guard
+        if: steps.gate.outputs.go == 'true'
+        env:
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          F=deploy/env-uzh-stg/values.yaml
+          git merge-base --is-ancestor "$SHA" origin/v3 \
+            || { echo "::error::$SHA is not an ancestor of origin/v3"; exit 1; }
+
+          CUR=$(sed -n "s/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release: '\(.*\)'$/\1/p" "$F" | head -1)
+          # Stale-promotion guard, and the idempotence check for the 13 re-fires:
+          # `--is-ancestor` is true for equal commits. A legacy value such as
+          # `v3.4.0-alpha.64` does not resolve to a commit and correctly falls through.
+          if [ -n "$CUR" ] && git cat-file -e "${CUR}^{commit}" 2>/dev/null; then
+            if git merge-base --is-ancestor "$SHA" "$CUR"; then
+              echo "::notice::${CUR} is already promoted and is newer than or equal to ${SHA}"
+              echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
+            fi
+          fi
+          echo "go=true" >>"$GITHUB_OUTPUT"
+
+      - name: Write the release annotation
+        id: write
+        if: steps.gate.outputs.go == 'true' && steps.guard.outputs.go == 'true'
+        env:
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          F=deploy/env-uzh-stg/values.yaml
+          SHORT=$(git rev-parse --short=12 "$SHA")
+
+          BEFORE=$(grep -c "rollout\.klicker\.uzh\.ch/release:" "$F")
+          [ "$BEFORE" -eq 15 ] || { echo "::error::expected 15 annotations, found $BEFORE"; exit 1; }
+
+          # sed, not yq: the file carries comments and hand-chosen quote styles that a
+          # yq round-trip reflows. The value MUST stay quoted -- an unquoted all-digit
+          # short SHA parses as a YAML integer and Kubernetes rejects the annotation.
+          sed -i -E "s|^([[:space:]]*rollout\.klicker\.uzh\.ch/release:).*|\1 '${SHORT}'|" "$F"
+
+          AFTER=$(grep -c "rollout\.klicker\.uzh\.ch/release: '${SHORT}'" "$F")
+          [ "$AFTER" -eq "$BEFORE" ] || { echo "::error::rewrote $AFTER of $BEFORE"; exit 1; }
+
+          git diff -- "$F"
+          echo "short=$SHORT" >>"$GITHUB_OUTPUT"
+
+      - name: Open the promotion PR and auto-merge it
+        if: steps.write.outcome == 'success' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.STG_PROMOTE_TOKEN }}
+          SHA: ${{ steps.target.outputs.sha }}
+          SHORT: ${{ steps.write.outputs.short }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/promote-stg-${SHORT}"
+
+          # Supersede any promotion still open: with `strict: true` an older one can
+          # sit un-mergeable behind a newer commit and would otherwise roll stg back.
+          for n in $(gh pr list --state open --limit 100 --json number,headRefName \
+                       --jq '.[] | select(.headRefName | startswith("chore/promote-stg-")) | .number'); do
+            gh pr close "$n" --delete-branch \
+              --comment "Superseded by the promotion of ${SHORT}." || true
+          done
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+          git add deploy/env-uzh-stg/values.yaml
+          git commit -m "chore(deploy): promote ${SHORT} to stg"
+          git push origin "$BRANCH"
+
+          # `[skip ci]` in the title becomes the squash commit message, which stops the
+          # merge from re-running all 13 builds and re-firing this workflow. The PR
+          # touches only `deploy/**`, so `Build Fallback` supplies build-amd/build-arm.
+          # The YAML block scalar strips this common indentation, so the heredoc body
+          # and its EOF terminator both land at column 0 in the generated script.
+          cat >/tmp/pr-body.md <<EOF
+          Automated staging promotion of \`${SHA}\`.
+
+          Writes the built commit into \`rollout.klicker.uzh.ch/release\` so ArgoCD
+          detects drift, runs the PreSync migration hook, and rolls the stg pods.
+          Opened only after every \`v3_*-stg.yml\` image build succeeded for this
+          commit. See ADR-0003.
+          EOF
+
+          gh pr create \
+            --base v3 --head "$BRANCH" \
+            --title "chore(deploy): promote ${SHORT} to stg [skip ci]" \
+            --body-file /tmp/pr-body.md
+
+          gh pr merge "$BRANCH" --squash --auto --delete-branch

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+        rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+        rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+        rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -159,7 +159,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -310,7 +310,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -363,7 +363,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -417,7 +417,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -470,7 +470,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -539,7 +539,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -592,7 +592,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
   replicaCount: 1
 
   affinity:
@@ -641,7 +641,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+    rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
 
   replicaCount: 1
 
@@ -695,7 +695,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+      rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -759,7 +759,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+      rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -837,7 +837,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: v3.4.0-alpha.64
+      rollout.klicker.uzh.ch/release: 'v3.4.0-alpha.64'
     replicaCount: 1
 
     autoscaling:

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -1,0 +1,43 @@
+# 3. Promote to staging by writing the built commit into a release annotation
+
+- **Status:** Accepted — 2026-08-04
+- **Deciders:** @rschlaefli
+- **Context:** [PR #5183](https://github.com/uzh-bf/klicker-uzh/pull/5183), [PR #5303](https://github.com/uzh-bf/klicker-uzh/pull/5303)
+
+## Context
+
+Staging pulls the floating `v3` image tag. A rebuild therefore leaves the rendered manifest byte-identical, ArgoCD detects no drift, and the new image sits in the registry until somebody restarts the pods by hand. Staging is the canary for everything merged since the prd-pinned tag, so "merged but not running" is the failure mode that matters most: [PR #5303](https://github.com/uzh-bf/klicker-uzh/pull/5303) was a regression that only production's tag pin had shielded, and it stayed unrolled on stg after merge with nothing signalling that.
+
+The same blind spot already bit the PreSync migration hook of [ADR-0001](./0001-automate-db-migrations-via-argocd-presync-hook.md): ArgoCD excludes hook manifests from the OutOfSync comparison, so the hook only ran after a manual sync.
+
+`deploy/env-uzh-stg/values.yaml` already carried a `rollout.klicker.uzh.ch/release` pod annotation, 15 times, with no automation and a value (`v3.4.0-alpha.64`) that had drifted far behind the code actually running. It is absent from prd, which needs no trigger because its pinned tags change on every release.
+
+## Decision
+
+Automate that annotation. `.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into all 15 occurrences, which changes the pod template and so produces a genuine ArgoCD sync: PreSync migration hook first, then the pods roll.
+
+Promotion is gated on **every** `v3_*-stg.yml` image build succeeding for that commit, with the required set derived from the workflow files present in the checkout rather than a hardcoded list. `skipped` is not treated as success. A rollout therefore cannot start against a half-published or stale `:v3`, and cannot run migrations from a stale migrator image.
+
+The workflow publishes as an **auto-merging pull request**, not a direct push.
+
+## Considered options
+
+**Publish mechanism — direct push vs pull request.** `v3` restricts pushes (an empty user/team/app allowlist) and requires 8 status checks, and the repository has no ruleset bypass actor. Granting the Actions bot a bypass would weaken the branch's protection for every workflow holding `contents: write`, not just this one. The PR route works within the existing protection: the promotion touches only `deploy/**`, so `Build Fallback` reports `build-amd`/`build-arm` in seconds and the remaining checks are the fast unconditional ones. The cost is a bot PR per merge and a dependency on `secrets.STG_PROMOTE_TOKEN`, because a PR opened with the default `GITHUB_TOKEN` does not trigger workflows and would never satisfy its own required checks.
+
+**Trigger — `workflow_run` fan-in vs restructuring the 13 builds into one workflow.** Chose `workflow_run` with a gate that re-evaluates on every build completion, so the last build to finish is the one that proceeds. Idempotent, and it leaves the 13 existing workflows untouched.
+
+**Write mechanism — `sed` vs `yq`.** Chose `sed` with a before/after count assertion. The values file carries comments and hand-chosen quote styles that a `yq` round-trip reflows. The annotation values were pre-quoted in the same change: an unquoted all-digit short SHA parses as a YAML integer and Kubernetes rejects a non-string annotation value.
+
+**Rejected — ArgoCD Image Updater.** Purpose-built and digest-aware, so it would solve provenance too, but it adds a cluster component plus repository write credentials to watch 15 images for a single environment whose trigger mechanism already existed.
+
+**Rejected — CI calling the ArgoCD API directly.** Not GitOps, and it would require cluster credentials in CI plus network reachability the cluster does not offer.
+
+## Consequences
+
+All 15 components roll on every merge to `v3`, including the Hatchet workers. The workers' SDK drains in-flight tasks on `SIGTERM` and their tasks declare retries, but the chart sets no `terminationGracePeriodSeconds` and no `preStop`, and both worker Dockerfiles use shell-form `CMD`, so signal delivery is not guaranteed. This is pre-existing and applies equally to every manual sync today; automation only changes how often it happens. Hardening it is tracked separately.
+
+A failed migration now blocks the entire staging rollout automatically rather than only when someone syncs by hand. That is the intended behaviour from ADR-0001, but it makes a bad migration a stop-the-world event on stg.
+
+The annotation records which commit **triggered** the rollout, not which bits are in the image. Two merges minutes apart cancel the first build and `:v3` then holds the later images. Immutable per-commit image tags would close that gap and are the natural successor to this decision.
+
+Turning it off is `gh workflow disable "Promote to stg"`: no commit, effective immediately, and the failure mode is the status quo ante — staging simply stops updating itself.

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -34,6 +34,12 @@ The workflow publishes as an **auto-merging pull request**, not a direct push.
 
 ## Consequences
 
+Each merge now produces a **second** commit on `v3` (the promotion). Because `v3` sets `required_status_checks.strict: true`, every other open PR is knocked out of date again by that second commit — with 20+ PRs typically open, that roughly doubles the branch-update churn. A promotion PR that is itself overtaken becomes un-mergeable and self-heals only when the next merge supersedes it.
+
+The required set is derived from the `v3_*-stg.yml` files, which includes `v3_analytics-stg.yml` — and `analytics` has **no** Deployment in the chart. A failed analytics image build therefore blocks the staging rollout of 15 components that do not depend on it. Accepted deliberately: a hardcoded exception would rot the moment a 14th stg app appears, and the failure is visible in the promoter's run log.
+
+Two repository settings are load-bearing and recorded nowhere else: `squash_merge_commit_title` must remain `PR_TITLE` so the `[skip ci]` marker reaches the squash commit, and auto-merge must stay enabled. The guard additionally refuses any commit whose subject starts with `chore(deploy): promote `, so a flipped setting degrades to wasted rebuilds rather than an unbounded promotion loop.
+
 All 15 components roll on every merge to `v3`, including the Hatchet workers. The workers' SDK drains in-flight tasks on `SIGTERM` and their tasks declare retries, but the chart sets no `terminationGracePeriodSeconds` and no `preStop`, and both worker Dockerfiles use shell-form `CMD`, so signal delivery is not guaranteed. This is pre-existing and applies equally to every manual sync today; automation only changes how often it happens. Hardening it is tracked separately.
 
 A failed migration now blocks the entire staging rollout automatically rather than only when someone syncs by hand. That is the intended behaviour from ADR-0001, but it makes a bad migration a stop-the-world event on stg.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ The durable record of **why** — the significant, hard-to-reverse choices behin
 ## Index
 
 - [0001](./0001-automate-db-migrations-via-argocd-presync-hook.md) — Automate database migrations via an ArgoCD PreSync hook
+- [0003](./0003-promote-stg-via-release-annotation-write-back.md) — Promote to staging by writing the built commit into a release annotation

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -67,6 +67,12 @@ The `rollout.klicker.uzh.ch/release` annotation exists to break that tie: it lan
 
 `.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into all 15, once **every** `v3_*-stg.yml` image build has succeeded for that commit — so a rollout can never start against a half-published `:v3`, and the PreSync migration hook always runs before the new pods. It publishes as an auto-merging PR rather than a direct push, because `v3` restricts pushes and requires 8 status checks with no bypass actor; the PR touches only `deploy/**`, so `Build Fallback` supplies `build-amd`/`build-arm` in seconds. `[skip ci]` in the PR title keeps the squash-merge from re-running the 13 builds and re-firing the promoter.
 
-Two operational notes. It needs `secrets.STG_PROMOTE_TOKEN` (a PAT or GitHub App token with `contents: write` + `pull-requests: write`) — a PR opened with the default `GITHUB_TOKEN` does not trigger workflows, so its required checks would never report and auto-merge would never fire. And the annotation records which commit _triggered_ the rollout, not which bits are in the image: two merges minutes apart cancel the first build (`cancel-in-progress: true`) and `:v3` then holds the later images. Immutable per-commit tags are the fix if that ever matters. Rationale and rejected alternatives: [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).
+Three operational notes.
+
+- It needs `secrets.STG_PROMOTE_TOKEN`, an **admin-owned PAT** with `contents: write` + `pull-requests: write`. Two independent reasons it cannot be the default `GITHUB_TOKEN` or a plain App token: a PR opened with `GITHUB_TOKEN` does not trigger workflows, so its required checks never report and auto-merge never fires; and `v3`'s push restrictions carry an _empty_ user/team/app allowlist, which only repository admins bypass.
+- Two settings outside this repo are load-bearing. `squash_merge_commit_title` must stay `PR_TITLE`, or the `[skip ci]` marker never reaches the squash commit and every promotion rebuilds all 13 images. The workflow does not rely on it alone — the guard also refuses to promote any commit whose subject starts with `chore(deploy): promote ` — but the belt is worth keeping. Auto-merge must be enabled on the repository.
+- The annotation records which commit _triggered_ the rollout, not which bits are in the image: two merges minutes apart cancel the first build (`cancel-in-progress: true`) and `:v3` then holds the later images. Immutable per-commit tags are the fix if that ever matters.
+
+Rationale and rejected alternatives: [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).
 
 Prd is unaffected — it promotes by hand-editing pinned tags in `deploy/env-uzh-prd/values.yaml`.

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -2,7 +2,7 @@
 type: Operations
 title: CI & Deployment
 description: PR gates, image builds, the standard-version release flow, Helm deployment reality, and what is NOT in this repo.
-timestamp: '2026-08-03'
+timestamp: '2026-08-04'
 tags:
   - ci
   - deployment
@@ -44,7 +44,7 @@ Version bumps are **local and manual** via standard-version: `pnpm run release[:
 
 ## Deployment values (facts, not procedures)
 
-- **stg** (`*.klicker.stg.df-app.ch`): workers ride the floating `v3` tag; releases tracked via a `rollout.klicker.uzh.ch/release` pod annotation.
+- **stg** (`*.klicker.stg.df-app.ch`): everything rides the floating `v3` tag, so the rendered manifest never changes on a rebuild and ArgoCD would never sync on its own. The `rollout.klicker.uzh.ch/release` pod annotation is what makes it move — see [Staging promotion](#staging-promotion) below.
 - **prd** (`*.klicker.uzh.ch`): pinned version tags, `replicaCount: 2` for web/API services.
 - **Secrets are external**: deployments reference `envFrom.secretRef` names, but the chart defines no `Secret` manifests — provision them out-of-band with matching names.
 - **Rollout strategy**: use `RollingUpdate` in prd values; `Recreate` can leave a service with zero endpoints during slow image pulls (PDBs don't protect against Deployment-driven scale-downs). `maxUnavailable: 0` only for singletons.
@@ -56,6 +56,17 @@ Version bumps are **local and manual** via standard-version: `pnpm run release[:
 
 Why this shape (ArgoCD-native hook, dedicated migrator image, manual demoted to break-glass): [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md).
 
-## Open questions (verify before documenting further)
+## Staging promotion
 
-Whether ArgoCD auto-syncs on git change or is synced manually, and the exact per-release image-tag bump/promotion trigger (the tag values in `deploy/env-uzh-{stg,prd}/values.yaml` are edited by hand today).
+**ArgoCD auto-syncs on git change** (prune + selfHeal, app `app-klicker`), but only when the _rendered manifest_ differs. Two things therefore do **not** trigger a sync, and both have bitten us:
+
+- **A rebuilt floating tag.** stg pulls `:v3`, so a new image leaves the Deployment spec byte-identical. `pullPolicy: Always` means a restart _would_ pick it up, but nothing asks for a restart.
+- **A hook-only change.** ArgoCD excludes hook manifests from the OutOfSync comparison, so a commit touching only the PreSync migration Job shows as "Synced" at the new revision with the hook never executed (this is why the hook in [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md) needed one manual sync to fire the first time).
+
+The `rollout.klicker.uzh.ch/release` annotation exists to break that tie: it lands in the **pod template**, so changing it is a real manifest change. It appears 15 times in `deploy/env-uzh-stg/values.yaml` and zero times in prd, which needs no such trigger because its pinned tags change on every release.
+
+`.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into all 15, once **every** `v3_*-stg.yml` image build has succeeded for that commit — so a rollout can never start against a half-published `:v3`, and the PreSync migration hook always runs before the new pods. It publishes as an auto-merging PR rather than a direct push, because `v3` restricts pushes and requires 8 status checks with no bypass actor; the PR touches only `deploy/**`, so `Build Fallback` supplies `build-amd`/`build-arm` in seconds. `[skip ci]` in the PR title keeps the squash-merge from re-running the 13 builds and re-firing the promoter.
+
+Two operational notes. It needs `secrets.STG_PROMOTE_TOKEN` (a PAT or GitHub App token with `contents: write` + `pull-requests: write`) — a PR opened with the default `GITHUB_TOKEN` does not trigger workflows, so its required checks would never report and auto-merge would never fire. And the annotation records which commit _triggered_ the rollout, not which bits are in the image: two merges minutes apart cancel the first build (`cancel-in-progress: true`) and `:v3` then holds the later images. Immutable per-commit tags are the fix if that ever matters. Rationale and rejected alternatives: [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).
+
+Prd is unaffected — it promotes by hand-editing pinned tags in `deploy/env-uzh-prd/values.yaml`.

--- a/docs/log/2026-08-04-stg-promotion.md
+++ b/docs/log/2026-08-04-stg-promotion.md
@@ -1,0 +1,4 @@
+## 2026-08-04
+
+- **Creation**: [adr/0003](../adr/0003-promote-stg-via-release-annotation-write-back.md) records why staging promotion writes the built commit into the `rollout.klicker.uzh.ch/release` pod annotation, why it is gated on all 13 stg image builds, and why it publishes as an auto-merging PR instead of a direct push to `v3`.
+- **Update**: [ci-and-deployment](../ci-and-deployment.md) replaces the "Open questions" section with a "Staging promotion" section — ArgoCD does auto-sync on git change, but neither a rebuilt floating tag nor a hook-only commit changes the rendered manifest, which is what the annotation exists to work around.


### PR DESCRIPTION
## Why

Staging pulls the floating `v3` image tag, so rebuilding an image leaves the rendered manifest byte-identical. ArgoCD detects no drift, never syncs, and merged code sits unrolled until somebody restarts the pods by hand.

That is not theoretical: #5303 fixed an assessment-login regression that only production's tag pin had shielded, it merged green, and staging kept serving the broken redirect afterwards with nothing signalling it. The same blind spot delayed the PreSync migration hook in #5183 — ArgoCD excludes hook manifests from the OutOfSync comparison, so that hook needed one manual sync to fire the first time.

## What

`.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into the 15 `rollout.klicker.uzh.ch/release` pod annotations. Those land in the **pod template**, so it is a genuine manifest change: ArgoCD syncs, the PreSync migration hook runs, then the pods roll — in that order.

The annotation already existed for exactly this purpose (15× in stg, 0× in prd, which needs no trigger because its pinned tags change every release). It was simply never automated, and had drifted to `v3.4.0-alpha.64` while staging ran far newer code.

Promotion is gated on **every** `v3_*-stg.yml` image build succeeding for that commit, so a rollout can never start against a half-published `:v3` and migrations can never run from a stale migrator image. `skipped` is not treated as success.

It publishes as an **auto-merging PR** rather than a direct push, because `v3` restricts pushes with an empty allowlist and requires 8 checks with no bypass actor. The promotion touches only `deploy/**`, so `Build Fallback` supplies `build-amd`/`build-arm` in seconds.

The 15 annotation values are pre-quoted in this PR: an unquoted all-digit short SHA parses as a YAML integer, and Kubernetes rejects a non-string annotation value.

## Prerequisites before merging

1. **`secrets.STG_PROMOTE_TOKEN`** — an admin-owned PAT with `contents: write` + `pull-requests: write`. It cannot be `GITHUB_TOKEN` (PRs it opens do not trigger workflows, so required checks never report) and cannot be a plain App token (the empty push allowlist is admin-only). The workflow fails loudly on its first run if the secret is missing.
2. **Auto-merge enabled** on the repository, and `squash_merge_commit_title` left at `PR_TITLE`.

## Verification after merge

```
gh workflow run "Promote to stg" -f sha=<v3-sha> -f dry_run=true   # prints the diff only
gh workflow run "Promote to stg" -f sha=<v3-sha> -f dry_run=false
curl -sS -o /dev/null -D - https://assessment.klicker.stg.df-app.ch/login | grep -i location
```

That last probe is the end-to-end proof: it currently returns `redirectTo=…pwa.klicker.stg…` (the #5303 bug, still live on stg), and must flip to `assessment.klicker.stg…` once the promotion rolls.

## Notes

- All 15 components roll on every merge, including the Hatchet workers. Pre-existing exposure — it already applies to every manual sync — but this makes it routine. Worker signal delivery (shell-form `CMD`, no `terminationGracePeriodSeconds`, no `preStop`) is worth hardening separately.
- A bad migration now blocks the whole staging rollout automatically. Intended per ADR-0001, but it becomes a stop-the-world event on stg.
- The annotation records which commit *triggered* the rollout, not which bits are in the image. Immutable per-commit tags would close that; out of scope here.
- Off switch: `gh workflow disable "Promote to stg"` — no commit, and the failure mode is the status quo ante.

Rationale and rejected alternatives (ArgoCD Image Updater, CI calling the ArgoCD API, direct push): [ADR-0003](https://github.com/uzh-bf/klicker-uzh/blob/chore/auto-promote-stg/docs/adr/0003-promote-stg-via-release-annotation-write-back.md).

Reviewed by a separate read-only reviewer pass; its two high findings (loop terminator depending on a repo setting, and no detection of a promotion PR that opens but never merges) are fixed in f574d5a46.
