### PR TITLE
fix(lti): drop the Node flag removed in Node 24 from the runtime CMD

### DIFF
--- a/apps/lti/Dockerfile
+++ b/apps/lti/Dockerfile
@@ -57,4 +57,4 @@ ARG NODE_ENV="production"
 
 EXPOSE 4000
 
-CMD ["node", "--experimental-default-type=module", "apps/lti/dist/index.js"]
+CMD ["node", "apps/lti/dist/index.js"]

--- a/docs/solutions/runtime-error/lti-node24-removed-experimental-default-type.md
+++ b/docs/solutions/runtime-error/lti-node24-removed-experimental-default-type.md
@@ -1,0 +1,66 @@
+---
+module: lti
+date: 2026-08-05
+problem_type: runtime_error
+severity: high
+symptoms:
+  - 'The stg lti Deployment sat in CrashLoopBackOff with over 100 restarts.'
+  - 'The container exited immediately with: node: bad option: --experimental-default-type=module'
+  - 'https://lti.klicker.stg.df-app.ch returned a 503 with the HAProxy body "No server is available to handle this request."'
+  - 'ArgoCD reported app-klicker as Synced but Progressing rather than Healthy.'
+root_cause: 'The lti Dockerfile CMD passed --experimental-default-type=module, a flag Node removed before the base image was bumped to node:24.16.0-alpine. The flag was already redundant because apps/lti/package.json declares "type": "module" and turbo prune copies it into the runner image.'
+tags:
+  - node24
+  - docker
+  - esm
+  - lti
+  - deployment
+---
+
+# LTI crashed on a Node flag removed in Node 24
+
+## Problem
+
+Every `lti` pod on staging exited at startup with
+
+```
+node: bad option: --experimental-default-type=module
+```
+
+and the ingress answered `lti.klicker.stg.df-app.ch` with a 503, because no
+backend pod ever became ready.
+
+## Why it stayed hidden
+
+The flag became invalid when the base image moved to Node 24, but staging runs
+the floating `:v3` tag and had not been rolled since **2026-06-15**. The break
+only surfaced on 2026-08-04, when the first `rollout.klicker.uzh.ch/release`
+promotion in seven weeks finally restarted the pods — see
+[CI & Deployment → Staging promotion](../../ci-and-deployment.md#staging-promotion).
+
+A build-time check could not have caught it: the image builds fine, and nothing
+executes the CMD until a container starts.
+
+## Fix
+
+Drop the flag:
+
+```dockerfile
+CMD ["node", "apps/lti/dist/index.js"]
+```
+
+This is safe because Node resolves module type from the nearest `package.json`
+to the entrypoint. The runner image's `COPY --from=deps /app/out/json/ .` places
+`turbo prune --docker`'s pruned manifests into the image, so
+`/app/apps/lti/package.json` exists and declares `"type": "module"`. Every
+sibling service (`backend-docker`, `olat-api`, `response-api`,
+`hatchet-worker-general`) already uses a bare `CMD node <path>` with the same
+Dockerfile shape.
+
+## Lesson
+
+A floating image tag hides startup-time regressions for as long as the pods
+happen to keep running. When a rollout follows a long gap, check that **every**
+Deployment reached Ready afterwards — an app-level `Progressing` health is the
+signal, and a single crash-looping service does not stop the other twelve from
+rolling successfully.


### PR DESCRIPTION
## Summary

Fixes the `lti` service, which has been un-deployable since the base image moved to Node 24 and crash-looped on every staging pod after last night's promotion.

The container exits at startup with:

```
node: bad option: --experimental-default-type=module
```

`apps/lti/Dockerfile:60` passed that flag; Node removed it. One line:

```diff
-CMD ["node", "--experimental-default-type=module", "apps/lti/dist/index.js"]
+CMD ["node", "apps/lti/dist/index.js"]
```

## Why removing it is safe

Node resolves module type from the nearest `package.json` to the entrypoint. `apps/lti/package.json` declares `"type": "module"`, and the runner stage's `COPY --from=deps /app/out/json/ .` places `turbo prune --docker`'s pruned manifests into the image — so `/app/apps/lti/package.json` is present and Node loads `apps/lti/dist/index.js` as ESM without the flag.

Every sibling service already runs a bare `CMD node <path>` with the identical Dockerfile shape: `backend-docker`, `olat-api`, `response-api`, `hatchet-worker-general`. All of them are Running on staging; `lti` was the only one carrying the flag.

## Why it went unnoticed

Staging runs the floating `:v3` tag and had not been rolled since **2026-06-15**. The image built fine the whole time — nothing executes the CMD until a container starts. The first `rollout.klicker.uzh.ch/release` promotion in seven weeks (#5307) restarted the pods and surfaced it: 104 restarts, and `lti.klicker.stg.df-app.ch` serving HAProxy's 503 "No server is available to handle this request."

## Verification

Deployment-time only — this cannot be verified by a local build, since the image builds successfully either way. Confirmation is the stg `lti` pod reaching Ready after the next promotion.

Observed on staging before the fix:

- `app-klicker` ArgoCD app: Synced at `3e13159fc`, health `Progressing` (caused by this crashloop alone; all 12 other services rolled Ready).
- `app-klicker-klicker-uzh-v2-lti-94b788d8d-rtfsx`: `CrashLoopBackOff`, 104 restarts, image `ghcr.io/uzh-bf/klicker-uzh/lti-arm:v3`, annotation `release=40556f1f2373`.

## Docs

Adds `docs/solutions/runtime-error/lti-node24-removed-experimental-default-type.md` recording the failure mode and the general lesson: a floating image tag hides startup-time regressions until something restarts the pods.
