### PR TITLE
chore(deploy): promote 31da9647f4a3 to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '40556f1f2373'
+        rollout.klicker.uzh.ch/release: '31da9647f4a3'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '40556f1f2373'
+        rollout.klicker.uzh.ch/release: '31da9647f4a3'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '40556f1f2373'
+        rollout.klicker.uzh.ch/release: '31da9647f4a3'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -159,7 +159,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -310,7 +310,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -363,7 +363,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -417,7 +417,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -470,7 +470,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -539,7 +539,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -592,7 +592,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
   replicaCount: 1
 
   affinity:
@@ -641,7 +641,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '40556f1f2373'
+    rollout.klicker.uzh.ch/release: '31da9647f4a3'
 
   replicaCount: 1
 
@@ -695,7 +695,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '40556f1f2373'
+      rollout.klicker.uzh.ch/release: '31da9647f4a3'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -759,7 +759,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '40556f1f2373'
+      rollout.klicker.uzh.ch/release: '31da9647f4a3'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -837,7 +837,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '40556f1f2373'
+      rollout.klicker.uzh.ch/release: '31da9647f4a3'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `31da9647f4a331ecaebbba98de5795048969bb6b`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
