### PR TITLE
docs(agents): configure engineering workflows

### DIFF
--- a/.agents/skills/klicker-feature-design/SKILL.md
+++ b/.agents/skills/klicker-feature-design/SKILL.md
@@ -9,7 +9,7 @@ Spec before code. A design that answers the questions below prevents the classic
 
 ## The plan file
 
-Non-trivial work gets a plan in `project/plans_wip/PLAN-<slug>.md` (existing files there are the template). Keep it short: Goal, Non-goals, the answers below, slice list, Progress log. Update Progress as you work; move to `project/plans/` (or per repo convention) when done.
+Non-trivial work gets a plan in `project/plans_wip/PLAN-<slug>.md` (existing files there are the template). Keep it short: Goal, Non-goals, the answers below, slice list, Progress log. Update Progress as you work; move completed plans to `project/plans_archive/`. Deferred or future plans live in `project/plans_future/`.
 
 ## Questions a design MUST answer
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,20 @@ Ground truth for working on this codebase is the agent-facing wiki at **[docs/in
 
 Architectural decisions are recorded as ADRs in [docs/adr/](docs/adr/README.md) — the decision record of _why_. The wiki explains non-obvious concepts and links the relevant ADR; it does not itself hold the decision. Retrospective fixes and durable lessons live in `docs/solutions/`; check both before re-deriving a solved problem.
 
+## Agent skills
+
+### Issue tracker
+
+ClickUp is the source of truth for tasks; supporting plans and research artifacts live under `project/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the five default canonical labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context layout anchored by the engineering wiki in `docs/`. See `docs/agents/domain.md`.
+
 ## AI Assistance (Skills)
 
 Skills live in `.agents/skills/` (the canonical location); `.claude/skills` and `.github/skills` symlink to it, so Claude Code and GitHub stay in sync. Task-shaped `klicker-*` skills cover the feature lifecycle — environment diagnosis (`klicker-environment-doctor`), design (`klicker-feature-design`), API (`klicker-graphql-api`), schema/data (`klicker-data-model`), UI (`klicker-frontend-ui`), testing/verification (`klicker-testing-verification`), e2e (`klicker-playwright-e2e`), and wiki upkeep (`klicker-wiki-maintenance`); the routing table lives in [docs/index.md](docs/index.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,62 @@
+---
+type: Agent Configuration
+title: Domain Docs
+description: Source-of-truth and reading rules for domain documentation consumed by engineering skills.
+timestamp: '2026-08-05'
+tags:
+  - agents
+  - domain
+  - workflow
+---
+
+# Domain Docs
+
+The engineering wiki under `docs/` is the canonical source for durable domain and architectural knowledge. ADRs under `docs/adr/` record significant decisions, while `docs/solutions/` records retrospective fixes and durable lessons.
+
+## Before exploring, read these
+
+- `docs/index.md` for routing to the relevant engineering wiki pages.
+- `docs/domain-model.md` for core entities and vocabulary.
+- Other relevant pages under `docs/` for the system being changed.
+- Relevant ADRs under `docs/adr/`.
+- Relevant prior solutions under `docs/solutions/`.
+
+For this repository, `docs/domain-model.md` is the glossary consumed and maintained by the `domain-modeling` skill. It replaces that generic skill's default `CONTEXT.md` location; do not create `CONTEXT.md` or `CONTEXT-MAP.md` unless the repository intentionally migrates its documentation layout.
+
+## Layout
+
+This repository uses a single-context layout:
+
+```
+/
+├── docs/
+│   ├── index.md                     ← canonical documentation map
+│   ├── domain-model.md              ← canonical domain model
+│   ├── <area>.md                    ← system-specific knowledge
+│   ├── adr/                         ← significant decisions
+│   └── solutions/                   ← durable fixes and lessons
+├── apps/
+├── packages/
+└── project/
+    ├── plans_wip/                   ← active plans
+    ├── plans_future/                ← deferred or future plans
+    └── plans_archive/               ← historical plans
+```
+
+Do not introduce root, per-app, or per-package context files unless the repository intentionally migrates to the generic context-file layout.
+
+## Use established vocabulary
+
+Use terminology from `docs/domain-model.md` and the relevant wiki pages in issue titles, plans, proposals, hypotheses, and test names.
+
+If required terminology is missing, reconsider whether the proposed language matches the project. Record genuine gaps through the `domain-modeling` workflow in `docs/domain-model.md`.
+
+## Keep plans and durable documentation distinct
+
+Plans under `project/` describe intended or ongoing work. They do not supersede the engineering wiki, ADRs, or documented solutions.
+
+When implemented behavior changes, update the relevant pages under `docs/` in the same change.
+
+## Flag ADR conflicts
+
+If proposed work contradicts an existing ADR, surface the conflict explicitly rather than silently overriding the decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,51 @@
+---
+type: Agent Configuration
+title: Work Tracking
+description: ClickUp task tracking and repository planning-artifact conventions for engineering skills.
+timestamp: '2026-08-05'
+tags:
+  - agents
+  - workflow
+  - planning
+---
+
+# Work tracking: ClickUp and repository plans
+
+## Source of truth
+
+ClickUp is the source of truth for tasks, ownership, priority, and workflow status. GitHub Issues are not actively used.
+
+When available, connect branches, pull requests, and repository plans to their corresponding ClickUp task.
+
+## Repository planning artifacts
+
+Implementation plans and supporting artifacts are committed under `project/`:
+
+- Active plans: `project/plans_wip/PLAN-<slug>.md`
+- Future or deferred plans: `project/plans_future/`
+- Historical or completed plans: `project/plans_archive/`
+- Reviews, research, handoffs, and related artifacts: use the appropriate existing location under `project/`
+
+The engineering wiki under `docs/` contains durable facts about the codebase. Do not use `project/` plans as a replacement for updating affected wiki pages when behavior changes.
+
+## When a skill says “publish to the issue tracker”
+
+Create or update the corresponding ClickUp task. Do not create a GitHub issue as a fallback.
+
+If ClickUp access is unavailable, prepare a ready-to-paste task title and body and ask the user to publish it or provide the destination.
+
+## When a skill says “write a plan”
+
+Write an active implementation plan under `project/plans_wip/`, following nearby plans and repository-specific planning skills.
+
+Cross-link the plan and ClickUp task when a task reference is available.
+
+## When a skill says “fetch the relevant ticket”
+
+Read the referenced ClickUp task, including its description, status, comments, relationships, and acceptance criteria.
+
+If no task reference or ClickUp access is available, ask the user for the task URL, task ID, or relevant content.
+
+## Triage operations
+
+Apply the labels from `docs/agents/triage-labels.md` using corresponding ClickUp tags or workflow fields. Do not mirror triage state into GitHub Issues.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,26 @@
+---
+type: Agent Configuration
+title: Triage Labels
+description: Mapping between canonical engineering-skill triage roles and ClickUp labels.
+timestamp: '2026-08-05'
+tags:
+  - agents
+  - workflow
+  - triage
+---
+
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. “apply the AFK-ready triage label”), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/developing-a-feature.md
+++ b/docs/developing-a-feature.md
@@ -2,7 +2,7 @@
 type: Playbook
 title: Developing a Feature
 description: The full-stack feature lifecycle step by step, with a real commit as the worked example and routing to the page or skill for each step.
-timestamp: '2026-07-07'
+timestamp: '2026-08-05'
 tags:
   - workflow
 ---
@@ -13,7 +13,7 @@ tags:
 
 ## The lifecycle
 
-1. **Design first.** Nail the domain vocabulary ([Domain Model](./domain-model.md)): which activity type, which user population, gamification impact, which auth layer guards it, what i18n strings and test level it needs.
+1. **Design first.** Nail the domain vocabulary ([Domain Model](./domain-model.md)): which activity type, which user population, gamification impact, which auth layer guards it, what i18n strings and test level it needs. Record non-trivial work in `project/plans_wip/PLAN-<slug>.md`; move completed plans to `project/plans_archive/`, while deferred or future plans live in `project/plans_future/`.
 2. **Schema/data change** (only if needed): edit the split Prisma schema, then migrate → sync → generate ([Data & Migrations](./data-and-migrations.md)). Update seeds if e2e needs the fixture — remember the three seed paths are independent.
 3. **Shared types**: extend `packages/types` when frontend and backend share a shape.
 4. **API**: Pothos object/field in `packages/graphql/src/schema/`, logic in `services/`, three-layer auth (`t.withAuth` + `withPermission`) ([GraphQL API Layer](./graphql-api-layer.md)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,12 @@ Conventions: one concept per file (OKF v0.1), claims cite `path:Symbol`, command
 
 Architectural decisions live in [docs/adr/](./adr/README.md) as numbered ADRs — the durable record of _why_, kept separate from the concept pages above (which explain _what_ and _how_). The wiki links the relevant ADR for the rationale; it is not itself the decision record. Record a new ADR when a choice is hard to reverse, surprising without context, and a real trade-off.
 
+## Agent workflow configuration
+
+- [Work Tracking](./agents/issue-tracker.md) - ClickUp as the task source of truth and `project/` conventions for active, future, and archived plans.
+- [Triage Labels](./agents/triage-labels.md) - Mapping from the five canonical engineering-skill triage roles to ClickUp labels.
+- [Domain Docs](./agents/domain.md) - Reading and maintenance rules that keep the engineering wiki, ADRs, and documented solutions authoritative for domain work.
+
 ## Skill routing
 
 Task-shaped procedures live in [.agents/skills/](../.agents/skills/); the wiki holds facts, skills hold workflows.

--- a/docs/log/2026-08-05-agent-skills-setup.md
+++ b/docs/log/2026-08-05-agent-skills-setup.md
@@ -1,0 +1,17 @@
+---
+type: Change Log
+title: Agent Skills Setup
+description: Repository-specific work tracking, triage, planning, and domain-documentation configuration for engineering skills.
+timestamp: '2026-08-05'
+tags:
+  - agents
+  - workflow
+  - documentation
+---
+
+# Agent Skills Setup
+
+## 2026-08-05
+
+- **Creation**: [Work Tracking](../agents/issue-tracker.md), [Triage Labels](../agents/triage-labels.md), and [Domain Docs](../agents/domain.md) configure the engineering skills for ClickUp, the repository's `project/` plan lifecycle, default triage labels, and the existing engineering-wiki domain model.
+- **Update**: [Developing a Feature](../developing-a-feature.md) and the matching `klicker-feature-design` skill now route active plans to `project/plans_wip/`, completed plans to `project/plans_archive/`, and deferred plans to `project/plans_future/`.


### PR DESCRIPTION
## Summary

- configure ClickUp as the canonical task tracker while keeping implementation plans and supporting artifacts under `project/`
- define the default five-role triage label mapping
- route domain work through the existing engineering wiki, ADRs, and documented solutions without introducing a competing `CONTEXT.md`
- align the feature-design skill and feature lifecycle docs with `plans_wip`, `plans_future`, and `plans_archive`
- register the new agent configuration pages in the wiki index and dated change log

## Why

The Matt Pocock engineering skills need repository-specific issue-tracker, triage, and domain-documentation conventions. KlickerUZH already has established ClickUp, planning, wiki, ADR, and solution-note workflows, so this change records those conventions rather than introducing parallel sources of truth.

## Impact

Documentation and agent workflow configuration only. There is no application runtime or user-facing behavior change.

## Validation

- `git diff --check origin/v3..HEAD`
- Prettier check for all changed Markdown files
- `node ./util/check-agents-md.mjs` — zero warnings
- manual frontmatter, index-link, source-of-truth, and stale-path checks
- independent final staged-diff review — no remaining blockers
- repository commit and pre-push hooks completed successfully

## Limitation

The wiki-maintenance skill references `~/.agents/skills/rs-llm-wiki-okf/scripts/validate.sh`, but that validator is not installed in the current environment. Equivalent structural checks were run manually.
