### PR TITLE
chore(deploy): increase chat memory headroom

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -333,9 +333,10 @@ chat:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 250Mi
     limits:
-      memory: 200Mi
+      cpu: 200m
+      memory: 768Mi
 
 frontendPWA:
   allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://ius.zone https://*.df-app.ch'

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -301,10 +301,10 @@ chat:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 250Mi
     limits:
       cpu: 200m
-      memory: 200Mi
+      memory: 768Mi
 
 frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'


### PR DESCRIPTION
## What This Fixes

This PR increases the memory headroom for the chat deployment in staging and production after the staging chat pod was OOM-killed.

- Memory requests: `50Mi -> 250Mi`
- Memory limits: `200Mi -> 768Mi`
- CPU request remains `50m`
- CPU limit is `200m` in both environments; production now declares the same limit as staging

The `250Mi` request matches KRR's OOM-aware recommendation for the chat deployment. The `768Mi` limit adds operational headroom for large streamed chats and image/tool workloads.

## Branch Coverage

- Base: `v3`
- Head: `d871d8eac`
- Reviewed: 1 commit, 2 files, 5 insertions, 4 deletions
- Covered: staging and production chat resource values only

## Verification

Current head:
- YAML parsing for both values files -> pass
- Prettier check for both values files -> pass
- `git diff --check` -> pass
- staged gitleaks scan -> pass

Failed/Warning:
- Local pre-commit `check:all` -> blocked by unrelated baseline `ChatMessageRating` TypeScript errors in chat and Playwright
- Local pre-push `build` -> blocked by unrelated baseline Rollup parsing of `process.env.LTI_ENCRYPTION_KEY as string` in `apps/lti`
- Hosted CI for this PR -> pending

## Security / Privacy

- No application code, secrets, credentials, or personal data changed.
- No direct cluster mutation was performed.

## Blocking Before Merge

- Hosted CI for the current head must pass.

## Follow-Up After Merge

- Observe the next staging chat rollout for OOM kills and pod readiness.
- Promote to production through the normal GitOps workflow after staging verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased available memory for the chat service in production and staging environments.
  * Added a 200m CPU limit in production to support more consistent service performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->