### PR TITLE
fix(chat): repoint auto model to LiteLLM auto-router

### DIFF
--- a/apps/chat/src/lib/server/chatModelRegistry.ts
+++ b/apps/chat/src/lib/server/chatModelRegistry.ts
@@ -101,10 +101,9 @@ function parseRegistryValue(value: unknown): ChatModelConfig[] {
 export const DEFAULT_MODEL_REGISTRY: ChatModelConfig[] = [
   {
     id: 'auto',
-    deploymentId: 'complexity-router',
+    deploymentId: 'auto-router',
     name: 'Auto Mode',
-    description:
-      'Automatic model selection through the LiteLLM complexity router',
+    description: 'Automatic model selection through the LiteLLM auto router',
     fallback: false,
     supportsReasoning: false,
     supportsImageAttachments: true,

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -208,16 +208,17 @@ chat:
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
-    # "Auto" routes through the LiteLLM complexity-router, which self-selects the
-    # tier per request (SIMPLE=gpt-4.1, MEDIUM=gpt-5.4-low, COMPLEX=gpt-5.4-medium,
-    # REASONING=gpt-5.5-low). It is a normal selectable model (fallback: false), so
+    # "Auto" routes through the LiteLLM auto-router, which self-selects the
+    # tier per request (SIMPLE=gpt-5.6-luna-medium, MEDIUM=gpt-5.6-luna-high,
+    # COMPLEX=gpt-5.6-luna-xhigh, REASONING=gpt-5.6-sol-medium; match_threshold
+    # 0.55). It is a normal selectable model (fallback: false), so
     # it does NOT change automatic selection for existing chatbots — they still
     # default to gpt-5.5. A chatbot can be pinned to Auto-only via its DB columns
     # (modelSelection=false + allowedModelIds=["auto"]).
-    # cost mirrors the gpt-5.4 tier (the typical COMPLEX route); REASONING (gpt-5.5)
-    # is rare. Tune if the routed mix shifts.
+    # cost mirrors the gpt-5.6-luna tier (the typical COMPLEX route); REASONING
+    # (gpt-5.6-sol-medium) is rare. Tune if the routed mix shifts.
     - id: auto
-      deploymentId: klickeruzh/azure/complexity-router
+      deploymentId: klickeruzh/azure/auto-router
       name: Auto
       description: Automatic model selection (routes to the best model per request)
       supportsImageAttachments: true

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -173,16 +173,17 @@ chat:
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
-    # "Auto" routes through the LiteLLM complexity-router, which self-selects the
-    # tier per request (SIMPLE=gpt-4.1, MEDIUM=gpt-5.4-low, COMPLEX=gpt-5.4-medium,
-    # REASONING=gpt-5.5-low). It is a normal selectable model (fallback: false), so
+    # "Auto" routes through the LiteLLM auto-router, which self-selects the
+    # tier per request (SIMPLE=gpt-5.6-luna-medium, MEDIUM=gpt-5.6-luna-high,
+    # COMPLEX=gpt-5.6-luna-xhigh, REASONING=gpt-5.6-sol-medium; match_threshold
+    # 0.55). It is a normal selectable model (fallback: false), so
     # it does NOT change automatic selection for existing chatbots — they still
     # default to gpt-5.5. A chatbot can be pinned to Auto-only via its DB columns
     # (modelSelection=false + allowedModelIds=["auto"]); see the vorkurs chatbot.
-    # cost mirrors the gpt-5.4 tier (the typical COMPLEX route); REASONING (gpt-5.5)
-    # is rare. Tune if the routed mix shifts.
+    # cost mirrors the gpt-5.6-luna tier (the typical COMPLEX route); REASONING
+    # (gpt-5.6-sol-medium) is rare. Tune if the routed mix shifts.
     - id: auto
-      deploymentId: klickeruzh/azure/complexity-router
+      deploymentId: klickeruzh/azure/auto-router
       name: Auto
       description: Automatic model selection (routes to the best model per request)
       supportsImageAttachments: true

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -47,15 +47,16 @@ Three steps: `getParticipantId` → `getChatbotOr404` → `requireParticipation`
 
 `chatModelRegistry.ts` loads `CHAT_MODEL_REGISTRY_JSON` (deployment override in `deploy/env-uzh-*/values.yaml`). The backend keeps its own copy of the registry in `packages/graphql/src/services/chatbots.ts` for the lecturer-facing allow-list; both pods receive the same `CHAT_MODEL_REGISTRY_JSON` from the one `.Values.chat.modelRegistry` source (`cm-chat.yaml` and `cm-backend-graphql.yaml`), and `apps/chat/test/modelRegistryParity.test.ts` pins the two built-in defaults against each other — the deployed values.yaml registries are NOT covered by that test, so values-only drift still needs a manual check. Registry gotchas that have caused production incidents:
 
-The deployed Klicker Auto option is a LiteLLM `complexity-router` endpoint. The
+The deployed Klicker Auto option is a LiteLLM `auto-router` endpoint. The
 only in-repo record of its tier map is the comment above `modelRegistry` in
-`deploy/env-uzh-{stg,prd}/values.yaml`: SIMPLE = `gpt-4.1`, MEDIUM =
-`gpt-5.4-low`, COMPLEX = `gpt-5.4-medium`, REASONING = `gpt-5.5-low`. The
-authoritative router configuration lives in the external AI deployment
-repository's `litellm/config.yaml` and **cannot be verified from this
-repository** — treat the values.yaml comment as the best available record and
-confirm against the deployment before making a routing claim. Neither
-deployment ships a GPT-5.6 model at all.
+`deploy/env-uzh-{stg,prd}/values.yaml`: SIMPLE = `gpt-5.6-luna-medium`, MEDIUM
+= `gpt-5.6-luna-high`, COMPLEX = `gpt-5.6-luna-xhigh`, REASONING =
+`gpt-5.6-sol-medium` (match_threshold 0.55). The authoritative router
+configuration lives in the external AI deployment repository's
+`litellm/config.yaml` and **cannot be verified from this repository** — treat
+the values.yaml comment as the best available record and confirm against the
+deployment before making a routing claim. The deployed registry exposes no
+direct GPT-5.6 picker option; the router's tier targets are internal.
 
 The local devcontainer simulation in `util/litellm/config.yaml` is deliberately
 **not** a copy of that map: it uses different model names (GPT-5.6 Luna/Sol),
@@ -63,7 +64,7 @@ its own tier assignment, and the generic
 `UPSTREAM_OPENAI_BASE_URL`/`UPSTREAM_OPENAI_API_KEY` boundary instead of
 production Azure URLs or secret names. Local Auto Mode behaviour is therefore
 evidence about the wiring only, never about production routing. The local chat
-registry maps the user-facing `auto` model id to the `complexity-router`
+registry maps the user-facing `auto` model id to the `auto-router`
 LiteLLM deployment and exposes `gpt-5.6-luna` for a direct comparison. The
 seeded Benibot fixture allow-lists all three of `auto`, `gpt-5.6-luna` and
 `gpt-4.1-mini` explicitly, so it satisfies the fallback invariant below without

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,7 @@ For authoring specifics, helper patterns, and failure triage, use the `klicker-p
 
 ## E2E environment dependencies
 
-- The local Chat model simulation includes LiteLLM's `complexity-router` and
+- The local Chat model simulation includes LiteLLM's `auto-router` and
   the GPT-5.6 Luna/Sol target aliases. After `devrouter ensure .`, verify the
   LiteLLM liveness endpoint and the chat credits response before browser
   testing the `Auto Mode`/`GPT-5.6 Luna` picker. A real

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -48,10 +48,9 @@ type ChatbotReasoningConfigEntry = {
 export const DEFAULT_CHAT_MODEL_REGISTRY: ChatModelCapability[] = [
   {
     id: 'auto',
-    deploymentId: 'complexity-router',
+    deploymentId: 'auto-router',
     name: 'Auto Mode',
-    description:
-      'Automatic model selection through the LiteLLM complexity router',
+    description: 'Automatic model selection through the LiteLLM auto router',
     fallback: false,
     supportsReasoning: false,
     supportedReasoningEfforts: [],

--- a/util/litellm/config.yaml
+++ b/util/litellm/config.yaml
@@ -1,10 +1,10 @@
 # LiteLLM Proxy Configuration
 
 model_list:
-  # Production's Auto model is a LiteLLM complexity-router endpoint. The
+  # Production's Auto model is a LiteLLM auto-router endpoint. The
   # local names intentionally omit the production Azure/product prefix; the
-  # chat registry maps its `auto` model id to `complexity-router` below.
-  - model_name: 'complexity-router'
+  # chat registry maps its `auto` model id to `auto-router` below.
+  - model_name: 'auto-router'
     litellm_params:
       model: 'auto_router/complexity_router'
       complexity_router_config:


### PR DESCRIPTION
## Summary

The Aug 1 LiteLLM migration renamed the Klicker tenant router from `klickeruzh/azure/complexity-router` to `klickeruzh/azure/auto-router` in the deployed LiteLLM config, but the chat model registry still pointed the user-facing `auto` model at the old name. This broke the Vorkurs chatbot (pinned to Auto-only) in production with `403 team not allowed to access model` until the LiteLLM key/team allowlists were updated.

This PR repoints the registry to `auto-router` in all four places:

- `deploy/env-uzh-prd/values.yaml` + `deploy/env-uzh-stg/values.yaml` — deployed `CHAT_MODEL_REGISTRY_JSON` (the actual runtime source)
- `apps/chat/src/lib/server/chatModelRegistry.ts` + `packages/graphql/src/services/chatbots.ts` — built-in defaults (parity-pinned by `modelRegistryParity.test.ts`)
- `util/litellm/config.yaml` — local devcontainer simulation, renamed to match the new default so local Auto Mode keeps working
- `docs/chat-platform.md` + `docs/testing.md` — updated tier map (verified against the live prd LiteLLM config: SIMPLE=gpt-5.6-luna-medium, MEDIUM=gpt-5.6-luna-high, COMPLEX=gpt-5.6-luna-xhigh, REASONING=gpt-5.6-sol-medium, match_threshold 0.55)

## Verification

- prd LiteLLM team `KlickerUZH` allowlist now includes `auto-router` + gpt-5.6 models (verified via `/team/info`)
- Direct chat-completions from the prd chat pod against `klickeruzh/azure/auto-router` return 200
- `pnpm --filter @klicker-uzh/chat run test:run` — 28 files / 223 tests pass (incl. modelRegistryParity)
- Pre-commit gates green (gitleaks, biome, prettier, 24-package typecheck, syncpack, prisma-sync)

Note: the graphql package test suite and the pre-push full build fail on this host for pre-existing environmental reasons (test DB/Redis not provisioned; lti-service Rollup parse error in `apps/lti/src/index.ts:43` from PR #5308) — unrelated to this change; CI will run the real gates.

Substantive size: ~60 lines (7 files, no lockfiles/generated output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the automatic chat model to use LiteLLM’s auto-routing service.
  * Improved automatic routing with newer GPT-5.6 Luna and Sol deployments and a refined matching threshold.
  * Preserved existing fallback, pricing, and model-selection behavior.

* **Documentation**
  * Updated platform and testing documentation to reflect the new automatic routing setup.
  * Clarified that deployed environments do not offer direct GPT-5.6 model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->