### PR TITLE
chore(deploy): promote d206d64fe36c to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -159,7 +159,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -311,7 +311,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -364,7 +364,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -418,7 +418,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -471,7 +471,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -540,7 +540,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -593,7 +593,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
   replicaCount: 1
 
   affinity:
@@ -642,7 +642,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
 
   replicaCount: 1
 
@@ -696,7 +696,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -760,7 +760,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -838,7 +838,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '528f3f0ed8f9'
+      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `d206d64fe36cb8045b25b61bfc316270f64c6ac8`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
