### PR TITLE
chore(deploy): align staging resource limits with production

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -355,11 +355,10 @@ frontendPWA:
 
   resources:
     requests:
-      cpu: 50m
-      memory: 50Mi
-    limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
+    limits:
+      memory: 600Mi
 
 frontendManage:
   priorityClassName: staging-workload
@@ -531,11 +530,10 @@ backendGraphql:
 
   resources:
     requests:
-      cpu: 50m
-      memory: 50Mi
-    limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
+    limits:
+      memory: 600Mi
 
 olatApi:
   priorityClassName: staging-workload
@@ -751,11 +749,10 @@ assessment:
 
     resources:
       requests:
-        cpu: 50m
-        memory: 50Mi
-      limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
+      limits:
+        memory: 600Mi
 
   backendGraphql:
     priorityClassName: staging-workload
@@ -826,11 +823,10 @@ assessment:
 
     resources:
       requests:
-        cpu: 50m
-        memory: 50Mi
-      limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
+      limits:
+        memory: 600Mi
 
   responseApi:
     corsAllowedOrigins: 'https://assessment.klicker.stg.df-app.ch'

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -152,7 +152,6 @@ auth:
       cpu: 50m
       memory: 50Mi
     limits:
-      cpu: 200m
       memory: 200Mi
 
 chat:
@@ -410,7 +409,6 @@ frontendManage:
       cpu: 50m
       memory: 50Mi
     limits:
-      cpu: 200m
       memory: 200Mi
 
 frontendControl:
@@ -464,7 +462,6 @@ frontendControl:
       cpu: 50m
       memory: 50Mi
     limits:
-      cpu: 200m
       memory: 200Mi
 
 backendGraphql:
@@ -585,7 +582,6 @@ olatApi:
       cpu: 50m
       memory: 50Mi
     limits:
-      cpu: 200m
       memory: 200Mi
 
 lti:
@@ -687,7 +683,6 @@ responseApi:
       cpu: 50m
       memory: 50Mi
     limits:
-      cpu: 200m
       memory: 200Mi
 
 assessment:
@@ -893,7 +888,6 @@ assessment:
         cpu: 50m
         memory: 50Mi
       limits:
-        cpu: 200m
         memory: 200Mi
 
 # Migration hook image: only the repo is pinned; the tag auto-tracks the


### PR DESCRIPTION
## Summary

Staging backend pods are unstable: `backend-graphql` restarted 22 times and `backend-assessment` 7 times in the last 40h, all OOMKilled (exit 137) against a 200Mi memory limit while idling at ~120Mi (~60% of limit). Any load spike OOMs the pod, and with `replicaCount: 1` + `strategy: Recreate` every restart is full downtime — which is what the PWA/assessment frontends hit as 503s (reported as CORS errors because a 503 carries no CORS headers).

This aligns all staging resource blocks with production exactly:

1. **Raise limits for the OOM-prone workloads** (frontendPWA, backendGraphql, assessment.frontendPWA, assessment.backendGraphql): 50m/50Mi requests + 200m/200Mi limits → 100m/200Mi requests + 600Mi memory-only limits.
2. **Drop CPU limits from the remaining services** (auth, frontendManage, frontendControl, olatApi, responseApi, assessment.responseApi): remove `cpu: 200m` from limits, keeping memory limits at 200Mi — matching prod, which removed CPU limits everywhere in `40556f1f2` (chat production-readiness, Aug 4).
3. **chat keeps its `cpu: 200m` limit** — prod deliberately re-added it in `528f3f0ed` (chat memory headroom, Aug 5), so staging matches.

Verified: all 11 resource blocks in `deploy/env-uzh-stg/values.yaml` now exactly match `deploy/env-uzh-prd/values.yaml` (programmatic comparison). `lti` has no resources block in either env and inherits the chart default.

## Verification

- YAML parses, Prettier clean, pre-commit hooks (gitleaks + check:all) passed, pre-push build passed
- Read-only review (agy) passed with no findings on the final two-commit scope: all resource blocks match prd exactly, no YAML issues, no secrets
- Substantive size: 34 lines (12 insertions, 22 deletions) in `deploy/env-uzh-stg/values.yaml` — floor-exempt as an urgent production-readiness fix unblocking staging validation