### PR TITLE
chore(deploy): promote 410dd18638ec to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+        rollout.klicker.uzh.ch/release: '410dd18638ec'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+        rollout.klicker.uzh.ch/release: '410dd18638ec'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+        rollout.klicker.uzh.ch/release: '410dd18638ec'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -158,7 +158,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -310,7 +310,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -362,7 +362,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -415,7 +415,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -467,7 +467,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -535,7 +535,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -587,7 +587,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
   replicaCount: 1
 
   affinity:
@@ -636,7 +636,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+    rollout.klicker.uzh.ch/release: '410dd18638ec'
 
   replicaCount: 1
 
@@ -689,7 +689,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+      rollout.klicker.uzh.ch/release: '410dd18638ec'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -752,7 +752,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+      rollout.klicker.uzh.ch/release: '410dd18638ec'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -829,7 +829,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd206d64fe36c'
+      rollout.klicker.uzh.ch/release: '410dd18638ec'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `410dd18638ec408e482b13b46a70900ddc6f1f08`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
