### PR TITLE
fix(pwa): expose every course chatbot from the header as a real link

### DIFF
--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -64,7 +64,9 @@ function Header({
       participant?.role !== UserRole.Participant ||
       process.env.NEXT_PUBLIC_IS_ASSESSMENT === 'true',
   })
-  const courseChatbots = chatbotData?.courseChatbots ?? []
+  // courses are limited to a single chatbot for now, so the header links the
+  // first one and does not build a multi-chatbot affordance
+  const courseChatbot = chatbotData?.courseChatbots?.[0]
 
   const pageInFrame =
     global?.window &&
@@ -148,36 +150,23 @@ function Header({
             </Link>
           ))}
 
-        {courseId &&
-          courseChatbots.map((chatbot) => (
-            <Link
-              key={chatbot.id}
-              href={`/course/${courseId}/chatbot/${chatbot.id}`}
-              target="_blank"
-              rel="noopener"
-              title={chatbot.name}
-              className="min-w-0"
+        {courseId && courseChatbot && (
+          <Link
+            href={`/course/${courseId}/chatbot/${courseChatbot.id}`}
+            target="_blank"
+            rel="noopener"
+          >
+            <Button
+              primary
+              className={{
+                root: 'h-8 bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
+              }}
+              data={{ cy: 'student-course-chatbot-link' }}
             >
-              <Button
-                primary
-                className={{
-                  // shrink overrides the design-system shrink-0, so several chatbots
-                  // cannot push the avatar dropdown off a narrow header
-                  root: 'h-8 min-w-0 shrink bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
-                }}
-                data={{ cy: `student-course-chatbot-link-${chatbot.id}` }}
-              >
-                <Button.Label
-                  className={{ root: 'line-clamp-1 max-w-32 break-all' }}
-                >
-                  {/* a single chatbot keeps the generic label, multiple ones need their names to be distinguishable */}
-                  {courseChatbots.length > 1
-                    ? chatbot.name
-                    : t('pwa.chatbot.openCourseChat')}
-                </Button.Label>
-              </Button>
-            </Link>
-          ))}
+              <Button.Label>{t('pwa.chatbot.openCourseChat')}</Button.Label>
+            </Button>
+          </Link>
+        )}
 
         <Dropdown
           trigger={

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -64,7 +64,7 @@ function Header({
       participant?.role !== UserRole.Participant ||
       process.env.NEXT_PUBLIC_IS_ASSESSMENT === 'true',
   })
-  const courseChatbot = chatbotData?.courseChatbots?.[0]
+  const courseChatbots = chatbotData?.courseChatbots ?? []
 
   const pageInFrame =
     global?.window &&
@@ -148,24 +148,32 @@ function Header({
             </Link>
           ))}
 
-        {courseId && courseChatbot && (
-          <Button
-            primary
-            onClick={() =>
-              window.open(
-                `/course/${courseId}/chatbot/${courseChatbot.id}`,
-                '_blank',
-                'noopener'
-              )
-            }
-            className={{
-              root: 'h-8 bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
-            }}
-            data={{ cy: 'student-course-chatbot-link' }}
-          >
-            <Button.Label>{t('pwa.chatbot.openCourseChat')}</Button.Label>
-          </Button>
-        )}
+        {courseId &&
+          courseChatbots.map((chatbot) => (
+            <Link
+              key={chatbot.id}
+              href={`/course/${courseId}/chatbot/${chatbot.id}`}
+              target="_blank"
+              rel="noopener"
+            >
+              <Button
+                primary
+                className={{
+                  root: 'h-8 bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
+                }}
+                data={{ cy: `student-course-chatbot-link-${chatbot.id}` }}
+              >
+                <Button.Label
+                  className={{ root: 'line-clamp-1 max-w-32 break-all' }}
+                >
+                  {/* a single chatbot keeps the generic label, multiple ones need their names to be distinguishable */}
+                  {courseChatbots.length > 1
+                    ? chatbot.name
+                    : t('pwa.chatbot.openCourseChat')}
+                </Button.Label>
+              </Button>
+            </Link>
+          ))}
 
         <Dropdown
           trigger={

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -155,11 +155,15 @@ function Header({
               href={`/course/${courseId}/chatbot/${chatbot.id}`}
               target="_blank"
               rel="noopener"
+              title={chatbot.name}
+              className="min-w-0"
             >
               <Button
                 primary
                 className={{
-                  root: 'h-8 bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
+                  // shrink overrides the design-system shrink-0, so several chatbots
+                  // cannot push the avatar dropdown off a narrow header
+                  root: 'h-8 min-w-0 shrink bg-slate-800 py-0 text-white hover:bg-slate-700 hover:text-white',
                 }}
                 data={{ cy: `student-course-chatbot-link-${chatbot.id}` }}
               >

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -134,9 +134,14 @@ Participants reach a chatbot from the shared PWA header (`apps/frontend-pwa/src/
 on any course page on v3 (`/course/[courseId]/…`) without any v3-ai dependency.
 The header runs `GetCourseChatbots` (`courseChatbots(courseId)` query backed by
 `getParticipantCourseChatbots` in `packages/graphql/src/services/chatbots.ts`)
-and renders an "AI tutor" button (`data-cy="student-course-chatbot-link"`) next
-to the home/back button when a chatbot is linked to the course and the caller is
-a participant; the button opens the first chatbot of the course in a new tab.
+and renders one link-wrapped button per chatbot
+(`data-cy="student-course-chatbot-link-<chatbotId>"`) next to the home/back
+button when the caller is a participant of the course. A single chatbot keeps the
+generic "AI tutor" label; with several chatbots each button carries the chatbot
+name, since `Chatbot` has no ordering or visibility field that would let a
+lecturer designate a primary one. The buttons are real anchors
+(`<Link target="_blank" rel="noopener">`), so middle-click and copy-link behave
+as expected.
 The query is deliberately **not** `withAuth(asParticipant)`: course pages are
 publicly reachable, and a scope error would surface as the literal message
 `Unauthorized`, which the PWA `errorLink` (`apps/frontend-pwa/src/lib/apollo.ts`)
@@ -144,7 +149,7 @@ turns into a hard redirect to `/login?expired=true` for every anonymous visitor
 and every logged-in lecturer. Instead the resolver mirrors its page siblings
 `getCourseOverviewData` and `getStudentCourseLeaderboard` — a public field whose
 service returns `[]` unless the caller is a `PARTICIPANT` with a `Participation`
-record for the course. The button opens the existing PWA deep-link route
+record for the course. Each button opens the existing PWA deep-link route
 `course/[courseId]/chatbot/[chatbotId]` in a new tab, which redirects to login
 when needed, runs `ensureParticipation` server-side, and then 302-redirects to
 `chat.klicker.uzh.ch/<chatbotId>`. The public GraphQL shape is `ChatbotPublic`

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -134,14 +134,16 @@ Participants reach a chatbot from the shared PWA header (`apps/frontend-pwa/src/
 on any course page on v3 (`/course/[courseId]/…`) without any v3-ai dependency.
 The header runs `GetCourseChatbots` (`courseChatbots(courseId)` query backed by
 `getParticipantCourseChatbots` in `packages/graphql/src/services/chatbots.ts`)
-and renders one link-wrapped button per chatbot
-(`data-cy="student-course-chatbot-link-<chatbotId>"`) next to the home/back
-button when the caller is a participant of the course. A single chatbot keeps the
-generic "AI tutor" label; with several chatbots each button carries the chatbot
-name, since `Chatbot` has no ordering or visibility field that would let a
-lecturer designate a primary one. The buttons are real anchors
-(`<Link target="_blank" rel="noopener">`), so middle-click and copy-link behave
-as expected.
+and renders an "AI tutor" button (`data-cy="student-course-chatbot-link"`) next
+to the home/back button when the caller is a participant of the course. The
+button is a real anchor (`<Link target="_blank" rel="noopener">` wrapping the
+design-system `Button`, the same pattern as the sibling home button), so
+middle-click and copy-link behave as expected. It links `courseChatbots[0]`:
+courses are deliberately limited to a single chatbot for now, which is also why
+`Chatbot` carries no ordering or visibility field. Lifting that limit means
+deciding the multi-chatbot affordance first — the header row does not wrap and
+the design-system button is `shrink-0`, so several buttons would squeeze the
+course title on a narrow viewport.
 The query is deliberately **not** `withAuth(asParticipant)`: course pages are
 publicly reachable, and a scope error would surface as the literal message
 `Unauthorized`, which the PWA `errorLink` (`apps/frontend-pwa/src/lib/apollo.ts`)

--- a/docs/log/2026-08-07-course-chatbot-entry-link.md
+++ b/docs/log/2026-08-07-course-chatbot-entry-link.md
@@ -1,3 +1,3 @@
 ## 2026-08-07
 
-- **Creation**: [chat-platform](../chat-platform.md) documents the participant entry point on every student course page — the `courseChatbots` GraphQL query (`ChatbotPublic` shape), the buttons rendered in the shared PWA header, and the PWA deep-link route that redirects to `chat.klicker.uzh.ch/<chatbotId>` after `ensureParticipation`. Minimal v3 change; no v3-ai dependency.
+- **Creation**: [chat-platform](../chat-platform.md) documents the participant entry point on every student course page — the `courseChatbots` GraphQL query (`ChatbotPublic` shape), the "AI tutor" button rendered in the shared PWA header, and the PWA deep-link route that redirects to `chat.klicker.uzh.ch/<chatbotId>` after `ensureParticipation`. Minimal v3 change; no v3-ai dependency.

--- a/docs/log/2026-08-07-course-chatbot-entry-link.md
+++ b/docs/log/2026-08-07-course-chatbot-entry-link.md
@@ -1,3 +1,3 @@
 ## 2026-08-07
 
-- **Creation**: [chat-platform](../chat-platform.md) documents the participant entry point on the student course page — the `courseChatbots` GraphQL query (`ChatbotPublic` shape), the button row above the tabs, and the PWA deep-link route that redirects to `chat.klicker.uzh.ch/<chatbotId>` after `ensureParticipation`. Minimal v3 change; no v3-ai dependency.
+- **Creation**: [chat-platform](../chat-platform.md) documents the participant entry point on every student course page — the `courseChatbots` GraphQL query (`ChatbotPublic` shape), the buttons rendered in the shared PWA header, and the PWA deep-link route that redirects to `chat.klicker.uzh.ch/<chatbotId>` after `ensureParticipation`. Minimal v3 change; no v3-ai dependency.

--- a/project/2026-08-07-course-chatbot-entry-link.md
+++ b/project/2026-08-07-course-chatbot-entry-link.md
@@ -46,9 +46,12 @@ Service returns `[]` when the participant is not enrolled (mirrors v3-ai), so th
 
 1. **Service** — `packages/graphql/src/services/chatbots.ts`: `getParticipantCourseChatbots({ courseId }, ctx: ContextWithUser)` — participation lookup (`courseId_participantId`), return `[]` if absent, else `chatbot.findMany({ where: { courseId }, orderBy: [{ name: 'asc' }, { createdAt: 'asc' }], select: { id, name, description, avatar } })`.
 2. **Type** — `packages/graphql/src/schema/resource.ts`: `IChatbotPublic` interface + `ChatbotPublicRef`/`ChatbotPublic` object (copy shape from v3-ai).
-3. **Query field** — `packages/graphql/src/schema/query.ts`: `courseChatbots: t.withAuth(asParticipant).field({ type: [ChatbotPublic], args: { courseId: t.arg.string({ required: true }) }, resolve: one-liner → service })`. `asParticipant` is exact-role; no `withPermission` needed (participant-facing field, pattern at `query.ts:128`).
+3. **Query field** — `packages/graphql/src/schema/query.ts`: `courseChatbots: t.withAuth(asParticipant).field({ type: [ChatbotPublic], args: { courseId: t.arg.string({ required: true }) }, resolve: one-liner → service })`. `asParticipant` is exact-role; no `withPermission` needed (participant-facing field, pattern at `query.ts:128`). **Superseded during implementation:** the field ships as a public `t.field` whose service returns `[]` for non-participants — `withAuth(asParticipant)` throws a literal `Unauthorized`, which the PWA `errorLink` turns into a hard `/login?expired=true` redirect for anonymous visitors and lecturers. See `docs/chat-platform.md`.
 4. **Client op** — `packages/graphql/src/graphql/ops/QGetCourseChatbots.graphql` (`query GetCourseChatbots($courseId: String!) { courseChatbots(courseId: $courseId) { id name description avatar } }`), then codegen `pnpm --filter @klicker-uzh/graphql generate` and commit all regenerated artifacts (`ops.ts`, `ops.schema.json`, `public/schema.graphql`, `public/client.json`, `public/server.json` — stale `server.json` breaks persisted queries in prod).
-5. **PWA shared header** — `apps/frontend-pwa/src/components/common/Header.tsx`:
+5. **PWA shared header** — `apps/frontend-pwa/src/components/common/Header.tsx`
+   (steps below superseded by the follow-up fix: one button per chatbot rather
+   than `courseChatbots[0]`, `data-cy="student-course-chatbot-link-<chatbotId>"`,
+   and a `<Link target="_blank">` anchor instead of `window.open`):
    - `useQuery(GetCourseChatbotsDocument, { variables: { courseId: course?.id } })`, skipped unless `course.id` exists and the caller is a `Participant` (header also renders for anonymous visitors and lecturers on public course pages).
    - Render a single "AI tutor" button next to the home/back button when `courseChatbots[0]` exists; `window.open('/course/' + courseId + '/chatbot/' + id, '_blank', 'noopener')` (deep link; new tab).
    - `data-cy="student-course-chatbot-link"` for e2e.

--- a/project/2026-08-07-course-chatbot-entry-link.md
+++ b/project/2026-08-07-course-chatbot-entry-link.md
@@ -49,9 +49,8 @@ Service returns `[]` when the participant is not enrolled (mirrors v3-ai), so th
 3. **Query field** — `packages/graphql/src/schema/query.ts`: `courseChatbots: t.withAuth(asParticipant).field({ type: [ChatbotPublic], args: { courseId: t.arg.string({ required: true }) }, resolve: one-liner → service })`. `asParticipant` is exact-role; no `withPermission` needed (participant-facing field, pattern at `query.ts:128`). **Superseded during implementation:** the field ships as a public `t.field` whose service returns `[]` for non-participants — `withAuth(asParticipant)` throws a literal `Unauthorized`, which the PWA `errorLink` turns into a hard `/login?expired=true` redirect for anonymous visitors and lecturers. See `docs/chat-platform.md`.
 4. **Client op** — `packages/graphql/src/graphql/ops/QGetCourseChatbots.graphql` (`query GetCourseChatbots($courseId: String!) { courseChatbots(courseId: $courseId) { id name description avatar } }`), then codegen `pnpm --filter @klicker-uzh/graphql generate` and commit all regenerated artifacts (`ops.ts`, `ops.schema.json`, `public/schema.graphql`, `public/client.json`, `public/server.json` — stale `server.json` breaks persisted queries in prod).
 5. **PWA shared header** — `apps/frontend-pwa/src/components/common/Header.tsx`
-   (steps below superseded by the follow-up fix: one button per chatbot rather
-   than `courseChatbots[0]`, `data-cy="student-course-chatbot-link-<chatbotId>"`,
-   and a `<Link target="_blank">` anchor instead of `window.open`):
+   (`window.open` below superseded by the follow-up fix: the button is a
+   `<Link target="_blank" rel="noopener">` anchor wrapping the `Button`):
    - `useQuery(GetCourseChatbotsDocument, { variables: { courseId: course?.id } })`, skipped unless `course.id` exists and the caller is a `Participant` (header also renders for anonymous visitors and lecturers on public course pages).
    - Render a single "AI tutor" button next to the home/back button when `courseChatbots[0]` exists; `window.open('/course/' + courseId + '/chatbot/' + id, '_blank', 'noopener')` (deep link; new tab).
    - `data-cy="student-course-chatbot-link"` for e2e.


### PR DESCRIPTION
Follow-up to #5335 (already merged). The header entry point that shipped there was never reviewed in its final form — the implementation pivoted from a button row on the course overview page to a single button in the shared PWA `Header` late in the PR. This PR carries the findings from reviewing the merged state.

## What changed

1. **Real anchor instead of `window.open`.** The button now uses the `<Link target="_blank" rel="noopener">` pattern already used by the sibling home button two blocks up, so middle-click, copy-link-address, and assistive-tech announcement work. Behaviour is unchanged: still a new tab, still the same deep-link route, still `data-cy="student-course-chatbot-link"`.

2. **Docs.** `docs/log/2026-08-07-course-chatbot-entry-link.md` still described "the button row above the tabs" from the pre-pivot implementation. `docs/chat-platform.md` now records that linking only `courseChatbots[0]` is deliberate — a course is not allowed more than one chatbot for now, which is also why `Chatbot` carries no ordering or visibility field — and what lifting that limit would require: the header row does not wrap and the design-system button is `shrink-0`, so several buttons would squeeze the course title on a narrow viewport.

3. **Plan file.** Two build steps in `project/2026-08-07-course-chatbot-entry-link.md` are marked superseded — the auth posture (the field ships public with a service-level guard, not `withAuth(asParticipant)`) and the `window.open` call — so a later re-derivation from the plan does not reintroduce the login-redirect regression that #5335 fixed.

A multi-chatbot rendering was implemented and then reverted (`35dc8f3`) on the product ruling that courses stay limited to one chatbot; the reasoning is preserved in the wiki rather than in code.

## Verification

- `pnpm --filter @klicker-uzh/frontend-pwa run check` (next typegen + `tsc --noEmit`) passes in the devcontainer; `biome format` and `prettier --check` clean.
- Full CI green on `5d18ec3`, including all 8 Playwright shards. Shards 4 and 6 failed on a first attempt at that same commit in `loginStudentPassword` (`playwright/util/workflow.ts:376`) and passed on re-run with identical code — a flake in that serial suite, not a regression.
- Read-only combined final review (correctness, security, maintainability): **APPROVE-WITH-NITS**. Verified negatives: no XSS or scheme-injection surface (fixed `/course/` prefix, UUID path segments, React-escaped text); `rel="noopener"` without `noreferrer` is correct for a first-party deep link; the service still gates on `PARTICIPANT` + `Participation`.
- **Browser verification is still open** — the local devrouter/Traefik routing is down for unrelated reasons and the pass has not been performed yet.

## Size

24 added / 14 removed across one component and three docs. Sub-floor, and floor-exempt as a fix for a defect in a change merged the same day.