### PR TITLE
enhance(chat): tailor welcome starters by mode

### DIFF
--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -393,8 +393,8 @@ const ThreadWelcomeSuggestions: FC = () => {
   const { modeOptions, modeOptionsChatbotId, selectedMode } = useSettingsStore()
 
   // `selectedMode` is persisted globally, while mode options arrive after the
-  // current chatbot mounts. Hide auto-send starters until the current
-  // chatbot's options have replaced that persisted value.
+  // current chatbot mounts. Hide starters until the current chatbot's
+  // options have replaced that persisted value.
   if (
     modeOptionsChatbotId !== chatbotId ||
     Object.keys(modeOptions).length === 0
@@ -415,7 +415,8 @@ const ThreadWelcomeSuggestions: FC = () => {
             SUGGESTION_DELAY_CLASSNAMES[index] ?? 'delay-200'
           )}
           prompt={t(`chat.suggestions.${suggestion.id}Prompt`)}
-          autoSend
+          send={false}
+          clearComposer
         >
           {t(`chat.suggestions.${suggestion.id}`)}
         </ThreadPrimitive.Suggestion>

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -389,7 +389,20 @@ const SUGGESTION_DELAY_CLASSNAMES = ['delay-150', 'delay-200']
 
 const ThreadWelcomeSuggestions: FC = () => {
   const t = useTranslations()
-  const suggestions = getThreadSuggestions()
+  const { chatbotId } = useParams<{ chatbotId: string }>()
+  const { modeOptions, modeOptionsChatbotId, selectedMode } = useSettingsStore()
+
+  // `selectedMode` is persisted globally, while mode options arrive after the
+  // current chatbot mounts. Hide auto-send starters until the current
+  // chatbot's options have replaced that persisted value.
+  if (
+    modeOptionsChatbotId !== chatbotId ||
+    Object.keys(modeOptions).length === 0
+  ) {
+    return null
+  }
+
+  const suggestions = getThreadSuggestions(selectedMode)
 
   return (
     <div className="mt-4 grid w-full grid-cols-1 gap-3 px-8 sm:grid-cols-2">

--- a/apps/chat/src/lib/config/suggestions.ts
+++ b/apps/chat/src/lib/config/suggestions.ts
@@ -1,20 +1,27 @@
+import { isKnownMode, type KnownMode } from './modes'
+
 // Ids only — the user-visible label and the prompt text that actually gets
 // sent both live in i18n (`chat.suggestions.<id>` / `chat.suggestions.<id>Prompt`)
-// so a German student sees and sends German text. This config only fixes the
-// set of suggestions, their display order, and (via the literal union below)
-// lets the i18n template-literal keys type-check against the generated
-// `Messages` type.
-export type ThreadSuggestionId = 'explainConcept' | 'examPrep'
+// so a German student sees and sends German text. This config fixes the set of
+// suggestions and their display order, while the literal union lets the
+// i18n template-literal keys type-check against the generated `Messages` type.
+export type ThreadSuggestionId =
+  | 'practiceTopic'
+  | 'workThroughProblem'
+  | 'explainConcept'
+  | 'summarizeTopic'
 
 export interface ThreadSuggestion {
   id: ThreadSuggestionId
 }
 
-export const THREAD_SUGGESTIONS: ThreadSuggestion[] = [
-  { id: 'explainConcept' },
-  { id: 'examPrep' },
-]
+const THREAD_SUGGESTIONS_BY_MODE: Record<KnownMode, ThreadSuggestion[]> = {
+  tutor: [{ id: 'practiceTopic' }, { id: 'workThroughProblem' }],
+  explainer: [{ id: 'explainConcept' }, { id: 'summarizeTopic' }],
+}
 
-export function getThreadSuggestions(): ThreadSuggestion[] {
-  return THREAD_SUGGESTIONS
+export function getThreadSuggestions(mode: string): ThreadSuggestion[] {
+  return isKnownMode(mode)
+    ? THREAD_SUGGESTIONS_BY_MODE[mode]
+    : THREAD_SUGGESTIONS_BY_MODE.tutor
 }

--- a/apps/chat/src/lib/config/suggestions.ts
+++ b/apps/chat/src/lib/config/suggestions.ts
@@ -1,15 +1,16 @@
 import { isKnownMode, type KnownMode } from './modes'
 
-// Ids only — the user-visible label and the prompt text that actually gets
-// sent both live in i18n (`chat.suggestions.<id>` / `chat.suggestions.<id>Prompt`)
-// so a German student sees and sends German text. This config fixes the set of
-// suggestions and their display order, while the literal union lets the
-// i18n template-literal keys type-check against the generated `Messages` type.
+// Ids only — the user-visible label and the prompt text inserted into the
+// composer both live in i18n (`chat.suggestions.<id>` /
+// `chat.suggestions.<id>Prompt`) so a German student sees German text. This
+// config fixes the set of suggestions and their display order, while the
+// literal union lets the i18n template-literal keys type-check against the
+// generated `Messages` type.
 export type ThreadSuggestionId =
   | 'practiceTopic'
   | 'workThroughProblem'
   | 'explainConcept'
-  | 'summarizeTopic'
+  | 'compareConcepts'
 
 export interface ThreadSuggestion {
   id: ThreadSuggestionId
@@ -17,7 +18,7 @@ export interface ThreadSuggestion {
 
 const THREAD_SUGGESTIONS_BY_MODE: Record<KnownMode, ThreadSuggestion[]> = {
   tutor: [{ id: 'practiceTopic' }, { id: 'workThroughProblem' }],
-  explainer: [{ id: 'explainConcept' }, { id: 'summarizeTopic' }],
+  explainer: [{ id: 'explainConcept' }, { id: 'compareConcepts' }],
 }
 
 export function getThreadSuggestions(mode: string): ThreadSuggestion[] {

--- a/apps/chat/src/stores/settingsStore.ts
+++ b/apps/chat/src/stores/settingsStore.ts
@@ -13,6 +13,7 @@ export interface ModeOption {
 const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'none'
 let creditsRequestGeneration = 0
 let creditsLoadedChatbotId: string | null = null
+let modeOptionsRequestGeneration = 0
 
 const resolveAllowedReasoningEfforts = (
   model?: ModelOption
@@ -66,6 +67,7 @@ interface SettingsState {
   // Available options
   modelOptions: ModelOption[]
   modeOptions: Record<string, string>
+  modeOptionsChatbotId: string | null
 
   // Actions
   setSelectedModel: (model: ModelID) => void
@@ -92,6 +94,7 @@ export const useSettingsStore = create<SettingsState>()(
       creditsLoaded: false,
       modelSelectionEnabled: false,
       modeOptions: {},
+      modeOptionsChatbotId: null,
 
       // available options
       modelOptions: [],
@@ -126,9 +129,18 @@ export const useSettingsStore = create<SettingsState>()(
         }),
 
       loadModeOptions: async (chatbotId: string) => {
+        const requestGeneration = ++modeOptionsRequestGeneration
+        set({
+          modeOptions: {},
+          modeOptionsChatbotId: null,
+          modelSelectionEnabled: false,
+        })
+
         try {
           const response = await fetch(`/api/chatbots/${chatbotId}`)
           const responseData = await response.json()
+          if (requestGeneration !== modeOptionsRequestGeneration) return
+
           if (!response.ok) {
             console.warn(
               'No valid mode options found, falling back to defaults.'
@@ -140,6 +152,7 @@ export const useSettingsStore = create<SettingsState>()(
                   (value as { description: string }).description,
                 ])
               ),
+              modeOptionsChatbotId: chatbotId,
               selectedMode:
                 Object.keys(DEFAULT_PROMPT)[0] ?? state.selectedMode,
               modelSelectionEnabled: false,
@@ -178,12 +191,15 @@ export const useSettingsStore = create<SettingsState>()(
 
             return {
               modeOptions: resolvedModeOptions,
+              modeOptionsChatbotId: chatbotId,
               modelSelectionEnabled,
               selectedMode,
             }
           })
         } catch (error) {
           console.error('Error fetching mode options:', error)
+          if (requestGeneration !== modeOptionsRequestGeneration) return
+
           set((state) => ({
             modeOptions: Object.fromEntries(
               Object.entries(DEFAULT_PROMPT).map(([key, value]) => [
@@ -191,6 +207,7 @@ export const useSettingsStore = create<SettingsState>()(
                 (value as { description: string }).description,
               ])
             ),
+            modeOptionsChatbotId: chatbotId,
             selectedMode: Object.keys(DEFAULT_PROMPT)[0] ?? state.selectedMode,
             modelSelectionEnabled: false,
           }))

--- a/apps/chat/test/settings-store-credits.test.ts
+++ b/apps/chat/test/settings-store-credits.test.ts
@@ -29,6 +29,8 @@ describe('settingsStore credits loading', () => {
       credits: { current: 0, total: 0, nextResetAt: null },
       creditsLoaded: false,
       modelOptions: [],
+      modeOptions: {},
+      modeOptionsChatbotId: null,
     })
   })
 

--- a/apps/chat/test/settings-store-modes.test.ts
+++ b/apps/chat/test/settings-store-modes.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { useSettingsStore } from '../src/stores/settingsStore'
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function modesResponse(mode: string) {
+  return {
+    ok: true,
+    json: async () => ({
+      systemPrompts: { [mode]: { description: `${mode} mode` } },
+    }),
+  }
+}
+
+describe('settingsStore mode loading', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    useSettingsStore.setState({
+      modeOptions: {},
+      modeOptionsChatbotId: null,
+      selectedMode: 'tutor',
+    })
+  })
+
+  test('clears persisted mode context until the current chatbot is loaded', async () => {
+    const pending = deferred<ReturnType<typeof modesResponse>>()
+    vi.stubGlobal('fetch', vi.fn().mockReturnValueOnce(pending.promise))
+
+    const load = useSettingsStore.getState().loadModeOptions('chatbot-1')
+
+    expect(useSettingsStore.getState().modeOptions).toEqual({})
+    expect(useSettingsStore.getState().modeOptionsChatbotId).toBeNull()
+
+    pending.resolve(modesResponse('explainer'))
+    await load
+
+    expect(useSettingsStore.getState().modeOptionsChatbotId).toBe('chatbot-1')
+  })
+
+  test('ignores a stale response from a previous chatbot', async () => {
+    const first = deferred<ReturnType<typeof modesResponse>>()
+    const second = deferred<ReturnType<typeof modesResponse>>()
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise)
+    )
+
+    const firstLoad = useSettingsStore.getState().loadModeOptions('chatbot-1')
+    const secondLoad = useSettingsStore.getState().loadModeOptions('chatbot-2')
+
+    second.resolve(modesResponse('explainer'))
+    await secondLoad
+    first.resolve(modesResponse('tutor'))
+    await firstLoad
+
+    expect(useSettingsStore.getState().modeOptionsChatbotId).toBe('chatbot-2')
+    expect(useSettingsStore.getState().modeOptions).toEqual({
+      explainer: 'explainer mode',
+    })
+  })
+})

--- a/apps/chat/test/suggestions.test.ts
+++ b/apps/chat/test/suggestions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import { getThreadSuggestions } from '../src/lib/config/suggestions'
+
+describe('thread suggestions', () => {
+  test('uses practice starters for Tutor and explanation starters for Explainer', () => {
+    expect(getThreadSuggestions('tutor')).toEqual([
+      { id: 'practiceTopic' },
+      { id: 'workThroughProblem' },
+    ])
+    expect(getThreadSuggestions('explainer')).toEqual([
+      { id: 'explainConcept' },
+      { id: 'summarizeTopic' },
+    ])
+  })
+
+  test('does not offer the broad whole-course study-plan starter', () => {
+    const suggestionIds = [
+      ...getThreadSuggestions('tutor'),
+      ...getThreadSuggestions('explainer'),
+    ].map(({ id }) => id)
+
+    expect(suggestionIds).not.toContain('examPrep')
+  })
+
+  test('falls back to Tutor starters for unknown chatbot modes', () => {
+    expect(getThreadSuggestions('custom-mode')).toEqual(
+      getThreadSuggestions('tutor')
+    )
+  })
+})

--- a/apps/chat/test/suggestions.test.ts
+++ b/apps/chat/test/suggestions.test.ts
@@ -9,7 +9,7 @@ describe('thread suggestions', () => {
     ])
     expect(getThreadSuggestions('explainer')).toEqual([
       { id: 'explainConcept' },
-      { id: 'summarizeTopic' },
+      { id: 'compareConcepts' },
     ])
   })
 

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -196,11 +196,13 @@ localized `chat.response.truncated` notice, and a failed image-attachment read s
 typed `AttachmentAdapterError` from `imageAttachmentAdapter.ts` as a localized composer error
 rather than a stringified `ProgressEvent`. A cached thread list intentionally remains visible if only its background refresh fails.
 The welcome view contains localized, mode-aware starter suggestions: Tutor offers interactive
-practice prompts that ask one question at a time and provide hints, while Explainer offers
-source-oriented concept explanations and topic summaries. The broad whole-course study-plan
-starter is intentionally not offered here; a reliable planner needs a separate structured
-planning flow and tool/result budget. Starters remain hidden until the current chatbot's mode
-options have loaded, because the selected mode is persisted across chatbots. Message action bars
+practice prompts for a specific topic or pasted problem, while Explainer offers source-oriented
+explanations of a specific concept or comparisons between two concepts. The prompts are inserted
+into the composer without sending, so students can replace the bracketed placeholders before
+retrieval. Broad whole-course summaries and study plans are intentionally not offered here; a
+reliable planner needs a separate structured planning flow and tool/result budget. Starters remain
+hidden until the current chatbot's mode options have loaded, because the selected mode is
+persisted across chatbots. Message action bars
 remain mounted for touch users rather than relying on hover. An unavailable image edit uses
 `aria-disabled` instead of native `disabled`, so its explanatory Radix tooltip remains focusable.
 Each thread row shows the thread's last chat mode as an icon plus localized label under the title

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -195,10 +195,15 @@ partial text from being re-pushed alongside the error part. Truncated responses 
 localized `chat.response.truncated` notice, and a failed image-attachment read surfaces the
 typed `AttachmentAdapterError` from `imageAttachmentAdapter.ts` as a localized composer error
 rather than a stringified `ProgressEvent`. A cached thread list intentionally remains visible if only its background refresh fails.
-The welcome view contains localized starter suggestions, and message action bars remain mounted
-for touch users rather than relying on hover. An unavailable image edit uses `aria-disabled`
-instead of native `disabled`, so its explanatory Radix tooltip remains focusable. Each thread
-row shows the thread's last chat mode as an icon plus localized label under the title
+The welcome view contains localized, mode-aware starter suggestions: Tutor offers interactive
+practice prompts that ask one question at a time and provide hints, while Explainer offers
+source-oriented concept explanations and topic summaries. The broad whole-course study-plan
+starter is intentionally not offered here; a reliable planner needs a separate structured
+planning flow and tool/result budget. Starters remain hidden until the current chatbot's mode
+options have loaded, because the selected mode is persisted across chatbots. Message action bars
+remain mounted for touch users rather than relying on hover. An unavailable image edit uses
+`aria-disabled` instead of native `disabled`, so its explanatory Radix tooltip remains focusable.
+Each thread row shows the thread's last chat mode as an icon plus localized label under the title
 (`thread.lastChatMode` via `formatModeLabel`), and Markdown blockquotes in answers render as
 amber info callouts (the `blockquote` override in `markdown-text.tsx`, which only assistant
 messages render through — user text never gets the callout styling). A reply to an

--- a/docs/log/2026-08-09-vorkurs-mode-aware-starters.md
+++ b/docs/log/2026-08-09-vorkurs-mode-aware-starters.md
@@ -1,0 +1,20 @@
+---
+type: Change Log
+title: Vorkurs mode-aware chat starters
+description: Mode-specific welcome prompts for Tutor and Explainer.
+timestamp: '2026-08-09'
+tags:
+  - chat
+  - ai
+  - ux
+---
+
+## 2026-08-09
+
+- **Update**: [chat-platform](../chat-platform.md) now documents mode-aware
+  welcome starters: Tutor starts interactive practice and Explainer starts
+  source-based explanation or summarization.
+- **Update**: The broad whole-course study-plan starter was removed from the
+  welcome view. A structured study-planner flow remains a separate follow-up.
+- **Update**: Welcome starters now wait for the current chatbot's mode options,
+  so a persisted mode from another chatbot cannot trigger the wrong prompt.

--- a/docs/log/2026-08-09-vorkurs-mode-aware-starters.md
+++ b/docs/log/2026-08-09-vorkurs-mode-aware-starters.md
@@ -13,7 +13,10 @@ tags:
 
 - **Update**: [chat-platform](../chat-platform.md) now documents mode-aware
   welcome starters: Tutor starts interactive practice and Explainer starts
-  source-based explanation or summarization.
+  focused, source-based explanations or comparisons.
+- **Update**: Starters now fill the composer without sending. Their prompts use
+  bracketed placeholders for a specific topic, concept, or problem so students
+  can focus the retrieval query before submitting it.
 - **Update**: The broad whole-course study-plan starter was removed from the
   welcome view. A structured study-planner flow remains a separate follow-up.
 - **Update**: Welcome starters now wait for the current chatbot's mode options,

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -120,12 +120,18 @@ export default {
       welcomeSubtitle: 'Wie kann ich Dir helfen?',
     },
     suggestions: {
-      explainConcept: 'Erkläre mir ein zufälliges Konzept aus dem Skript',
+      practiceTopic: 'Ein Thema üben',
+      practiceTopicPrompt:
+        'Ich möchte für die Prüfung üben. Frag mich zuerst, welches einzelne Thema aus den Kursunterlagen ich üben möchte. Stelle mir danach eine Frage nach der anderen und gib mir Hinweise statt direkt die Antwort zu zeigen.',
+      workThroughProblem: 'Eine Aufgabe bearbeiten',
+      workThroughProblemPrompt:
+        'Hilf mir, eine Aufgabe aus den Kursunterlagen Schritt für Schritt zu bearbeiten. Stell mir Fragen und gib mir Hinweise, bevor du die Lösung zeigst.',
+      explainConcept: 'Ein Konzept erklären',
       explainConceptPrompt:
-        'Nimm ein zufälliges Konzept aus dem Kursskript und erkläre es mir in einfachen Worten.',
-      examPrep: 'Hilf mir bei der Prüfungsvorbereitung',
-      examPrepPrompt:
-        'Erstelle einen Lernplan für die bevorstehende Prüfung, der alle wichtigen Themen aus den Vorlesungsunterlagen abdeckt.',
+        'Erkläre mir ein einzelnes Konzept aus dem Kursskript in einfachen Worten, mit einem Beispiel und Quellenangaben.',
+      summarizeTopic: 'Ein Thema zusammenfassen',
+      summarizeTopicPrompt:
+        'Fasse ein einzelnes Thema aus dem Kursskript zusammen, inklusive der wichtigsten Ideen, Formeln und eines Beispiels.',
     },
     message: {
       creditsUsed:

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -122,16 +122,16 @@ export default {
     suggestions: {
       practiceTopic: 'Ein Thema üben',
       practiceTopicPrompt:
-        'Ich möchte für die Prüfung üben. Frag mich zuerst, welches einzelne Thema aus den Kursunterlagen ich üben möchte. Stelle mir danach eine Frage nach der anderen und gib mir Hinweise statt direkt die Antwort zu zeigen.',
+        'Ich möchte [ein bestimmtes Thema] aus den Kursunterlagen üben. Stelle mir eine Frage nach der anderen und gib mir Hinweise, statt die Antwort sofort zu verraten.',
       workThroughProblem: 'Eine Aufgabe bearbeiten',
       workThroughProblemPrompt:
-        'Hilf mir, eine Aufgabe aus den Kursunterlagen Schritt für Schritt zu bearbeiten. Stell mir Fragen und gib mir Hinweise, bevor du die Lösung zeigst.',
+        'Hilf mir, diese Aufgabe Schritt für Schritt zu bearbeiten: [füge eine Aufgabe aus den Kursunterlagen ein]. Stell mir Fragen und gib mir Hinweise, bevor du die Lösung zeigst.',
       explainConcept: 'Ein Konzept erklären',
       explainConceptPrompt:
-        'Erkläre mir ein einzelnes Konzept aus dem Kursskript in einfachen Worten, mit einem Beispiel und Quellenangaben.',
-      summarizeTopic: 'Ein Thema zusammenfassen',
-      summarizeTopicPrompt:
-        'Fasse ein einzelnes Thema aus dem Kursskript zusammen, inklusive der wichtigsten Ideen, Formeln und eines Beispiels.',
+        'Erkläre [ein bestimmtes Konzept] aus den Kursunterlagen in einfachen Worten, mit einem durchgerechneten Beispiel und Quellenangaben.',
+      compareConcepts: 'Zwei Konzepte vergleichen',
+      compareConceptsPrompt:
+        'Vergleiche [Konzept A] und [Konzept B] anhand der Kursunterlagen. Erkläre den wichtigsten Unterschied, wann welches Konzept gilt, und nenne die relevanten Quellen.',
     },
     message: {
       creditsUsed:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -117,12 +117,18 @@ export default {
       welcomeSubtitle: 'How can I help you?',
     },
     suggestions: {
-      explainConcept: 'Explain a random concept from the script',
+      practiceTopic: 'Practise a topic',
+      practiceTopicPrompt:
+        'I want to practise for the exam. Ask me which single topic from the course materials I want to practise, then ask me one question at a time and give hints instead of revealing the answer immediately.',
+      workThroughProblem: 'Work through a problem',
+      workThroughProblemPrompt:
+        'Help me work through one problem from the course materials step by step. Ask me questions and give hints before revealing the solution.',
+      explainConcept: 'Explain a concept',
       explainConceptPrompt:
-        'Take a random concept from the course script and explain it in simple terms.',
-      examPrep: 'Help me prepare for the exam',
-      examPrepPrompt:
-        'Create a study plan for the upcoming exam covering all key topics based on the lecture materials.',
+        'Explain one concept from the course script in simple terms, with a worked example and citations.',
+      summarizeTopic: 'Summarize a topic',
+      summarizeTopicPrompt:
+        'Summarize one topic from the course script, including the key ideas, formulas, and one example.',
     },
     message: {
       creditsUsed:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -119,16 +119,16 @@ export default {
     suggestions: {
       practiceTopic: 'Practise a topic',
       practiceTopicPrompt:
-        'I want to practise for the exam. Ask me which single topic from the course materials I want to practise, then ask me one question at a time and give hints instead of revealing the answer immediately.',
+        'I want to practise [a specific topic] from the course materials. Ask me one question at a time and give hints instead of revealing the answer immediately.',
       workThroughProblem: 'Work through a problem',
       workThroughProblemPrompt:
-        'Help me work through one problem from the course materials step by step. Ask me questions and give hints before revealing the solution.',
+        'Help me work through this problem step by step: [paste a problem from the course materials]. Ask me questions and give hints before revealing the solution.',
       explainConcept: 'Explain a concept',
       explainConceptPrompt:
-        'Explain one concept from the course script in simple terms, with a worked example and citations.',
-      summarizeTopic: 'Summarize a topic',
-      summarizeTopicPrompt:
-        'Summarize one topic from the course script, including the key ideas, formulas, and one example.',
+        'Explain [a specific concept] from the course materials in simple terms, using one worked example and citations.',
+      compareConcepts: 'Compare two concepts',
+      compareConceptsPrompt:
+        'Compare [concept A] and [concept B] using the course materials. Explain the key difference, when each applies, and cite the relevant sources.',
     },
     message: {
       creditsUsed:


### PR DESCRIPTION
## What This Adds

This PR makes the chat welcome starters match the selected learning mode:

1. Tutor offers interactive practice for a specific topic and step-by-step problem solving.
2. Explainer offers focused concept explanation and comparison of two concepts.
3. Starters fill the composer without sending, so students can replace the bracketed placeholders before retrieval.
4. Broad whole-course summaries and study plans remain out of scope; a full planner needs a separate structured flow.

## How It Works

- Starter definitions are mapped explicitly to the Tutor and Explainer modes.
- Prompts use concrete topic, concept, and problem placeholders instead of broad overview requests.
- Clicking a starter replaces the composer text without sending a message.
- Welcome starters stay hidden until the current chatbot's mode options have loaded, so a persisted mode from another chatbot cannot trigger the wrong starter.
- Mode-option request generations ignore stale responses when a user changes chatbots quickly.
- English and German prompts follow the same behavior contract.

## Branch Coverage

- Base: `v3`
- Head: `96ce75ddf`
- Reviewed: 2 commits; 238 additions and 55 deletions across 10 files.
- Covered: mode-specific starter configuration, stale-load protection, composer-only behavior, focused RAG prompts, localized prompts, tests, chat-platform documentation, and the dated change log.

## Review Focus

- Confirm Tutor and Explainer starter intent remains distinct.
- Check that persisted mode state cannot render stale starters for a new chatbot.
- Check that the localized prompts preserve the same interaction contract.
- Check that starter clicks leave the message in the composer and do not create a thread message.

## Verification

Current head:

- `pnpm --filter @klicker-uzh/chat test:run` -> 31 test files and 231 tests passed.
- `pnpm --filter @klicker-uzh/chat check` -> passed.
- `pnpm exec prettier --check docs/chat-platform.md docs/log/2026-08-09-vorkurs-mode-aware-starters.md` -> passed.
- `git diff --check` -> passed.
- Authenticated local browser run against the seeded Benibot chatbot -> Tutor showed `Practise a topic` and `Work through a problem`; Explainer showed `Explain a concept` and `Compare two concepts`; starter clicks populated the composer and emitted no `/api/chatbots/.../chat` request.

Earlier branch verification:

- Sol read-only review of the first commit -> no code findings; the composer-only and focused-prompt correction is a new follow-up commit awaiting review.

Failed/Warning:

- `pnpm run check:all` remains blocked by unrelated repository-wide generated GraphQL artifacts and an analytics `uv` cache permission error; the changed chat package checks are green.

## Screenshots

- Tutor composer-filled state: captured at `/private/tmp/mode-aware-tutor-composer.png` during the authenticated local browser run.
- Explainer composer-filled state: captured at `/private/tmp/mode-aware-explainer-composer.png` during the authenticated local browser run.

## Security / Privacy

- No secrets or private course data were added.
- The change only selects localized starter text and guards client-side loading state.

## Blocking Before Merge

- [ ] Repeat the read-only final review on the corrected head.

## Follow-Up After Merge

- Consider a dedicated study-planner flow if whole-course planning becomes a product requirement.

## Local Session Artifacts

- Machine: local development Mac
- Worktree: `trees/mode-aware-chat-starters` in repository `klicker-uzh`
- Environment: isolated local DevPod/browser run used for authenticated UI verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mode-aware welcome suggestions for Tutor and Explainer chats.
  * Suggestions now reflect the selected chatbot mode and load after mode options are available.
  * Added starters for practicing topics, working through problems, explaining concepts, and comparing concepts.
  * Selecting a suggestion now fills the composer without sending it, preserving existing chat control.

* **Bug Fixes**
  * Prevented outdated mode data from replacing options for the currently selected chatbot.

* **Documentation**
  * Updated chat platform documentation and changelog with the new starter behavior and accessibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->