### PR TITLE
fix(chat): stabilize streamed conversations and feedback

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -29,10 +29,11 @@ replace a real-upstream staging smoke test.
 
 For chat conversation-rendering changes, `playwright/util/chat.ts` supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
-`ReadableStream`. Use that seam to test the assistant row while it is still
-streaming, and capture DOM identity around feedback clicks when the bug concerns
-remounts or flicker. A passing final-text assertion alone does not prove that the
-conversation stayed mounted.
+`ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic
+intermediate state until the test releases it. Use that seam to test the assistant
+row while it is still streaming, and capture DOM identity around feedback clicks
+when the bug concerns remounts or flicker. A passing final-text assertion alone
+does not prove that the conversation stayed mounted.
 
 Direct checks for `auth`, `chat`, `frontend-control`, `frontend-manage`, and `frontend-pwa` generate ignored Next route types first through each app's `check` script. Do not hand-edit or commit `next-env.d.ts`; keep it ignored and included by `tsconfig.json`. The three PWA apps use `tsconfig.check.json` only for raw package checks so stale `.next/dev/types` cannot duplicate fresh Pages Router validators. Next builds use the canonical `tsconfig.json`; Next 16 filters development validators on its production typecheck path. Auth and Chat use their main config for both checks and builds.
 

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -27,6 +27,13 @@ fixture uses injected OpenAI-compatible SSE with a sparse first tool-call index
 and proves public tool-call/finish conversion without a model key; it does not
 replace a real-upstream staging smoke test.
 
+For chat conversation-rendering changes, `playwright/util/chat.ts` supports
+`textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
+`ReadableStream`. Use that seam to test the assistant row while it is still
+streaming, and capture DOM identity around feedback clicks when the bug concerns
+remounts or flicker. A passing final-text assertion alone does not prove that the
+conversation stayed mounted.
+
 Direct checks for `auth`, `chat`, `frontend-control`, `frontend-manage`, and `frontend-pwa` generate ignored Next route types first through each app's `check` script. Do not hand-edit or commit `next-env.d.ts`; keep it ignored and included by `tsconfig.json`. The three PWA apps use `tsconfig.check.json` only for raw package checks so stale `.next/dev/types` cannot duplicate fresh Pages Router validators. Next builds use the canonical `tsconfig.json`; Next 16 filters development validators on its production typecheck path. Auth and Chat use their main config for both checks and builds.
 
 For Next framework or bundler changes, verify both repository-supported paths. `pnpm run build:test` uses Turbopack in all five Next apps. `pnpm run build` uses Turbopack for auth/chat and Webpack for control/manage/PWA until their service-worker integration moves to Serwist. Confirm standalone server paths for all five apps and `sw.js`, Workbox, and custom worker outputs for the three PWA apps.

--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -13,9 +13,11 @@ import {
   type ThreadMessageLike,
 } from '@assistant-ui/react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useChatUi } from '../components/chat-ui-context'
 import { imageAttachmentAdapter } from '../lib/attachments/imageAttachmentAdapter'
+
+const EMPTY_MESSAGES: ExtendedThreadMessageLike[] = []
 
 export function RuntimeProvider({
   chatbotId,
@@ -25,25 +27,35 @@ export function RuntimeProvider({
   children: React.ReactNode
 }>) {
   const { embedded } = useChatUi()
-  const {
-    activeThreadId,
-    threads,
-    setMessages: setMessagesInternal,
-    loadThreads,
-    switchToThread,
-    resyncModeFromThread,
-    resetSession,
-    rateMessage,
-  } = useChatStore()
-  const {
-    selectedModel,
-    selectedMode,
-    selectedReasoningEffort,
-    modelOptions,
-    loadCredits,
-    loadModeOptions,
-  } = useSettingsStore()
   const { threadId } = useParams<{ chatbotId: string; threadId?: string }>()
+  const activeThreadId = useChatStore((state) => state.activeThreadId)
+  const activeThread = useChatStore((state) =>
+    state.threads.find((thread) => thread.id === state.activeThreadId)
+  )
+  const existingThread = useChatStore((state) =>
+    threadId
+      ? (state.threads.find((thread) => thread.id === threadId) ?? null)
+      : null
+  )
+  const setMessagesInternal = useChatStore((state) => state.setMessages)
+  const loadThreads = useChatStore((state) => state.loadThreads)
+  const switchToThread = useChatStore((state) => state.switchToThread)
+  const resyncModeFromThread = useChatStore(
+    (state) => state.resyncModeFromThread
+  )
+  const resetSession = useChatStore((state) => state.resetSession)
+  const selectedModel = useSettingsStore((state) => state.selectedModel)
+  const selectedMode = useSettingsStore((state) => state.selectedMode)
+  const selectedReasoningEffort = useSettingsStore(
+    (state) => state.selectedReasoningEffort
+  )
+  const supportsImageAttachments = useSettingsStore(
+    (state) =>
+      state.modelOptions.find((model) => model.id === selectedModel)
+        ?.supportsImageAttachments !== false
+  )
+  const loadCredits = useSettingsStore((state) => state.loadCredits)
+  const loadModeOptions = useSettingsStore((state) => state.loadModeOptions)
   const router = useRouter()
   const searchParams = useSearchParams()
   const queryString = searchParams.toString()
@@ -64,9 +76,8 @@ export function RuntimeProvider({
   } | null>(null)
 
   // get current thread state
-  const activeThread = threads.find((t) => t.id === activeThreadId)
-  const messages = activeThread?.messages || []
-  const isRunning = activeThread?.isRunning || false
+  const messages = activeThread?.messages ?? EMPTY_MESSAGES
+  const isRunning = activeThread?.isRunning ?? false
 
   // reset session for embedded mode without a thread
   useEffect(() => {
@@ -123,7 +134,7 @@ export function RuntimeProvider({
       await loadModeOptions(chatbotId)
       await loadCredits(chatbotId)
     })()
-  }, [chatbotId, embedded, loadCredits, loadModeOptions, loadThreads])
+  }, [chatbotId, embedded, loadCredits, loadModeOptions, loadThreads, threadId])
 
   // sync active thread with URL params
   useEffect(() => {
@@ -139,8 +150,6 @@ export function RuntimeProvider({
       syncRetryCount.current = 0
       return
     }
-
-    const existingThread = threads.find((thread) => thread.id === threadId)
 
     if (!existingThread) {
       router.replace(missingThreadRedirectPath)
@@ -213,7 +222,7 @@ export function RuntimeProvider({
     switchToThread,
     syncRetryTrigger,
     threadId,
-    threads,
+    existingThread,
     threadsLoaded,
   ])
 
@@ -238,10 +247,10 @@ export function RuntimeProvider({
         reasoningEffort,
         creditsUsed,
         imageAttachments,
-        rating,
         metadata,
         ...rest
       } = message
+      delete rest.rating
       const custom = {
         ...(metadata?.custom ?? {}),
         chatMode: chatMode ?? null,
@@ -251,28 +260,11 @@ export function RuntimeProvider({
         imageAttachments: imageAttachments ?? [],
       }
 
-      // The feedback adapter's active state (`ActionBarPrimitive.FeedbackPositive`
-      // / `FeedbackNegative`) reads `metadata.submittedFeedback` on every
-      // render. The zustand store is the source of truth for the vote
-      // (persisted via the feedback route and loaded back from the API), so
-      // it has to be mapped in here rather than relying on the runtime's own
-      // optimistic patch: that patch lives in the runtime's internal message
-      // repository and would be clobbered the next time this converter runs
-      // from a fresh store snapshot (thread switch, reload, or the next
-      // store update), leaving a stale/missing vote after reload.
-      const submittedFeedback =
-        rating === 'UP'
-          ? ({ type: 'positive' } as const)
-          : rating === 'DOWN'
-            ? ({ type: 'negative' } as const)
-            : undefined
-
       return {
         ...rest,
         metadata: {
           ...metadata,
           custom,
-          submittedFeedback,
         },
       }
     },
@@ -287,6 +279,12 @@ export function RuntimeProvider({
     [setMessagesInternal]
   )
 
+  const adapters = useMemo(
+    () =>
+      supportsImageAttachments ? { attachments: imageAttachmentAdapter } : {},
+    [supportsImageAttachments]
+  )
+
   // runtime config for assistant UI
   const runtime = useExternalStoreRuntime({
     messages,
@@ -297,25 +295,7 @@ export function RuntimeProvider({
     onReload,
     onCancel,
     convertMessage,
-    adapters: {
-      ...(modelOptions.find((m) => m.id === selectedModel)
-        ?.supportsImageAttachments !== false && {
-        attachments: imageAttachmentAdapter,
-      }),
-      // Only the "submit a vote" path goes through this adapter — assistant-ui's
-      // FeedbackAdapter has no concept of retracting a vote, so clearing an
-      // existing one (clicking the active vote again) is handled directly in
-      // `MessageRatingButtons` via the same store action.
-      feedback: {
-        submit: ({ message, type }) => {
-          void rateMessage(
-            chatbotId,
-            message.id,
-            type === 'positive' ? 'UP' : 'DOWN'
-          )
-        },
-      },
-    },
+    adapters,
   })
 
   return (

--- a/apps/chat/src/components/assistant.tsx
+++ b/apps/chat/src/components/assistant.tsx
@@ -48,7 +48,12 @@ export const Assistant = ({
 }) => {
   const t = useTranslations()
   const embedded = useEmbedded()
-  const { participationRequired, participationMessage } = useChatStore()
+  const participationRequired = useChatStore(
+    (state) => state.participationRequired
+  )
+  const participationMessage = useChatStore(
+    (state) => state.participationMessage
+  )
   const [disclaimer, setDisclaimer] = useState<ChatbotDisclaimer | null>(null)
   const [disclaimerStatus, setDisclaimerStatus] =
     useState<DisclaimerStatus | null>(null)
@@ -356,7 +361,11 @@ function SidebarMain({
   const { open } = useSidebar()
   const { chatbotId } = useParams<{ chatbotId: string }>()
   const router = useRouter()
-  const { createThread, participationRequired, isLoading } = useChatStore()
+  const createThread = useChatStore((state) => state.createThread)
+  const participationRequired = useChatStore(
+    (state) => state.participationRequired
+  )
+  const isLoading = useChatStore((state) => state.isLoading)
 
   const handleNewThread = async () => {
     if (participationRequired) return
@@ -438,7 +447,7 @@ function AssistantLayout({
   chatbot: { id: string; name: string; avatar?: string }
 }) {
   const { showSidebar } = useChatUi()
-  const { isLoading } = useChatStore()
+  const isLoading = useChatStore((state) => state.isLoading)
 
   if (showSidebar) {
     return (

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -35,10 +35,12 @@ import {
 } from 'lucide-react'
 import {
   type FC,
-  type MouseEvent,
   type PropsWithChildren,
   type ReactNode,
+  createContext,
+  useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -83,6 +85,7 @@ import { twMerge } from 'tailwind-merge'
 type ThreadProps = { chatbotAvatar: string }
 const EMPTY_REMOVED_ATTACHMENT_KEYS: string[] = []
 const EMPTY_MESSAGES: ExtendedThreadMessageLike[] = []
+const ChatbotAvatarContext = createContext('')
 
 const formatTitleCase = (value: string) =>
   value
@@ -125,11 +128,11 @@ const extractMessageText = (message: {
     .join('')
 
 const useSupportsImageAttachments = () => {
-  const { selectedModel, modelOptions } = useSettingsStore()
-
-  return (
-    modelOptions.find((model) => model.id === selectedModel)
-      ?.supportsImageAttachments !== false
+  const selectedModel = useSettingsStore((state) => state.selectedModel)
+  return useSettingsStore(
+    (state) =>
+      state.modelOptions.find((model) => model.id === selectedModel)
+        ?.supportsImageAttachments !== false
   )
 }
 
@@ -144,7 +147,7 @@ const MessageMetadata: FC<{ includeCredits?: boolean }> = ({
     // `role`/`status` above.
     createdAt: Date
   }
-  const { modelOptions } = useSettingsStore()
+  const modelOptions = useSettingsStore((state) => state.modelOptions)
   const t = useTranslations()
   const format = useFormatter()
   // A ticking `now`, not `new Date()`: the caption is rendered once and its
@@ -247,6 +250,14 @@ const MessageMetadata: FC<{ includeCredits?: boolean }> = ({
 
 export const Thread: FC<ThreadProps> = ({ chatbotAvatar }) => {
   const { embedded } = useChatUi()
+  const messageComponents = useMemo(
+    () => ({
+      UserMessage,
+      EditComposer,
+      AssistantMessage,
+    }),
+    []
+  )
 
   return (
     <ThreadPrimitive.Root
@@ -266,15 +277,9 @@ export const Thread: FC<ThreadProps> = ({ chatbotAvatar }) => {
       >
         <ThreadWelcome chatbotAvatar={chatbotAvatar} />
 
-        <ThreadPrimitive.Messages
-          components={{
-            UserMessage: UserMessage,
-            EditComposer: EditComposer,
-            AssistantMessage: (props) => (
-              <AssistantMessage {...props} chatbotAvatar={chatbotAvatar} />
-            ),
-          }}
-        />
+        <ChatbotAvatarContext.Provider value={chatbotAvatar}>
+          <ThreadPrimitive.Messages components={messageComponents} />
+        </ChatbotAvatarContext.Provider>
       </ThreadPrimitive.Viewport>
 
       <div
@@ -390,7 +395,11 @@ const SUGGESTION_DELAY_CLASSNAMES = ['delay-150', 'delay-200']
 const ThreadWelcomeSuggestions: FC = () => {
   const t = useTranslations()
   const { chatbotId } = useParams<{ chatbotId: string }>()
-  const { modeOptions, modeOptionsChatbotId, selectedMode } = useSettingsStore()
+  const modeOptions = useSettingsStore((state) => state.modeOptions)
+  const modeOptionsChatbotId = useSettingsStore(
+    (state) => state.modeOptionsChatbotId
+  )
+  const selectedMode = useSettingsStore((state) => state.selectedMode)
 
   // `selectedMode` is persisted globally, while mode options arrive after the
   // current chatbot mounts. Hide starters until the current chatbot's
@@ -1235,9 +1244,8 @@ const ImageAnalyzedChip: FC = () => {
   )
 }
 
-const AssistantMessage: FC<{
-  chatbotAvatar: string
-}> = ({ chatbotAvatar }) => {
+const AssistantMessage: FC = () => {
+  const chatbotAvatar = useContext(ChatbotAvatarContext)
   const { embedded } = useChatUi()
   // True only for the synthetic empty assistant message the runtime injects
   // while a response is pending (before the first streamed part arrives).
@@ -1383,25 +1391,26 @@ const MessageRatingButtons: FC = () => {
   const message = useMessage()
   const { chatbotId } = useParams<{ chatbotId: string }>()
   const rateMessage = useChatStore((state) => state.rateMessage)
-  // The active vote comes from the feedback adapter's own metadata field
-  // (populated by `convertMessage` in RuntimeProvider from the store's
-  // persisted rating), not a separate zustand selector.
-  const submittedFeedbackType = message.metadata.submittedFeedback?.type ?? null
+  const submittedRating = useChatStore((state) => {
+    const activeThread = state.threads.find(
+      (thread) => thread.id === state.activeThreadId
+    )
+    return (
+      activeThread?.messages.find((candidate) => candidate.id === message.id)
+        ?.rating ?? null
+    )
+  })
 
   if (!chatbotId) return null
 
   const options = [
     {
       value: 'UP' as const,
-      feedbackType: 'positive' as const,
-      FeedbackPrimitive: ActionBarPrimitive.FeedbackPositive,
       Icon: ThumbsUpIcon,
       label: t('chat.message.rateUp'),
     },
     {
       value: 'DOWN' as const,
-      feedbackType: 'negative' as const,
-      FeedbackPrimitive: ActionBarPrimitive.FeedbackNegative,
       Icon: ThumbsDownIcon,
       label: t('chat.message.rateDown'),
     },
@@ -1409,48 +1418,39 @@ const MessageRatingButtons: FC = () => {
 
   return (
     <>
-      {options.map(
-        ({ value, feedbackType, FeedbackPrimitive, Icon, label }) => {
-          const isActive = submittedFeedbackType === feedbackType
-          return (
-            <Tooltip key={value}>
-              <TooltipTrigger asChild>
-                <FeedbackPrimitive
-                  asChild
-                  // The feedback adapter only models "submit a vote": clicking
-                  // the already-active vote here clears it instead, so a
-                  // misclick is undoable. That clear path bypasses the
-                  // adapter (there is no "retract" concept in assistant-ui)
-                  // and calls the same store action directly.
-                  onClick={(event: MouseEvent) => {
-                    if (isActive) {
-                      event.preventDefault()
-                      void rateMessage(chatbotId, message.id, null)
-                    }
-                  }}
-                >
-                  <button
-                    data-cy={`chat-rate-${value.toLowerCase()}-button`}
-                    aria-pressed={isActive}
-                    className={twMerge(
-                      actionBarButtonClassName,
-                      isActive && 'text-primary'
-                    )}
-                  >
-                    {/* The cast icon is filled, not merely recoloured: primary
-                      against muted-foreground is only ~2.4:1 (~2.0:1 in dark
-                      mode), so colour alone would leave the active vote
-                      indistinguishable under WCAG 1.4.1/1.4.11. */}
-                    <Icon className={isActive ? 'fill-current' : undefined} />
-                    <span className="sr-only">{label}</span>
-                  </button>
-                </FeedbackPrimitive>
-              </TooltipTrigger>
-              <TooltipContent>{label}</TooltipContent>
-            </Tooltip>
-          )
-        }
-      )}
+      {options.map(({ value, Icon, label }) => {
+        const isActive = submittedRating === value
+        return (
+          <Tooltip key={value}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                data-cy={`chat-rate-${value.toLowerCase()}-button`}
+                aria-pressed={isActive}
+                onClick={() => {
+                  void rateMessage(
+                    chatbotId,
+                    message.id,
+                    isActive ? null : value
+                  )
+                }}
+                className={twMerge(
+                  actionBarButtonClassName,
+                  isActive && 'text-primary'
+                )}
+              >
+                {/* The cast icon is filled, not merely recoloured: primary
+                    against muted-foreground is only ~2.4:1 (~2.0:1 in dark
+                    mode), so colour alone would leave the active vote
+                    indistinguishable under WCAG 1.4.1/1.4.11. */}
+                <Icon className={isActive ? 'fill-current' : undefined} />
+                <span className="sr-only">{label}</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        )
+      })}
     </>
   )
 }

--- a/apps/chat/src/hooks/useChatResponse.ts
+++ b/apps/chat/src/hooks/useChatResponse.ts
@@ -34,7 +34,7 @@ export function useChatResponse(
   const { chatbotId } = useParams<{ chatbotId: string }>()
   const t = useTranslations()
 
-  const { loadCredits } = useSettingsStore()
+  const loadCredits = useSettingsStore((state) => state.loadCredits)
 
   // AbortController to handle request cancellation
   const abortControllerRef = useRef<AbortController | null>(null)

--- a/apps/chat/src/hooks/useThreadManagement.ts
+++ b/apps/chat/src/hooks/useThreadManagement.ts
@@ -41,9 +41,14 @@ export function useThreadManagement(
   const { chatbotId } = useParams<{ chatbotId: string }>()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { createThread, addMessage, setIsRunning } = useChatStore()
-  const { selectedMode, selectedModel, selectedReasoningEffort } =
-    useSettingsStore()
+  const createThread = useChatStore((state) => state.createThread)
+  const addMessage = useChatStore((state) => state.addMessage)
+  const setIsRunning = useChatStore((state) => state.setIsRunning)
+  const selectedMode = useSettingsStore((state) => state.selectedMode)
+  const selectedModel = useSettingsStore((state) => state.selectedModel)
+  const selectedReasoningEffort = useSettingsStore(
+    (state) => state.selectedReasoningEffort
+  )
 
   /**
    * Handles creation of new user messages and generates response

--- a/apps/chat/test/chat-response-hydration.test.ts
+++ b/apps/chat/test/chat-response-hydration.test.ts
@@ -33,9 +33,10 @@ vi.mock('../src/lib/utils/chatUtils', () => ({
 }))
 
 vi.mock('../src/stores/settingsStore', () => ({
-  useSettingsStore: () => ({
-    loadCredits: loadCreditsMock,
-  }),
+  useSettingsStore: (selector?: (state: any) => unknown) => {
+    const state = { loadCredits: loadCreditsMock }
+    return selector ? selector(state) : state
+  },
 }))
 
 vi.mock('../src/stores/chatStore', () => ({

--- a/apps/chat/test/message-editing.test.ts
+++ b/apps/chat/test/message-editing.test.ts
@@ -29,11 +29,14 @@ vi.mock('../src/lib/utils/chatUtils', () => ({
 }))
 
 vi.mock('../src/stores/settingsStore', () => ({
-  useSettingsStore: () => ({
-    selectedMode: 'chat',
-    selectedModel: 'gpt-test',
-    selectedReasoningEffort: 'medium',
-  }),
+  useSettingsStore: (selector?: (state: any) => unknown) => {
+    const state = {
+      selectedMode: 'chat',
+      selectedModel: 'gpt-test',
+      selectedReasoningEffort: 'medium',
+    }
+    return selector ? selector(state) : state
+  },
 }))
 
 vi.mock('../src/stores/chatStore', () => ({
@@ -50,6 +53,11 @@ type MockState = {
 }
 
 let storeState: MockState
+let chatActions: {
+  createThread: ReturnType<typeof vi.fn>
+  addMessage: ReturnType<typeof vi.fn>
+  setIsRunning: ReturnType<typeof vi.fn>
+}
 
 describe('getEditedMessageSource', () => {
   beforeEach(() => {
@@ -59,11 +67,17 @@ describe('getEditedMessageSource', () => {
     }
 
     mockUseChatStore.mockReset()
-    mockUseChatStore.mockReturnValue({
+    chatActions = {
       createThread: vi.fn(),
       addMessage: vi.fn(),
       setIsRunning: vi.fn(),
-    })
+    }
+    mockUseChatStore.mockImplementation(
+      (selector?: (state: any) => unknown) => {
+        const state = { ...storeState, ...chatActions }
+        return selector ? selector(state) : state
+      }
+    )
     mockUseChatStore.getState.mockImplementation(() => storeState)
     mockUseChatStore.setState.mockImplementation((updater: any) => {
       const partial =
@@ -213,11 +227,11 @@ describe('getEditedMessageSource', () => {
   test('new user message preserves attachment previews from composer attachments', async () => {
     const addMessage = vi.fn().mockResolvedValue('thread-1')
 
-    mockUseChatStore.mockReturnValue({
+    chatActions = {
       createThread: vi.fn(),
       addMessage,
       setIsRunning: vi.fn(),
-    })
+    }
 
     storeState = {
       activeThreadId: 'thread-1',

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -394,7 +394,8 @@ The live reasoning/tool/credit matrix additionally needs a configured model key;
 those checks remain an explicit environment-gated follow-up rather than an unverified claim.
 
 The chat Playwright fixture can emit `textChunks` through a delayed browser
-`ReadableStream` with `chunkDelayMs`. The streaming stability regression in
+`ReadableStream` with `chunkDelayMs`, and can pause after a chosen text delta
+with `pauseAfterTextChunk` until the test explicitly releases it. The streaming stability regression in
 `playwright/tests/Y-chat.spec.ts` captures the assistant row before later deltas arrive and
 asserts that the same DOM node remains mounted; the rating regression performs the same identity
 check across an optimistic feedback update. These checks target remounts, which are the visible

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -2,7 +2,7 @@
 type: App Guide
 title: Chat Platform
 description: The apps/chat island — app router, zustand, assistant-ui, route-handler auth guards, and the model registry.
-timestamp: '2026-08-09'
+timestamp: '2026-08-10'
 tags:
   - frontend
   - chat
@@ -144,12 +144,18 @@ composition lives in `src/components/message-parts.tsx:AssistantMessageParts`: a
 reasoning parts share one disclosure, adjacent tool calls share one group when there is more
 than one, and a single tool call keeps its direct result disclosure. Reasoning auto-opens only
 while active until the participant manually chooses an open state; that manual choice then wins.
-The runtime's feedback adapter delegates votes to `src/stores/chatStore.ts:rateMessage`, while
-the adapter maps the persisted `ChatMessage.rating` back into `metadata.submittedFeedback` so
-votes survive store refreshes and reloads. AI SDK 7 powers the server route (`ai`,
-`@ai-sdk/openai`, and `@ai-sdk/mcp`); `src/hooks/useChatResponse.ts` remains the client transport
-because the spike-gated `useAISDKRuntime` replacement could not be live-verified without an LLM
-key.
+The runtime render boundary is deliberately narrow: `RuntimeProvider` selects only the active
+thread's messages/running state and the actions it calls, while `Thread` keeps a memoized
+`ThreadPrimitive.Messages` component map and passes the chatbot avatar through context. Runtime
+attachment adapters are memoized as well, so a streamed message or a feedback update does not
+replace every message row's component type or adapter object. Ratings have one owner: the plain
+buttons in `thread.tsx` read the active `ChatMessage.rating` from `chatStore` and call
+`chatStore.rateMessage` for set, switch, and clear; assistant-ui's feedback adapter is not used.
+This preserves the store's optimistic persistence, per-message request serialization, and rollback
+without a second runtime-owned feedback state competing with it. AI SDK 7 powers the server route
+(`ai`, `@ai-sdk/openai`, and `@ai-sdk/mcp`); `src/hooks/useChatResponse.ts` remains the client
+transport because the spike-gated `useAISDKRuntime` replacement could not be live-verified without
+an LLM key.
 
 ## Participant entry points (course page)
 
@@ -352,7 +358,7 @@ Two recurring traps in this app's strings:
 
 Participants rate assistant answers through `ChatMessage.rating` (`ChatMessageRating` enum, nullable — null means no vote; [ADR 0002](./adr/0002-message-feedback-as-a-rating-field.md) records why a field on the message beat a separate feedback entity). `POST …/threads/[threadId]/messages/[messageId]/feedback` scopes its lookup by participant _and_ chatbot and reports someone else's message as 404, not 403, so the endpoint cannot be used to probe which message ids exist.
 
-A failed rating request (`chatStore.rateMessage`) reverts the optimistic vote **silently** — no toast, no inline error. This is deliberate: `@uzh-bf/design-system` exports a `toast`/`Toaster` primitive used by `frontend-pwa`/`frontend-manage`, but `apps/chat` neither mounts a `<Toaster/>` nor imports `toast` anywhere, so wiring one in just for this rare, low-stakes failure was judged out of scope for a P3 polish pass. Revisit if a `<Toaster/>` provider gets added for another reason. Rapid votes are serialized per thread/message, not globally: `src/stores/ratingRequestCoordinator.ts` applies each choice optimistically, starts each request after the previous same-message request settles, and lets only the latest failed request roll the visible value back to the last confirmed database rating.
+A failed rating request (`chatStore.rateMessage`) reverts the optimistic vote **silently** — no toast, no inline error. This is deliberate: `@uzh-bf/design-system` exports a `toast`/`Toaster` primitive used by `frontend-pwa`/`frontend-manage`, but `apps/chat` neither mounts a `<Toaster/>` nor imports `toast` anywhere, so wiring one in just for this rare, low-stakes failure was judged out of scope for a P3 polish pass. Revisit if a `<Toaster/>` provider gets added for another reason. Rapid votes are serialized per thread/message, not globally: `src/stores/ratingRequestCoordinator.ts` applies each choice optimistically, starts each request after the previous same-message request settles, and lets only the latest failed request roll the visible value back to the last confirmed database rating. The action-bar buttons intentionally bypass assistant-ui's feedback adapter so clicking the active vote can send `rating: null` and retract it without remounting the conversation.
 
 Ratings are currently **write-only**: nothing in the repository reads them back. There is no lecturer-facing view and no GraphQL field or aggregate over `ChatMessage.rating`, so votes accumulate in the database for a consumer that does not exist yet — do not cite them as a feedback loop that lecturers can act on.
 
@@ -386,6 +392,14 @@ the package Vitest suite (`pnpm --filter @klicker-uzh/chat test:run` — the pac
 plain `test` script), and the package production build in the worktree's devcontainer.
 The live reasoning/tool/credit matrix additionally needs a configured model key; without one,
 those checks remain an explicit environment-gated follow-up rather than an unverified claim.
+
+The chat Playwright fixture can emit `textChunks` through a delayed browser
+`ReadableStream` with `chunkDelayMs`. The streaming stability regression in
+`playwright/tests/Y-chat.spec.ts` captures the assistant row before later deltas arrive and
+asserts that the same DOM node remains mounted; the rating regression performs the same identity
+check across an optimistic feedback update. These checks target remounts, which are the visible
+flicker signal, rather than treating a successful final answer as proof that the conversation
+stayed stable.
 
 For mobile UI verification, use a real Chromium mobile emulation or Android
 Chrome and check the focused composer, the visible conversation tail, and every

--- a/docs/log/2026-08-10-chat-conversation-stability.md
+++ b/docs/log/2026-08-10-chat-conversation-stability.md
@@ -16,7 +16,8 @@ tags:
   adapters, and direct store-owned rating buttons used to prevent conversation
   remounts during streaming and feedback.
 - **Update**: [testing](../testing.md) documents the delayed multi-delta
-  browser-stream fixture and DOM-identity assertion used for this regression.
+  browser-stream fixture, its deterministic intermediate pause, and the
+  DOM-identity assertion used for this regression.
 - **Update**: [klicker-testing-verification](../../.agents/skills/klicker-testing-verification/SKILL.md)
   routes future chat-rendering regressions through the same fixture instead of
   treating a final answer as evidence that the conversation stayed mounted.

--- a/docs/log/2026-08-10-chat-conversation-stability.md
+++ b/docs/log/2026-08-10-chat-conversation-stability.md
@@ -1,0 +1,22 @@
+---
+type: Change Log
+title: Chat conversation stability
+description: Render ownership and regression coverage for streamed messages and feedback.
+timestamp: '2026-08-10'
+tags:
+  - chat
+  - frontend
+  - testing
+---
+
+## 2026-08-10
+
+- **Update**: [chat-platform](../chat-platform.md) records the narrow Zustand
+  subscriptions, stable assistant-ui message component map, memoized runtime
+  adapters, and direct store-owned rating buttons used to prevent conversation
+  remounts during streaming and feedback.
+- **Update**: [testing](../testing.md) documents the delayed multi-delta
+  browser-stream fixture and DOM-identity assertion used for this regression.
+- **Update**: [klicker-testing-verification](../../.agents/skills/klicker-testing-verification/SKILL.md)
+  routes future chat-rendering regressions through the same fixture instead of
+  treating a final answer as evidence that the conversation stayed mounted.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,10 +33,11 @@ first turn works in staging.
 
 For chat conversation-rendering changes, `playwright/util/chat.ts` also supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
-`ReadableStream`. Use that seam to test the assistant row while it is still
-streaming, and capture DOM identity around feedback clicks when the bug concerns
-remounts or flicker. A passing final-text assertion alone does not prove that the
-conversation stayed mounted.
+`ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic
+intermediate state until the test releases it. Use that seam to test the assistant
+row while it is still streaming, and capture DOM identity around feedback clicks
+when the bug concerns remounts or flicker. A passing final-text assertion alone
+does not prove that the conversation stayed mounted.
 
 The Office Add-in has a separate host boundary. Its pure URL contract runs under Node, while `check`, `lint`, `build:docs`, `verify:docs`, and `validate` cover compilation, source quality, the production bundle, exact deployment parity, and manifest acceptance. A browser run with a stubbed Office API verifies UI states only. Persistence, multiple content-add-in instances, and embedded evaluation rendering require a real PowerPoint sideload before release.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 type: Testing Guide
 title: Testing
 description: Which test level to use when, what runs safely without services, the Playwright e2e stack and its seeds, and the CI test matrix.
-timestamp: '2026-08-09'
+timestamp: '2026-08-10'
 tags:
   - testing
   - ci
@@ -30,6 +30,13 @@ OpenAI-compatible SSE response whose first tool call uses a sparse provider
 index, so it proves provider conversion without a database, MCP server, or
 model key. It is a local regression gate, not evidence that a real upstream
 first turn works in staging.
+
+For chat conversation-rendering changes, `playwright/util/chat.ts` also supports
+`textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
+`ReadableStream`. Use that seam to test the assistant row while it is still
+streaming, and capture DOM identity around feedback clicks when the bug concerns
+remounts or flicker. A passing final-text assertion alone does not prove that the
+conversation stayed mounted.
 
 The Office Add-in has a separate host boundary. Its pure URL contract runs under Node, while `check`, `lint`, `build:docs`, `verify:docs`, and `validate` cover compilation, source quality, the production bundle, exact deployment parity, and manifest acceptance. A browser run with a stubbed Office API verifies UI states only. Persistence, multiple content-add-in instances, and embedded evaluation rendering require a real PowerPoint sideload before release.
 

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -440,15 +440,18 @@ test.describe('Chatbot Messaging Interface', () => {
     await mockChatStream(page, {
       textChunks: ['The first part', ' and the second part', ' and the end.'],
       chunkDelayMs: 80,
+      pauseAfterTextChunk: 1,
     })
     await visitChat(page)
 
     await sendMessage(page, 'Stream a stable answer')
 
     const assistant = page.getByTestId('chat-assistant-message')
-    await expect(assistant).toContainText('The first part', {
+    const assistantContent = page.getByTestId('chat-assistant-message-content')
+    await expect(assistantContent).toContainText('The first part', {
       timeout: 15_000,
     })
+    await expect(assistantContent).not.toContainText('and the end.')
     await assistant.evaluate((node) => {
       const state = window as typeof window & {
         __assistantMessageBeforeStreamUpdate?: Element
@@ -456,9 +459,16 @@ test.describe('Chatbot Messaging Interface', () => {
       state.__assistantMessageBeforeStreamUpdate = node
     })
 
-    await expect(
-      page.getByTestId('chat-assistant-message-content')
-    ).toContainText('and the end.', { timeout: 15_000 })
+    await page.evaluate(() => {
+      const state = window as typeof window & {
+        __releaseMockChatStream?: () => void
+      }
+      state.__releaseMockChatStream?.()
+    })
+
+    await expect(assistantContent).toContainText('and the end.', {
+      timeout: 15_000,
+    })
 
     const stayedMounted = await page.evaluate(() => {
       const state = window as typeof window & {
@@ -733,10 +743,9 @@ test.describe('Chatbot Message Actions & Branching', () => {
     await expect.poll(() => getMessageRating(assistantMessageId)).toBeNull()
   })
 
-  // A vote only counts if it survives leaving the page: the runtime's own
-  // optimistic patch lives in its message repository, so the pressed state
-  // after a reload can only come from the persisted rating being mapped back
-  // in (`convertMessage` in RuntimeProvider).
+  // A vote only counts if it survives leaving the page: the reloaded thread
+  // carries its persisted rating into chatStore, and MessageRatingButtons reads
+  // that store value directly rather than relying on assistant-ui metadata.
   test('A stored rating is restored after a page reload', async ({ page }) => {
     const assistantMessageId = '3f0c1a7e-4d2b-4a91-8f6c-2b7d1e5a9c41'
     await seedThread(participantId, {

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -434,6 +434,45 @@ test.describe('Chatbot Messaging Interface', () => {
     ).toBeVisible()
   })
 
+  test('Streaming keeps the assistant message mounted as text arrives', async ({
+    page,
+  }) => {
+    await mockChatStream(page, {
+      textChunks: ['The first part', ' and the second part', ' and the end.'],
+      chunkDelayMs: 80,
+    })
+    await visitChat(page)
+
+    await sendMessage(page, 'Stream a stable answer')
+
+    const assistant = page.getByTestId('chat-assistant-message')
+    await expect(assistant).toContainText('The first part', {
+      timeout: 15_000,
+    })
+    await assistant.evaluate((node) => {
+      const state = window as typeof window & {
+        __assistantMessageBeforeStreamUpdate?: Element
+      }
+      state.__assistantMessageBeforeStreamUpdate = node
+    })
+
+    await expect(
+      page.getByTestId('chat-assistant-message-content')
+    ).toContainText('and the end.', { timeout: 15_000 })
+
+    const stayedMounted = await page.evaluate(() => {
+      const state = window as typeof window & {
+        __assistantMessageBeforeStreamUpdate?: Element
+      }
+      const current = document.querySelector(
+        '[data-cy="chat-assistant-message"]'
+      )
+      return state.__assistantMessageBeforeStreamUpdate === current
+    })
+
+    expect(stayedMounted).toBe(true)
+  })
+
   test('Welcome message disappears after sending first message', async ({
     page,
   }) => {
@@ -658,9 +697,29 @@ test.describe('Chatbot Message Actions & Branching', () => {
     const up = page.getByTestId('chat-rate-up-button')
     const down = page.getByTestId('chat-rate-down-button')
 
+    await assistant.evaluate((node) => {
+      const state = window as typeof window & {
+        __assistantMessageBeforeFeedback?: Element
+      }
+      state.__assistantMessageBeforeFeedback = node
+    })
+
     await up.click()
     await expect(up).toHaveAttribute('aria-pressed', 'true')
     await expect.poll(() => getMessageRating(assistantMessageId)).toBe('UP')
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const state = window as typeof window & {
+            __assistantMessageBeforeFeedback?: Element
+          }
+          return (
+            state.__assistantMessageBeforeFeedback ===
+            document.querySelector('[data-cy="chat-assistant-message"]')
+          )
+        })
+      )
+      .toBe(true)
 
     // Changing one's mind replaces the vote rather than stacking a second one.
     await down.click()

--- a/playwright/util/chat.ts
+++ b/playwright/util/chat.ts
@@ -365,6 +365,8 @@ export type StreamOptions = {
   textChunks?: string[]
   /** Delays each streamed SSE line by this many milliseconds. */
   chunkDelayMs?: number
+  /** Pauses after this many text deltas until the test releases the stream. */
+  pauseAfterTextChunk?: number
   /** Payload of the `finish` part; omitted entirely when not given. */
   metadata?: StreamFinishMetadata
   /** Tool calls emitted before the answer text. */
@@ -441,8 +443,18 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
     const lines = makeStreamLines(options.text ?? 'assistant reply #1', options)
 
     await page.addInitScript(
-      ({ chatbotPath, lines: streamLines, delayMs }) => {
+      ({ chatbotPath, lines: streamLines, delayMs, pauseAfterTextChunk }) => {
         const originalFetch = window.fetch.bind(window)
+        let releasePausedStream: (() => void) | undefined
+        ;(
+          window as typeof window & {
+            __releaseMockChatStream?: () => void
+          }
+        ).__releaseMockChatStream = () => {
+          releasePausedStream?.()
+          releasePausedStream = undefined
+        }
+
         window.fetch = async (input, init) => {
           const requestUrl =
             typeof input === 'string'
@@ -459,6 +471,7 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
           }
 
           let lineIndex = 0
+          let textChunkCount = 0
           const encoder = new TextEncoder()
           const stream = new ReadableStream<Uint8Array>({
             async pull(controller) {
@@ -471,8 +484,25 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
                 await new Promise((resolve) => setTimeout(resolve, delayMs))
               }
 
-              controller.enqueue(encoder.encode(`${streamLines[lineIndex]}\n`))
+              const line = streamLines[lineIndex]
+              controller.enqueue(encoder.encode(`${line}\n`))
               lineIndex += 1
+
+              let eventType: string | undefined
+              try {
+                eventType = JSON.parse(line.slice('data: '.length)).type
+              } catch {
+                // The trailing [DONE] marker is not JSON.
+              }
+
+              if (eventType === 'text-delta') {
+                textChunkCount += 1
+                if (textChunkCount === pauseAfterTextChunk) {
+                  await new Promise<void>((resolve) => {
+                    releasePausedStream = resolve
+                  })
+                }
+              }
             },
           })
 
@@ -486,6 +516,7 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
         chatbotPath: `/api/chatbots/${CHATBOT_ID}/chat`,
         lines,
         delayMs: options.chunkDelayMs,
+        pauseAfterTextChunk: options.pauseAfterTextChunk,
       }
     )
     return

--- a/playwright/util/chat.ts
+++ b/playwright/util/chat.ts
@@ -361,6 +361,10 @@ export type StreamToolCall = {
 export type StreamOptions = {
   /** Replaces the default `assistant reply #N` answer text. */
   text?: string
+  /** Emits the answer as separate text deltas, in order. */
+  textChunks?: string[]
+  /** Delays each streamed SSE line by this many milliseconds. */
+  chunkDelayMs?: number
   /** Payload of the `finish` part; omitted entirely when not given. */
   metadata?: StreamFinishMetadata
   /** Tool calls emitted before the answer text. */
@@ -370,7 +374,7 @@ export type StreamOptions = {
   errorText?: string
 }
 
-function makeStreamBody(text: string, options: StreamOptions = {}) {
+function makeStreamLines(text: string, options: StreamOptions = {}) {
   const { metadata, toolCalls = [], errorText } = options
 
   const lines = [
@@ -399,11 +403,11 @@ function makeStreamBody(text: string, options: StreamOptions = {}) {
     )
   }
 
-  lines.push(
-    `data: ${JSON.stringify({ type: 'text-start' })}`,
-    `data: ${JSON.stringify({ type: 'text-delta', delta: text })}`,
-    `data: ${JSON.stringify({ type: 'text-end' })}`
-  )
+  lines.push(`data: ${JSON.stringify({ type: 'text-start' })}`)
+  for (const delta of options.textChunks ?? [text]) {
+    lines.push(`data: ${JSON.stringify({ type: 'text-delta', delta })}`)
+  }
+  lines.push(`data: ${JSON.stringify({ type: 'text-end' })}`)
 
   if (errorText) {
     lines.push(`data: ${JSON.stringify({ type: 'error', errorText })}`)
@@ -420,7 +424,11 @@ function makeStreamBody(text: string, options: StreamOptions = {}) {
     'data: [DONE]'
   )
 
-  return lines.join('\n')
+  return lines
+}
+
+function makeStreamBody(text: string, options: StreamOptions = {}) {
+  return makeStreamLines(text, options).join('\n')
 }
 
 /**
@@ -429,6 +437,60 @@ function makeStreamBody(text: string, options: StreamOptions = {}) {
  * unless `options.text` overrides the answer text.
  */
 export async function mockChatStream(page: Page, options: StreamOptions = {}) {
+  if (options.chunkDelayMs !== undefined) {
+    const lines = makeStreamLines(options.text ?? 'assistant reply #1', options)
+
+    await page.addInitScript(
+      ({ chatbotPath, lines: streamLines, delayMs }) => {
+        const originalFetch = window.fetch.bind(window)
+        window.fetch = async (input, init) => {
+          const requestUrl =
+            typeof input === 'string'
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url
+          const requestMethod = (
+            init?.method ?? (input instanceof Request ? input.method : 'GET')
+          ).toUpperCase()
+
+          if (requestMethod !== 'POST' || !requestUrl.includes(chatbotPath)) {
+            return originalFetch(input, init)
+          }
+
+          let lineIndex = 0
+          const encoder = new TextEncoder()
+          const stream = new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              if (lineIndex >= streamLines.length) {
+                controller.close()
+                return
+              }
+
+              if (lineIndex > 0) {
+                await new Promise((resolve) => setTimeout(resolve, delayMs))
+              }
+
+              controller.enqueue(encoder.encode(`${streamLines[lineIndex]}\n`))
+              lineIndex += 1
+            },
+          })
+
+          return new Response(stream, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          })
+        }
+      },
+      {
+        chatbotPath: `/api/chatbots/${CHATBOT_ID}/chat`,
+        lines,
+        delayMs: options.chunkDelayMs,
+      }
+    )
+    return
+  }
+
   let counter = 0
   await page.route(`**/api/chatbots/${CHATBOT_ID}/chat`, (route) => {
     if (route.request().method() !== 'POST') return route.fallback()

--- a/project/2026-08-10-chat-conversation-stability-plan.md
+++ b/project/2026-08-10-chat-conversation-stability-plan.md
@@ -177,11 +177,19 @@ Check:
 - [x] Reproduced stale pre-#5349 starter labels in a fresh authenticated STG
   chat after cache-busting navigation.
 - [x] Received Sol planning-stage review and accepted the scope boundaries.
-- [ ] Commit this plan before implementation.
+- [x] Commit this plan before implementation (`487f891c7`).
 - [ ] Establish and red-test the local/browser flicker repro.
 - [ ] Implement and verify Slice 2.
 - [ ] Decide whether Slice 3 is needed from measurement.
 - [ ] Run full verification, Sol final review, and open the ready PR.
+
+### Execution note
+
+The local app container is healthy and chat's direct health endpoint returns
+200, but the host route is currently blocked by devrouter's workspace lifecycle
+lock/readiness path and no usable Chromium binary is installed in the container.
+The focused browser assertions remain CI-gated until a real browser run succeeds;
+the repository and unit checks do not substitute for that evidence.
 
 ## Hardest decision and rejected alternatives
 

--- a/project/2026-08-10-chat-conversation-stability-plan.md
+++ b/project/2026-08-10-chat-conversation-stability-plan.md
@@ -1,0 +1,194 @@
+# Chat Conversation Stability Plan
+
+## Goal
+
+Prepare one focused PR that removes the reported chat conversation flicker during
+streaming and feedback interactions, preserves rating semantics, and leaves the
+already-merged mode-aware starter change intact. The PR must be ready for review
+with repository checks, browser evidence, Sol's final review, and green CI.
+
+## Non-goals
+
+- Do not rewrite the mode-aware starter copy or prompt contract from PR #5349.
+- Do not patch the STG cluster, ArgoCD, ReplicaSets, image digests, or any
+  external deployment system.
+- Do not change RAG prompts, model routing, credits, auth, or assistant-ui's
+  broader runtime architecture.
+- Do not add dependencies or batch stream updates without a measured repro that
+  still needs it after the causal render fixes.
+
+## Plan identity
+
+- Plan path: `project/2026-08-10-chat-conversation-stability-plan.md`
+- Branch: `rs/chat-stability-fix`
+- Target branch: `v3`
+- PR: not opened yet
+- Base: `origin/v3` at `338763a41393eb1e773bdb43efcfac3ef4e43334`
+- Related history: PR #5349 (mode-aware starters), promotion PR #5350
+- Worktree: `trees/chat-stability-fix`
+
+## Problem and evidence
+
+- The authenticated STG page still rendered the pre-#5349 starters after the
+  promotion PR merged and after a cache-busting navigation.
+- GitHub `v3` contains the new `practiceTopic`, `workThroughProblem`,
+  `explainConcept`, and `compareConcepts` source and the STG values file carries
+  release `8565b047cc9b` in all 15 annotations.
+- `docs/ci-and-deployment.md` identifies ArgoCD as external to this repository;
+  no repository evidence currently identifies a source or workflow defect.
+- Therefore the stale STG bundle is an external release-runtime gate, not a
+  second starter implementation. Recheck it after the new image is deployed.
+- Sol's prior diagnosis found broad Zustand subscriptions, an inline assistant
+  message component map, per-delta store publications, and two optimistic
+  feedback owners as the causal render paths to test.
+
+## Planning-stage review
+
+- Reviewer: Sol planner `Hume`, read-only, on the live worktree before this plan
+  was created.
+- Verdict: `DONE_WITH_CONCERNS`.
+- Accepted findings:
+  - Keep the STG mismatch outside the implementation diff unless new evidence
+    proves repository ownership.
+  - Narrow only causal subscriptions and stabilize the message-component map
+    and runtime adapters; do not sweep the sidebar without profiler evidence.
+  - Make Zustand the sole feedback owner with plain buttons, retaining
+    persisted rating metadata, serialization, and rollback.
+  - Make stream batching conditional on the post-fix browser measurement.
+
+## Research and feedback loop
+
+- Browser repro: a delayed multi-delta stream and a feedback click must record
+  assistant-message DOM identity, animation state, and render/commit counts.
+- Baseline: run the repro against this branch before the behavior fix; if the
+  browser fixture cannot fail on the baseline, stop and revise the hypothesis.
+- Deployment boundary: use GitHub source/promotion evidence and the authenticated
+  STG browser only; do not infer Argo health from the merged annotation.
+- Review rubric: `/Users/rschlae/.homesick/repos/dotfiles/home/.local/share/agent-skills/rs-sliced-development-workflow/references/review-rubric.md`.
+
+## Approved slices
+
+### Slice 1: Plan and red-capable repro
+
+Files:
+
+- This plan file.
+- Existing chat Playwright fixtures/specs only if the baseline repro has a
+  correct seam.
+
+Do:
+
+- Establish the delayed streaming and feedback interaction that can go red on
+  remounts or repeated commits.
+- Keep existing starter tests unchanged; they already cover the merged source
+  contract.
+
+Check:
+
+- Baseline reproduces the user's flicker symptom or the exact DOM remount/
+  animation restart signal.
+
+Commit:
+
+- `docs(project): plan chat conversation stability fix`
+
+### Slice 2: Isolate conversation rendering and feedback state
+
+Files:
+
+- `apps/chat/src/app/RuntimeProvider.tsx`
+- `apps/chat/src/components/assistant.tsx`
+- `apps/chat/src/components/thread.tsx`
+- `apps/chat/src/hooks/useThreadManagement.ts`
+- `apps/chat/src/hooks/useChatResponse.ts` only for store-selector changes
+- `apps/chat/test/chat-store-rating.test.ts`
+- `docs/chat-platform.md`
+- `docs/log/2026-08-10-chat-conversation-stability.md`
+
+Do:
+
+- Replace broad store subscriptions at the runtime and direct parents with
+  selectors for the state each surface actually renders.
+- Keep the assistant message component type and component map stable across
+  runtime updates, while retaining the chatbot avatar through stable context.
+- Memoize runtime adapters so feedback and attachment adapter identities do not
+  change on every message update.
+- Remove assistant-ui feedback optimism from the path and make Zustand own set,
+  switch, clear, persistence, serialization, and rollback through plain buttons.
+
+Check:
+
+- Chat tests plus the focused browser repro pass; active vote, vote switching,
+  clearing, persistence, and failed-request rollback remain covered.
+- Browser screenshots cover the changed conversation and feedback states.
+
+Commit:
+
+- `fix(chat): stabilize streamed conversations and feedback`
+
+### Slice 3: Conditional stream publication batching
+
+Do only if Slice 2's browser evidence still shows multiple message-content
+commits per animation frame or visible streaming jitter.
+
+Files:
+
+- `apps/chat/src/hooks/useChatResponse.ts`
+- A small scheduler module and focused test if the seam is cleaner than inline
+  state.
+- `apps/chat/test/chat-response-hydration.test.ts` or the scheduler test.
+
+Do:
+
+- Coalesce text and reasoning deltas to one publication per frame.
+- Flush before tool lifecycle, error, abort, and finish transitions so semantic
+  state is immediate and no stale scheduled update can overwrite final state.
+
+Check:
+
+- A red/green test proves latest-delta coalescing and terminal flush behavior.
+- The original browser stream repro is visibly stable after the change.
+
+Commit:
+
+- `fix(chat): coalesce streamed message updates`
+
+### Slice 4: Finish and release handoff
+
+Do:
+
+- Update the chat wiki and dated log with the render ownership and verification
+  boundary.
+- Run targeted chat tests, browser evidence, `pnpm run check:all`, and
+  `pnpm run build` using the repository's supported environment.
+- Review staged content for secrets, PII, generated churn, and unrelated user
+  changes.
+- Obtain Sol's integrated final review on the exact committed range, resolve and
+  verify every finding, then open a ready PR with substantive size and evidence.
+
+Check:
+
+- Required CI is green; no claim of STG starter runtime success is made until a
+  fresh deployed browser run shows the new labels and composer-only behavior.
+
+## Progress
+
+- [x] Confirmed merged source and STG promotion annotation.
+- [x] Reproduced stale pre-#5349 starter labels in a fresh authenticated STG
+  chat after cache-busting navigation.
+- [x] Received Sol planning-stage review and accepted the scope boundaries.
+- [ ] Commit this plan before implementation.
+- [ ] Establish and red-test the local/browser flicker repro.
+- [ ] Implement and verify Slice 2.
+- [ ] Decide whether Slice 3 is needed from measurement.
+- [ ] Run full verification, Sol final review, and open the ready PR.
+
+## Hardest decision and rejected alternatives
+
+- Hardest decision: keep the observed STG starter mismatch as an external
+  rollout gate instead of mixing unverified deployment changes into the chat
+  render fix.
+- Rejected: another starter rewrite, assistant-ui-owned optimism, blanket
+  sidebar subscription cleanup, and unconditional stream batching.
+- Least confident area: whether stable identities and causal selectors alone
+  remove all streaming jitter; the browser repro decides whether Slice 3 runs.


### PR DESCRIPTION
## Summary

- Narrow the chat runtime's Zustand subscriptions to the state each surface renders, stabilize the assistant-ui message component map, and memoize runtime adapters so streamed updates and feedback do not remount the conversation.
- Make `chatStore` the single feedback owner. Plain action-bar buttons preserve set, switch, clear, persistence, optimistic serialization, and rollback without assistant-ui feedback optimism.
- Add deterministic Playwright coverage for an intermediate streamed delta and feedback DOM identity, plus the corresponding chat wiki, testing guidance, skill guidance, dated log, and execution plan.

## Scope and STG gate

The mode-aware starters from PR #5349 remain unchanged. Source `v3` contains the Tutor practice and Explainer explanation starters, and promotion PR #5350 carries release `8565b047cc9b`. A fresh authenticated STG browser run still showed the old generic labels after cache-busting navigation. That is an external STG release/runtime or cache gate; this PR does not rewrite the starter source or patch cluster/deployment state.

## Verification

- `pnpm --filter @klicker-uzh/chat test:run`: 31 files, 231 tests passed.
- Chat TypeScript and Playwright TypeScript checks passed.
- `pnpm --filter @klicker-uzh/chat lint` passed with five existing warnings only.
- `pnpm run build` passed; existing Next.js, dependency, and unrelated manage-page warnings remain.
- Staged formatting, `git diff --check`, and gitleaks passed.
- `pnpm run check:all` was attempted. The local ARM64 container stopped in unrelated `apps/analytics` lint because pandas required a C compiler; hosted CI is the authoritative full-repository gate.
- Local Playwright execution is blocked by the devrouter lifecycle-lock/readiness failure and unavailable container Chromium. The exact-head Y-chat regression must pass in hosted CI before merge.

## Review and package size

- Sol final review of `487f891c7..e8bc8c1e3`: `PASS WITH CONCERNS`; the only remaining concern is the exact-head hosted Playwright gate above.
- Substantive size: 568 changed lines (396 additions, 172 deletions), excluding the 202-line project execution artifact.
- Target: `v3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat stability while assistant responses stream, reducing message flicker and unnecessary remounts.
  * Improved feedback interactions, including reliable rating persistence and the ability to retract an existing rating.
  * Attachments are now enabled only when supported by the selected model.

* **Tests**
  * Added coverage for streamed message rendering and stable message elements during feedback updates.

* **Documentation**
  * Updated chat testing guidance and documented conversation stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->