### PR TITLE
chore(deploy): promote cba673628982 to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '8565b047cc9b'
+        rollout.klicker.uzh.ch/release: 'cba673628982'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '8565b047cc9b'
+        rollout.klicker.uzh.ch/release: 'cba673628982'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '8565b047cc9b'
+        rollout.klicker.uzh.ch/release: 'cba673628982'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -158,7 +158,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -311,7 +311,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -363,7 +363,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -416,7 +416,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -468,7 +468,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -536,7 +536,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -588,7 +588,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
   replicaCount: 1
 
   affinity:
@@ -637,7 +637,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '8565b047cc9b'
+    rollout.klicker.uzh.ch/release: 'cba673628982'
 
   replicaCount: 1
 
@@ -690,7 +690,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '8565b047cc9b'
+      rollout.klicker.uzh.ch/release: 'cba673628982'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -753,7 +753,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '8565b047cc9b'
+      rollout.klicker.uzh.ch/release: 'cba673628982'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -830,7 +830,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '8565b047cc9b'
+      rollout.klicker.uzh.ch/release: 'cba673628982'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `cba673628982835bdf9b7834ea5f551e8326b8d3`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
