### PR TITLE
enhance(chat): clarify usage and model choices

### DIFF
--- a/.agents/skills/klicker-playwright-e2e/SKILL.md
+++ b/.agents/skills/klicker-playwright-e2e/SKILL.md
@@ -75,6 +75,14 @@ branded `error.tsx` retry/return surface without exposing the server error
 text. Keep the `/noLogin` assertion focused on the login action and concise
 return copy, not a raw redirect URL.
 
+For chat settings coverage, seed credits through the existing `setCredits`
+helper rather than mocking the credits route. A zero-credit response must leave
+only the fallback model available, reconcile an unavailable persisted model to
+that fallback, and expose the fallback notice in the sidebar-enabled mobile
+layout outside the closed drawer. Set the viewport before `visitChat`; embedded
+chat already owns its compact `EmbeddedCreditsBar` and should not receive the
+sidebar mobile bar.
+
 ## Fast Failure Triage
 
 - `net::ERR_CONNECTION_REFUSED http://127.0.0.1:3002/`: the app server is down, not a selector issue. Check `pnpm run dev:playwright` and service readiness first.

--- a/apps/chat/src/components/assistant.tsx
+++ b/apps/chat/src/components/assistant.tsx
@@ -19,6 +19,7 @@ import { useChatStore } from '../stores/chatStore'
 import { AppSidebar } from './app-sidebar'
 import { ChatUiProvider, useChatUi } from './chat-ui-context'
 import { DisclaimerModal } from './disclaimer-modal'
+import { MobileCreditsBar } from './credits-footer'
 import { EmbeddedCreditsBar, EmbeddedSettings } from './embedded-settings'
 import { ModeSwitcher } from './mode-switcher'
 import { Thread } from './thread'
@@ -532,6 +533,7 @@ function SidebarMain({
           <TooltipContent>{t('chat.sidebar.newChat')}</TooltipContent>
         </Tooltip>
       </div>
+      <MobileCreditsBar />
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="relative flex min-h-0 flex-1 flex-col">
           {isLoading && (

--- a/apps/chat/src/components/credits-footer.tsx
+++ b/apps/chat/src/components/credits-footer.tsx
@@ -5,6 +5,55 @@ import { Zap } from 'lucide-react'
 import { useFormatter, useTranslations } from 'next-intl'
 import { useSettingsStore } from '../stores/settingsStore'
 
+function CreditBalance({ current, total }: { current: number; total: number }) {
+  return (
+    <>
+      {Math.round(current)} / {total}
+    </>
+  )
+}
+
+/**
+ * Keeps the balance and the fallback state visible in the main mobile layout
+ * while the sidebar is closed. The embedded layout has its own
+ * `EmbeddedCreditsBar`, so this is rendered only by `SidebarMain`.
+ */
+export function MobileCreditsBar() {
+  const t = useTranslations()
+  const credits = useSettingsStore((state) => state.credits)
+  const creditsLoaded = useSettingsStore((state) => state.creditsLoaded)
+
+  if (!creditsLoaded) return null
+
+  return (
+    <div
+      data-cy="chat-mobile-credits-bar"
+      className="bg-background border-b px-3 py-1.5 md:hidden"
+    >
+      <div className="flex items-center gap-1.5 text-xs">
+        <Zap className="text-muted-foreground size-3.5 shrink-0" />
+        <span className="text-muted-foreground truncate">
+          {t('chat.credits.title')}
+        </span>
+        <span
+          data-cy="chat-mobile-credits-display"
+          className="ml-auto shrink-0 font-medium tabular-nums"
+        >
+          <CreditBalance current={credits.current} total={credits.total} />
+        </span>
+      </div>
+      {credits.current === 0 ? (
+        <p
+          data-cy="chat-mobile-fallback-notice"
+          className="text-muted-foreground mt-0.5 text-xs text-pretty"
+        >
+          {t('chat.credits.fallbackNotice')}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 export function CreditsFooter() {
   const t = useTranslations()
   const format = useFormatter()

--- a/apps/chat/src/components/credits-footer.tsx
+++ b/apps/chat/src/components/credits-footer.tsx
@@ -4,11 +4,12 @@ import { Progress } from '@uzh-bf/design-system'
 import { Zap } from 'lucide-react'
 import { useFormatter, useTranslations } from 'next-intl'
 import { useSettingsStore } from '../stores/settingsStore'
+import { formatCredits } from './thread-credits-format'
 
 function CreditBalance({ current, total }: { current: number; total: number }) {
   return (
     <>
-      {Math.round(current)} / {total}
+      {formatCredits(current)} / {formatCredits(total)}
     </>
   )
 }

--- a/apps/chat/src/components/mode-switcher.tsx
+++ b/apps/chat/src/components/mode-switcher.tsx
@@ -67,6 +67,9 @@ export function ModeSwitcher() {
         const label = isKnownMode(mode)
           ? t(`chat.modes.${mode}`)
           : mode.charAt(0).toUpperCase() + mode.slice(1)
+        const description = isKnownMode(mode)
+          ? t(`chat.modes.${mode}Description`)
+          : modeOptions[mode]?.trim()
         const isActive = mode === selectedMode
 
         return (
@@ -79,6 +82,7 @@ export function ModeSwitcher() {
                 }}
                 type="button"
                 aria-pressed={isActive}
+                aria-label={description ? `${label}: ${description}` : label}
                 data-cy={`chat-mode-option-${mode}`}
                 onClick={() => setSelectedMode(mode)}
                 className={twMerge(
@@ -97,7 +101,14 @@ export function ModeSwitcher() {
                 <span>{label}</span>
               </button>
             </TooltipTrigger>
-            <TooltipContent>{label}</TooltipContent>
+            <TooltipContent className="max-w-64 text-left text-pretty">
+              <p className="font-medium">{label}</p>
+              {description ? (
+                <p data-cy={`chat-mode-description-${mode}`} className="mt-1">
+                  {description}
+                </p>
+              ) : null}
+            </TooltipContent>
           </Tooltip>
         )
       })}

--- a/apps/chat/src/components/settings-panel.tsx
+++ b/apps/chat/src/components/settings-panel.tsx
@@ -10,7 +10,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 
 import { Select } from '@uzh-bf/design-system'
 import { ChevronDown, ChevronUp, Settings2 } from 'lucide-react'
-import { useLocale, useTranslations } from 'next-intl'
+import { useTranslations } from 'next-intl'
 
 /**
  * Ids that tie each visible label to the control it names. The design system
@@ -23,7 +23,6 @@ const REASONING_EFFORT_SELECT_ID = 'chat-reasoning-effort-select'
 
 export function SettingsPanel() {
   const t = useTranslations()
-  const locale = useLocale()
   const {
     selectedModel,
     selectedReasoningEffort,
@@ -51,6 +50,15 @@ export function SettingsPanel() {
       ? selectedModelOption.allowedReasoningEfforts
       : []
   const showReasoningEffortSelector = availableReasoningEfforts.length > 1
+  const selectedModelDescription = selectedModelOption
+    ? selectedModelOption.id === 'auto'
+      ? t('chat.settingsPanel.autoModelDescription')
+      : selectedModelOption.fallback
+        ? t('chat.settingsPanel.fallbackModelDescription')
+        : selectedModelOption.supportsReasoning
+          ? t('chat.settingsPanel.reasoningModelDescription')
+          : t('chat.settingsPanel.standardModelDescription')
+    : null
 
   return (
     <div>
@@ -115,21 +123,11 @@ export function SettingsPanel() {
                     }}
                     value={selectedModel}
                   />
-                  {/* D3: registry model descriptions are English-only text
-                      from the deployment model registry, not translated
-                      copy — showing them in a DE UI leaks raw English.
-                      Hide until the registry supports per-locale
-                      descriptions rather than mistranslate or drop them
-                      for `en` users. */}
-                  {locale === 'en' && (
+                  {selectedModelDescription ? (
                     <p className="text-muted-foreground text-sm">
-                      {
-                        modelOptions.find(
-                          (option) => option.id === selectedModel
-                        )?.description
-                      }
+                      {selectedModelDescription}
                     </p>
-                  )}
+                  ) : null}
                 </>
               ) : (
                 <>

--- a/apps/chat/test/settings-store-credits.test.ts
+++ b/apps/chat/test/settings-store-credits.test.ts
@@ -9,14 +9,21 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
-function creditsResponse(current: number) {
+function creditsResponse(
+  current: number,
+  options: {
+    availableModels?: unknown[]
+    automaticModelId?: string
+  } = {}
+) {
   return {
     ok: true,
     json: async () => ({
       current,
       total: 100,
       nextResetAt: null,
-      availableModels: [],
+      availableModels: options.availableModels ?? [],
+      automaticModelId: options.automaticModelId,
     }),
   }
 }
@@ -92,5 +99,36 @@ describe('settingsStore credits loading', () => {
     await useSettingsStore.getState().loadCredits('chatbot-1')
 
     expect(useSettingsStore.getState().creditsLoaded).toBe(false)
+  })
+
+  test('replaces a persisted unavailable model with the credit-safe fallback', async () => {
+    useSettingsStore.setState({
+      modelSelectionEnabled: true,
+      selectedModel: 'gpt-5.6-luna',
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(
+        creditsResponse(0, {
+          automaticModelId: 'gpt-4.1-mini',
+          availableModels: [
+            {
+              id: 'gpt-4.1-mini',
+              name: 'GPT-4.1 Mini',
+              description: 'fallback',
+              fallback: true,
+              supportsReasoning: false,
+              allowedReasoningEfforts: [],
+              supportsImageAttachments: true,
+            },
+          ],
+        })
+      )
+    )
+
+    await useSettingsStore.getState().loadCredits('chatbot-fallback')
+
+    expect(useSettingsStore.getState().selectedModel).toBe('gpt-4.1-mini')
+    expect(useSettingsStore.getState().modelOptions).toHaveLength(1)
   })
 })

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -112,6 +112,20 @@ response from another chatbot cannot expose stale credit/model state as current.
 is sticky once a load has succeeded: a refresh (including a failing one) keeps the last known
 balance on screen instead of hiding the footer for the rest of the session.
 
+The settings panel translates model capabilities into student-facing descriptions. It does not
+render deployment registry descriptions, because those can expose provider or router terminology
+and are not localized. Automatic, reasoning, general-purpose, and fallback models each have a
+localized explanation in `packages/i18n/messages/en.ts` and `de.ts`; the read-only automatic
+selection state uses the same plain-language contract. Known Tutor and Explainer modes use their
+localized purpose descriptions in `src/components/mode-switcher.tsx`; custom modes fall back to
+their configured description.
+
+In the sidebar layout, `src/components/credits-footer.tsx:MobileCreditsBar` keeps the current
+balance visible below the header at mobile widths, even while the design-system sidebar drawer
+is closed. When the balance reaches zero it also states that new messages use the smaller model.
+The bar is rendered only by `SidebarMain`; embedded mode continues to use its existing
+`EmbeddedCreditsBar` so the two compact readouts are never shown together.
+
 Two further credit conventions are easy to break:
 
 - `getNextResetTime` (`src/utils/creditPeriods.ts`) returns **`null` for

--- a/docs/log/2026-08-11-chat-usage-settings.md
+++ b/docs/log/2026-08-11-chat-usage-settings.md
@@ -1,0 +1,15 @@
+## 2026-08-11
+
+**Update**
+
+- Added localized purpose descriptions to the Tutor and Explainer mode
+  tooltips, including accessible button names.
+- Replaced deployment/provider model descriptions with localized explanations
+  of automatic, reasoning, general-purpose, and fallback model behavior.
+- Added a sidebar-mobile credit balance and fallback notice that stays visible
+  while the drawer is closed; embedded mode keeps its existing compact bar.
+- Added store and Playwright coverage for persisted-model fallback selection,
+  provider-neutral settings copy, mode explanations, and the mobile zero-credit
+  state.
+- Documented the UI and E2E contracts in [Chat Platform](../chat-platform.md)
+  and the [Playwright skill](../../.agents/skills/klicker-playwright-e2e/SKILL.md).

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -3,17 +3,30 @@ export default {
     modes: {
       switcherLabel: 'Chat-Modus',
       tutor: 'Tutor',
+      tutorDescription:
+        'Erhalte geduldige, schrittweise Hilfe bei Deinen Fragen.',
       explainer: 'Erklärer',
+      explainerDescription:
+        'Erhalte klare Erklärungen zu schwierigen Konzepten.',
     },
     settingsPanel: {
       title: 'Einstellungen',
       aiModelLabel: 'KI-Modell',
       selectAiModel: 'KI-Modell auswählen',
+      autoModelDescription:
+        'Wählt automatisch für jede Nachricht ein passendes Modell aus.',
+      reasoningModelDescription:
+        'Für schwierige Aufgaben mit mehreren Schritten. Die Antwort kann länger dauern und mehr Credits verbrauchen.',
+      standardModelDescription:
+        'Ein vielseitiges Modell für alltägliche Fragen.',
+      fallbackModelDescription:
+        'Verbraucht weniger Credits und bleibt verfügbar, wenn Deine Credits aufgebraucht sind.',
       autoSelectionInfo:
-        'Automatische Auswahl basierend auf verfügbaren Credits.',
+        'KlickerUZH wählt für jede Nachricht ein passendes Modell aus.',
       usingPrimaryModel:
-        'Primäres Modell wird mit verfügbaren Credits verwendet.',
-      usingFallbackModel: 'Ausweichmodell wird verwendet (keine Credits mehr).',
+        'Das Standardmodell wird verwendet, solange Credits verfügbar sind.',
+      usingFallbackModel:
+        'Es sind keine Credits mehr übrig. Neue Nachrichten verwenden daher das kleinere Modell.',
       reasoningEffortLabel: 'Denkaufwand',
       selectReasoningEffort: 'Denkaufwand auswählen',
       reasoningEffortHint:
@@ -35,6 +48,8 @@ export default {
       resetNone: 'Diese Credits werden nicht automatisch aufgefüllt.',
       exhausted:
         'Du hast alle Deine Credits aufgebraucht. Du kannst jedoch weiterhin das kleinere Modell verwenden.',
+      fallbackNotice:
+        'Deine Credits sind aufgebraucht. Neue Nachrichten verwenden das kleinere Modell.',
     },
     sidebar: {
       newChat: 'Neuer Chat',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -3,15 +3,28 @@ export default {
     modes: {
       switcherLabel: 'Chat mode',
       tutor: 'Tutor',
+      tutorDescription: 'Get patient, step-by-step help with your questions.',
       explainer: 'Explainer',
+      explainerDescription: 'Get clear explanations of difficult concepts.',
     },
     settingsPanel: {
       title: 'Settings',
       aiModelLabel: 'AI Model',
       selectAiModel: 'Select AI Model',
-      autoSelectionInfo: 'Automatic selection based on credit availability.',
-      usingPrimaryModel: 'Using primary model with available credits.',
-      usingFallbackModel: 'Using fallback model (no credits remaining).',
+      autoModelDescription:
+        'Automatically chooses a suitable model for each message.',
+      reasoningModelDescription:
+        'Built for difficult, multi-step questions. It may take longer and use more credits.',
+      standardModelDescription:
+        'A general-purpose model for everyday questions.',
+      fallbackModelDescription:
+        'Uses fewer credits and remains available when your credits run out.',
+      autoSelectionInfo:
+        'KlickerUZH chooses a suitable model for each message.',
+      usingPrimaryModel:
+        'The standard model is used while credits are available.',
+      usingFallbackModel:
+        'No credits remain, so new messages use the smaller model.',
       reasoningEffortLabel: 'Reasoning Effort',
       selectReasoningEffort: 'Select reasoning effort',
       reasoningEffortHint:
@@ -33,6 +46,8 @@ export default {
       resetNone: 'These credits do not refill automatically.',
       exhausted:
         'You have used up all your credits. However, you can still use the smaller model.',
+      fallbackNotice:
+        'Your credits are used up. New messages use the smaller model.',
     },
     sidebar: {
       newChat: 'New Chat',

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -1325,13 +1325,13 @@ test.describe('Chatbot Settings Panel', () => {
     await visitChat(page)
 
     await page.getByTestId('chat-mode-option-tutor').hover()
-    await expect(page.getByTestId('chat-mode-description-tutor')).toContainText(
-      'patient'
-    )
+    await expect(
+      page.getByRole('tooltip').getByTestId('chat-mode-description-tutor')
+    ).toContainText('patient')
 
     await page.getByTestId('chat-mode-option-explainer').hover()
     await expect(
-      page.getByTestId('chat-mode-description-explainer')
+      page.getByRole('tooltip').getByTestId('chat-mode-description-explainer')
     ).toContainText('difficult concepts')
   })
 

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -1321,6 +1321,20 @@ test.describe('Chatbot Settings Panel', () => {
     )
   })
 
+  test('Mode switcher explains what each mode is for', async ({ page }) => {
+    await visitChat(page)
+
+    await page.getByTestId('chat-mode-option-tutor').hover()
+    await expect(page.getByTestId('chat-mode-description-tutor')).toContainText(
+      'patient'
+    )
+
+    await page.getByTestId('chat-mode-option-explainer').hover()
+    await expect(
+      page.getByTestId('chat-mode-description-explainer')
+    ).toContainText('difficult concepts')
+  })
+
   test('AI model section displays current model (automatic mode)', async ({
     page,
   }) => {
@@ -1356,6 +1370,27 @@ test.describe('Chatbot Settings Panel', () => {
     )
     await expect(page.getByTestId('chat-credits-empty-message')).toContainText(
       'You have used up all your credits'
+    )
+
+    await openSettings(page)
+    await expect(page.getByTestId('chat-model-selection')).toContainText(
+      'GPT-4.1 Mini'
+    )
+  })
+
+  test('Mobile keeps the credit balance and fallback notice outside the sidebar', async ({
+    page,
+  }) => {
+    await setCredits(participantId, 0, 100)
+    await page.setViewportSize({ width: 390, height: 844 })
+    await visitChat(page)
+
+    await expect(page.getByTestId('chat-mobile-credits-bar')).toBeVisible()
+    await expect(page.getByTestId('chat-mobile-credits-display')).toContainText(
+      '0 / 100'
+    )
+    await expect(page.getByTestId('chat-mobile-fallback-notice')).toContainText(
+      'New messages use the smaller model'
     )
   })
 
@@ -1399,6 +1434,23 @@ test.describe('Chatbot Settings Panel', () => {
       'assistant reply #1',
       { timeout: 15_000 }
     )
+  })
+
+  test('Model descriptions explain capabilities without provider jargon', async ({
+    page,
+  }) => {
+    await setModelSelection(participantId, true)
+    await visitChat(page)
+    await openSettings(page)
+
+    const modelSection = page.getByTestId('chat-model-selection')
+    await selectOption(page, '[data-cy="chat-model-select"]', 'GPT-5.6 Luna')
+
+    await expect(modelSection).toContainText(
+      'Built for difficult, multi-step questions'
+    )
+    await expect(modelSection).not.toContainText('LiteLLM')
+    await expect(modelSection).not.toContainText('OpenAI reasoning model')
   })
 
   // The selector only appears for a model that supports reasoning with more

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -423,6 +423,18 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   retry/return actions and no raw server error; after the throw was removed,
   clicking Retry refreshed the route back to the authenticated composer. The
   same fault-injection and retry proof passed in German at 1440x900.
+- Verified for layer 03 (2026-08-11) in the real in-app Browser after the
+  documented devrouter restart: EN desktop shows the informative Tutor
+  tooltip and provider-neutral model descriptions; EN mobile at 390x844 keeps
+  the `0 / 100` balance and fallback notice below the header while the sidebar
+  is closed; DE desktop reconciles a persisted premium selection to the
+  `GPT-4.1 Mini` fallback at zero credits with localized copy; and EN/DE
+  embedded layouts show only the existing `EmbeddedCreditsBar`, not the
+  sidebar mobile bar. The
+  seeded test balance was restored to 100 after the proof. Focused Playwright
+  reached all four new tests but remains blocked before assertions because the
+  DevPod lacks the Chromium headless shell; hosted CI remains the automated
+  gate.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,


### PR DESCRIPTION
## What this changes

This is layer 03 of the [student-chat UX remediation stack](https://github.com/uzh-bf/klicker-uzh/blob/rs/chat-ux-audit/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md). It makes usage and model choices understandable at the point of choice:

- Mode and model controls explain concepts in student language without provider jargon.
- Credit balance and exhausted-credit fallback state are visible in the correct desktop, mobile, and embedded contexts.
- Persisted unavailable premium selections reconcile to the configured fallback model, and the outgoing request uses the reconciled selection.
- Fractional credit balances remain intact rather than being rounded away.
- The settings-store and zero-credit journeys cover the fallback contract in EN and DE.

## Stack position

- Base: `rs/chat-ux-error-states` at `5fec773454350eed295af4adacb0ceaabd8a5906`
- Head: `rs/chat-ux-usage-settings` at `fceb36471313999993f7d9853f939dc18895e9fb`
- Depends on: [PR #5358](https://github.com/uzh-bf/klicker-uzh/pull/5358)
- This PR remains draft and is not ready to merge independently of the stack.
- Substantive size: **266 changed lines** (242 additions, 24 deletions), excluding the 12-line project roadmap update. This clears the approximately 50-line packaging floor.

## Visual evidence

The real in-app Browser verified the informative Tutor tooltip and provider-neutral descriptions on EN desktop; the `0 / 100` balance and fallback notice on EN mobile; localized fallback reconciliation for a persisted premium selection on DE desktop; and the embedded layout's single existing credits bar in both EN and DE. The seeded test balance was restored after the proof.

## Verification

- Chat package typecheck and lint pass; lint has the repository's five pre-existing warnings and no errors.
- The integrated stack head passes `pnpm --filter @klicker-uzh/chat test:run` with 31 files and 239 tests.
- Root `pnpm run check:all` passes all 24 workspace tasks.
- The chat production build passes.
- Focused local Playwright remains blocked by the missing Chromium headless shell in the DevPod; hosted CI is the automated browser gate.

## Review focus

- Confirm model and mode explanations remain provider-neutral and localized.
- Confirm zero-credit reconciliation keeps the UI, store, and outgoing request on the same fallback model.
- Confirm desktop, mobile, and embedded layouts do not duplicate credit indicators.
## Current stack readback — 2026-08-12

The live GitHub stack currently reports head `rs/chat-ux-usage-settings@b026700` · base `rs/chat-ux-error-states@aa5f217`.
Required checks: all pass on the current head after the provider-side `pnpm/action-setup` retry.
All seven PRs remain drafts with no recorded human review decision. GitHub reports this PR as mergeable but blocked by the draft/review/check gates; this readback does not mark it ready or authorize merge.
