### PR TITLE
enhance(chat): polish conversation presentation

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -34,10 +34,11 @@ intermediate state until the test releases it. Use that seam to test the assista
 row while it is still streaming, and capture DOM identity around feedback clicks
 when the bug concerns remounts or flicker. A passing final-text assertion alone
 does not prove that the conversation stayed mounted.
-For message-presentation changes, include a heading-rich answer and a streamed
-failure in the focused browser contract: headings should remain hierarchical and
-proportional, while failed assistant turns should not expose reload, rating, or
-relative-time metadata alongside their dedicated retry callout.
+For message-presentation changes, include a heading-rich answer and both explicit
+and silent streamed failures in the focused browser contract: headings should
+remain hierarchical and proportional, while failed assistant turns should not
+expose reload, rating, or relative-time metadata alongside their dedicated retry
+callout.
 
 Direct checks for `auth`, `chat`, `frontend-control`, `frontend-manage`, and `frontend-pwa` generate ignored Next route types first through each app's `check` script. Do not hand-edit or commit `next-env.d.ts`; keep it ignored and included by `tsconfig.json`. The three PWA apps use `tsconfig.check.json` only for raw package checks so stale `.next/dev/types` cannot duplicate fresh Pages Router validators. Next builds use the canonical `tsconfig.json`; Next 16 filters development validators on its production typecheck path. Auth and Chat use their main config for both checks and builds.
 

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -34,6 +34,10 @@ intermediate state until the test releases it. Use that seam to test the assista
 row while it is still streaming, and capture DOM identity around feedback clicks
 when the bug concerns remounts or flicker. A passing final-text assertion alone
 does not prove that the conversation stayed mounted.
+For message-presentation changes, include a heading-rich answer and a streamed
+failure in the focused browser contract: headings should remain hierarchical and
+proportional, while failed assistant turns should not expose reload, rating, or
+relative-time metadata alongside their dedicated retry callout.
 
 Direct checks for `auth`, `chat`, `frontend-control`, `frontend-manage`, and `frontend-pwa` generate ignored Next route types first through each app's `check` script. Do not hand-edit or commit `next-env.d.ts`; keep it ignored and included by `tsconfig.json`. The three PWA apps use `tsconfig.check.json` only for raw package checks so stale `.next/dev/types` cannot duplicate fresh Pages Router validators. Next builds use the canonical `tsconfig.json`; Next 16 filters development validators on its production typecheck path. Auth and Chat use their main config for both checks and builds.
 

--- a/apps/chat/src/components/markdown-text.tsx
+++ b/apps/chat/src/components/markdown-text.tsx
@@ -131,7 +131,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h5: ({ className, ...props }) => (
     <h6
       className={cn(
-        'my-3 text-base font-semibold text-pretty first:mt-0 last:mb-0',
+        'my-3 text-[15px] font-semibold text-pretty first:mt-0 last:mb-0 sm:text-base',
         className
       )}
       {...props}

--- a/apps/chat/src/components/markdown-text.tsx
+++ b/apps/chat/src/components/markdown-text.tsx
@@ -138,12 +138,14 @@ const defaultComponents = memoizeMarkdownComponents({
     />
   ),
   h6: ({ className, ...props }) => (
-    <h6
+    <div
+      {...props}
+      role="heading"
+      aria-level={7}
       className={cn(
         'my-3 text-sm font-semibold text-pretty first:mt-0 last:mb-0',
         className
       )}
-      {...props}
     />
   ),
   p: ({ className, ...props }) => (

--- a/apps/chat/src/components/markdown-text.tsx
+++ b/apps/chat/src/components/markdown-text.tsx
@@ -89,48 +89,49 @@ const useCopyToClipboard = ({
 }
 
 const defaultComponents = memoizeMarkdownComponents({
-  // Rendered as h2: the chatbot name is the page's single h1, so message
-  // headings must not compete at the same rank (visual size unchanged).
+  // Shift Markdown headings down one level because the chatbot shell owns the
+  // page's h1. The smaller scale keeps answer structure readable without
+  // making a chat bubble look like a document title page.
   h1: ({ className, ...props }) => (
     <h2
       className={cn(
-        'mb-8 scroll-m-20 text-4xl font-extrabold tracking-tight last:mb-0',
+        'mb-4 scroll-m-20 text-2xl font-extrabold tracking-tight text-pretty last:mb-0 sm:text-3xl',
         className
       )}
       {...props}
     />
   ),
   h2: ({ className, ...props }) => (
-    <h2
+    <h3
       className={cn(
-        'mb-4 mt-8 scroll-m-20 text-3xl font-semibold tracking-tight first:mt-0 last:mb-0',
+        'mb-4 mt-6 scroll-m-20 text-xl font-semibold tracking-tight text-pretty first:mt-0 last:mb-0 sm:text-2xl',
         className
       )}
       {...props}
     />
   ),
   h3: ({ className, ...props }) => (
-    <h3
+    <h4
       className={cn(
-        'mb-4 mt-6 scroll-m-20 text-2xl font-semibold tracking-tight first:mt-0 last:mb-0',
+        'mb-3 mt-5 scroll-m-20 text-lg font-semibold tracking-tight text-pretty first:mt-0 last:mb-0 sm:text-xl',
         className
       )}
       {...props}
     />
   ),
   h4: ({ className, ...props }) => (
-    <h4
+    <h5
       className={cn(
-        'mb-4 mt-6 scroll-m-20 text-xl font-semibold tracking-tight first:mt-0 last:mb-0',
+        'mb-3 mt-4 scroll-m-20 text-base font-semibold tracking-tight text-pretty first:mt-0 last:mb-0 sm:text-lg',
         className
       )}
       {...props}
     />
   ),
   h5: ({ className, ...props }) => (
-    <h5
+    <h6
       className={cn(
-        'my-4 text-lg font-semibold first:mt-0 last:mb-0',
+        'my-3 text-base font-semibold text-pretty first:mt-0 last:mb-0',
         className
       )}
       {...props}
@@ -138,7 +139,10 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   h6: ({ className, ...props }) => (
     <h6
-      className={cn('my-4 font-semibold first:mt-0 last:mb-0', className)}
+      className={cn(
+        'my-3 text-sm font-semibold text-pretty first:mt-0 last:mb-0',
+        className
+      )}
       {...props}
     />
   ),

--- a/apps/chat/src/components/mode-switcher.tsx
+++ b/apps/chat/src/components/mode-switcher.tsx
@@ -7,14 +7,24 @@ import {
   getModeDescription,
   getModeIcon,
   isKnownMode,
+  resolveSelectedMode,
 } from '../lib/config/modes'
 import { useSettingsStore } from '../stores/settingsStore'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 
-export function ModeSwitcher() {
+export function ModeSwitcher({
+  modeOptions: modeOptionsOverride,
+}: {
+  modeOptions?: Record<string, string>
+} = {}) {
   const t = useTranslations()
-  const { modeOptions, selectedMode, setSelectedMode } = useSettingsStore()
+  const storeModeOptions = useSettingsStore((state) => state.modeOptions)
+  const selectedMode = useSettingsStore((state) => state.selectedMode)
+  const setSelectedMode = useSettingsStore((state) => state.setSelectedMode)
+  const modeOptions = modeOptionsOverride ?? storeModeOptions
   const modeKeys = Object.keys(modeOptions)
+  const modeKeysSignature = modeKeys.join('|')
+  const effectiveSelectedMode = resolveSelectedMode(modeOptions, selectedMode)
 
   const containerRef = useRef<HTMLDivElement>(null)
   const buttonRefs = useRef(new Map<string, HTMLButtonElement>())
@@ -26,7 +36,7 @@ export function ModeSwitcher() {
 
   useLayoutEffect(() => {
     const measure = () => {
-      const activeButton = buttonRefs.current.get(selectedMode)
+      const activeButton = buttonRefs.current.get(effectiveSelectedMode)
       if (!activeButton) return
       setThumb({
         left: activeButton.offsetLeft,
@@ -43,7 +53,7 @@ export function ModeSwitcher() {
     const observer = new ResizeObserver(measure)
     buttonRefs.current.forEach((button) => observer.observe(button))
     return () => observer.disconnect()
-  }, [selectedMode, modeKeys.join('|')])
+  }, [effectiveSelectedMode, modeKeysSignature])
 
   // Nothing to switch between when a chatbot exposes a single mode.
   if (modeKeys.length <= 1) return null
@@ -72,7 +82,7 @@ export function ModeSwitcher() {
           ? t(`chat.modes.${mode}`)
           : mode.charAt(0).toUpperCase() + mode.slice(1)
         const description = getModeDescription(t, mode, modeOptions)
-        const isActive = mode === selectedMode
+        const isActive = mode === effectiveSelectedMode
 
         return (
           <Tooltip key={mode}>

--- a/apps/chat/src/components/mode-switcher.tsx
+++ b/apps/chat/src/components/mode-switcher.tsx
@@ -14,8 +14,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 
 export function ModeSwitcher({
   modeOptions: modeOptionsOverride,
+  testIdPrefix = 'chat-mode',
 }: {
   modeOptions?: Record<string, string>
+  testIdPrefix?: string
 } = {}) {
   const t = useTranslations()
   const storeModeOptions = useSettingsStore((state) => state.modeOptions)
@@ -63,7 +65,7 @@ export function ModeSwitcher({
       ref={containerRef}
       role="group"
       aria-label={t('chat.modes.switcherLabel')}
-      data-cy="chat-mode-switcher"
+      data-cy={`${testIdPrefix}-switcher`}
       className="bg-muted scrollbar-none relative flex max-w-full items-center gap-0.5 overflow-x-auto rounded-full p-0.5"
     >
       {thumb && (
@@ -95,7 +97,7 @@ export function ModeSwitcher({
                 type="button"
                 aria-pressed={isActive}
                 aria-label={description ? `${label}: ${description}` : label}
-                data-cy={`chat-mode-option-${mode}`}
+                data-cy={`${testIdPrefix}-option-${mode}`}
                 onClick={() => setSelectedMode(mode)}
                 className={twMerge(
                   'relative z-10 inline-flex min-h-11 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-colors touch-manipulation fine-pointer:min-h-8',
@@ -116,7 +118,10 @@ export function ModeSwitcher({
             <TooltipContent className="max-w-64 text-left text-pretty">
               <p className="font-medium">{label}</p>
               {description ? (
-                <p data-cy={`chat-mode-description-${mode}`} className="mt-1">
+                <p
+                  data-cy={`${testIdPrefix}-description-${mode}`}
+                  className="mt-1"
+                >
                   {description}
                 </p>
               ) : null}

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -172,6 +172,11 @@ const MessageMetadata: FC<{ includeCredits?: boolean }> = ({
     return null
   }
 
+  // A failed turn has its own localized callout and retry action. The normal
+  // answer timestamp and feedback controls would make an incomplete response
+  // look like a finished answer that is ready to rate.
+  if (hasChatError(message)) return null
+
   const custom = message.metadata?.custom ?? {}
   const chatMode = typeof custom.chatMode === 'string' ? custom.chatMode : null
   const modelId = typeof custom.modelId === 'string' ? custom.modelId : null
@@ -1424,6 +1429,7 @@ const AssistantActionBar: FC<{ embedded?: boolean }> = ({ embedded }) => {
   const { showMessageActions } = useChatUi()
   const message = useMessage() as MessageWithCustomMetadata
   if (!showMessageActions) return null
+  const hasError = hasChatError(message)
 
   return (
     <div
@@ -1455,7 +1461,7 @@ const AssistantActionBar: FC<{ embedded?: boolean }> = ({ embedded }) => {
           </TooltipTrigger>
           <TooltipContent>{t('chat.message.copy')}</TooltipContent>
         </Tooltip>
-        {!hasChatError(message) && (
+        {!hasError && (
           <Tooltip>
             <TooltipTrigger asChild>
               <ActionBarPrimitive.Reload asChild>
@@ -1472,7 +1478,7 @@ const AssistantActionBar: FC<{ embedded?: boolean }> = ({ embedded }) => {
           </Tooltip>
         )}
 
-        <MessageRatingButtons />
+        {!hasError && <MessageRatingButtons />}
 
         <BranchPickerWrapper />
       </ActionBarPrimitive.Root>

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -76,6 +76,7 @@ import { MessageAttachments } from './message-attachments'
 import { AssistantMessageParts } from './message-parts'
 import { hasChatError } from './message-parts-state'
 import { MessageSourcesProvider } from './message-sources-context'
+import { ModeSwitcher } from './mode-switcher'
 import { SourcesSection } from './sources-section'
 import { formatCredits } from './thread-credits-format'
 import { actionBarButtonClassName } from './ui/action-bar-button'
@@ -466,11 +467,16 @@ const ThreadWelcome: FC<{
             {modeLabel && (
               <div
                 data-cy="chat-welcome-mode"
-                className="bg-muted/60 text-foreground animate-in fade-in slide-in-from-bottom-2 mt-5 max-w-md rounded-xl px-4 py-3 text-left text-sm delay-150 duration-300 motion-reduce:animate-none"
+                className="border-border bg-muted/60 text-foreground animate-in fade-in slide-in-from-bottom-2 mt-5 max-w-md rounded-xl border px-4 py-3 text-left text-sm shadow-sm delay-150 duration-300 motion-reduce:animate-none"
               >
                 <p className="font-medium">
                   {t('chat.thread.welcomeMode', { mode: modeLabel })}
                 </p>
+                {Object.keys(modeOptions).length > 1 && (
+                  <div className="mt-3 flex justify-center">
+                    <ModeSwitcher modeOptions={modeOptions} />
+                  </div>
+                )}
                 {modeDescription ? (
                   <p className="text-muted-foreground mt-1 text-pretty">
                     {modeDescription}
@@ -518,7 +524,7 @@ const ThreadWelcomeSuggestions: FC<{
             key={suggestion.id}
             data-cy="chat-welcome-suggestion"
             className={twMerge(
-              'border-border bg-background hover:bg-accent animate-in fade-in slide-in-from-bottom-2 min-h-11 rounded-lg border p-3 text-left text-sm transition-colors duration-300 motion-reduce:animate-none',
+              'border-foreground/15 bg-background hover:border-primary/30 hover:bg-accent animate-in fade-in slide-in-from-bottom-2 min-h-11 rounded-lg border p-3 text-left text-sm shadow-sm transition-colors duration-300 motion-reduce:animate-none',
               SUGGESTION_DELAY_CLASSNAMES[index] ?? 'delay-200'
             )}
             prompt={t(`chat.suggestions.${suggestion.id}Prompt`)}

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -474,7 +474,10 @@ const ThreadWelcome: FC<{
                 </p>
                 {Object.keys(modeOptions).length > 1 && (
                   <div className="mt-3 flex justify-center">
-                    <ModeSwitcher modeOptions={modeOptions} />
+                    <ModeSwitcher
+                      modeOptions={modeOptions}
+                      testIdPrefix="chat-welcome-mode"
+                    />
                   </div>
                 )}
                 {modeDescription ? (

--- a/apps/chat/src/hooks/useChatResponse.ts
+++ b/apps/chat/src/hooks/useChatResponse.ts
@@ -589,12 +589,15 @@ export function useChatResponse(
               text: `\n\n_(${t('chat.response.truncated')})_`,
             })
           } else if (!hasFinishEvent && !hasStreamError) {
-            // only append the interrupted-connection suffix when the stream
-            // just cut out silently; a stream 'error' part already added its
-            // own error bubble above, so don't stack this on top of it
+            // Treat a silent stream cutoff like an explicit stream error so
+            // the incomplete answer keeps the same retry-only presentation.
             orderedContentParts.push({
-              type: 'text',
-              text: `\n\n_(${t('chat.response.connectionInterrupted')})_`,
+              type: 'data',
+              name: 'chat-error',
+              data: {
+                errorLabel: t('chat.response.errorLabel'),
+                message: t('chat.response.connectionInterrupted'),
+              },
             })
           }
 

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -233,6 +233,9 @@ empty one, overrides the localized generic mode explanation; the synthesized Tut
 the localized generic copy. Message action bars
 remain mounted for touch users rather than relying on hover. An unavailable image edit uses
 `aria-disabled` instead of native `disabled`, so its explanatory Radix tooltip remains focusable.
+Failed assistant turns keep their own localized retry callout but omit the normal reload and
+thumbs-rating actions and the relative timestamp, so an incomplete answer is not presented as a
+finished answer ready for feedback.
 Each thread row shows the thread's last chat mode as an icon plus localized label under the title
 (`thread.lastChatMode` via `formatModeLabel`), and Markdown blockquotes in answers render as
 amber info callouts (the `blockquote` override in `markdown-text.tsx`, which only assistant

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -233,9 +233,9 @@ empty one, overrides the localized generic mode explanation; the synthesized Tut
 the localized generic copy. Message action bars
 remain mounted for touch users rather than relying on hover. An unavailable image edit uses
 `aria-disabled` instead of native `disabled`, so its explanatory Radix tooltip remains focusable.
-Failed assistant turns keep their own localized retry callout but omit the normal reload and
-thumbs-rating actions and the relative timestamp, so an incomplete answer is not presented as a
-finished answer ready for feedback.
+Failed assistant turns, including silent stream interruptions, keep their own localized retry
+callout but omit the normal reload and thumbs-rating actions and the relative timestamp, so an
+incomplete answer is not presented as a finished answer ready for feedback.
 Each thread row shows the thread's last chat mode as an icon plus localized label under the title
 (`thread.lastChatMode` via `formatModeLabel`), and Markdown blockquotes in answers render as
 amber info callouts (the `blockquote` override in `markdown-text.tsx`, which only assistant

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -230,7 +230,8 @@ needs a separate structured planning flow and tool/result budget. Chatbot-scoped
 are supplied with the initial shell, so the welcome view and starters do not wait for the settings
 request or briefly render the wrong persisted mode. A genuine configured description, including an
 empty one, overrides the localized generic mode explanation; the synthesized Tutor fallback keeps
-the localized generic copy. Message action bars
+the localized generic copy. On an empty thread, the selected-mode card also renders the same mode
+switcher as the header, so participants can change modes before choosing a starter. Message action bars
 remain mounted for touch users rather than relying on hover. An unavailable image edit uses
 `aria-disabled` instead of native `disabled`, so its explanatory Radix tooltip remains focusable.
 Failed assistant turns, including silent stream interruptions, keep their own localized retry

--- a/docs/log/2026-08-11-chat-conversation-polish.md
+++ b/docs/log/2026-08-11-chat-conversation-polish.md
@@ -2,3 +2,4 @@
 
 - **Update**: [chat-platform](../chat-platform.md) now records that failed assistant turns keep only their dedicated retry callout and omit normal reload, rating, and relative-time metadata.
 - **Update**: [testing verification](../../.agents/skills/klicker-testing-verification/SKILL.md) records the heading-rich and streamed-failure browser contracts for chat conversation presentation.
+- **Update**: Silent stream interruptions now use the same retry-only error callout as explicit stream errors, and deep Markdown headings retain a distinct accessible level.

--- a/docs/log/2026-08-11-chat-conversation-polish.md
+++ b/docs/log/2026-08-11-chat-conversation-polish.md
@@ -1,0 +1,4 @@
+## 2026-08-11
+
+- **Update**: [chat-platform](../chat-platform.md) now records that failed assistant turns keep only their dedicated retry callout and omit normal reload, rating, and relative-time metadata.
+- **Update**: [testing verification](../../.agents/skills/klicker-testing-verification/SKILL.md) records the heading-rich and streamed-failure browser contracts for chat conversation presentation.

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -79,8 +79,8 @@ export default {
       openKlickerUzh: 'Open KlickerUZH',
     },
     branchPicker: {
-      previous: 'Previous branch',
-      next: 'Next branch',
+      previous: 'Previous version',
+      next: 'Next version',
     },
     disclaimer: {
       mediaTitle: 'Disclaimer media',

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -2150,11 +2150,13 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     const headingSelector =
       'h2, h3, h4, h5, h6, [role="heading"][aria-level="7"]'
     const readHeadingSizes = () =>
-      content.locator(headingSelector).evaluateAll((headings) =>
-        headings.map((heading) =>
-          Number.parseFloat(getComputedStyle(heading).fontSize)
+      content
+        .locator(headingSelector)
+        .evaluateAll((headings) =>
+          headings.map((heading) =>
+            Number.parseFloat(getComputedStyle(heading).fontSize)
+          )
         )
-      )
     const assertHeadingScale = (headingSizes: number[]) => {
       expect(headingSizes).toHaveLength(6)
       for (let index = 1; index < headingSizes.length; index += 1) {

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -2129,7 +2129,7 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     page,
   }) => {
     await mockChatStream(page, {
-      text: '# Main heading\n\n## Supporting heading\n\n### Detail heading',
+      text: '# Main heading\n\n## Supporting heading\n\n### Detail heading\n\n#### Fourth heading\n\n##### Fifth heading\n\n###### Sixth heading',
     })
     await visitChat(page)
 
@@ -2141,17 +2141,23 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     })
     await expect(content.locator('h3')).toContainText('Supporting heading')
     await expect(content.locator('h4')).toContainText('Detail heading')
+    await expect(content.locator('h5')).toContainText('Fourth heading')
+    await expect(content.locator('h6')).toContainText('Fifth heading')
+    await expect(
+      content.locator('[role="heading"][aria-level="7"]')
+    ).toContainText('Sixth heading')
 
     const headingSizes = await content
-      .locator('h2, h3, h4')
+      .locator('h2, h3, h4, h5, h6, [role="heading"][aria-level="7"]')
       .evaluateAll((headings) =>
         headings.map((heading) =>
           Number.parseFloat(getComputedStyle(heading).fontSize)
         )
       )
-    expect(headingSizes).toHaveLength(3)
-    expect(headingSizes[0]).toBeGreaterThan(headingSizes[1])
-    expect(headingSizes[1]).toBeGreaterThan(headingSizes[2])
+    expect(headingSizes).toHaveLength(6)
+    for (let index = 1; index < headingSizes.length; index += 1) {
+      expect(headingSizes[index - 1]).toBeGreaterThan(headingSizes[index])
+    }
     expect(Math.max(...headingSizes)).toBeLessThan(36)
   })
 
@@ -2216,6 +2222,31 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     await expect(
       page.getByTestId('chat-assistant-message-content')
     ).toContainText('Partial answer before the failure.')
+
+    const assistant = page.getByTestId('chat-assistant-message').last()
+    await expect(
+      assistant.getByTestId('chat-reload-message-button')
+    ).toHaveCount(0)
+    await expect(assistant.getByTestId('chat-rate-up-button')).toHaveCount(0)
+    await expect(assistant.getByTestId('chat-rate-down-button')).toHaveCount(0)
+    await expect(assistant.locator('time')).toHaveCount(0)
+  })
+
+  test('A silent stream interruption keeps failed-turn actions suppressed', async ({
+    page,
+  }) => {
+    await mockChatStream(page, {
+      text: 'Partial answer before the connection closed.',
+      omitFinish: true,
+    })
+    await visitChat(page)
+
+    await sendMessage(page, 'Trigger a silent interruption')
+
+    const callout = page.getByTestId('chat-message-error')
+    await expect(callout).toBeVisible({ timeout: 15_000 })
+    await expect(callout).toContainText('Connection interrupted')
+    await expect(callout.getByTestId('chat-retry-message-button')).toBeVisible()
 
     const assistant = page.getByTestId('chat-assistant-message').last()
     await expect(

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -1003,6 +1003,12 @@ test.describe('Chatbot Message Actions & Branching', () => {
     await expect(
       page.getByTestId('chat-branch-indicator').first()
     ).toContainText('/ 2')
+    await expect(
+      page.getByTestId('chat-branch-previous').first()
+    ).toHaveAccessibleName('Previous version')
+    await expect(
+      page.getByTestId('chat-branch-next').first()
+    ).toHaveAccessibleName('Next version')
   })
 
   test('Message tree: branches keep independent continuations and navigation restores them', async ({
@@ -2119,6 +2125,36 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     await setDisclaimerState(participantId, 'accepted')
   })
 
+  test('Heading-rich answers keep hierarchy and conversation scale', async ({
+    page,
+  }) => {
+    await mockChatStream(page, {
+      text: '# Main heading\n\n## Supporting heading\n\n### Detail heading',
+    })
+    await visitChat(page)
+
+    await sendMessage(page, 'Show me a structured answer')
+
+    const content = page.getByTestId('chat-assistant-message-content')
+    await expect(content.locator('h2')).toContainText('Main heading', {
+      timeout: 15_000,
+    })
+    await expect(content.locator('h3')).toContainText('Supporting heading')
+    await expect(content.locator('h4')).toContainText('Detail heading')
+
+    const headingSizes = await content
+      .locator('h2, h3, h4')
+      .evaluateAll((headings) =>
+        headings.map((heading) =>
+          Number.parseFloat(getComputedStyle(heading).fontSize)
+        )
+      )
+    expect(headingSizes).toHaveLength(3)
+    expect(headingSizes[0]).toBeGreaterThan(headingSizes[1])
+    expect(headingSizes[1]).toBeGreaterThan(headingSizes[2])
+    expect(Math.max(...headingSizes)).toBeLessThan(36)
+  })
+
   test('Caption under a streamed answer shows the mode and credit cost', async ({
     page,
   }) => {
@@ -2180,6 +2216,14 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
     await expect(
       page.getByTestId('chat-assistant-message-content')
     ).toContainText('Partial answer before the failure.')
+
+    const assistant = page.getByTestId('chat-assistant-message').last()
+    await expect(
+      assistant.getByTestId('chat-reload-message-button')
+    ).toHaveCount(0)
+    await expect(assistant.getByTestId('chat-rate-up-button')).toHaveCount(0)
+    await expect(assistant.getByTestId('chat-rate-down-button')).toHaveCount(0)
+    await expect(assistant.locator('time')).toHaveCount(0)
   })
 
   test('A length-truncated answer appends the truncation notice', async ({

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -2147,18 +2147,26 @@ test.describe('Chatbot Streamed Answer Metadata & Failure States', () => {
       content.locator('[role="heading"][aria-level="7"]')
     ).toContainText('Sixth heading')
 
-    const headingSizes = await content
-      .locator('h2, h3, h4, h5, h6, [role="heading"][aria-level="7"]')
-      .evaluateAll((headings) =>
+    const headingSelector =
+      'h2, h3, h4, h5, h6, [role="heading"][aria-level="7"]'
+    const readHeadingSizes = () =>
+      content.locator(headingSelector).evaluateAll((headings) =>
         headings.map((heading) =>
           Number.parseFloat(getComputedStyle(heading).fontSize)
         )
       )
-    expect(headingSizes).toHaveLength(6)
-    for (let index = 1; index < headingSizes.length; index += 1) {
-      expect(headingSizes[index - 1]).toBeGreaterThan(headingSizes[index])
+    const assertHeadingScale = (headingSizes: number[]) => {
+      expect(headingSizes).toHaveLength(6)
+      for (let index = 1; index < headingSizes.length; index += 1) {
+        expect(headingSizes[index - 1]).toBeGreaterThan(headingSizes[index])
+      }
+      expect(Math.max(...headingSizes)).toBeLessThan(36)
     }
-    expect(Math.max(...headingSizes)).toBeLessThan(36)
+
+    assertHeadingScale(await readHeadingSizes())
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    assertHeadingScale(await readHeadingSizes())
   })
 
   test('Caption under a streamed answer shows the mode and credit cost', async ({

--- a/playwright/util/chat.ts
+++ b/playwright/util/chat.ts
@@ -374,10 +374,12 @@ export type StreamOptions = {
   /** Emits an SSE `error` part after the text. The client stops reading there
    * and renders its error callout instead of finishing normally. */
   errorText?: string
+  /** Closes the stream after its text without emitting a finish event. */
+  omitFinish?: boolean
 }
 
 function makeStreamLines(text: string, options: StreamOptions = {}) {
-  const { metadata, toolCalls = [], errorText } = options
+  const { metadata, toolCalls = [], errorText, omitFinish } = options
 
   const lines = [
     `data: ${JSON.stringify({ type: 'start' })}`,
@@ -415,16 +417,18 @@ function makeStreamLines(text: string, options: StreamOptions = {}) {
     lines.push(`data: ${JSON.stringify({ type: 'error', errorText })}`)
   }
 
-  lines.push(
-    `data: ${JSON.stringify({ type: 'finish-step' })}`,
-    `data: ${JSON.stringify({
-      type: 'finish',
-      ...(metadata ? { messageMetadata: metadata } : {}),
-    })}`,
-    // Trailing line: the client keeps the last (possibly incomplete) line
-    // buffered, so nothing after this point is parsed anyway.
-    'data: [DONE]'
-  )
+  if (!omitFinish) {
+    lines.push(
+      `data: ${JSON.stringify({ type: 'finish-step' })}`,
+      `data: ${JSON.stringify({
+        type: 'finish',
+        ...(metadata ? { messageMetadata: metadata } : {}),
+      })}`,
+      // Trailing line: the client keeps the last (possibly incomplete) line
+      // buffered, so nothing after this point is parsed anyway.
+      'data: [DONE]'
+    )
+  }
 
   return lines
 }

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -469,13 +469,21 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   class-only and is covered by those package gates. Focused Playwright could
   not launch locally because the container lacks Chromium's
   `headless_shell-1208` executable; hosted CI remains the browser-runner gate.
-- Review follow-up (2026-08-11): the integrated review found that silent stream
-  interruptions bypassed failed-turn chrome and that source Markdown h5/h6
-  collapsed to one accessible level. Both fixes and their focused contracts are
-  now included in the working layer; the reviewed commit remains
-  `2854f753e` until this follow-up is committed.
-- Next: rerun the package gates and integrated final review on the follow-up,
-  then push and create its draft PR before closing the stack.
+- Review follow-up (2026-08-11): integrated review findings are resolved in
+  `fd1bc9c60`. Silent stream interruptions now use the same localized retry
+  callout as explicit errors, and source Markdown h6 uses a distinct
+  `role="heading"`/`aria-level="7"` representation. Focused contracts cover
+  both paths and all six shifted heading levels.
+- Verification after the follow-up: chat typecheck, chat Vitest (31 files,
+  239 tests), repository `check:all` (24/24 tasks), production build,
+  Prettier, and gitleaks all passed. The real in-app Browser still showed the
+  branched heading treatment and mobile failed-turn chrome. Focused Playwright
+  launched the global setup but all three selected tests were blocked before
+  execution because `headless_shell-1208` is absent; hosted CI remains the
+  browser-runner gate. The configured simplifier could not authenticate because
+  its Claude OAuth token expired, so no simplifier finding is inferred.
+- Next: rerun the integrated final review on `ebcac875..fd1bc9c60`, record its
+  closure, then push and create the layer-05 draft PR before closing the stack.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -469,9 +469,13 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   class-only and is covered by those package gates. Focused Playwright could
   not launch locally because the container lacks Chromium's
   `headless_shell-1208` executable; hosted CI remains the browser-runner gate.
-- Next: commit the verified layer-05 package, run the required simplifier and
-  integrated final review, then push and create its draft PR before closing the
-  stack.
+- Review follow-up (2026-08-11): the integrated review found that silent stream
+  interruptions bypassed failed-turn chrome and that source Markdown h5/h6
+  collapsed to one accessible level. Both fixes and their focused contracts are
+  now included in the working layer; the reviewed commit remains
+  `2854f753e` until this follow-up is committed.
+- Next: rerun the package gates and integrated final review on the follow-up,
+  then push and create its draft PR before closing the stack.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -470,20 +470,22 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   not launch locally because the container lacks Chromium's
   `headless_shell-1208` executable; hosted CI remains the browser-runner gate.
 - Review follow-up (2026-08-11): integrated review findings are resolved in
-  `fd1bc9c60`. Silent stream interruptions now use the same localized retry
-  callout as explicit errors, and source Markdown h6 uses a distinct
-  `role="heading"`/`aria-level="7"` representation. Focused contracts cover
-  both paths and all six shifted heading levels.
+  `fd1bc9c60` and `c69a38cff`. Silent stream interruptions now use the same
+  localized retry callout as explicit errors, source Markdown h6 uses a
+  distinct `role="heading"`/`aria-level="7"` representation, and source h5
+  retains a distinct mobile size. Focused contracts cover both failure paths,
+  all six shifted heading levels, and desktop plus 390x844 scaling.
 - Verification after the follow-up: chat typecheck, chat Vitest (31 files,
-  239 tests), repository `check:all` (24/24 tasks), production build,
-  Prettier, and gitleaks all passed. The real in-app Browser still showed the
-  branched heading treatment and mobile failed-turn chrome. Focused Playwright
-  launched the global setup but all three selected tests were blocked before
-  execution because `headless_shell-1208` is absent; hosted CI remains the
-  browser-runner gate. The configured simplifier could not authenticate because
-  its Claude OAuth token expired, so no simplifier finding is inferred.
-- Next: rerun the integrated final review on `ebcac875..fd1bc9c60`, record its
-  closure, then push and create the layer-05 draft PR before closing the stack.
+  239 tests), repository `check:all` (24/24 tasks), Prettier, and gitleaks all
+  passed. The real in-app Browser still showed the branched heading treatment
+  and mobile failed-turn chrome. Focused Playwright launched the global setup
+  but all three selected tests were blocked before execution because
+  `headless_shell-1208` is absent; hosted CI remains the browser-runner gate.
+  The configured simplifier could not authenticate because its Claude OAuth
+  token expired, so no simplifier finding is inferred.
+- Next: run the production build and integrated final review on
+  `ebcac875..c69a38cff`, record closure, then push and create the layer-05 draft
+  PR before closing the stack.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -468,7 +468,8 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   `check:all` gate passed. The final `text-pretty` heading refinement is
   class-only and is covered by those package gates. Focused Playwright could
   not launch locally because the container lacks Chromium's
-  `headless_shell-1208` executable; hosted CI remains the browser-runner gate.
+  `headless_shell-1208` executable; hosted CI supplied the browser-runner
+  proof.
 - Review follow-up (2026-08-11): integrated review findings are resolved in
   `fd1bc9c60` and `c69a38cff`. Silent stream interruptions now use the same
   localized retry callout as explicit errors, source Markdown h6 uses a
@@ -480,13 +481,14 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   passed. The real in-app Browser still showed the branched heading treatment
   and mobile failed-turn chrome. Focused Playwright launched the global setup
   but all three selected tests were blocked before execution because
-  `headless_shell-1208` is absent; hosted CI remains the browser-runner gate.
+  `headless_shell-1208` is absent.
   The configured simplifier could not authenticate because its Claude OAuth
   token expired, so no simplifier finding is inferred.
 - Hosted CI for [PR #5363](https://github.com/uzh-bf/klicker-uzh/pull/5363)
-  passed its active checks: TypeScript, gitleaks, syncpack, CodeQL, Greptile,
-  and the related package status checks. The stack workflow skipped the chat
-  test and image-build jobs.
+  passed all active checks, including all eight Playwright shards and
+  `test-playwright-status`, after the mode-tooltip assertion was scoped to the
+  visible tooltip. The stack workflow skipped the chat test and image-build
+  jobs. The final branch head is `c69364478`.
 - Next: keep all five PRs in draft for layer-by-layer human review. No ready,
   merge, or deployment action has been taken.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -457,8 +457,21 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   chatbot name and configured Tutor description. The welcome distinguishes
   genuine configured descriptions, including an intentionally empty value,
   from the synthesized Tutor fallback so fallback copy remains localized.
-- Next: push the reviewed layer-04 head, create or refresh the draft PRs for
-  layers 02–05, then implement and review layer 05 conversation presentation.
+- Current (2026-08-11): layer 05 conversation presentation is implemented on
+  `rs/chat-ux-conversation-polish`. Markdown headings now shift down one
+  semantic level and use conversation-scale typography; branch navigation uses
+  student-facing version copy; and failed assistant turns keep only their
+  dedicated retry callout, without reload/rating actions or relative timestamps.
+- Verification (2026-08-11): the real in-app Browser showed heading-rich,
+  branched, and failed responses in EN and DE on desktop and at 390x844; the
+  focused chat suite passed with 31 files and 239 tests, and the repository
+  `check:all` gate passed. The final `text-pretty` heading refinement is
+  class-only and is covered by those package gates. Focused Playwright could
+  not launch locally because the container lacks Chromium's
+  `headless_shell-1208` executable; hosted CI remains the browser-runner gate.
+- Next: commit the verified layer-05 package, run the required simplifier and
+  integrated final review, then push and create its draft PR before closing the
+  stack.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,

--- a/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
+++ b/project/2026-08-10-pr-5355-chat-ux-stacked-roadmap.md
@@ -483,9 +483,12 @@ evidence; they do not receive redundant implementation-coupled unit tests.
   `headless_shell-1208` is absent; hosted CI remains the browser-runner gate.
   The configured simplifier could not authenticate because its Claude OAuth
   token expired, so no simplifier finding is inferred.
-- Next: run the production build and integrated final review on
-  `ebcac875..c69a38cff`, record closure, then push and create the layer-05 draft
-  PR before closing the stack.
+- Hosted CI for [PR #5363](https://github.com/uzh-bf/klicker-uzh/pull/5363)
+  passed its active checks: TypeScript, gitleaks, syncpack, CodeQL, Greptile,
+  and the related package status checks. The stack workflow skipped the chat
+  test and image-build jobs.
+- Next: keep all five PRs in draft for layer-by-layer human review. No ready,
+  merge, or deployment action has been taken.
 - Intermediate review of the initial layer-02 commit `c7765925f` returned
   `NEEDS CHANGES`: the boundary used `reset`, which did not refresh a failed
   server layout payload. The follow-up fix uses Next 16's `unstable_retry`,


### PR DESCRIPTION
## Summary

Layer 05 completes the conversation-presentation pass from the [chat UX
roadmap](../2026-08-10-pr-5355-chat-ux-stacked-roadmap.md) on top of [PR
#5360](https://github.com/uzh-bf/klicker-uzh/pull/5360).

- Markdown answer headings shift one semantic level below the chatbot shell's
  page heading and use a proportional responsive scale, including a distinct
  accessible level for source h6.
- Branch navigation uses student-facing version language in English while
  preserving the existing German localization.
- Explicit stream errors and silent stream interruptions keep their localized
  retry callout without normal reload, rating, or relative-time metadata.
- The focused browser contracts cover all six heading levels, desktop and
  390x844 typography, explicit stream errors, and silent stream interruption.

## Scope and size

This is a complete, independently reviewable presentation package. It contains
181 substantive changed lines against the layer-04 head, excluding the roadmap
artifact. No dependency, database, authentication, or production configuration
changes are included.

## Verification

- `pnpm --filter @klicker-uzh/chat check` passed.
- `pnpm --filter @klicker-uzh/chat test:run` passed: 31 files and 239 tests.
- `pnpm run check:all` passed: 24/24 tasks.
- `pnpm --filter @klicker-uzh/chat build` passed.
- Prettier and staged gitleaks passed.
- Real in-app Browser proof covered the routed German branched-heading state
  and the 390x844 failed-turn state. The screenshots showed proportional
  headings, localized version controls, and a retry-only failed callout.
- The focused Playwright selection completed global setup but could not launch
  its three tests because Chromium is missing at
  `/root/.cache/ms-playwright/chromium_headless_shell-1208/chrome-linux/headless_shell`.
- Hosted CI passed all active checks, including all eight Playwright shards and
  `test-playwright-status`, after the mode-tooltip assertion was scoped to the
  visible tooltip. The stack workflow skipped the chat test and image-build
  jobs.
- The host pre-push hook could not run because its native Turborepo binary was
  for the wrong platform. The equivalent container build reached an unrelated,
  unchanged `apps/response-api/src/index.ts` Rollup parser error on its existing
  `type JWTPayload` import. This layer does not touch response-api.

## Review gates

- Integrated Sol review: approved for implementation range
  `ebcac87594b8e2b4c817d71fe653e030dda45922..535be10ef`; final branch head
  after the CI-only test correction and final roadmap update is `d4e1ed8ff`.
- Bounded security review: no high-confidence vulnerabilities identified.
- Strict maintainability review: approved with no actionable findings.
- The configured simplifier could not authenticate because its Claude OAuth
  token expired; no simplifier finding is inferred.

This PR remains a draft for layer-by-layer human review. No ready, merge, or
deployment action has been taken.
## Current stack readback — 2026-08-12

The live GitHub stack currently reports head `rs/chat-ux-conversation-polish@2290aa3` · base `rs/chat-ux-welcome-composer@2d64acf`.
Required checks: all pass on the current head after the provider-side setup retry.
All seven PRs remain drafts with no recorded human review decision. GitHub reports this PR as mergeable but blocked by the draft/review/check gates; this readback does not mark it ready or authorize merge.
