### PR TITLE
enhance(chat): add turn-scoped routing cost evidence

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -27,6 +27,33 @@ fixture uses injected OpenAI-compatible SSE with a sparse first tool-call index
 and proves public tool-call/finish conversion without a model key; it does not
 replace a real-upstream staging smoke test.
 
+For provider-option changes that must serialize through both OpenAI transports,
+also run the focused provider-options fixture:
+
+```bash
+pnpm --filter @klicker-uzh/chat exec vitest run test/openai-provider-options.test.ts test/openai-chat-streaming.test.ts
+```
+
+It checks the turn-scoped `metadata.session_id` and thread-stable
+`prompt_cache_key` on Chat Completions and Responses request bodies. This is
+local serialization evidence only; it does not prove deployed routing or
+provider cache hits.
+
+For aggregate gateway cost evidence, run the pure synthetic contract from
+`packages/prisma-data`:
+
+```bash
+pnpm exec tsx src/scripts/lib/aggregateCostReconciliation.test.ts
+```
+
+The report mode in
+`src/scripts/2026-06-16_analyze_chatbot_usage.ts` uses a half-open UTC window
+and secret-backed read-only Langfuse/LiteLLM access. It counts positive-cost
+generations and fails closed when cache buckets, scope, model/count parity, or
+cost reconciliation are incomplete. Never infer cache tokens from price drift
+and never report this aggregate mode as exact course allocation or Azure invoice
+proof.
+
 For chat conversation-rendering changes, `playwright/util/chat.ts` supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
 `ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -44,9 +44,11 @@ For aggregate gateway cost evidence, run the pure synthetic contract from
 
 ```bash
 pnpm exec tsx src/scripts/lib/aggregateCostReconciliation.test.ts
+pnpm exec tsx src/scripts/lib/litellmCostSource.test.ts
 ```
 
-The report mode in
+The first command covers aggregate reconciliation; the second covers the
+team-scoped, paginated LiteLLM request contract. The report mode in
 `src/scripts/2026-06-16_analyze_chatbot_usage.ts` uses a half-open UTC window
 and secret-backed read-only Langfuse/LiteLLM access. It counts positive-cost
 generations and fails closed when cache buckets, scope, model/count parity, or

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@/src/lib/server/langfuseTracing'
 import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions'
 import { getOpenAIResponsesStore } from '@/src/lib/server/openaiResponsesOptions'
+import { getOpenAIProviderOptions } from '@/src/lib/server/openaiProviderOptions'
 import {
   mapAssistantStepContent,
   type PersistedAssistantContentPart,
@@ -1206,6 +1207,10 @@ export async function POST(
   const traceId = isAiTelemetryEnabled
     ? await getTraceIdForMessage(assistantMessageId)
     : null
+  const openAIProviderOptions = await getOpenAIProviderOptions({
+    assistantMessageId,
+    owningThreadId: owningThread?.id ?? null,
+  })
 
   const startStream = () =>
     streamText({
@@ -1214,6 +1219,7 @@ export async function POST(
       telemetry: { isEnabled: isAiTelemetryEnabled },
       providerOptions: {
         openai: {
+          ...openAIProviderOptions,
           ...(selectedModelConfig.supportsReasoning && {
             store: getOpenAIResponsesStore(),
           }),

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -1210,6 +1210,7 @@ export async function POST(
   const openAIProviderOptions = await getOpenAIProviderOptions({
     assistantMessageId,
     owningThreadId: owningThread?.id ?? null,
+    routingSource: routing.source,
   })
 
   const startStream = () =>

--- a/apps/chat/src/lib/server/openaiProviderOptions.ts
+++ b/apps/chat/src/lib/server/openaiProviderOptions.ts
@@ -6,19 +6,39 @@ const PROMPT_CACHE_KEY_SEED = 'klicker:prompt-cache:v1:'
 type OpenAIProviderOptionsInput = {
   assistantMessageId: string
   owningThreadId: string | null
+  routingSource: 'custom' | 'default'
 }
+
+type DefaultOpenAIProviderOptions = {
+  metadata: { session_id: string }
+  promptCacheKey?: string
+}
+
+export function getOpenAIProviderOptions(
+  input: OpenAIProviderOptionsInput & { routingSource: 'default' }
+): Promise<DefaultOpenAIProviderOptions>
+export function getOpenAIProviderOptions(
+  input: OpenAIProviderOptionsInput & { routingSource: 'custom' }
+): Promise<Record<string, never>>
+export function getOpenAIProviderOptions(
+  input: OpenAIProviderOptionsInput
+): Promise<DefaultOpenAIProviderOptions | Record<string, never>>
 
 /**
  * Build provider fields that are stable for one response and one thread.
  *
- * LiteLLM reads metadata.session_id for routing affinity, while the OpenAI
- * provider uses promptCacheKey for prefix-cache locality. Both values stay
- * pseudonymous so provider requests do not expose Klicker database ids.
+ * The default route sends LiteLLM's metadata.session_id for routing affinity
+ * and the OpenAI provider's promptCacheKey for prefix-cache locality. Both
+ * values stay pseudonymous so provider requests do not expose Klicker
+ * database ids. Custom chatbot endpoints do not receive these gateway fields.
  */
 export async function getOpenAIProviderOptions({
   assistantMessageId,
   owningThreadId,
+  routingSource,
 }: OpenAIProviderOptionsInput) {
+  if (routingSource !== 'default') return {}
+
   const sessionId = await getTraceIdForMessage(assistantMessageId)
 
   return {

--- a/apps/chat/src/lib/server/openaiProviderOptions.ts
+++ b/apps/chat/src/lib/server/openaiProviderOptions.ts
@@ -1,0 +1,34 @@
+import { createTraceId } from '@langfuse/tracing'
+import { getTraceIdForMessage } from './langfuseTracing'
+
+const PROMPT_CACHE_KEY_SEED = 'klicker:prompt-cache:v1:'
+
+type OpenAIProviderOptionsInput = {
+  assistantMessageId: string
+  owningThreadId: string | null
+}
+
+/**
+ * Build provider fields that are stable for one response and one thread.
+ *
+ * LiteLLM reads metadata.session_id for routing affinity, while the OpenAI
+ * provider uses promptCacheKey for prefix-cache locality. Both values stay
+ * pseudonymous so provider requests do not expose Klicker database ids.
+ */
+export async function getOpenAIProviderOptions({
+  assistantMessageId,
+  owningThreadId,
+}: OpenAIProviderOptionsInput) {
+  const sessionId = await getTraceIdForMessage(assistantMessageId)
+
+  return {
+    metadata: { session_id: sessionId },
+    ...(owningThreadId
+      ? {
+          promptCacheKey: await createTraceId(
+            `${PROMPT_CACHE_KEY_SEED}${owningThreadId}`
+          ),
+        }
+      : {}),
+  }
+}

--- a/apps/chat/test/openai-provider-options.test.ts
+++ b/apps/chat/test/openai-provider-options.test.ts
@@ -73,6 +73,7 @@ describe('OpenAI provider routing and cache options', () => {
         openai: await getOpenAIProviderOptions({
           assistantMessageId: 'assistant-1',
           owningThreadId: 'thread-1',
+          routingSource: 'default',
         }),
       },
       tools: {
@@ -102,10 +103,12 @@ describe('OpenAI provider routing and cache options', () => {
     const first = await getOpenAIProviderOptions({
       assistantMessageId: 'assistant-1',
       owningThreadId: 'thread-1',
+      routingSource: 'default',
     })
     const second = await getOpenAIProviderOptions({
       assistantMessageId: 'assistant-2',
       owningThreadId: 'thread-1',
+      routingSource: 'default',
     })
 
     expect(first.metadata.session_id).not.toBe(second.metadata.session_id)
@@ -153,6 +156,7 @@ describe('OpenAI provider routing and cache options', () => {
     const options = await getOpenAIProviderOptions({
       assistantMessageId: 'assistant-1',
       owningThreadId: 'thread-1',
+      routingSource: 'default',
     })
 
     const result = await generateText({
@@ -171,9 +175,20 @@ describe('OpenAI provider routing and cache options', () => {
     const options = await getOpenAIProviderOptions({
       assistantMessageId: 'assistant-1',
       owningThreadId: null,
+      routingSource: 'default',
     })
 
     expect(options.metadata.session_id).toEqual(expect.any(String))
     expect(options).not.toHaveProperty('promptCacheKey')
+  })
+
+  test('does not send gateway options to custom chatbot endpoints', async () => {
+    const options = await getOpenAIProviderOptions({
+      assistantMessageId: 'assistant-1',
+      owningThreadId: 'thread-1',
+      routingSource: 'custom',
+    })
+
+    expect(options).toEqual({})
   })
 })

--- a/apps/chat/test/openai-provider-options.test.ts
+++ b/apps/chat/test/openai-provider-options.test.ts
@@ -1,0 +1,179 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateText, isStepCount, streamText, tool } from 'ai'
+import { describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
+import { getOpenAIProviderOptions } from '../src/lib/server/openaiProviderOptions'
+
+function openAIEventStream(chunks: unknown[]): string {
+  return `${chunks
+    .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+    .join('')}data: [DONE]\n\n`
+}
+
+describe('OpenAI provider routing and cache options', () => {
+  test('reuses one routing and cache key across a tool loop', async () => {
+    const toolInput = JSON.stringify({ query: 'vorkurs' })
+    const responses = [
+      openAIEventStream([
+        {
+          id: 'chatcmpl-tool',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call-vorkurs',
+                    type: 'function',
+                    function: {
+                      name: 'doc_query',
+                      arguments: toolInput,
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        },
+      ]),
+      openAIEventStream([
+        {
+          id: 'chatcmpl-answer',
+          choices: [
+            {
+              index: 0,
+              delta: { role: 'assistant', content: 'Answer' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      ]),
+    ]
+    const requestBodies: Record<string, unknown>[] = []
+    const fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)))
+      return new Response(responses[requestBodies.length - 1], {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    })
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch,
+    })
+
+    const result = streamText({
+      model: provider.chat('test-model'),
+      prompt: 'Find the Vorkurs information.',
+      providerOptions: {
+        openai: await getOpenAIProviderOptions({
+          assistantMessageId: 'assistant-1',
+          owningThreadId: 'thread-1',
+        }),
+      },
+      tools: {
+        doc_query: tool({
+          inputSchema: z.object({ query: z.string() }),
+          execute: async () => ({ result: 'course information' }),
+        }),
+      },
+      stopWhen: isStepCount(2),
+    })
+
+    await result.text
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(requestBodies).toHaveLength(2)
+    expect(requestBodies[0]?.metadata).toEqual(requestBodies[1]?.metadata)
+    expect(requestBodies[0]?.prompt_cache_key).toBe(
+      requestBodies[1]?.prompt_cache_key
+    )
+    expect(requestBodies[0]?.metadata).toMatchObject({
+      session_id: expect.any(String),
+    })
+    expect(requestBodies[0]?.prompt_cache_key).toEqual(expect.any(String))
+  })
+
+  test('changes the session key per response and keeps the thread cache key stable', async () => {
+    const first = await getOpenAIProviderOptions({
+      assistantMessageId: 'assistant-1',
+      owningThreadId: 'thread-1',
+    })
+    const second = await getOpenAIProviderOptions({
+      assistantMessageId: 'assistant-2',
+      owningThreadId: 'thread-1',
+    })
+
+    expect(first.metadata.session_id).not.toBe(second.metadata.session_id)
+    expect(first.promptCacheKey).toBe(second.promptCacheKey)
+  })
+
+  test('serializes the same options through the Responses API transport', async () => {
+    const requestBodies: Record<string, unknown>[] = []
+    const fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)))
+      return new Response(
+        JSON.stringify({
+          id: 'response-1',
+          created_at: 1,
+          model: 'gpt-5.6-sol',
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              id: 'message-1',
+              content: [
+                { type: 'output_text', text: 'Answer', annotations: [] },
+              ],
+              execution: 'server',
+              call_id: null,
+              status: 'completed',
+              arguments: null,
+            },
+          ],
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    })
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch,
+    })
+    const options = await getOpenAIProviderOptions({
+      assistantMessageId: 'assistant-1',
+      owningThreadId: 'thread-1',
+    })
+
+    const result = await generateText({
+      model: provider.responses('gpt-5.6-sol'),
+      prompt: 'Answer briefly.',
+      providerOptions: { openai: options },
+    })
+
+    expect(result.text).toBe('Answer')
+    expect(requestBodies).toHaveLength(1)
+    expect(requestBodies[0]?.metadata).toEqual(options.metadata)
+    expect(requestBodies[0]?.prompt_cache_key).toBe(options.promptCacheKey)
+  })
+
+  test('omits the cache key when thread ownership is unavailable', async () => {
+    const options = await getOpenAIProviderOptions({
+      assistantMessageId: 'assistant-1',
+      owningThreadId: null,
+    })
+
+    expect(options.metadata.session_id).toEqual(expect.any(String))
+    expect(options).not.toHaveProperty('promptCacheKey')
+  })
+})

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -125,11 +125,13 @@ For aggregate evidence, run the explicit
 `packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts:runGatewayCostReport`.
 The window is UTC and half-open. The mode reads Langfuse generation pages and
 LiteLLM spend rows in memory, emits model/count/token/cost aggregates as JSON,
-and never writes raw observations or credentials. It counts positive-cost
+and never writes raw observations or credentials. The date-based LiteLLM query
+is widened to the enclosing UTC dates, then each positive-cost row is filtered
+by its exact `startTime` and required team id. It counts positive-cost
 generations and requires the mutually exclusive algebra
 `input = uncached + cache-read + cache-write`; missing cache fields, scope
-drift, model/count drift, or cost drift fail closed. This is aggregate gateway
-evidence, not an exact course allocation or Azure invoice.
+or type drift, model/count/token drift, or cost drift fail closed. This is
+aggregate gateway evidence, not an exact course allocation or Azure invoice.
 
 Credit fields are Prisma `Decimal` — never truthy-check them ([Data & Migrations](./data-and-migrations.md)).
 `src/stores/settingsStore.ts:loadCredits` accepts only the latest request generation, so a late

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -2,7 +2,7 @@
 type: App Guide
 title: Chat Platform
 description: The apps/chat island — app router, zustand, assistant-ui, route-handler auth guards, and the model registry.
-timestamp: '2026-08-10'
+timestamp: '2026-08-11'
 tags:
   - frontend
   - chat
@@ -103,6 +103,33 @@ claim an end-to-end answer stream.
 - Omitted `supportsImageAttachments` defaults to **false** — every image-capable model must set it explicitly in deployment values or the attach button disappears.
 - Zero-credit course chatbots need a usable fallback model (`CHAT_FALLBACK_MODEL_ID`, default `gpt-4.1-mini`) AND explicit chatbot `allowedModelIds` must include it. Audit/fix with `packages/prisma-data/src/scripts/2026-06-15_ensure_chatbot_fallback_model.ts`.
 - OpenAI Responses backends: keep `CHAT_OPENAI_STORE_RESPONSES=true` in shared/staged deployments — with `store: false`, LiteLLM/Azure can return "item not found" when a model references prior response items across tool-call steps. Local OpenRouter-style setups can leave it false.
+
+### Turn and cost evidence
+
+`apps/chat/src/lib/server/openaiProviderOptions.ts:getOpenAIProviderOptions`
+derives two provider-only keys from existing identifiers. The assistant message
+id becomes a pseudonymous `metadata.session_id`, so all internal calls in one
+`streamText` tool loop share a turn key. The owning thread id becomes a stable,
+pseudonymous `promptCacheKey`; it is omitted when ownership cannot be verified.
+The route creates these options once before
+`apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts:POST` starts the stream,
+so the key does not make the conversation sticky across assistant responses.
+
+The gateway's current affinity experiment is deliberately disabled in the
+paired deployment configuration. The `x-litellm-session-id` correlation header
+and the Langfuse trace/session headers remain separate observability contracts;
+keeping them does not mean routing affinity is enabled.
+
+For aggregate evidence, run the explicit
+`--gateway-cost --from YYYY-MM-DD --to YYYY-MM-DD` mode of
+`packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts:runGatewayCostReport`.
+The window is UTC and half-open. The mode reads Langfuse generation pages and
+LiteLLM spend rows in memory, emits model/count/token/cost aggregates as JSON,
+and never writes raw observations or credentials. It counts positive-cost
+generations and requires the mutually exclusive algebra
+`input = uncached + cache-read + cache-write`; missing cache fields, scope
+drift, model/count drift, or cost drift fail closed. This is aggregate gateway
+evidence, not an exact course allocation or Azure invoice.
 
 Credit fields are Prisma `Decimal` — never truthy-check them ([Data & Migrations](./data-and-migrations.md)).
 `src/stores/settingsStore.ts:loadCredits` accepts only the latest request generation, so a late

--- a/docs/log/2026-08-11-chat-affinity-cost-evidence.md
+++ b/docs/log/2026-08-11-chat-affinity-cost-evidence.md
@@ -1,0 +1,18 @@
+## 2026-08-11
+
+**Creation**
+
+- Documented the turn-scoped provider-option contract in
+  [Chat Platform](../chat-platform.md): one pseudonymous turn key per
+  assistant response and one thread-stable prompt-cache key.
+- Documented the paired deployment experiment: LiteLLM router affinity is
+  disabled explicitly while request and Langfuse correlation headers remain.
+- Added the aggregate `--gateway-cost` report contract and synthetic
+  fail-closed reconciliation checks to [Testing](../testing.md).
+
+**Update**
+
+- Local evidence covers Chat Completions and Responses request serialization,
+  aggregate token algebra, and Langfuse/LiteLLM parity checks only. A staging
+  rollout, paid measurement window, deployed cache hit rate, and Azure invoice
+  remain separate approval gates.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,9 @@ serialization evidence, not proof that a deployed gateway routes or caches the
 request.
 
 The aggregate cost reconciler is a dependency-light script test and does not
-need a database or network:
+need a database or network. It covers exact UTC row boundaries, source-scope
+and generation-type drift, token/cache algebra, tolerance validation, and
+Langfuse/LiteLLM model parity:
 
 ```bash
 pnpm exec tsx src/scripts/lib/aggregateCostReconciliation.test.ts

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,13 +51,16 @@ Langfuse/LiteLLM model parity:
 
 ```bash
 pnpm exec tsx src/scripts/lib/aggregateCostReconciliation.test.ts
+pnpm exec tsx src/scripts/lib/litellmCostSource.test.ts
 ```
 
-Run it from `packages/prisma-data`. The explicit gateway report mode uses
-secret-backed runtime environment variables and must be run only with an
-approved read-only measurement window. It fails closed when cache buckets or
-Langfuse/LiteLLM scope and cost parity are incomplete; local synthetic fixtures
-do not establish staging, production, or Azure billing evidence.
+Run both commands from `packages/prisma-data`. The first covers aggregate
+reconciliation; the second covers the team-scoped, paginated LiteLLM request
+contract. The explicit gateway report mode uses secret-backed runtime
+environment variables and must be run only with an approved read-only
+measurement window. It fails closed when cache buckets or Langfuse/LiteLLM
+scope and cost parity are incomplete; local synthetic fixtures do not
+establish staging, production, or Azure billing evidence.
 
 For chat conversation-rendering changes, `playwright/util/chat.ts` also supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,32 @@ index, so it proves provider conversion without a database, MCP server, or
 model key. It is a local regression gate, not evidence that a real upstream
 first turn works in staging.
 
+For provider-option changes that affect both OpenAI transports, also run the
+focused chat fixture:
+
+```bash
+pnpm --filter @klicker-uzh/chat exec vitest run \
+  test/openai-provider-options.test.ts test/openai-chat-streaming.test.ts
+```
+
+`test/openai-provider-options.test.ts` proves the turn key and thread cache key
+on both Chat Completions and Responses request bodies. It is still local
+serialization evidence, not proof that a deployed gateway routes or caches the
+request.
+
+The aggregate cost reconciler is a dependency-light script test and does not
+need a database or network:
+
+```bash
+pnpm exec tsx src/scripts/lib/aggregateCostReconciliation.test.ts
+```
+
+Run it from `packages/prisma-data`. The explicit gateway report mode uses
+secret-backed runtime environment variables and must be run only with an
+approved read-only measurement window. It fails closed when cache buckets or
+Langfuse/LiteLLM scope and cost parity are incomplete; local synthetic fixtures
+do not establish staging, production, or Azure billing evidence.
+
 For chat conversation-rendering changes, `playwright/util/chat.ts` also supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
 `ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -10,6 +10,7 @@ import {
   incompleteCostResult,
   reconcileCostLedgers,
 } from './lib/aggregateCostReconciliation.js'
+import { loadLiteLLMCostRows } from './lib/litellmCostSource.js'
 import type { SheetValue, WorkbookSheet } from './lib/simpleWorkbook.js'
 import {
   formatDate,
@@ -1077,9 +1078,6 @@ function parseCostAnalysisConfig(): CostAnalysisConfig {
   }
 }
 
-const GATEWAY_COST_PAGE_SIZE = 100
-const GATEWAY_COST_MAX_PAGES = 1000
-
 function requiredEnvironment(name: string) {
   const value = process.env[name]?.trim()
   if (!value) throw new Error(`${name} is required for --gateway-cost.`)
@@ -1126,40 +1124,6 @@ function responseRows(payload: unknown, label: string) {
     throw new Error(`${label} response data must be an array.`)
   }
   return data
-}
-
-function listRows(payload: unknown, label: string) {
-  if (Array.isArray(payload)) return payload
-  return responseRows(payload, label)
-}
-
-function nextUtcDate(isoTimestamp: string) {
-  const date = new Date(isoTimestamp)
-  if (Number.isNaN(date.getTime())) {
-    throw new Error('Gateway cost window must use valid UTC timestamps.')
-  }
-  date.setUTCDate(date.getUTCDate() + 1)
-  return date.toISOString().slice(0, 10)
-}
-
-function litellmEndDate(isoTimestamp: string) {
-  const date = new Date(isoTimestamp)
-  if (Number.isNaN(date.getTime())) {
-    throw new Error('Gateway cost window must use valid UTC timestamps.')
-  }
-
-  // A midnight half-open boundary does not need the following calendar day;
-  // fetching it can make the LiteLLM spend response too large to serve.
-  if (
-    date.getUTCHours() === 0 &&
-    date.getUTCMinutes() === 0 &&
-    date.getUTCSeconds() === 0 &&
-    date.getUTCMilliseconds() === 0
-  ) {
-    return date.toISOString().slice(0, 10)
-  }
-
-  return nextUtcDate(isoTimestamp)
 }
 
 function costTolerance(name: string, fallback: number) {
@@ -1214,25 +1178,6 @@ async function loadLangfuseCostRows(
   throw new Error('Langfuse cost evidence exceeded the page safety limit.')
 }
 
-async function loadLiteLLMCostRows(
-  scope: AggregateScope,
-  host: string,
-  authorization: string
-) {
-  const params = new URLSearchParams({
-    start_date: scope.from.slice(0, 10),
-    // LiteLLM accepts calendar dates here. Fetch the enclosing end date and
-    // apply the exact half-open UTC boundary to each returned startTime row.
-    end_date: litellmEndDate(scope.to),
-    summarize: 'false',
-  })
-  const payload = await requestCostJson(
-    `${host}/spend/logs?${params.toString()}`,
-    { 'x-litellm-api-key': authorization }
-  )
-  return listRows(payload, 'LiteLLM spend')
-}
-
 async function runGatewayCostReport(options: CliOptions) {
   const scope: AggregateScope = {
     from: options.from.toISOString(),
@@ -1259,7 +1204,12 @@ async function runGatewayCostReport(options: CliOptions) {
 
   const [langfuseRows, litellmRows] = await Promise.all([
     loadLangfuseCostRows(scope, langfuseHost, langfuseAuthorization),
-    loadLiteLLMCostRows(scope, litellmHost, `Bearer ${litellmApiKey}`),
+    loadLiteLLMCostRows(
+      scope,
+      litellmHost,
+      `Bearer ${litellmApiKey}`,
+      requestCostJson
+    ),
   ])
 
   try {

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -1133,6 +1133,24 @@ function listRows(payload: unknown, label: string) {
   return responseRows(payload, label)
 }
 
+function nextUtcDate(isoTimestamp: string) {
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Gateway cost window must use valid UTC timestamps.')
+  }
+  date.setUTCDate(date.getUTCDate() + 1)
+  return date.toISOString().slice(0, 10)
+}
+
+function costTolerance(name: string, fallback: number) {
+  const raw = process.env[name]
+  const value = raw === undefined ? fallback : Number(raw)
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a finite non-negative number.`)
+  }
+  return value
+}
+
 async function loadLangfuseCostRows(
   scope: AggregateScope,
   host: string,
@@ -1183,7 +1201,9 @@ async function loadLiteLLMCostRows(
 ) {
   const params = new URLSearchParams({
     start_date: scope.from.slice(0, 10),
-    end_date: scope.to.slice(0, 10),
+    // LiteLLM accepts calendar dates here. Fetch the enclosing end date and
+    // apply the exact half-open UTC boundary to each returned startTime row.
+    end_date: nextUtcDate(scope.to),
     summarize: 'false',
   })
   const payload = await requestCostJson(
@@ -1205,6 +1225,14 @@ async function runGatewayCostReport(options: CliOptions) {
   const langfusePublicKey = requiredEnvironment('LANGFUSE_PUBLIC_KEY')
   const langfuseSecretKey = requiredEnvironment('LANGFUSE_SECRET_KEY')
   const litellmApiKey = requiredEnvironment('LITELLM_API_KEY')
+  const absoluteTolerance = costTolerance(
+    'GATEWAY_COST_ABSOLUTE_TOLERANCE_USD',
+    0.000001
+  )
+  const relativeTolerance = costTolerance(
+    'GATEWAY_COST_RELATIVE_TOLERANCE',
+    0.001
+  )
   const langfuseAuthorization = `Basic ${Buffer.from(
     `${langfusePublicKey}:${langfuseSecretKey}`
   ).toString('base64')}`
@@ -1219,12 +1247,8 @@ async function runGatewayCostReport(options: CliOptions) {
       aggregateLangfuseObservations(langfuseRows, scope),
       aggregateLiteLLMSpend(litellmRows, scope),
       {
-        absoluteTolerance: Number(
-          process.env.GATEWAY_COST_ABSOLUTE_TOLERANCE_USD ?? '0.000001'
-        ),
-        relativeTolerance: Number(
-          process.env.GATEWAY_COST_RELATIVE_TOLERANCE ?? '0.001'
-        ),
+        absoluteTolerance,
+        relativeTolerance,
       }
     )
 

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -3,6 +3,13 @@ import { Prisma } from '@klicker-uzh/prisma/client'
 import { open } from 'fs/promises'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
+import {
+  type AggregateScope,
+  aggregateLangfuseObservations,
+  aggregateLiteLLMSpend,
+  incompleteCostResult,
+  reconcileCostLedgers,
+} from './lib/aggregateCostReconciliation.js'
 import type { SheetValue, WorkbookSheet } from './lib/simpleWorkbook.js'
 import {
   formatDate,
@@ -11,6 +18,7 @@ import {
 } from './lib/simpleWorkbook.js'
 
 type CliOptions = {
+  gatewayCost: boolean
   all: boolean
   query?: string
   chatbotId?: string
@@ -578,6 +586,7 @@ function usage() {
     '  pnpm --filter @klicker-uzh/prisma-data script:prod src/scripts/2026-06-16_analyze_chatbot_usage.ts --chatbotId <uuid>',
     '  pnpm --filter @klicker-uzh/prisma-data script:prod src/scripts/2026-06-16_analyze_chatbot_usage.ts --courseId <uuid>',
     '  pnpm --filter @klicker-uzh/prisma-data script:prod src/scripts/2026-06-16_analyze_chatbot_usage.ts --query MAT183',
+    '  pnpm --filter @klicker-uzh/prisma-data script:prod src/scripts/2026-06-16_analyze_chatbot_usage.ts --gateway-cost --from 2026-08-01 --to 2026-08-08',
     '',
     'Options:',
     '  --all                      Analyze all chatbots with activity in the date window.',
@@ -593,6 +602,7 @@ function usage() {
     '  --minTopicMessages <n>      Minimum user messages for topic labels. Default: 5.',
     '  --minTopicParticipants <n>  Minimum participants for topic labels. Default: 3.',
     '  --includeMessageContent     Write full raw message content JSONL and include workbook previews.',
+    '  --gateway-cost              Read aggregate Langfuse/LiteLLM cost evidence and print JSON. Requires --from and --to as a UTC half-open window.',
   ].join('\n')
 }
 
@@ -627,6 +637,7 @@ function validateArgs(args: string[]) {
     '--minTopicMessages',
     '--minTopicParticipants',
     '--includeMessageContent',
+    '--gateway-cost',
   ])
 
   for (const arg of args) {
@@ -739,12 +750,45 @@ function parseArgs(): CliOptions {
   const query = getArgValue(args, '--query') ?? getArgValue(args, '--course')
   const chatbotId = getArgValue(args, '--chatbotId')
   const courseId = getArgValue(args, '--courseId')
+  const gatewayCost = hasFlag(args, '--gateway-cost')
   const selectors = [
     all ? 'all' : undefined,
     query,
     chatbotId,
     courseId,
   ].filter(Boolean)
+
+  if (gatewayCost) {
+    if (selectors.length > 0) {
+      throw new Error(
+        '--gateway-cost cannot be combined with a chatbot selector.'
+      )
+    }
+
+    const from = parseDate(getArgValue(args, '--from'))
+    const to = parseDate(getArgValue(args, '--to'))
+    if (!from || !to) {
+      throw new Error('--gateway-cost requires --from and --to.')
+    }
+    if (from.getTime() >= to.getTime()) {
+      throw new Error('Gateway cost window must have --from before --to.')
+    }
+
+    return {
+      gatewayCost: true,
+      all: false,
+      scopeLabel: 'gateway_cost',
+      semester: 'gateway_cost',
+      from,
+      to,
+      outDir: resolve(repoRoot, 'output'),
+      filePrefix: 'gateway_cost',
+      minTopicMessages: 5,
+      minTopicParticipants: 3,
+      includeMessageContent: false,
+    }
+  }
+
   if (selectors.length === 0) {
     throw new Error(
       'Pass one selector: --all, --chatbotId, --courseId, or --query. No course is selected by default.'
@@ -784,6 +828,7 @@ function parseArgs(): CliOptions {
     `${todayPrefix}_chatbot_usage_analytics_${sanitizeFilename(windowLabel)}_${scope}`
 
   return {
+    gatewayCost: false,
     all,
     query,
     chatbotId,
@@ -1029,6 +1074,183 @@ function parseCostAnalysisConfig(): CostAnalysisConfig {
       'CHATBOT_ANALYSIS_CALIBRATED_TOTAL_COST'
     ),
     modelCostMultipliers: parseModelCostMultipliers(),
+  }
+}
+
+const GATEWAY_COST_PAGE_SIZE = 100
+const GATEWAY_COST_MAX_PAGES = 1000
+
+function requiredEnvironment(name: string) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required for --gateway-cost.`)
+  return value
+}
+
+function costSourceBaseUrl(...names: string[]) {
+  const value = names.map((name) => process.env[name]?.trim()).find(Boolean)
+  if (!value) {
+    throw new Error(`${names.join(' or ')} is required for --gateway-cost.`)
+  }
+
+  const url = new URL(value).toString().replace(/\/$/, '')
+  if (url.startsWith('http://') || url.startsWith('https://')) return url
+  throw new Error('Cost source URLs must use HTTP or HTTPS.')
+}
+
+async function requestCostJson(url: string, headers: Record<string, string>) {
+  let response: Response
+  try {
+    response = await fetch(url, { headers })
+  } catch {
+    throw new Error('A cost source is unreachable.')
+  }
+
+  if (!response.ok) {
+    throw new Error(`A cost source returned HTTP ${response.status}.`)
+  }
+
+  try {
+    return (await response.json()) as unknown
+  } catch {
+    throw new Error('A cost source returned invalid JSON.')
+  }
+}
+
+function responseRows(payload: unknown, label: string) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error(`${label} response must be an object.`)
+  }
+
+  const data = (payload as { data?: unknown }).data
+  if (!Array.isArray(data)) {
+    throw new Error(`${label} response data must be an array.`)
+  }
+  return data
+}
+
+function listRows(payload: unknown, label: string) {
+  if (Array.isArray(payload)) return payload
+  return responseRows(payload, label)
+}
+
+async function loadLangfuseCostRows(
+  scope: AggregateScope,
+  host: string,
+  authorization: string
+) {
+  const rows: unknown[] = []
+
+  for (let page = 1; page <= GATEWAY_COST_MAX_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      type: 'GENERATION',
+      environment: scope.environment,
+      fromStartTime: scope.from,
+      toStartTime: scope.to,
+      limit: String(GATEWAY_COST_PAGE_SIZE),
+      page: String(page),
+    })
+    const payload = await requestCostJson(
+      `${host}/api/public/observations?${params.toString()}`,
+      { Authorization: authorization }
+    )
+    const pageRows = responseRows(payload, 'Langfuse observations')
+    rows.push(...pageRows)
+
+    const meta =
+      payload && typeof payload === 'object' && !Array.isArray(payload)
+        ? (payload as { meta?: unknown }).meta
+        : undefined
+    const totalPages =
+      meta && typeof meta === 'object' && !Array.isArray(meta)
+        ? Number((meta as { totalPages?: unknown }).totalPages)
+        : Number.NaN
+
+    if (
+      pageRows.length < GATEWAY_COST_PAGE_SIZE ||
+      (Number.isInteger(totalPages) && page >= totalPages)
+    ) {
+      return rows
+    }
+  }
+
+  throw new Error('Langfuse cost evidence exceeded the page safety limit.')
+}
+
+async function loadLiteLLMCostRows(
+  scope: AggregateScope,
+  host: string,
+  authorization: string
+) {
+  const params = new URLSearchParams({
+    start_date: scope.from.slice(0, 10),
+    end_date: scope.to.slice(0, 10),
+    summarize: 'false',
+  })
+  const payload = await requestCostJson(
+    `${host}/spend/logs?${params.toString()}`,
+    { Authorization: authorization }
+  )
+  return listRows(payload, 'LiteLLM spend')
+}
+
+async function runGatewayCostReport(options: CliOptions) {
+  const scope: AggregateScope = {
+    from: options.from.toISOString(),
+    to: options.to.toISOString(),
+    environment: requiredEnvironment('LANGFUSE_TRACING_ENVIRONMENT'),
+    teamId: requiredEnvironment('LITELLM_TEAM_ID'),
+  }
+  const langfuseHost = costSourceBaseUrl('LANGFUSE_HOST', 'LANGFUSE_BASE_URL')
+  const litellmHost = costSourceBaseUrl('LITELLM_BASE_URL')
+  const langfusePublicKey = requiredEnvironment('LANGFUSE_PUBLIC_KEY')
+  const langfuseSecretKey = requiredEnvironment('LANGFUSE_SECRET_KEY')
+  const litellmApiKey = requiredEnvironment('LITELLM_API_KEY')
+  const langfuseAuthorization = `Basic ${Buffer.from(
+    `${langfusePublicKey}:${langfuseSecretKey}`
+  ).toString('base64')}`
+
+  const [langfuseRows, litellmRows] = await Promise.all([
+    loadLangfuseCostRows(scope, langfuseHost, langfuseAuthorization),
+    loadLiteLLMCostRows(scope, litellmHost, `Bearer ${litellmApiKey}`),
+  ])
+
+  try {
+    const result = reconcileCostLedgers(
+      aggregateLangfuseObservations(langfuseRows, scope),
+      aggregateLiteLLMSpend(litellmRows, scope),
+      {
+        absoluteTolerance: Number(
+          process.env.GATEWAY_COST_ABSOLUTE_TOLERANCE_USD ?? '0.000001'
+        ),
+        relativeTolerance: Number(
+          process.env.GATEWAY_COST_RELATIVE_TOLERANCE ?? '0.001'
+        ),
+      }
+    )
+
+    return {
+      ...result,
+      scope: {
+        from: scope.from,
+        to: scope.to,
+        environment: scope.environment,
+        teamScope: 'configured LiteLLM team',
+      },
+      countGrain: 'positive-cost generations',
+      cacheAccounting: 'mutually exclusive input buckets required',
+    }
+  } catch (error) {
+    return {
+      ...incompleteCostResult(error),
+      scope: {
+        from: scope.from,
+        to: scope.to,
+        environment: scope.environment,
+        teamScope: 'configured LiteLLM team',
+      },
+      countGrain: 'positive-cost generations',
+      cacheAccounting: 'mutually exclusive input buckets required',
+    }
   }
 }
 
@@ -3192,6 +3414,15 @@ async function writeMessageContentJsonl(
 
 async function main() {
   const options = parseArgs()
+  if (options.gatewayCost) {
+    const result = await runGatewayCostReport(options)
+    console.log(JSON.stringify(result, null, 2))
+    if (result.status !== 'reconciled') {
+      process.exitCode = result.status === 'incomplete' ? 2 : 1
+    }
+    return
+  }
+
   const modelRegistry = parseModelRegistry()
   const costConfig = parseCostAnalysisConfig()
   const chatbots = await loadChatbots(options)

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -1142,6 +1142,26 @@ function nextUtcDate(isoTimestamp: string) {
   return date.toISOString().slice(0, 10)
 }
 
+function litellmEndDate(isoTimestamp: string) {
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Gateway cost window must use valid UTC timestamps.')
+  }
+
+  // A midnight half-open boundary does not need the following calendar day;
+  // fetching it can make the LiteLLM spend response too large to serve.
+  if (
+    date.getUTCHours() === 0 &&
+    date.getUTCMinutes() === 0 &&
+    date.getUTCSeconds() === 0 &&
+    date.getUTCMilliseconds() === 0
+  ) {
+    return date.toISOString().slice(0, 10)
+  }
+
+  return nextUtcDate(isoTimestamp)
+}
+
 function costTolerance(name: string, fallback: number) {
   const raw = process.env[name]
   const value = raw === undefined ? fallback : Number(raw)
@@ -1203,12 +1223,12 @@ async function loadLiteLLMCostRows(
     start_date: scope.from.slice(0, 10),
     // LiteLLM accepts calendar dates here. Fetch the enclosing end date and
     // apply the exact half-open UTC boundary to each returned startTime row.
-    end_date: nextUtcDate(scope.to),
+    end_date: litellmEndDate(scope.to),
     summarize: 'false',
   })
   const payload = await requestCostJson(
     `${host}/spend/logs?${params.toString()}`,
-    { Authorization: authorization }
+    { 'x-litellm-api-key': authorization }
   )
   return listRows(payload, 'LiteLLM spend')
 }

--- a/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.test.ts
+++ b/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.test.ts
@@ -35,13 +35,13 @@ function litellmSpend(overrides: Record<string, unknown> = {}) {
   return {
     team_id: 'team-aibuddy',
     model: 'aibuddy/azure/gpt-5.6-luna',
+    startTime: '2026-08-03T12:00:00.000Z',
     prompt_tokens: 100,
     completion_tokens: 20,
     prompt_tokens_details: {
       cached_tokens: 40,
       cache_creation_input_tokens: 10,
     },
-    metadata: { session_id: 'assistant-1' },
     spend: 0.2,
     ...overrides,
   }
@@ -53,10 +53,7 @@ function matchingLedgers(): { langfuse: CostLedger; litellm: CostLedger } {
       [langfuseObservation(), langfuseObservation({ totalCost: 0 })],
       scope
     ),
-    litellm: aggregateLiteLLMSpend(
-      [litellmSpend(), litellmSpend({ team_id: 'other-team', spend: 2 })],
-      scope
-    ),
+    litellm: aggregateLiteLLMSpend([litellmSpend()], scope),
   }
 }
 
@@ -73,8 +70,19 @@ function testMatchingLedgersReconcile() {
   assert.equal(result.langfuse?.cacheReadInputTokens, 40)
   assert.equal(result.langfuse?.cacheReadRate, 0.4)
   assert.equal(result.langfuse?.averageCostPerGeneration, 0.2)
-  assert.equal(result.litellm?.assistantResponseCount, 1)
-  assert.equal(result.litellm?.averageCostPerAssistantResponse, 0.2)
+  assert.deepEqual(result.litellm?.modelDistribution, [
+    {
+      model: 'aibuddy/azure/gpt-5.6-luna',
+      generationCount: 1,
+      inputTokens: 100,
+      uncachedInputTokens: 50,
+      cacheReadInputTokens: 40,
+      cacheWriteInputTokens: 10,
+      outputTokens: 20,
+      share: 1,
+      totalCost: 0.2,
+    },
+  ])
 }
 
 function testMissingCacheWriteIsIncomplete() {
@@ -122,6 +130,37 @@ function testNegativeCacheAlgebraIsRejected() {
   )
 }
 
+function testExactWindowAndSourceScopeAreFailClosed() {
+  const inWindow = aggregateLiteLLMSpend(
+    [
+      litellmSpend(),
+      litellmSpend({ startTime: scope.to }),
+      litellmSpend({ startTime: '2026-07-31T23:59:59.999Z' }),
+    ],
+    scope
+  )
+  assert.equal(inWindow.rows[0]?.generationCount, 1)
+
+  assert.throws(
+    () =>
+      aggregateLiteLLMSpend([litellmSpend({ startTime: undefined })], scope),
+    /startTime is missing/
+  )
+  assert.throws(
+    () =>
+      aggregateLiteLLMSpend([litellmSpend({ team_id: 'other-team' })], scope),
+    /outside the requested team scope/
+  )
+  assert.throws(
+    () =>
+      aggregateLangfuseObservations(
+        [langfuseObservation({ type: undefined })],
+        scope
+      ),
+    /type must be GENERATION/
+  )
+}
+
 function testModelSetCountCostAndScopeDriftAreNotReconciled() {
   const { langfuse, litellm } = matchingLedgers()
   const differentModel = aggregateLiteLLMSpend(
@@ -165,6 +204,18 @@ function testModelSetCountCostAndScopeDriftAreNotReconciled() {
     /cost differs/
   )
 
+  const tokenDrift = {
+    ...litellm,
+    rows: litellm.rows.map((row) => ({ ...row, outputTokens: 21 })),
+  }
+  assert.match(
+    reconcileCostLedgers(langfuse, tokenDrift, {
+      absoluteTolerance: 0.000001,
+      relativeTolerance: 0.001,
+    }).issues.join('|'),
+    /outputTokens differs/
+  )
+
   assert.match(
     reconcileCostLedgers(langfuse, differentScope, {
       absoluteTolerance: 0.000001,
@@ -178,19 +229,39 @@ function testSummaryOfEmptyLedgerIsExplicit() {
   const summary = summarizeCostLedger({
     scope,
     rows: [],
-    assistantResponseCount: null,
   })
   assert.equal(summary.generationCount, 0)
   assert.equal(summary.cacheReadRate, null)
   assert.equal(summary.averageCostPerGeneration, null)
-  assert.equal(summary.averageCostPerAssistantResponse, null)
   assert.deepEqual(summary.modelDistribution, [])
+}
+
+function testInvalidTolerancesAreRejected() {
+  const { langfuse, litellm } = matchingLedgers()
+  assert.throws(
+    () =>
+      reconcileCostLedgers(langfuse, litellm, {
+        absoluteTolerance: Number.NaN,
+        relativeTolerance: 0.001,
+      }),
+    /absoluteTolerance must be a finite non-negative number/
+  )
+  assert.throws(
+    () =>
+      reconcileCostLedgers(langfuse, litellm, {
+        absoluteTolerance: 0.000001,
+        relativeTolerance: Number.POSITIVE_INFINITY,
+      }),
+    /relativeTolerance must be a finite non-negative number/
+  )
 }
 
 testMatchingLedgersReconcile()
 testMissingCacheWriteIsIncomplete()
 testNegativeCacheAlgebraIsRejected()
+testExactWindowAndSourceScopeAreFailClosed()
 testModelSetCountCostAndScopeDriftAreNotReconciled()
 testSummaryOfEmptyLedgerIsExplicit()
+testInvalidTolerancesAreRejected()
 
 console.log('aggregate cost reconciliation tests passed')

--- a/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.test.ts
+++ b/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.test.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict'
+import {
+  type AggregateScope,
+  aggregateLangfuseObservations,
+  aggregateLiteLLMSpend,
+  type CostLedger,
+  incompleteCostResult,
+  reconcileCostLedgers,
+  summarizeCostLedger,
+} from './aggregateCostReconciliation.js'
+
+const scope: AggregateScope = {
+  from: '2026-08-01T00:00:00.000Z',
+  to: '2026-08-08T00:00:00.000Z',
+  environment: 'stg',
+  teamId: 'team-aibuddy',
+}
+
+function langfuseObservation(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'GENERATION',
+    providedModelName: 'aibuddy/azure/gpt-5.6-luna',
+    usageDetails: {
+      input: 100,
+      output: 20,
+      cache_read_input_tokens: 40,
+      cache_creation_input_tokens: 10,
+    },
+    totalCost: 0.2,
+    ...overrides,
+  }
+}
+
+function litellmSpend(overrides: Record<string, unknown> = {}) {
+  return {
+    team_id: 'team-aibuddy',
+    model: 'aibuddy/azure/gpt-5.6-luna',
+    prompt_tokens: 100,
+    completion_tokens: 20,
+    prompt_tokens_details: {
+      cached_tokens: 40,
+      cache_creation_input_tokens: 10,
+    },
+    metadata: { session_id: 'assistant-1' },
+    spend: 0.2,
+    ...overrides,
+  }
+}
+
+function matchingLedgers(): { langfuse: CostLedger; litellm: CostLedger } {
+  return {
+    langfuse: aggregateLangfuseObservations(
+      [langfuseObservation(), langfuseObservation({ totalCost: 0 })],
+      scope
+    ),
+    litellm: aggregateLiteLLMSpend(
+      [litellmSpend(), litellmSpend({ team_id: 'other-team', spend: 2 })],
+      scope
+    ),
+  }
+}
+
+function testMatchingLedgersReconcile() {
+  const { langfuse, litellm } = matchingLedgers()
+  const result = reconcileCostLedgers(langfuse, litellm, {
+    absoluteTolerance: 0.000001,
+    relativeTolerance: 0.001,
+  })
+
+  assert.equal(result.status, 'reconciled')
+  assert.deepEqual(result.issues, [])
+  assert.equal(result.langfuse?.generationCount, 1)
+  assert.equal(result.langfuse?.cacheReadInputTokens, 40)
+  assert.equal(result.langfuse?.cacheReadRate, 0.4)
+  assert.equal(result.langfuse?.averageCostPerGeneration, 0.2)
+  assert.equal(result.litellm?.assistantResponseCount, 1)
+  assert.equal(result.litellm?.averageCostPerAssistantResponse, 0.2)
+}
+
+function testMissingCacheWriteIsIncomplete() {
+  assert.throws(
+    () =>
+      aggregateLangfuseObservations(
+        [
+          langfuseObservation({
+            usageDetails: {
+              input: 100,
+              output: 20,
+              cache_read_input_tokens: 40,
+            },
+          }),
+        ],
+        scope
+      ),
+    /cacheWriteInputTokens is missing/
+  )
+
+  const result = incompleteCostResult(
+    new Error('Langfuse cacheWriteInputTokens is missing')
+  )
+  assert.equal(result.status, 'incomplete')
+  assert.deepEqual(result.issues, ['Langfuse cacheWriteInputTokens is missing'])
+}
+
+function testNegativeCacheAlgebraIsRejected() {
+  assert.throws(
+    () =>
+      aggregateLangfuseObservations(
+        [
+          langfuseObservation({
+            usageDetails: {
+              input: 100,
+              output: 20,
+              cache_read_input_tokens: 110,
+              cache_creation_input_tokens: 0,
+            },
+          }),
+        ],
+        scope
+      ),
+    /cache buckets exceed inclusive input tokens/
+  )
+}
+
+function testModelSetCountCostAndScopeDriftAreNotReconciled() {
+  const { langfuse, litellm } = matchingLedgers()
+  const differentModel = aggregateLiteLLMSpend(
+    [litellmSpend({ model: 'aibuddy/azure/gpt-5.6-sol' })],
+    scope
+  )
+  const differentScope = {
+    ...litellm,
+    scope: { ...scope, teamId: 'other-team' },
+  }
+
+  assert.match(
+    reconcileCostLedgers(langfuse, differentModel, {
+      absoluteTolerance: 0.000001,
+      relativeTolerance: 0.001,
+    }).issues.join('|'),
+    /model set differs/
+  )
+
+  const countDrift = {
+    ...litellm,
+    rows: litellm.rows.map((row) => ({ ...row, generationCount: 2 })),
+  }
+  assert.match(
+    reconcileCostLedgers(langfuse, countDrift, {
+      absoluteTolerance: 0.000001,
+      relativeTolerance: 0.001,
+    }).issues.join('|'),
+    /generation count differs/
+  )
+
+  const costDrift = {
+    ...litellm,
+    rows: litellm.rows.map((row) => ({ ...row, totalCost: 0.3 })),
+  }
+  assert.match(
+    reconcileCostLedgers(langfuse, costDrift, {
+      absoluteTolerance: 0.000001,
+      relativeTolerance: 0.001,
+    }).issues.join('|'),
+    /cost differs/
+  )
+
+  assert.match(
+    reconcileCostLedgers(langfuse, differentScope, {
+      absoluteTolerance: 0.000001,
+      relativeTolerance: 0.001,
+    }).issues.join('|'),
+    /scopes differ/
+  )
+}
+
+function testSummaryOfEmptyLedgerIsExplicit() {
+  const summary = summarizeCostLedger({
+    scope,
+    rows: [],
+    assistantResponseCount: null,
+  })
+  assert.equal(summary.generationCount, 0)
+  assert.equal(summary.cacheReadRate, null)
+  assert.equal(summary.averageCostPerGeneration, null)
+  assert.equal(summary.averageCostPerAssistantResponse, null)
+  assert.deepEqual(summary.modelDistribution, [])
+}
+
+testMatchingLedgersReconcile()
+testMissingCacheWriteIsIncomplete()
+testNegativeCacheAlgebraIsRejected()
+testModelSetCountCostAndScopeDriftAreNotReconciled()
+testSummaryOfEmptyLedgerIsExplicit()
+
+console.log('aggregate cost reconciliation tests passed')

--- a/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.ts
+++ b/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.ts
@@ -1,0 +1,526 @@
+export type AggregateScope = {
+  from: string
+  to: string
+  environment: string
+  teamId: string
+}
+
+export type CostAggregate = {
+  model: string
+  generationCount: number
+  inputTokens: number
+  uncachedInputTokens: number
+  cacheReadInputTokens: number
+  cacheWriteInputTokens: number
+  outputTokens: number
+  totalCost: number
+}
+
+export type CostLedger = {
+  scope: AggregateScope
+  rows: CostAggregate[]
+  assistantResponseCount: number | null
+}
+
+export type CostSummary = {
+  generationCount: number
+  inputTokens: number
+  uncachedInputTokens: number
+  cacheReadInputTokens: number
+  cacheWriteInputTokens: number
+  outputTokens: number
+  totalCost: number
+  assistantResponseCount: number | null
+  cacheReadRate: number | null
+  averageCostPerGeneration: number | null
+  averageCostPerAssistantResponse: number | null
+  modelDistribution: Array<{
+    model: string
+    generationCount: number
+    share: number
+    totalCost: number
+  }>
+}
+
+export type ReconciliationResult = {
+  status: 'reconciled' | 'incomplete' | 'mismatch'
+  issues: string[]
+  langfuse: CostSummary | null
+  litellm: CostSummary | null
+}
+
+export class CostEvidenceError extends Error {}
+
+type JsonObject = Record<string, unknown>
+
+function asObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new CostEvidenceError(`${label} must be an object`)
+  }
+  return value as JsonObject
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new CostEvidenceError(`${label} must be an array`)
+  }
+  return value
+}
+
+function readRequiredNumber(
+  object: JsonObject,
+  candidates: string[],
+  label: string,
+  nested: JsonObject[] = []
+) {
+  for (const candidate of candidates) {
+    const values = [object[candidate], ...nested.map((item) => item[candidate])]
+    const value = values.find((item) => item !== undefined && item !== null)
+    if (value === undefined || value === null || value === '') continue
+
+    const parsed = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(parsed)) {
+      throw new CostEvidenceError(`${label} must be finite`)
+    }
+    return parsed
+  }
+
+  throw new CostEvidenceError(`${label} is missing`)
+}
+
+function readRequiredString(
+  object: JsonObject,
+  candidates: string[],
+  label: string
+) {
+  for (const candidate of candidates) {
+    const value = object[candidate]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+
+  throw new CostEvidenceError(`${label} is missing`)
+}
+
+function validateAggregate(row: CostAggregate, label: string) {
+  const integerFields: Array<keyof CostAggregate> = [
+    'generationCount',
+    'inputTokens',
+    'uncachedInputTokens',
+    'cacheReadInputTokens',
+    'cacheWriteInputTokens',
+    'outputTokens',
+  ]
+
+  for (const field of integerFields) {
+    const value = row[field] as number
+    if (!Number.isInteger(value) || value < 0) {
+      throw new CostEvidenceError(
+        `${label}.${field} must be a non-negative integer`
+      )
+    }
+  }
+
+  if (!Number.isFinite(row.totalCost) || row.totalCost < 0) {
+    throw new CostEvidenceError(`${label}.totalCost must be non-negative`)
+  }
+
+  if (
+    row.uncachedInputTokens +
+      row.cacheReadInputTokens +
+      row.cacheWriteInputTokens !==
+    row.inputTokens
+  ) {
+    throw new CostEvidenceError(
+      `${label} input buckets do not equal inclusive input tokens`
+    )
+  }
+}
+
+function addAggregate(
+  rows: Map<string, CostAggregate>,
+  next: CostAggregate,
+  label: string
+) {
+  validateAggregate(next, label)
+  const current = rows.get(next.model)
+  if (!current) {
+    rows.set(next.model, next)
+    return
+  }
+
+  rows.set(next.model, {
+    model: next.model,
+    generationCount: current.generationCount + next.generationCount,
+    inputTokens: current.inputTokens + next.inputTokens,
+    uncachedInputTokens: current.uncachedInputTokens + next.uncachedInputTokens,
+    cacheReadInputTokens:
+      current.cacheReadInputTokens + next.cacheReadInputTokens,
+    cacheWriteInputTokens:
+      current.cacheWriteInputTokens + next.cacheWriteInputTokens,
+    outputTokens: current.outputTokens + next.outputTokens,
+    totalCost: current.totalCost + next.totalCost,
+  })
+}
+
+function inputBuckets(object: JsonObject, nested: JsonObject[], label: string) {
+  const inputTokens = readRequiredNumber(
+    object,
+    ['inputUsage', 'inputTokens', 'promptTokens', 'prompt_tokens', 'input'],
+    `${label}.inputTokens`,
+    nested
+  )
+  const cacheReadInputTokens = readRequiredNumber(
+    object,
+    [
+      'cacheReadInputTokens',
+      'cache_read_input_tokens',
+      'cachedTokens',
+      'cached_tokens',
+    ],
+    `${label}.cacheReadInputTokens`,
+    nested
+  )
+  const cacheWriteInputTokens = readRequiredNumber(
+    object,
+    [
+      'cacheWriteInputTokens',
+      'cache_write_input_tokens',
+      'cacheCreationInputTokens',
+      'cache_creation_input_tokens',
+    ],
+    `${label}.cacheWriteInputTokens`,
+    nested
+  )
+  const uncachedInputTokens =
+    inputTokens - cacheReadInputTokens - cacheWriteInputTokens
+
+  if (uncachedInputTokens < 0) {
+    throw new CostEvidenceError(
+      `${label} cache buckets exceed inclusive input tokens`
+    )
+  }
+
+  return {
+    inputTokens,
+    uncachedInputTokens,
+    cacheReadInputTokens,
+    cacheWriteInputTokens,
+  }
+}
+
+export function aggregateLangfuseObservations(
+  payload: unknown,
+  scope: AggregateScope
+): CostLedger {
+  const rows = asArray(payload, 'Langfuse observations')
+  const aggregates = new Map<string, CostAggregate>()
+
+  for (const [index, value] of rows.entries()) {
+    const object = asObject(value, `Langfuse observation ${index}`)
+    if (object.type !== undefined && object.type !== 'GENERATION') continue
+
+    const totalCost = readRequiredNumber(
+      object,
+      ['totalCost', 'calculatedTotalCost', 'total_cost'],
+      `Langfuse observation ${index}.totalCost`,
+      [
+        asObject(
+          object.costDetails ?? {},
+          `Langfuse observation ${index}.costDetails`
+        ),
+      ]
+    )
+
+    // Zero-cost observations are not part of the cost-bearing reconciliation
+    // contract. This matches the gateway audit's positive-spend count grain.
+    if (totalCost <= 0) continue
+
+    const usageDetails = asObject(
+      object.usageDetails ?? {},
+      `Langfuse observation ${index}.usageDetails`
+    )
+    const buckets = inputBuckets(
+      object,
+      [usageDetails],
+      `Langfuse observation ${index}`
+    )
+    const outputTokens = readRequiredNumber(
+      object,
+      [
+        'outputUsage',
+        'outputTokens',
+        'completionTokens',
+        'completion_tokens',
+        'output',
+      ],
+      `Langfuse observation ${index}.outputTokens`,
+      [usageDetails]
+    )
+    const model = readRequiredString(
+      object,
+      ['providedModelName', 'model', 'modelName'],
+      `Langfuse observation ${index}.model`
+    )
+
+    addAggregate(
+      aggregates,
+      {
+        model,
+        generationCount: 1,
+        ...buckets,
+        outputTokens,
+        totalCost,
+      },
+      `Langfuse observation ${index}`
+    )
+  }
+
+  return {
+    scope,
+    rows: Array.from(aggregates.values()).sort(byModel),
+    assistantResponseCount: null,
+  }
+}
+
+function nestedPromptDetails(object: JsonObject) {
+  const details = object.prompt_tokens_details
+  return details && typeof details === 'object' && !Array.isArray(details)
+    ? [details as JsonObject]
+    : []
+}
+
+function assistantResponseId(object: JsonObject) {
+  const rawMetadata = object.metadata
+  let metadata: JsonObject | null = null
+  if (
+    rawMetadata &&
+    typeof rawMetadata === 'object' &&
+    !Array.isArray(rawMetadata)
+  ) {
+    metadata = rawMetadata as JsonObject
+  } else if (typeof rawMetadata === 'string') {
+    try {
+      const parsed = JSON.parse(rawMetadata)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        metadata = parsed as JsonObject
+      }
+    } catch {
+      metadata = null
+    }
+  }
+
+  const candidates = [
+    object.session_id,
+    object.sessionId,
+    metadata?.session_id,
+    metadata?.sessionId,
+  ]
+  return candidates.find(
+    (value): value is string => typeof value === 'string' && value.length > 0
+  )
+}
+
+export function aggregateLiteLLMSpend(
+  payload: unknown,
+  scope: AggregateScope
+): CostLedger {
+  const rows = asArray(payload, 'LiteLLM spend')
+  const aggregates = new Map<string, CostAggregate>()
+  const responseIds = new Set<string>()
+  let missingResponseId = false
+
+  for (const [index, value] of rows.entries()) {
+    const object = asObject(value, `LiteLLM spend row ${index}`)
+    if (String(object.team_id ?? '') !== scope.teamId) continue
+
+    const totalCost = readRequiredNumber(
+      object,
+      ['spend', 'totalCost', 'total_cost'],
+      `LiteLLM spend row ${index}.totalCost`
+    )
+    if (totalCost <= 0) continue
+
+    const responseId = assistantResponseId(object)
+    if (responseId) responseIds.add(responseId)
+    else missingResponseId = true
+
+    const buckets = inputBuckets(
+      object,
+      nestedPromptDetails(object),
+      `LiteLLM spend row ${index}`
+    )
+    const outputTokens = readRequiredNumber(
+      object,
+      [
+        'completion_tokens',
+        'completionTokens',
+        'output_tokens',
+        'outputTokens',
+      ],
+      `LiteLLM spend row ${index}.outputTokens`
+    )
+    const model = readRequiredString(
+      object,
+      ['model', 'model_name', 'modelName'],
+      `LiteLLM spend row ${index}.model`
+    )
+
+    addAggregate(
+      aggregates,
+      {
+        model,
+        generationCount: 1,
+        ...buckets,
+        outputTokens,
+        totalCost,
+      },
+      `LiteLLM spend row ${index}`
+    )
+  }
+
+  return {
+    scope,
+    rows: Array.from(aggregates.values()).sort(byModel),
+    assistantResponseCount: missingResponseId ? null : responseIds.size,
+  }
+}
+
+function byModel(left: CostAggregate, right: CostAggregate) {
+  return left.model.localeCompare(right.model)
+}
+
+function sameScope(left: AggregateScope, right: AggregateScope) {
+  return (
+    left.from === right.from &&
+    left.to === right.to &&
+    left.environment === right.environment &&
+    left.teamId === right.teamId
+  )
+}
+
+export function summarizeCostLedger(ledger: CostLedger): CostSummary {
+  const totals = ledger.rows.reduce(
+    (summary, row) => ({
+      generationCount: summary.generationCount + row.generationCount,
+      inputTokens: summary.inputTokens + row.inputTokens,
+      uncachedInputTokens:
+        summary.uncachedInputTokens + row.uncachedInputTokens,
+      cacheReadInputTokens:
+        summary.cacheReadInputTokens + row.cacheReadInputTokens,
+      cacheWriteInputTokens:
+        summary.cacheWriteInputTokens + row.cacheWriteInputTokens,
+      outputTokens: summary.outputTokens + row.outputTokens,
+      totalCost: summary.totalCost + row.totalCost,
+    }),
+    {
+      generationCount: 0,
+      inputTokens: 0,
+      uncachedInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      outputTokens: 0,
+      totalCost: 0,
+    }
+  )
+
+  const assistantResponseCount = ledger.assistantResponseCount
+
+  return {
+    ...totals,
+    assistantResponseCount,
+    cacheReadRate:
+      totals.inputTokens > 0
+        ? totals.cacheReadInputTokens / totals.inputTokens
+        : null,
+    averageCostPerGeneration:
+      totals.generationCount > 0
+        ? totals.totalCost / totals.generationCount
+        : null,
+    averageCostPerAssistantResponse:
+      assistantResponseCount !== null && assistantResponseCount > 0
+        ? totals.totalCost / assistantResponseCount
+        : null,
+    modelDistribution: ledger.rows.map((row) => ({
+      model: row.model,
+      generationCount: row.generationCount,
+      share:
+        totals.generationCount > 0
+          ? row.generationCount / totals.generationCount
+          : 0,
+      totalCost: row.totalCost,
+    })),
+  }
+}
+
+export function reconcileCostLedgers(
+  langfuse: CostLedger,
+  litellm: CostLedger,
+  options: { absoluteTolerance: number; relativeTolerance: number }
+): ReconciliationResult {
+  const langfuseSummary = summarizeCostLedger(langfuse)
+  const litellmSummary = summarizeCostLedger(litellm)
+  const issues: string[] = []
+
+  if (!sameScope(langfuse.scope, litellm.scope)) {
+    issues.push('Langfuse and LiteLLM scopes differ')
+  }
+
+  const langfuseByModel = new Map(langfuse.rows.map((row) => [row.model, row]))
+  const litellmByModel = new Map(litellm.rows.map((row) => [row.model, row]))
+  const models = new Set([...langfuseByModel.keys(), ...litellmByModel.keys()])
+
+  for (const model of Array.from(models).sort()) {
+    const left = langfuseByModel.get(model)
+    const right = litellmByModel.get(model)
+    if (!left || !right) {
+      issues.push(`model set differs at ${model}`)
+      continue
+    }
+
+    if (left.generationCount !== right.generationCount) {
+      issues.push(`generation count differs at ${model}`)
+    }
+
+    for (const field of [
+      'inputTokens',
+      'uncachedInputTokens',
+      'cacheReadInputTokens',
+      'cacheWriteInputTokens',
+      'outputTokens',
+    ] as const) {
+      if (left[field] !== right[field]) {
+        issues.push(`${field} differs at ${model}`)
+      }
+    }
+
+    const absoluteDrift = Math.abs(left.totalCost - right.totalCost)
+    const denominator = Math.max(left.totalCost, right.totalCost, 1e-12)
+    if (
+      absoluteDrift >
+      Math.max(
+        options.absoluteTolerance,
+        denominator * options.relativeTolerance
+      )
+    ) {
+      issues.push(`cost differs at ${model}`)
+    }
+  }
+
+  return {
+    status: issues.length === 0 ? 'reconciled' : 'mismatch',
+    issues,
+    langfuse: langfuseSummary,
+    litellm: litellmSummary,
+  }
+}
+
+export function incompleteCostResult(error: unknown): ReconciliationResult {
+  return {
+    status: 'incomplete',
+    issues: [error instanceof Error ? error.message : String(error)],
+    langfuse: null,
+    litellm: null,
+  }
+}

--- a/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.ts
+++ b/packages/prisma-data/src/scripts/lib/aggregateCostReconciliation.ts
@@ -19,7 +19,6 @@ export type CostAggregate = {
 export type CostLedger = {
   scope: AggregateScope
   rows: CostAggregate[]
-  assistantResponseCount: number | null
 }
 
 export type CostSummary = {
@@ -30,13 +29,16 @@ export type CostSummary = {
   cacheWriteInputTokens: number
   outputTokens: number
   totalCost: number
-  assistantResponseCount: number | null
   cacheReadRate: number | null
   averageCostPerGeneration: number | null
-  averageCostPerAssistantResponse: number | null
   modelDistribution: Array<{
     model: string
     generationCount: number
+    inputTokens: number
+    uncachedInputTokens: number
+    cacheReadInputTokens: number
+    cacheWriteInputTokens: number
+    outputTokens: number
     share: number
     totalCost: number
   }>
@@ -210,16 +212,52 @@ function inputBuckets(object: JsonObject, nested: JsonObject[], label: string) {
   }
 }
 
+function scopeBounds(scope: AggregateScope) {
+  const from = Date.parse(scope.from)
+  const to = Date.parse(scope.to)
+  if (!Number.isFinite(from) || !Number.isFinite(to) || from >= to) {
+    throw new CostEvidenceError(
+      'Cost evidence scope must be a valid half-open UTC window'
+    )
+  }
+  return { from, to }
+}
+
+function readRequiredTimestamp(
+  object: JsonObject,
+  candidates: string[],
+  label: string
+) {
+  const value = candidates
+    .map((candidate) => object[candidate])
+    .find((candidate) => candidate !== undefined && candidate !== null)
+
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new CostEvidenceError(`${label} is missing`)
+  }
+
+  const timestamp = new Date(value).getTime()
+  if (!Number.isFinite(timestamp)) {
+    throw new CostEvidenceError(`${label} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
 export function aggregateLangfuseObservations(
   payload: unknown,
   scope: AggregateScope
 ): CostLedger {
+  scopeBounds(scope)
   const rows = asArray(payload, 'Langfuse observations')
   const aggregates = new Map<string, CostAggregate>()
 
   for (const [index, value] of rows.entries()) {
     const object = asObject(value, `Langfuse observation ${index}`)
-    if (object.type !== undefined && object.type !== 'GENERATION') continue
+    if (object.type !== 'GENERATION') {
+      throw new CostEvidenceError(
+        `Langfuse observation ${index}.type must be GENERATION`
+      )
+    }
 
     const totalCost = readRequiredNumber(
       object,
@@ -235,7 +273,12 @@ export function aggregateLangfuseObservations(
 
     // Zero-cost observations are not part of the cost-bearing reconciliation
     // contract. This matches the gateway audit's positive-spend count grain.
-    if (totalCost <= 0) continue
+    if (totalCost < 0) {
+      throw new CostEvidenceError(
+        `Langfuse observation ${index}.totalCost must be non-negative`
+      )
+    }
+    if (totalCost === 0) continue
 
     const usageDetails = asObject(
       object.usageDetails ?? {},
@@ -280,7 +323,6 @@ export function aggregateLangfuseObservations(
   return {
     scope,
     rows: Array.from(aggregates.values()).sort(byModel),
-    assistantResponseCount: null,
   }
 }
 
@@ -291,60 +333,40 @@ function nestedPromptDetails(object: JsonObject) {
     : []
 }
 
-function assistantResponseId(object: JsonObject) {
-  const rawMetadata = object.metadata
-  let metadata: JsonObject | null = null
-  if (
-    rawMetadata &&
-    typeof rawMetadata === 'object' &&
-    !Array.isArray(rawMetadata)
-  ) {
-    metadata = rawMetadata as JsonObject
-  } else if (typeof rawMetadata === 'string') {
-    try {
-      const parsed = JSON.parse(rawMetadata)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        metadata = parsed as JsonObject
-      }
-    } catch {
-      metadata = null
-    }
-  }
-
-  const candidates = [
-    object.session_id,
-    object.sessionId,
-    metadata?.session_id,
-    metadata?.sessionId,
-  ]
-  return candidates.find(
-    (value): value is string => typeof value === 'string' && value.length > 0
-  )
-}
-
 export function aggregateLiteLLMSpend(
   payload: unknown,
   scope: AggregateScope
 ): CostLedger {
+  const { from, to } = scopeBounds(scope)
   const rows = asArray(payload, 'LiteLLM spend')
   const aggregates = new Map<string, CostAggregate>()
-  const responseIds = new Set<string>()
-  let missingResponseId = false
 
   for (const [index, value] of rows.entries()) {
     const object = asObject(value, `LiteLLM spend row ${index}`)
-    if (String(object.team_id ?? '') !== scope.teamId) continue
-
     const totalCost = readRequiredNumber(
       object,
       ['spend', 'totalCost', 'total_cost'],
       `LiteLLM spend row ${index}.totalCost`
     )
-    if (totalCost <= 0) continue
+    if (totalCost < 0) {
+      throw new CostEvidenceError(
+        `LiteLLM spend row ${index}.totalCost must be non-negative`
+      )
+    }
+    if (totalCost === 0) continue
 
-    const responseId = assistantResponseId(object)
-    if (responseId) responseIds.add(responseId)
-    else missingResponseId = true
+    const startTime = readRequiredTimestamp(
+      object,
+      ['startTime', 'start_time'],
+      `LiteLLM spend row ${index}.startTime`
+    )
+    if (startTime < from || startTime >= to) continue
+
+    if (object.team_id !== scope.teamId) {
+      throw new CostEvidenceError(
+        `LiteLLM spend row ${index}.team_id is outside the requested team scope`
+      )
+    }
 
     const buckets = inputBuckets(
       object,
@@ -383,7 +405,6 @@ export function aggregateLiteLLMSpend(
   return {
     scope,
     rows: Array.from(aggregates.values()).sort(byModel),
-    assistantResponseCount: missingResponseId ? null : responseIds.size,
   }
 }
 
@@ -425,11 +446,8 @@ export function summarizeCostLedger(ledger: CostLedger): CostSummary {
     }
   )
 
-  const assistantResponseCount = ledger.assistantResponseCount
-
   return {
     ...totals,
-    assistantResponseCount,
     cacheReadRate:
       totals.inputTokens > 0
         ? totals.cacheReadInputTokens / totals.inputTokens
@@ -438,13 +456,14 @@ export function summarizeCostLedger(ledger: CostLedger): CostSummary {
       totals.generationCount > 0
         ? totals.totalCost / totals.generationCount
         : null,
-    averageCostPerAssistantResponse:
-      assistantResponseCount !== null && assistantResponseCount > 0
-        ? totals.totalCost / assistantResponseCount
-        : null,
     modelDistribution: ledger.rows.map((row) => ({
       model: row.model,
       generationCount: row.generationCount,
+      inputTokens: row.inputTokens,
+      uncachedInputTokens: row.uncachedInputTokens,
+      cacheReadInputTokens: row.cacheReadInputTokens,
+      cacheWriteInputTokens: row.cacheWriteInputTokens,
+      outputTokens: row.outputTokens,
       share:
         totals.generationCount > 0
           ? row.generationCount / totals.generationCount
@@ -459,6 +478,17 @@ export function reconcileCostLedgers(
   litellm: CostLedger,
   options: { absoluteTolerance: number; relativeTolerance: number }
 ): ReconciliationResult {
+  for (const [label, value] of [
+    ['absoluteTolerance', options.absoluteTolerance],
+    ['relativeTolerance', options.relativeTolerance],
+  ] as const) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new CostEvidenceError(
+        `${label} must be a finite non-negative number`
+      )
+    }
+  }
+
   const langfuseSummary = summarizeCostLedger(langfuse)
   const litellmSummary = summarizeCostLedger(litellm)
   const issues: string[] = []

--- a/packages/prisma-data/src/scripts/lib/litellmCostSource.test.ts
+++ b/packages/prisma-data/src/scripts/lib/litellmCostSource.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import {
+  buildLiteLLMSpendRequest,
+  GATEWAY_COST_PAGE_SIZE,
+  loadLiteLLMCostRows,
+} from './litellmCostSource.js'
+
+const scope = {
+  from: '2026-08-01T00:00:00.000Z',
+  to: '2026-08-02T00:00:00.000Z',
+  environment: 'prd',
+  teamId: 'team-klicker',
+}
+
+function testRequestContract() {
+  const request = buildLiteLLMSpendRequest(
+    scope,
+    'https://litellm.example/',
+    'Bearer test-key',
+    2
+  )
+  const url = new URL(request.url)
+
+  assert.equal(url.pathname, '/spend/logs/v2')
+  assert.equal(url.searchParams.get('start_date'), '2026-08-01')
+  assert.equal(url.searchParams.get('end_date'), '2026-08-02')
+  assert.equal(url.searchParams.get('team_id'), 'team-klicker')
+  assert.equal(url.searchParams.get('page'), '2')
+  assert.equal(
+    url.searchParams.get('page_size'),
+    String(GATEWAY_COST_PAGE_SIZE)
+  )
+  assert.equal(url.searchParams.get('sort_by'), 'startTime')
+  assert.equal(url.searchParams.get('sort_order'), 'asc')
+  assert.deepEqual(request.headers, {
+    'x-litellm-api-key': 'Bearer test-key',
+  })
+}
+
+async function testPaginationStopsAtReportedLastPage() {
+  const requests: string[] = []
+  const requestJson = async (url: string) => {
+    requests.push(url)
+    const page = requests.length
+    return {
+      data:
+        page === 1
+          ? Array.from({ length: GATEWAY_COST_PAGE_SIZE }, (_, index) => ({
+              request_id: `request-${index}`,
+            }))
+          : [{ request_id: 'request-last' }],
+      page,
+      page_size: GATEWAY_COST_PAGE_SIZE,
+      total_pages: 2,
+    }
+  }
+
+  const rows = await loadLiteLLMCostRows(
+    scope,
+    'https://litellm.example',
+    'Bearer test-key',
+    requestJson
+  )
+
+  assert.equal(requests.length, 2)
+  assert.equal(rows.length, GATEWAY_COST_PAGE_SIZE + 1)
+  assert.match(requests[1]!, /[?&]page=2(?:&|$)/)
+}
+
+testRequestContract()
+await testPaginationStopsAtReportedLastPage()
+
+console.log('LiteLLM cost source tests passed')

--- a/packages/prisma-data/src/scripts/lib/litellmCostSource.ts
+++ b/packages/prisma-data/src/scripts/lib/litellmCostSource.ts
@@ -1,0 +1,105 @@
+import type { AggregateScope } from './aggregateCostReconciliation.js'
+
+export const GATEWAY_COST_PAGE_SIZE = 100
+export const GATEWAY_COST_MAX_PAGES = 1000
+
+export type CostJsonRequester = (
+  url: string,
+  headers: Record<string, string>
+) => Promise<unknown>
+
+export function buildLiteLLMSpendRequest(
+  scope: AggregateScope,
+  host: string,
+  authorization: string,
+  page: number
+) {
+  const params = new URLSearchParams({
+    start_date: scope.from.slice(0, 10),
+    end_date: litellmEndDate(scope.to),
+    team_id: scope.teamId,
+    page: String(page),
+    page_size: String(GATEWAY_COST_PAGE_SIZE),
+    sort_by: 'startTime',
+    sort_order: 'asc',
+  })
+
+  return {
+    url: `${host.replace(/\/$/, '')}/spend/logs/v2?${params.toString()}`,
+    headers: { 'x-litellm-api-key': authorization },
+  }
+}
+
+export async function loadLiteLLMCostRows(
+  scope: AggregateScope,
+  host: string,
+  authorization: string,
+  requestJson: CostJsonRequester
+) {
+  const rows: unknown[] = []
+
+  for (let page = 1; page <= GATEWAY_COST_MAX_PAGES; page += 1) {
+    const request = buildLiteLLMSpendRequest(
+      scope,
+      host,
+      authorization,
+      page
+    )
+    const payload = await requestJson(request.url, request.headers)
+    const pageRows = responseRows(payload)
+    rows.push(...pageRows)
+
+    const totalPages = readTotalPages(payload)
+    if (
+      pageRows.length < GATEWAY_COST_PAGE_SIZE ||
+      (totalPages !== null && page >= totalPages)
+    ) {
+      return rows
+    }
+  }
+
+  throw new Error('LiteLLM cost evidence exceeded the page safety limit.')
+}
+
+function responseRows(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('LiteLLM spend response must be an object.')
+  }
+
+  const data = (payload as { data?: unknown }).data
+  if (!Array.isArray(data)) {
+    throw new Error('LiteLLM spend response data must be an array.')
+  }
+  return data
+}
+
+function readTotalPages(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null
+  }
+
+  const object = payload as { total_pages?: unknown; totalPages?: unknown }
+  const totalPages = Number(object.total_pages ?? object.totalPages)
+  return Number.isInteger(totalPages) && totalPages >= 0 ? totalPages : null
+}
+
+function litellmEndDate(isoTimestamp: string) {
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Gateway cost window must use valid UTC timestamps.')
+  }
+
+  // A midnight half-open boundary does not need the following calendar day;
+  // fetching it can make the LiteLLM spend response too large to serve.
+  if (
+    date.getUTCHours() === 0 &&
+    date.getUTCMinutes() === 0 &&
+    date.getUTCSeconds() === 0 &&
+    date.getUTCMilliseconds() === 0
+  ) {
+    return date.toISOString().slice(0, 10)
+  }
+
+  date.setUTCDate(date.getUTCDate() + 1)
+  return date.toISOString().slice(0, 10)
+}

--- a/packages/prisma-data/src/scripts/lib/litellmCostSource.ts
+++ b/packages/prisma-data/src/scripts/lib/litellmCostSource.ts
@@ -39,12 +39,7 @@ export async function loadLiteLLMCostRows(
   const rows: unknown[] = []
 
   for (let page = 1; page <= GATEWAY_COST_MAX_PAGES; page += 1) {
-    const request = buildLiteLLMSpendRequest(
-      scope,
-      host,
-      authorization,
-      page
-    )
+    const request = buildLiteLLMSpendRequest(scope, host, authorization, page)
     const payload = await requestJson(request.url, request.headers)
     const pageRows = responseRows(payload)
     rows.push(...pageRows)

--- a/project/2026-08-11-chat-turn-affinity-cache-plan.md
+++ b/project/2026-08-11-chat-turn-affinity-cache-plan.md
@@ -1,0 +1,172 @@
+# Vorkurs turn-scoped routing and cost accounting
+
+## Goal
+
+Send one pseudonymous routing key per assistant response and one stable
+pseudonymous prompt-cache key per thread. Extend the existing usage report to
+reconcile aggregate Langfuse and LiteLLM evidence so the cost effect of
+disabling gateway affinity can be measured without storing per-call data in
+Klicker.
+
+## Non-goals
+
+- No `ChatModelCall` table, per-call model/cost fields, or schema migration.
+- No prompt, model-registry, credits, MCP, or answer-quality change.
+- No secret values, raw prompts, personal data, or raw production exports in
+  the repository.
+- No push, merge, cluster action, STG/PRD rollout, paid canary, or production
+  claim in this branch.
+- No exact course/chatbot gateway-cost allocation; only aggregate
+  team/window/model reconciliation is supported.
+
+## Plan identity
+
+- Plan: `project/2026-08-11-chat-turn-affinity-cache-plan.md`
+- Branch: `rs/chat-turn-affinity-cache`
+- Worktree: `trees/chat-turn-affinity-cache`
+- Target: `v3`
+- Paired deployment branch: `rs/klicker-turn-affinity`
+- Paired deployment plan: `2026-08-11-klicker-affinity-off-plan.md`
+- Base: `origin/v3` at `0d7b4e46126f2f01931f07deccbd719ad0c163a5`
+
+## Research
+
+- `apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts` already receives
+  `assistantMessageId`, resolves or creates `currentThreadId`, and has one
+  `providerOptions.openai` object shared by all `streamText` tool-loop calls.
+- AI SDK `7.0.52` and OpenAI provider `4.0.30` serialize OpenAI `metadata`,
+  `promptCacheKey`, and cache-read/cache-write usage details for both provider
+  paths. The installed source was checked because Context7 is unavailable.
+- `assistantMessageId` is generated for every assistant response. The thread
+  is stable across turns, so the two identifiers provide the required
+  turn/thread distinction without persistence.
+- The existing report uses stored `creditsUsed` and rough visible-text token
+  estimates. It has no external Langfuse/LiteLLM aggregate reader.
+- The deployment base currently enables gateway affinity everywhere. The
+  paired deployment change will make the disabled policy explicit before any
+  rollout; the app still sends metadata so controlled later experiments can
+  observe the routing key.
+
+## Decisions
+
+- `metadata.session_id` is the deterministic pseudonymous trace id derived
+  from `assistantMessageId`, reusing the existing Langfuse message-id helper.
+  It is the same for every internal call in one response and changes on the
+  next response.
+- `promptCacheKey` is a domain-separated deterministic hash of the verified
+  owning thread id. The raw thread id is never sent to the provider. Omit the
+  cache key if thread ownership cannot be established.
+- The provider-options helper is pure and receives identifiers as arguments;
+  the route owns authentication, thread lookup, and provider selection.
+- External cost evidence is grouped by UTC window, environment, team, and
+  routed model. Credits remain a separate product-ledger column.
+- Cache algebra is valid only when source fields are present and mutually
+  exclusive: `uncached = input - cached - cacheWrite`. Negative buckets,
+  missing required coverage, count drift, or cost drift make reconciliation
+  incomplete rather than inferred.
+- The report keeps its existing local-only path. An explicit reconciliation
+  mode reads credentials from the runtime environment and never writes them.
+
+## Test portfolio
+
+| Risk or behavior | Existing evidence | Obligation and seam | Owning slice |
+| --- | --- | --- | --- |
+| Same-turn tool-loop calls share one session key and cache key | Sparse streamed-tool fixture proves the provider path | Extend the synthetic OpenAI fetch fixture and inspect every request body | Runtime |
+| Next assistant response reclassifies while the thread cache key stays stable | No current protection | Add pure provider-options table cases | Runtime |
+| Missing thread ownership does not leak a raw id or invent a cache key | Route has ownership checks but no provider-option assertion | Add a pure helper case | Runtime |
+| Aggregate cache/cost reconciliation rejects incomplete or inconsistent data | No current external-ledger parser | Add synthetic parser/reconciler tests through existing `tsx`; no dependency | Accounting |
+| Existing product report remains usable without external credentials | Current report path | Extend existing report path without changing credits semantics; run package checks | Accounting |
+
+## Slices
+
+### Slice 1 — Reviewed plan
+
+**Do:** Commit this plan as the first commit on the branch.
+
+**Check:** Only this plan is staged; primary-checkout user files are outside
+the worktree and cannot enter the commit.
+
+**Commit:** `docs(project): add turn affinity and cost accounting plan`
+
+### Slice 2 — Turn-scoped provider options
+
+**Do:** Add the pure OpenAI provider-options helper, pass its values through the
+route's existing `providerOptions.openai` block, and extend the synthetic
+stream fixture. Preserve reasoning, response-store, tool, and telemetry
+options.
+
+**Check:** Assert same-turn tool-loop request bodies share one session id and
+cache key; different assistant ids produce different session ids; same thread
+produces the same cache key; missing ownership omits only the cache key. Run
+the focused test before and after the change, then the chat suite and package
+check.
+
+**Commit:** `enhance(chat): add turn-scoped routing and prompt cache keys`
+
+### Slice 3 — Aggregate ledger reconciliation
+
+**Do:** Add a small pure parser/reconciler under
+`packages/prisma-data/src/scripts/lib/`, synthetic tests, and an explicit
+report mode in `2026-06-16_analyze_chatbot_usage.ts`. Read Langfuse and LiteLLM
+aggregates with native `fetch`; keep host, key, and project values in the
+runtime environment. Add separate report fields for credits, gateway spend,
+cache buckets, counts, coverage, and reconciliation status.
+
+**Check:** Synthetic success, absent cache-write data, negative algebra, wrong
+team/window/model set, generation-count drift, and cost-tolerance drift all
+behave as specified. Run the script package checks and inspect output schemas
+without using real prompts or production data.
+
+**Commit:** `enhance(prisma-data): reconcile chatbot gateway cost aggregates`
+
+### Slice 4 — Wiki and verification contract
+
+**Do:** Update the relevant chat/testing wiki pages, the verification skill,
+and a new dated log entry with the provider-option contract, disabled-affinity
+cost experiment, synthetic evidence boundary, and STG/PRD gates.
+
+**Check:** Run focused tests, full chat tests, prisma-data checks, repository
+checks, and the data-hygiene review. Review the complete branch after all
+changes.
+
+**Commit:** `docs(chat): document turn routing and cost evidence`
+
+## Manual gates
+
+- First prove serialized request fields locally, then verify STG metadata and
+  aggregate ingestion with the deployment policy applied through the approved
+  GitOps path.
+- Compare matched seven-day UTC windows before and after affinity is disabled,
+  holding image, model catalog, environment, team scope, weekday mix, and
+  unrelated routing changes constant where possible. Report request and
+  generation counts, routed-model distribution, input/output/cache buckets,
+  cache-read rate, total spend, and average cost per assistant response.
+- STG and PRD rollout, secret-backed queries, paid measurement, merge, and
+  production claims each require separate approval. Local/CI evidence does not
+  prove route selection, cache hits, Langfuse ingestion, Azure billing, or
+  answer quality.
+
+## Planning-stage review
+
+- Reviewer: configured Codex planner, read-only, current repositories.
+- Result: `DONE_WITH_CONCERNS`.
+- Accepted findings: two independent packages; explicit `session_affinity:
+  false` in deployment; remove inactive TTL; keep correlation headers; fail
+  closed on incomplete cache algebra; use aggregate rather than exact
+  course-level cost.
+
+## Progress
+
+- [x] Reconciled live refs and dirty primary checkouts.
+- [x] Created clean worktree from current `origin/v3`.
+- [x] Completed the revised planning-stage review.
+- [ ] Commit this plan.
+- [ ] Implement runtime options.
+- [ ] Implement aggregate reconciliation.
+- [ ] Update durable documentation and complete final reviews.
+
+## Next Steps
+
+1. Commit this plan, then implement the runtime slice.
+2. Keep deployment rollout and cost measurement at their explicit approval
+   gates.

--- a/project/2026-08-11-chat-turn-affinity-cache-plan.md
+++ b/project/2026-08-11-chat-turn-affinity-cache-plan.md
@@ -140,7 +140,8 @@ changes.
   holding image, model catalog, environment, team scope, weekday mix, and
   unrelated routing changes constant where possible. Report request and
   generation counts, routed-model distribution, input/output/cache buckets,
-  cache-read rate, total spend, and average cost per assistant response.
+  cache-read rate, total spend, and average cost per generation. Do not infer
+  an assistant-response denominator from session correlation keys.
 - STG and PRD rollout, secret-backed queries, paid measurement, merge, and
   production claims each require separate approval. Local/CI evidence does not
   prove route selection, cache hits, Langfuse ingestion, Azure billing, or

--- a/project/2026-08-11-chat-turn-affinity-cache-plan.md
+++ b/project/2026-08-11-chat-turn-affinity-cache-plan.md
@@ -160,13 +160,14 @@ changes.
 - [x] Reconciled live refs and dirty primary checkouts.
 - [x] Created clean worktree from current `origin/v3`.
 - [x] Completed the revised planning-stage review.
-- [ ] Commit this plan.
-- [ ] Implement runtime options.
-- [ ] Implement aggregate reconciliation.
-- [ ] Update durable documentation and complete final reviews.
+- [x] Commit this plan.
+- [x] Implement runtime options.
+- [x] Implement aggregate reconciliation.
+- [x] Update durable documentation and verification contract.
+- [ ] Complete final reviews.
 
 ## Next Steps
 
-1. Commit this plan, then implement the runtime slice.
+1. Complete the integrated correctness, security, and maintainability reviews.
 2. Keep deployment rollout and cost measurement at their explicit approval
-   gates.
+   gates; the `--gateway-cost` mode is ready for a later matched UTC window.


### PR DESCRIPTION
## What This Changes

This PR adds turn-scoped routing and cost evidence for the chatbot path:

- Routes one assistant response's tool loop through one Auto Router model while
  allowing the next user turn to be classified again.
- Passes a stable thread-scoped prompt-cache key and an assistant-message
  session key through the existing OpenAI provider options on the default
  LiteLLM route; custom chatbot endpoints keep their existing request shape.
- Adds Langfuse/LiteLLM aggregate reconciliation with fail-closed handling for
  missing or ambiguous cache-token buckets.
- Adds focused routing/cache-option and aggregate-reconciliation tests and
  documents the runtime and verification contract.
- Hardens the gateway-cost analyzer's midnight half-open end boundary, uses
  LiteLLM's documented `x-litellm-api-key` header, and reads the paginated,
  team-scoped `/spend/logs/v2` endpoint.

Affinity is currently disabled in STG and PRD by the separately merged
deployment change. This PR contains the application and accounting work; it
does not enable production affinity or claim a measured cost reduction.

## Branch Coverage

- Base: `v3` at the current fetched `origin/v3`; this branch is currently 4
  commits behind that base and has not been rebased.
- Head: `1d12969f1` (`style(prisma-data): format LiteLLM cost source`).
- Reviewed: 9 commits from `origin/v3..HEAD`; 1,584 substantive additions and
  1 deletion across 13 files, excluding the 174-line committed project-plan
  artifact.
- Covered slices: plan and acceptance contract, turn-scoped provider routing,
  aggregate cost reconciliation, branch-wide chat/accounting documentation,
  analyzer hardening, and focused tests.

## Review Focus

- Confirm the provider options keep the session key scoped to one assistant
  response while keeping the prompt-cache key stable only for the thread.
- Confirm custom chatbot endpoints do not receive LiteLLM-specific routing or
  prompt-cache fields.
- Confirm Langfuse/LiteLLM reconciliation stays fail-closed when cache reads or
  writes are absent and does not double-count inclusive input tokens.
- Confirm the LiteLLM v2 request is team-scoped, paginated, and bounded
  correctly for midnight UTC windows.
- Treat the four-commit base divergence as a pre-merge integration task; no
  history rewrite was made without explicit approval.

## Verification

Current head:

- `pnpm --filter @klicker-uzh/prisma-data check` -> pass under the available
  Node 26 runtime; pnpm reports the repository's declared Node 24 engine
  warning.
- `pnpm --filter @klicker-uzh/chat check` -> pass after building the local
  markdown workspace dependency.
- `pnpm --filter @klicker-uzh/chat test:run` -> 32 files and 236 tests passed
  after the final review correction.
- `pnpm --filter @klicker-uzh/chat lint` -> 0 errors and 5 existing warnings.
- `pnpm --filter @klicker-uzh/markdown build` -> completed with existing
  unresolved `@uzh-bf/design-system` declaration warnings.
- `pnpm --filter @klicker-uzh/prisma-data exec tsx src/scripts/lib/litellmCostSource.test.ts` -> pass for the v2 URL/header contract and two-page termination.
- `pnpm exec prettier --check docs/testing.md .agents/skills/klicker-testing-verification/SKILL.md` -> pass.
- `pnpm run format:check` -> pass after the hosted formatter correction.
- `git show --check HEAD` and `git diff --check` -> pass.

Not run:

- The existing aggregate reconciliation test remains a direct TypeScript test
  because that package has no Vitest dependency or test script; no new test
  dependency was added.
- Live cache-inclusive cost analysis was not run because the required
  LiteLLM/Langfuse cache-token mapping is still absent and the prior runtime
  port-forward is no longer available.

Earlier branch verification:

- Deployment MR !570 separately merged affinity-off configuration and was
  reconciled in STG and PRD. That runtime state is context for this PR, not
  current-head proof of the application changes.

## Security / Privacy

- No secrets, credentials, production payloads, or personal data are included.
- No database schema, authentication boundary, or new data store is added.
- Runtime secret access for later cost analysis remains restricted to the
  existing Infisical operator allowlist.

## Blocking Before Merge

- [ ] Reconcile the branch with the four newer `v3` commits, then rerun the
  applicable checks and review the exact resulting head.
- [ ] Hosted CI for the rebased head.

## Follow-Up After Merge

- Implement and verify the active LiteLLM v1.96 `langfuse_otel` cache-token
  mapping. The handoff is
  `~/.handoffs/klicker-uzh/2026-08-12-cache-token-mapping-research-implementation-handoff.md`.
- Keep affinity disabled while the mapping is researched and evaluate matched
  pre/post windows only after Langfuse and LiteLLM counts and modeled costs
  reconcile.
- Treat any Azure invoice comparison as a separate billing reconciliation.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch:

- Machine: `MacBook-Pro`
- Handoff: `~/.handoffs/klicker-uzh/2026-08-12-cache-token-mapping-research-implementation-handoff.md`
- Worktree: `trees/chat-turn-affinity-cache` in repository `klicker-uzh`
