### PR TITLE
feat(live-quiz): admit correlated responses

### DIFF
--- a/apps/analytics/prisma/schema/quiz.prisma
+++ b/apps/analytics/prisma/schema/quiz.prisma
@@ -128,6 +128,7 @@ model LiveQuiz {
   temporaryLeaderboard TemporaryLeaderboardEntry[]
   respondents          LiveQuizRespondent[]
   respondentBindings   LiveQuizRespondentBinding[]
+  pendingResponses     LiveQuizPendingResponse[]
 
   feedbacks          Feedback[]
   confusionFeedbacks ConfusionTimestep[]

--- a/apps/analytics/prisma/schema/response.prisma
+++ b/apps/analytics/prisma/schema/response.prisma
@@ -146,6 +146,22 @@ model LiveQuizResponse {
   @@index([instanceId, elementBlockExecution])
 }
 
+model LiveQuizPendingResponse {
+  id               String   @id @db.Uuid
+  responseKey      String   @unique
+  eventPayload     String?
+  nextDeliveryAt   DateTime?
+  deliveryAttempts Int      @default(0)
+  createdAt        DateTime @default(now())
+  settledAt        DateTime?
+
+  liveQuiz   LiveQuiz @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String   @db.Uuid
+
+  @@index([liveQuizId])
+  @@index([nextDeliveryAt])
+}
+
 enum PointCorrectionType {
   ALL_COURSE
   PARTICIPATING

--- a/apps/analytics/prisma/schema/response.prisma
+++ b/apps/analytics/prisma/schema/response.prisma
@@ -157,8 +157,10 @@ model LiveQuizPendingResponse {
 
   liveQuiz   LiveQuiz @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   liveQuizId String   @db.Uuid
+  publicationGeneration Int @default(0)
 
   @@index([liveQuizId])
+  @@index([liveQuizId, publicationGeneration, settledAt])
   @@index([nextDeliveryAt])
 }
 

--- a/apps/response-api/package.json
+++ b/apps/response-api/package.json
@@ -34,7 +34,8 @@
     "dev:offline": "pnpm run dev",
     "dev:test": "cross-env NODE_ENV=test ASSESSMENT_MODE=false tsx --env-file=.env src/index.ts",
     "dev:ts": "cross-env NODE_ENV=development tsx --watch --env-file=.env src/index.ts",
-    "start:test": "node --env-file=.env dist/index.js"
+    "start:test": "node --env-file=.env dist/index.js",
+    "test:run": "node --import tsx --test test/*.test.ts"
   },
   "engines": {
     "node": "=24"

--- a/apps/response-api/src/aggregateResponse.ts
+++ b/apps/response-api/src/aggregateResponse.ts
@@ -1,0 +1,74 @@
+import { LiveQuizResponseCollectionMode } from '@klicker-uzh/prisma/client'
+import type { LiveQuizResponseEventMessage } from '@klicker-uzh/util'
+import type { LiveQuizResponseRequest } from './liveQuizResponseRequest.js'
+
+type AggregateResponseEvent =
+  | 'response-received:authenticated'
+  | 'response-received:anonymous'
+
+export async function handleAggregateResponse({
+  request,
+  responseCollectionMode,
+  pushEvent,
+}: {
+  request: LiveQuizResponseRequest
+  responseCollectionMode: LiveQuizResponseCollectionMode
+  pushEvent: (
+    eventName: AggregateResponseEvent,
+    message: LiveQuizResponseEventMessage
+  ) => Promise<unknown>
+}) {
+  if (
+    responseCollectionMode === LiveQuizResponseCollectionMode.CORRELATED_EXPORT
+  ) {
+    return {
+      status: 409,
+      body: {
+        error: 'Response endpoint does not match live quiz collection mode',
+      },
+    }
+  }
+
+  const cookie = getAggregateResponseCookie(request.cookieHeader)
+  const eventName: AggregateResponseEvent = cookie
+    ? 'response-received:authenticated'
+    : 'response-received:anonymous'
+  const message: LiveQuizResponseEventMessage = {
+    messageId: request.messageId,
+    sessionId: request.liveQuizId,
+    instanceId: request.instanceId,
+    response: request.response,
+    cookie,
+    responseTimestamp: request.responseTimestamp,
+  }
+
+  console.log(`Pushing event ${eventName}`, {
+    messageId: request.messageId,
+    sessionId: request.liveQuizId,
+    instanceId: request.instanceId,
+    responseTimestamp: request.responseTimestamp,
+  })
+  await pushEvent(eventName, message)
+
+  return {
+    status: 200,
+    body: { status: 'ok', responseTimestamp: request.responseTimestamp },
+  }
+}
+
+function getAggregateResponseCookie(cookieHeader: string | undefined) {
+  if (!cookieHeader) return undefined
+
+  const parts = cookieHeader.split(';').map((part) => part.trim())
+  const participantPair = parts.find((part) =>
+    part.startsWith('participant_token=')
+  )
+  const temporaryPair = parts.find((part) =>
+    part.startsWith('temporary_participant_token=')
+  )
+  const forwarded = [participantPair, temporaryPair].filter(
+    (pair): pair is string => Boolean(pair)
+  )
+
+  return forwarded.length > 0 ? forwarded.join('; ') : undefined
+}

--- a/apps/response-api/src/correlatedResponseAdmission.ts
+++ b/apps/response-api/src/correlatedResponseAdmission.ts
@@ -1,13 +1,11 @@
 import {
   ElementBlockStatus,
-  LiveQuizRespondentType,
   LiveQuizResponseCollectionMode,
   PublicationStatus,
   type PrismaClient,
 } from '@klicker-uzh/prisma/client'
 import {
   buildCorrelatedResponseKey,
-  buildLiveQuizResponseIdentityKey,
   encryptCorrelatedResponseEvent,
   getLiveQuizRespondentCookieName,
   hashLiveQuizRespondentToken,
@@ -17,6 +15,7 @@ import {
   type CorrelatedResponseInstanceInfo,
   type LiveQuizResponseIdentity,
 } from '@klicker-uzh/util'
+import { randomUUID } from 'node:crypto'
 
 const CORRELATED_OUTBOX_RETRY_MS = 30_000
 
@@ -36,18 +35,19 @@ export async function getCorrelatedResponseAdmission({
       pinCode: true,
       responseCollectionMode: true,
       status: true,
+      publicationGeneration: true,
     },
   })
 
   if (!liveQuiz || liveQuiz.status !== PublicationStatus.PUBLISHED) {
-    return 'not_found' as const
+    return { status: 'not_found' as const }
   }
   if (
     liveQuiz.isAssessmentEnabled ||
     liveQuiz.responseCollectionMode !==
       LiveQuizResponseCollectionMode.CORRELATED_EXPORT
   ) {
-    return 'not_required' as const
+    return { status: 'not_required' as const }
   }
   if (
     !hasValidLiveQuizPin({
@@ -56,9 +56,12 @@ export async function getCorrelatedResponseAdmission({
       pinCode: liveQuiz.pinCode,
     })
   ) {
-    return 'pin_required' as const
+    return { status: 'pin_required' as const }
   }
-  return 'ready' as const
+  return {
+    status: 'ready' as const,
+    publicationGeneration: liveQuiz.publicationGeneration,
+  }
 }
 
 export async function admitCorrelatedResponse({
@@ -112,6 +115,7 @@ export async function admitCorrelatedResponse({
           isAssessmentEnabled: boolean
           pinCode: string | null
           responseCollectionMode: LiveQuizResponseCollectionMode
+          publicationGeneration: number
           status: PublicationStatus
         }[]
       >`
@@ -123,6 +127,7 @@ export async function admitCorrelatedResponse({
           quiz."isAssessmentEnabled",
           quiz."pinCode",
           quiz."responseCollectionMode"::text AS "responseCollectionMode",
+          quiz."publicationGeneration",
           quiz."status"::text AS "status"
         FROM "public"."LiveQuiz" AS quiz
         JOIN "public"."ElementBlock" AS block
@@ -159,6 +164,16 @@ export async function admitCorrelatedResponse({
         return { status: 'pin_required' as const }
       }
 
+      if (identity.kind === 'temporary') {
+        return { status: 'invalid_identity' as const }
+      }
+      if (
+        identity.kind === 'anonymous' &&
+        identity.publicationGeneration !== admission.publicationGeneration
+      ) {
+        return { status: 'invalid_identity' as const }
+      }
+
       if (identity.kind === 'participant') {
         const participant = await prisma.participant.findUnique({
           where: { id: identity.id },
@@ -167,73 +182,143 @@ export async function admitCorrelatedResponse({
         if (!participant) {
           return { status: 'invalid_identity' as const }
         }
-      } else if (identity.kind === 'temporary') {
-        const temporaryEntry =
-          await prisma.temporaryLeaderboardEntry.findUnique({
-            where: {
-              id_quizId: {
-                id: identity.id,
-                quizId: liveQuizId,
-              },
-            },
-            select: { id: true },
-          })
-        if (!temporaryEntry) {
-          return { status: 'invalid_identity' as const }
-        }
+      }
 
-        const respondent = await prisma.liveQuizRespondent.upsert({
-          where: { id: identity.id },
-          update: {},
-          create: {
-            id: identity.id,
-            type: LiveQuizRespondentType.TEMPORARY_PSEUDONYM,
-            liveQuiz: { connect: { id: liveQuizId } },
+      const expiresAt = new Date(
+        Date.now() + LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS * 1000
+      )
+      const verificationSecretHash =
+        identity.kind === 'anonymous'
+          ? hashLiveQuizRespondentToken(identity.token)
+          : null
+      const bindingSelect = {
+        respondentId: true,
+        liveQuizId: true,
+        publicationGeneration: true,
+        participantId: true,
+        verificationSecretHash: true,
+        expiresAt: true,
+      } as const
+      const existingBinding =
+        identity.kind === 'participant'
+          ? await prisma.liveQuizRespondentBinding.findUnique({
+              where: {
+                liveQuizId_publicationGeneration_participantId: {
+                  liveQuizId,
+                  publicationGeneration: admission.publicationGeneration,
+                  participantId: identity.id,
+                },
+              },
+              select: bindingSelect,
+            })
+          : await prisma.liveQuizRespondentBinding.findUnique({
+              where: {
+                liveQuizId_publicationGeneration_verificationSecretHash: {
+                  liveQuizId,
+                  publicationGeneration: admission.publicationGeneration,
+                  verificationSecretHash: hashLiveQuizRespondentToken(
+                    identity.token
+                  ),
+                },
+              },
+              select: bindingSelect,
+            })
+      const existingRespondent = existingBinding
+        ? await prisma.liveQuizRespondent.findUnique({
+            where: { id: existingBinding.respondentId },
+            select: {
+              finalizedAt: true,
+              liveQuizId: true,
+              publicationGeneration: true,
+            },
+          })
+        : null
+
+      if (
+        existingBinding &&
+        (!existingRespondent ||
+          existingRespondent.liveQuizId !== liveQuizId ||
+          existingRespondent.publicationGeneration !==
+            admission.publicationGeneration ||
+          existingRespondent.finalizedAt !== null)
+      ) {
+        return { status: 'invalid_identity' as const }
+      }
+
+      const binding = existingBinding
+        ? await prisma.liveQuizRespondentBinding.update({
+            where: { respondentId: existingBinding.respondentId },
+            data: { expiresAt },
+            select: bindingSelect,
+          })
+        : await (async () => {
+            const respondentId =
+              identity.kind === 'anonymous' ? identity.id : randomUUID()
+            await prisma.liveQuizRespondent.create({
+              data: {
+                id: respondentId,
+                liveQuizId,
+                publicationGeneration: admission.publicationGeneration,
+              },
+            })
+            return prisma.liveQuizRespondentBinding.create({
+              data: {
+                respondentId,
+                liveQuizId,
+                publicationGeneration: admission.publicationGeneration,
+                participantId:
+                  identity.kind === 'participant' ? identity.id : null,
+                verificationSecretHash,
+                expiresAt,
+              },
+              select: bindingSelect,
+            })
+          })()
+
+      const respondent =
+        existingRespondent ??
+        (await prisma.liveQuizRespondent.findUnique({
+          where: { id: binding.respondentId },
+          select: {
+            finalizedAt: true,
+            liveQuizId: true,
+            publicationGeneration: true,
           },
-        })
-        if (
-          respondent.liveQuizId !== liveQuizId ||
-          respondent.type !== LiveQuizRespondentType.TEMPORARY_PSEUDONYM
-        ) {
-          return { status: 'invalid_identity' as const }
-        }
-      } else {
-        const verificationSecretHash = hashLiveQuizRespondentToken(
-          identity.token
-        )
-        const respondent = await prisma.liveQuizRespondent.upsert({
-          where: { id: identity.id },
-          update: {},
-          create: {
-            id: identity.id,
-            type: LiveQuizRespondentType.ANONYMOUS_CORRELATED,
-            verificationSecretHash,
-            liveQuiz: { connect: { id: liveQuizId } },
-          },
-        })
-        if (
-          respondent.liveQuizId !== liveQuizId ||
-          respondent.type !== LiveQuizRespondentType.ANONYMOUS_CORRELATED ||
-          respondent.verificationSecretHash !== verificationSecretHash
-        ) {
-          return { status: 'invalid_identity' as const }
-        }
+        }))
+
+      if (
+        binding.liveQuizId !== liveQuizId ||
+        binding.publicationGeneration !== admission.publicationGeneration ||
+        !respondent ||
+        respondent.liveQuizId !== liveQuizId ||
+        respondent.publicationGeneration !== admission.publicationGeneration ||
+        respondent.finalizedAt !== null ||
+        (identity.kind === 'participant' &&
+          binding.participantId !== identity.id) ||
+        (identity.kind === 'anonymous' &&
+          (binding.respondentId !== identity.id ||
+            binding.verificationSecretHash !==
+              hashLiveQuizRespondentToken(identity.token)))
+      ) {
+        return { status: 'invalid_identity' as const }
       }
 
       const acceptedIdentity = {
-        kind: identity.kind,
-        id: identity.id,
+        kind: 'anonymous' as const,
+        id: binding.respondentId,
       }
       const responseKey = buildCorrelatedResponseKey({
         liveQuizId,
+        publicationGeneration: admission.publicationGeneration,
         instanceId,
         blockExecution,
-        identityKey: buildLiveQuizResponseIdentityKey(identity),
+        identityKey: `respondent:${binding.respondentId}`,
       })
       const eventMessage: CorrelatedResponseEventMessage = {
         messageId,
         sessionId: liveQuizId,
         instanceId,
+        publicationGeneration: admission.publicationGeneration,
         response,
         responseTimestamp,
         acceptedIdentity,
@@ -243,6 +328,7 @@ export async function admitCorrelatedResponse({
         data: {
           id: messageId,
           liveQuizId,
+          publicationGeneration: admission.publicationGeneration,
           responseKey,
           eventPayload: encryptCorrelatedResponseEvent({
             message: eventMessage,

--- a/apps/response-api/src/correlatedResponseAdmission.ts
+++ b/apps/response-api/src/correlatedResponseAdmission.ts
@@ -1,23 +1,48 @@
+import { randomUUID } from 'node:crypto'
 import {
   ElementBlockStatus,
   LiveQuizResponseCollectionMode,
-  PublicationStatus,
   type PrismaClient,
+  PublicationStatus,
 } from '@klicker-uzh/prisma/client'
 import {
   buildCorrelatedResponseKey,
+  type CorrelatedResponseEventMessage,
+  type CorrelatedResponseInstanceInfo,
   encryptCorrelatedResponseEvent,
   getLiveQuizRespondentCookieName,
   hashLiveQuizRespondentToken,
   LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS,
-  parseCookiesHeader,
-  type CorrelatedResponseEventMessage,
-  type CorrelatedResponseInstanceInfo,
   type LiveQuizResponseIdentity,
+  parseCookiesHeader,
 } from '@klicker-uzh/util'
-import { randomUUID } from 'node:crypto'
 
 const CORRELATED_OUTBOX_RETRY_MS = 30_000
+
+const CORRELATED_ADMISSION_MAX_ATTEMPTS = 3
+
+type AdmitCorrelatedResponseInput = {
+  database: Pick<PrismaClient, '$transaction'>
+  identity: LiveQuizResponseIdentity
+  liveQuizId: string
+  instanceId: string
+  messageId: string
+  response: CorrelatedResponseEventMessage['response']
+  responseTimestamp: number
+  instanceInfo: CorrelatedResponseInstanceInfo
+  cookieHeader: string | undefined
+  secret: string
+  nextDeliveryAt?: Date
+}
+
+function isUniqueConstraintViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'P2002'
+  )
+}
 
 export async function getCorrelatedResponseAdmission({
   database,
@@ -64,7 +89,7 @@ export async function getCorrelatedResponseAdmission({
   }
 }
 
-export async function admitCorrelatedResponse({
+async function admitCorrelatedResponseAttempt({
   database,
   identity,
   liveQuizId,
@@ -76,19 +101,7 @@ export async function admitCorrelatedResponse({
   cookieHeader,
   secret,
   nextDeliveryAt = new Date(Date.now() + CORRELATED_OUTBOX_RETRY_MS),
-}: {
-  database: Pick<PrismaClient, '$transaction'>
-  identity: LiveQuizResponseIdentity
-  liveQuizId: string
-  instanceId: string
-  messageId: string
-  response: CorrelatedResponseEventMessage['response']
-  responseTimestamp: number
-  instanceInfo: CorrelatedResponseInstanceInfo
-  cookieHeader: string | undefined
-  secret: string
-  nextDeliveryAt?: Date
-}) {
+}: AdmitCorrelatedResponseInput) {
   const blockExecution = instanceInfo.blockExecution
   const parsedInstanceId = Number(instanceId)
   const parsedBlockExecution = Number(blockExecution)
@@ -104,21 +117,20 @@ export async function admitCorrelatedResponse({
     return { status: 'invalid_metadata' }
   }
 
-  try {
-    return await database.$transaction(async (prisma) => {
-      const [admission] = await prisma.$queryRaw<
-        {
-          activeBlockId: number | null
-          blockExecution: number
-          blockId: number
-          blockStatus: ElementBlockStatus
-          isAssessmentEnabled: boolean
-          pinCode: string | null
-          responseCollectionMode: LiveQuizResponseCollectionMode
-          publicationGeneration: number
-          status: PublicationStatus
-        }[]
-      >`
+  return database.$transaction(async (prisma) => {
+    const [admission] = await prisma.$queryRaw<
+      {
+        activeBlockId: number | null
+        blockExecution: number
+        blockId: number
+        blockStatus: ElementBlockStatus
+        isAssessmentEnabled: boolean
+        pinCode: string | null
+        responseCollectionMode: LiveQuizResponseCollectionMode
+        publicationGeneration: number
+        status: PublicationStatus
+      }[]
+    >`
         SELECT
           quiz."activeBlockId",
           block."execution" AS "blockExecution",
@@ -141,214 +153,234 @@ export async function admitCorrelatedResponse({
         FOR SHARE OF quiz, block
       `
 
-      if (
-        !admission ||
-        admission.status !== PublicationStatus.PUBLISHED ||
-        admission.isAssessmentEnabled ||
-        admission.responseCollectionMode !==
-          LiveQuizResponseCollectionMode.CORRELATED_EXPORT ||
-        admission.activeBlockId !== admission.blockId ||
-        admission.blockStatus !== ElementBlockStatus.ACTIVE ||
-        admission.blockId !== parsedSessionBlockId ||
-        admission.blockExecution !== parsedBlockExecution
-      ) {
-        return { status: 'not_found' as const }
-      }
-      if (
-        !hasValidLiveQuizPin({
-          cookieHeader,
-          liveQuizId,
-          pinCode: admission.pinCode,
-        })
-      ) {
-        return { status: 'pin_required' as const }
-      }
+    if (
+      !admission ||
+      admission.status !== PublicationStatus.PUBLISHED ||
+      admission.isAssessmentEnabled ||
+      admission.responseCollectionMode !==
+        LiveQuizResponseCollectionMode.CORRELATED_EXPORT ||
+      admission.activeBlockId !== admission.blockId ||
+      admission.blockStatus !== ElementBlockStatus.ACTIVE ||
+      admission.blockId !== parsedSessionBlockId ||
+      admission.blockExecution !== parsedBlockExecution
+    ) {
+      return { status: 'not_found' as const }
+    }
+    if (
+      !hasValidLiveQuizPin({
+        cookieHeader,
+        liveQuizId,
+        pinCode: admission.pinCode,
+      })
+    ) {
+      return { status: 'pin_required' as const }
+    }
 
-      if (identity.kind === 'temporary') {
+    if (identity.kind === 'temporary') {
+      return { status: 'invalid_identity' as const }
+    }
+    if (
+      identity.kind === 'anonymous' &&
+      identity.publicationGeneration !== admission.publicationGeneration
+    ) {
+      return { status: 'invalid_identity' as const }
+    }
+
+    if (identity.kind === 'participant') {
+      const participant = await prisma.participant.findUnique({
+        where: { id: identity.id },
+        select: { id: true },
+      })
+      if (!participant) {
         return { status: 'invalid_identity' as const }
       }
-      if (
-        identity.kind === 'anonymous' &&
-        identity.publicationGeneration !== admission.publicationGeneration
-      ) {
-        return { status: 'invalid_identity' as const }
-      }
+    }
 
-      if (identity.kind === 'participant') {
-        const participant = await prisma.participant.findUnique({
-          where: { id: identity.id },
-          select: { id: true },
-        })
-        if (!participant) {
-          return { status: 'invalid_identity' as const }
-        }
-      }
-
-      const expiresAt = new Date(
-        Date.now() + LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS * 1000
-      )
-      const verificationSecretHash =
-        identity.kind === 'anonymous'
-          ? hashLiveQuizRespondentToken(identity.token)
-          : null
-      const bindingSelect = {
-        respondentId: true,
-        liveQuizId: true,
-        publicationGeneration: true,
-        participantId: true,
-        verificationSecretHash: true,
-        expiresAt: true,
-      } as const
-      const existingBinding =
-        identity.kind === 'participant'
-          ? await prisma.liveQuizRespondentBinding.findUnique({
-              where: {
-                liveQuizId_publicationGeneration_participantId: {
-                  liveQuizId,
-                  publicationGeneration: admission.publicationGeneration,
-                  participantId: identity.id,
-                },
-              },
-              select: bindingSelect,
-            })
-          : await prisma.liveQuizRespondentBinding.findUnique({
-              where: {
-                liveQuizId_publicationGeneration_verificationSecretHash: {
-                  liveQuizId,
-                  publicationGeneration: admission.publicationGeneration,
-                  verificationSecretHash: hashLiveQuizRespondentToken(
-                    identity.token
-                  ),
-                },
-              },
-              select: bindingSelect,
-            })
-      const existingRespondent = existingBinding
-        ? await prisma.liveQuizRespondent.findUnique({
-            where: { id: existingBinding.respondentId },
-            select: {
-              finalizedAt: true,
-              liveQuizId: true,
-              publicationGeneration: true,
-            },
-          })
+    const expiresAt = new Date(
+      Date.now() + LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS * 1000
+    )
+    const verificationSecretHash =
+      identity.kind === 'anonymous'
+        ? hashLiveQuizRespondentToken(identity.token)
         : null
-
-      if (
-        existingBinding &&
-        (!existingRespondent ||
-          existingRespondent.liveQuizId !== liveQuizId ||
-          existingRespondent.publicationGeneration !==
-            admission.publicationGeneration ||
-          existingRespondent.finalizedAt !== null)
-      ) {
-        return { status: 'invalid_identity' as const }
-      }
-
-      const binding = existingBinding
-        ? await prisma.liveQuizRespondentBinding.update({
-            where: { respondentId: existingBinding.respondentId },
-            data: { expiresAt },
+    const bindingSelect = {
+      respondentId: true,
+      liveQuizId: true,
+      publicationGeneration: true,
+      participantId: true,
+      verificationSecretHash: true,
+      expiresAt: true,
+    } as const
+    const existingBinding =
+      identity.kind === 'participant'
+        ? await prisma.liveQuizRespondentBinding.findUnique({
+            where: {
+              liveQuizId_publicationGeneration_participantId: {
+                liveQuizId,
+                publicationGeneration: admission.publicationGeneration,
+                participantId: identity.id,
+              },
+            },
             select: bindingSelect,
           })
-        : await (async () => {
-            const respondentId =
-              identity.kind === 'anonymous' ? identity.id : randomUUID()
-            await prisma.liveQuizRespondent.create({
-              data: {
-                id: respondentId,
+        : await prisma.liveQuizRespondentBinding.findUnique({
+            where: {
+              liveQuizId_publicationGeneration_verificationSecretHash: {
                 liveQuizId,
                 publicationGeneration: admission.publicationGeneration,
+                verificationSecretHash: hashLiveQuizRespondentToken(
+                  identity.token
+                ),
               },
-            })
-            return prisma.liveQuizRespondentBinding.create({
-              data: {
-                respondentId,
-                liveQuizId,
-                publicationGeneration: admission.publicationGeneration,
-                participantId:
-                  identity.kind === 'participant' ? identity.id : null,
-                verificationSecretHash,
-                expiresAt,
-              },
-              select: bindingSelect,
-            })
-          })()
-
-      const respondent =
-        existingRespondent ??
-        (await prisma.liveQuizRespondent.findUnique({
-          where: { id: binding.respondentId },
+            },
+            select: bindingSelect,
+          })
+    const existingRespondent = existingBinding
+      ? await prisma.liveQuizRespondent.findUnique({
+          where: { id: existingBinding.respondentId },
           select: {
             finalizedAt: true,
             liveQuizId: true,
             publicationGeneration: true,
           },
-        }))
+        })
+      : null
 
-      if (
-        binding.liveQuizId !== liveQuizId ||
-        binding.publicationGeneration !== admission.publicationGeneration ||
-        !respondent ||
-        respondent.liveQuizId !== liveQuizId ||
-        respondent.publicationGeneration !== admission.publicationGeneration ||
-        respondent.finalizedAt !== null ||
-        (identity.kind === 'participant' &&
-          binding.participantId !== identity.id) ||
-        (identity.kind === 'anonymous' &&
-          (binding.respondentId !== identity.id ||
-            binding.verificationSecretHash !==
-              hashLiveQuizRespondentToken(identity.token)))
-      ) {
-        return { status: 'invalid_identity' as const }
-      }
-
-      const acceptedIdentity = {
-        kind: 'anonymous' as const,
-        id: binding.respondentId,
-      }
-      const responseKey = buildCorrelatedResponseKey({
-        liveQuizId,
-        publicationGeneration: admission.publicationGeneration,
-        instanceId,
-        blockExecution,
-        identityKey: `respondent:${binding.respondentId}`,
-      })
-      const eventMessage: CorrelatedResponseEventMessage = {
-        messageId,
-        sessionId: liveQuizId,
-        instanceId,
-        publicationGeneration: admission.publicationGeneration,
-        response,
-        responseTimestamp,
-        acceptedIdentity,
-        instanceInfo,
-      }
-      await prisma.liveQuizPendingResponse.create({
-        data: {
-          id: messageId,
-          liveQuizId,
-          publicationGeneration: admission.publicationGeneration,
-          responseKey,
-          eventPayload: encryptCorrelatedResponseEvent({
-            message: eventMessage,
-            secret,
-          }),
-          nextDeliveryAt,
-        },
-      })
-      return { status: 'registered' as const }
-    })
-  } catch (error) {
     if (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      error.code === 'P2002'
+      existingBinding &&
+      (!existingRespondent ||
+        existingRespondent.liveQuizId !== liveQuizId ||
+        existingRespondent.publicationGeneration !==
+          admission.publicationGeneration ||
+        existingRespondent.finalizedAt !== null)
     ) {
+      return { status: 'invalid_identity' as const }
+    }
+
+    const binding = existingBinding
+      ? await prisma.liveQuizRespondentBinding.update({
+          where: { respondentId: existingBinding.respondentId },
+          data: { expiresAt },
+          select: bindingSelect,
+        })
+      : await (async () => {
+          const respondentId =
+            identity.kind === 'anonymous' ? identity.id : randomUUID()
+          await prisma.liveQuizRespondent.create({
+            data: {
+              id: respondentId,
+              liveQuizId,
+              publicationGeneration: admission.publicationGeneration,
+            },
+          })
+          return prisma.liveQuizRespondentBinding.create({
+            data: {
+              respondentId,
+              liveQuizId,
+              publicationGeneration: admission.publicationGeneration,
+              participantId:
+                identity.kind === 'participant' ? identity.id : null,
+              verificationSecretHash,
+              expiresAt,
+            },
+            select: bindingSelect,
+          })
+        })()
+
+    const respondent =
+      existingRespondent ??
+      (await prisma.liveQuizRespondent.findUnique({
+        where: { id: binding.respondentId },
+        select: {
+          finalizedAt: true,
+          liveQuizId: true,
+          publicationGeneration: true,
+        },
+      }))
+
+    if (
+      binding.liveQuizId !== liveQuizId ||
+      binding.publicationGeneration !== admission.publicationGeneration ||
+      !respondent ||
+      respondent.liveQuizId !== liveQuizId ||
+      respondent.publicationGeneration !== admission.publicationGeneration ||
+      respondent.finalizedAt !== null ||
+      (identity.kind === 'participant' &&
+        binding.participantId !== identity.id) ||
+      (identity.kind === 'anonymous' &&
+        (binding.respondentId !== identity.id ||
+          binding.verificationSecretHash !==
+            hashLiveQuizRespondentToken(identity.token)))
+    ) {
+      return { status: 'invalid_identity' as const }
+    }
+
+    const acceptedIdentity = {
+      kind: 'anonymous' as const,
+      id: binding.respondentId,
+    }
+    const responseKey = buildCorrelatedResponseKey({
+      liveQuizId,
+      publicationGeneration: admission.publicationGeneration,
+      instanceId,
+      blockExecution,
+      identityKey: `respondent:${binding.respondentId}`,
+    })
+    // A receipt for this exact response key means the submission was
+    // already admitted. Identity-creation races surface as unique
+    // constraint errors instead and are retried by the public wrapper.
+    const existingReceipt = await prisma.liveQuizPendingResponse.findUnique({
+      where: { responseKey },
+      select: { id: true },
+    })
+    if (existingReceipt) {
       return { status: 'duplicate' as const }
     }
-    throw error
+    const eventMessage: CorrelatedResponseEventMessage = {
+      messageId,
+      sessionId: liveQuizId,
+      instanceId,
+      publicationGeneration: admission.publicationGeneration,
+      response,
+      responseTimestamp,
+      acceptedIdentity,
+      instanceInfo,
+    }
+    await prisma.liveQuizPendingResponse.create({
+      data: {
+        id: messageId,
+        liveQuizId,
+        publicationGeneration: admission.publicationGeneration,
+        responseKey,
+        eventPayload: encryptCorrelatedResponseEvent({
+          message: eventMessage,
+          secret,
+        }),
+        nextDeliveryAt,
+      },
+    })
+    return { status: 'registered' as const }
+  })
+}
+
+export async function admitCorrelatedResponse(
+  input: AdmitCorrelatedResponseInput
+) {
+  // Two concurrent first submissions by one identity can collide on the
+  // respondent or binding uniqueness constraints before either receipt
+  // exists. Retrying resolves the winning generation-scoped binding, while
+  // a receipt-key collision resolves as a duplicate on the next attempt.
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await admitCorrelatedResponseAttempt(input)
+    } catch (error) {
+      if (
+        attempt >= CORRELATED_ADMISSION_MAX_ATTEMPTS ||
+        !isUniqueConstraintViolation(error)
+      ) {
+        throw error
+      }
+    }
   }
 }
 

--- a/apps/response-api/src/correlatedResponseAdmission.ts
+++ b/apps/response-api/src/correlatedResponseAdmission.ts
@@ -1,0 +1,302 @@
+import {
+  ElementBlockStatus,
+  LiveQuizRespondentType,
+  LiveQuizResponseCollectionMode,
+  PublicationStatus,
+  type PrismaClient,
+} from '@klicker-uzh/prisma/client'
+import {
+  buildCorrelatedResponseKey,
+  buildLiveQuizResponseIdentityKey,
+  encryptCorrelatedResponseEvent,
+  getLiveQuizRespondentCookieName,
+  hashLiveQuizRespondentToken,
+  LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS,
+  parseCookiesHeader,
+  type CorrelatedResponseEventMessage,
+  type CorrelatedResponseInstanceInfo,
+  type LiveQuizResponseIdentity,
+} from '@klicker-uzh/util'
+
+const CORRELATED_OUTBOX_RETRY_MS = 30_000
+
+export async function getCorrelatedResponseAdmission({
+  database,
+  liveQuizId,
+  cookieHeader,
+}: {
+  database: Pick<PrismaClient, 'liveQuiz'>
+  liveQuizId: string
+  cookieHeader: string | undefined
+}) {
+  const liveQuiz = await database.liveQuiz.findUnique({
+    where: { id: liveQuizId },
+    select: {
+      isAssessmentEnabled: true,
+      pinCode: true,
+      responseCollectionMode: true,
+      status: true,
+    },
+  })
+
+  if (!liveQuiz || liveQuiz.status !== PublicationStatus.PUBLISHED) {
+    return 'not_found' as const
+  }
+  if (
+    liveQuiz.isAssessmentEnabled ||
+    liveQuiz.responseCollectionMode !==
+      LiveQuizResponseCollectionMode.CORRELATED_EXPORT
+  ) {
+    return 'not_required' as const
+  }
+  if (
+    !hasValidLiveQuizPin({
+      cookieHeader,
+      liveQuizId,
+      pinCode: liveQuiz.pinCode,
+    })
+  ) {
+    return 'pin_required' as const
+  }
+  return 'ready' as const
+}
+
+export async function admitCorrelatedResponse({
+  database,
+  identity,
+  liveQuizId,
+  instanceId,
+  messageId,
+  response,
+  responseTimestamp,
+  instanceInfo,
+  cookieHeader,
+  secret,
+  nextDeliveryAt = new Date(Date.now() + CORRELATED_OUTBOX_RETRY_MS),
+}: {
+  database: Pick<PrismaClient, '$transaction'>
+  identity: LiveQuizResponseIdentity
+  liveQuizId: string
+  instanceId: string
+  messageId: string
+  response: CorrelatedResponseEventMessage['response']
+  responseTimestamp: number
+  instanceInfo: CorrelatedResponseInstanceInfo
+  cookieHeader: string | undefined
+  secret: string
+  nextDeliveryAt?: Date
+}) {
+  const blockExecution = instanceInfo.blockExecution
+  const parsedInstanceId = Number(instanceId)
+  const parsedBlockExecution = Number(blockExecution)
+  const parsedSessionBlockId = Number(instanceInfo.sessionBlockId)
+  if (
+    !instanceId.trim() ||
+    !blockExecution.trim() ||
+    !instanceInfo.sessionBlockId.trim() ||
+    !Number.isInteger(parsedInstanceId) ||
+    !Number.isInteger(parsedBlockExecution) ||
+    !Number.isInteger(parsedSessionBlockId)
+  ) {
+    return { status: 'invalid_metadata' }
+  }
+
+  try {
+    return await database.$transaction(async (prisma) => {
+      const [admission] = await prisma.$queryRaw<
+        {
+          activeBlockId: number | null
+          blockExecution: number
+          blockId: number
+          blockStatus: ElementBlockStatus
+          isAssessmentEnabled: boolean
+          pinCode: string | null
+          responseCollectionMode: LiveQuizResponseCollectionMode
+          status: PublicationStatus
+        }[]
+      >`
+        SELECT
+          quiz."activeBlockId",
+          block."execution" AS "blockExecution",
+          block."id" AS "blockId",
+          block."status"::text AS "blockStatus",
+          quiz."isAssessmentEnabled",
+          quiz."pinCode",
+          quiz."responseCollectionMode"::text AS "responseCollectionMode",
+          quiz."status"::text AS "status"
+        FROM "public"."LiveQuiz" AS quiz
+        JOIN "public"."ElementBlock" AS block
+          ON block."liveQuizId" = quiz."id"
+        JOIN "public"."ElementInstance" AS instance
+          ON instance."elementBlockId" = block."id"
+        WHERE
+          quiz."id" = ${liveQuizId}::uuid AND
+          quiz."isDeleted" = false AND
+          instance."id" = ${parsedInstanceId}
+        FOR SHARE OF quiz, block
+      `
+
+      if (
+        !admission ||
+        admission.status !== PublicationStatus.PUBLISHED ||
+        admission.isAssessmentEnabled ||
+        admission.responseCollectionMode !==
+          LiveQuizResponseCollectionMode.CORRELATED_EXPORT ||
+        admission.activeBlockId !== admission.blockId ||
+        admission.blockStatus !== ElementBlockStatus.ACTIVE ||
+        admission.blockId !== parsedSessionBlockId ||
+        admission.blockExecution !== parsedBlockExecution
+      ) {
+        return { status: 'not_found' as const }
+      }
+      if (
+        !hasValidLiveQuizPin({
+          cookieHeader,
+          liveQuizId,
+          pinCode: admission.pinCode,
+        })
+      ) {
+        return { status: 'pin_required' as const }
+      }
+
+      if (identity.kind === 'participant') {
+        const participant = await prisma.participant.findUnique({
+          where: { id: identity.id },
+          select: { id: true },
+        })
+        if (!participant) {
+          return { status: 'invalid_identity' as const }
+        }
+      } else if (identity.kind === 'temporary') {
+        const temporaryEntry =
+          await prisma.temporaryLeaderboardEntry.findUnique({
+            where: {
+              id_quizId: {
+                id: identity.id,
+                quizId: liveQuizId,
+              },
+            },
+            select: { id: true },
+          })
+        if (!temporaryEntry) {
+          return { status: 'invalid_identity' as const }
+        }
+
+        const respondent = await prisma.liveQuizRespondent.upsert({
+          where: { id: identity.id },
+          update: {},
+          create: {
+            id: identity.id,
+            type: LiveQuizRespondentType.TEMPORARY_PSEUDONYM,
+            liveQuiz: { connect: { id: liveQuizId } },
+          },
+        })
+        if (
+          respondent.liveQuizId !== liveQuizId ||
+          respondent.type !== LiveQuizRespondentType.TEMPORARY_PSEUDONYM
+        ) {
+          return { status: 'invalid_identity' as const }
+        }
+      } else {
+        const verificationSecretHash = hashLiveQuizRespondentToken(
+          identity.token
+        )
+        const respondent = await prisma.liveQuizRespondent.upsert({
+          where: { id: identity.id },
+          update: {},
+          create: {
+            id: identity.id,
+            type: LiveQuizRespondentType.ANONYMOUS_CORRELATED,
+            verificationSecretHash,
+            liveQuiz: { connect: { id: liveQuizId } },
+          },
+        })
+        if (
+          respondent.liveQuizId !== liveQuizId ||
+          respondent.type !== LiveQuizRespondentType.ANONYMOUS_CORRELATED ||
+          respondent.verificationSecretHash !== verificationSecretHash
+        ) {
+          return { status: 'invalid_identity' as const }
+        }
+      }
+
+      const acceptedIdentity = {
+        kind: identity.kind,
+        id: identity.id,
+      }
+      const responseKey = buildCorrelatedResponseKey({
+        liveQuizId,
+        instanceId,
+        blockExecution,
+        identityKey: buildLiveQuizResponseIdentityKey(identity),
+      })
+      const eventMessage: CorrelatedResponseEventMessage = {
+        messageId,
+        sessionId: liveQuizId,
+        instanceId,
+        response,
+        responseTimestamp,
+        acceptedIdentity,
+        instanceInfo,
+      }
+      await prisma.liveQuizPendingResponse.create({
+        data: {
+          id: messageId,
+          liveQuizId,
+          responseKey,
+          eventPayload: encryptCorrelatedResponseEvent({
+            message: eventMessage,
+            secret,
+          }),
+          nextDeliveryAt,
+        },
+      })
+      return { status: 'registered' as const }
+    })
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'P2002'
+    ) {
+      return { status: 'duplicate' as const }
+    }
+    throw error
+  }
+}
+
+export function serializeLiveQuizRespondentCookie({
+  token,
+  liveQuizId,
+  secure,
+}: {
+  token: string
+  liveQuizId: string
+  secure: boolean
+}) {
+  const attributes = [
+    `${getLiveQuizRespondentCookieName(liveQuizId)}=${token}`,
+    `Max-Age=${LIVE_QUIZ_RESPONDENT_TOKEN_MAX_AGE_SECONDS}`,
+  ]
+  attributes.push('Path=/', 'HttpOnly')
+  if (secure) attributes.push('Secure')
+  attributes.push('SameSite=Lax')
+
+  return attributes.join('; ')
+}
+
+export function hasValidLiveQuizPin({
+  cookieHeader,
+  liveQuizId,
+  pinCode,
+}: {
+  cookieHeader: string | undefined
+  liveQuizId: string
+  pinCode: string | null
+}) {
+  if (!pinCode) return true
+
+  const cookies = parseCookiesHeader(cookieHeader)
+  return cookies[`live-quiz-pin-${liveQuizId}`] === pinCode
+}

--- a/apps/response-api/src/correlatedResponseHandler.ts
+++ b/apps/response-api/src/correlatedResponseHandler.ts
@@ -1,0 +1,157 @@
+import type { PrismaClient } from '@klicker-uzh/prisma/client'
+import { LiveQuizResponseCollectionMode } from '@klicker-uzh/prisma/client'
+import {
+  CORRELATED_RESPONSE_EVENT,
+  parseCorrelatedResponseInstanceInfo,
+  resolveLiveQuizResponseIdentity,
+  validateStudentResponse,
+  type CorrelatedResponseDeliveryMessage,
+} from '@klicker-uzh/util'
+import { admitCorrelatedResponse } from './correlatedResponseAdmission.js'
+import type { LiveQuizResponseRequest } from './liveQuizResponseRequest.js'
+
+export async function handleCorrelatedResponse({
+  request,
+  instanceInfo,
+  responseCollectionMode,
+  database,
+  getIdentityConfig,
+  pushEvent,
+}: {
+  request: LiveQuizResponseRequest
+  instanceInfo: Record<string, string>
+  responseCollectionMode: LiveQuizResponseCollectionMode
+  database: PrismaClient
+  getIdentityConfig: () => { secret: string; issuer: string }
+  pushEvent: (
+    eventName: typeof CORRELATED_RESPONSE_EVENT,
+    message: CorrelatedResponseDeliveryMessage
+  ) => Promise<unknown>
+}) {
+  if (
+    responseCollectionMode !== LiveQuizResponseCollectionMode.CORRELATED_EXPORT
+  ) {
+    return {
+      status: 409,
+      body: {
+        error: 'Response endpoint does not match live quiz collection mode',
+      },
+    }
+  }
+
+  const identityConfig = getIdentityConfig()
+  const identity = await resolveLiveQuizResponseIdentity({
+    cookieHeader: request.cookieHeader,
+    liveQuizId: request.liveQuizId,
+    secret: identityConfig.secret,
+    issuer: identityConfig.issuer,
+  })
+  if (!identity) {
+    return {
+      status: 401,
+      body: { error: 'Live quiz response identity required' },
+    }
+  }
+
+  const acceptedInstanceInfo = parseCorrelatedResponseInstanceInfo(instanceInfo)
+  if (!acceptedInstanceInfo) {
+    return {
+      status: 400,
+      body: { error: 'Invalid correlated response metadata' },
+    }
+  }
+
+  let restrictions: unknown
+  try {
+    restrictions = acceptedInstanceInfo.restrictions
+      ? JSON.parse(acceptedInstanceInfo.restrictions)
+      : undefined
+  } catch (error) {
+    throw new Error(
+      `Invalid response restrictions for live quiz ${request.liveQuizId}, instance ${request.instanceId}: ${String(error)}`
+    )
+  }
+
+  const validation = validateStudentResponse({
+    type: acceptedInstanceInfo.type,
+    response: request.response,
+    instanceInfo: acceptedInstanceInfo,
+    restrictions:
+      typeof restrictions === 'object' && restrictions !== null
+        ? restrictions
+        : undefined,
+  })
+  if (!validation.valid) {
+    return { status: 400, body: { error: validation.message } }
+  }
+
+  const registration = await admitCorrelatedResponse({
+    database,
+    identity,
+    liveQuizId: request.liveQuizId,
+    instanceId: request.instanceId,
+    messageId: request.messageId,
+    response: request.response,
+    responseTimestamp: request.responseTimestamp,
+    instanceInfo: acceptedInstanceInfo,
+    cookieHeader: request.cookieHeader,
+    secret: identityConfig.secret,
+  })
+  if (registration.status === 'invalid_metadata') {
+    return {
+      status: 400,
+      body: { error: 'Invalid correlated response metadata' },
+    }
+  }
+  if (registration.status === 'invalid_identity') {
+    return {
+      status: 401,
+      body: { error: 'Live quiz response identity is no longer active' },
+    }
+  }
+  if (registration.status === 'pin_required') {
+    return { status: 403, body: { error: 'Live quiz PIN required' } }
+  }
+  if (registration.status === 'duplicate') {
+    return {
+      status: 208,
+      body: {
+        status: 'response_recorded_before',
+        responseTimestamp: request.responseTimestamp,
+      },
+    }
+  }
+  if (registration.status === 'not_found') {
+    return { status: 404, body: { error: 'Live quiz not found' } }
+  }
+
+  console.log('Pushing correlated response event', {
+    event: CORRELATED_RESPONSE_EVENT,
+    messageId: request.messageId,
+    sessionId: request.liveQuizId,
+    instanceId: request.instanceId,
+    responseTimestamp: request.responseTimestamp,
+  })
+  try {
+    await pushEvent(CORRELATED_RESPONSE_EVENT, {
+      messageId: request.messageId,
+    })
+  } catch (error) {
+    console.error('Immediate correlated response delivery failed', {
+      messageId: request.messageId,
+      error,
+    })
+    return {
+      status: 200,
+      body: {
+        status: 'queued',
+        responseTimestamp: request.responseTimestamp,
+      },
+    }
+  }
+
+  return {
+    status: 200,
+    body: { status: 'ok', responseTimestamp: request.responseTimestamp },
+  }
+}

--- a/apps/response-api/src/correlatedResponseHandler.ts
+++ b/apps/response-api/src/correlatedResponseHandler.ts
@@ -2,10 +2,10 @@ import type { PrismaClient } from '@klicker-uzh/prisma/client'
 import { LiveQuizResponseCollectionMode } from '@klicker-uzh/prisma/client'
 import {
   CORRELATED_RESPONSE_EVENT,
+  type CorrelatedResponseDeliveryMessage,
   parseCorrelatedResponseInstanceInfo,
   resolveLiveQuizResponseIdentity,
   validateStudentResponse,
-  type CorrelatedResponseDeliveryMessage,
 } from '@klicker-uzh/util'
 import { admitCorrelatedResponse } from './correlatedResponseAdmission.js'
 import type { LiveQuizResponseRequest } from './liveQuizResponseRequest.js'
@@ -66,20 +66,18 @@ export async function handleCorrelatedResponse({
     restrictions = acceptedInstanceInfo.restrictions
       ? JSON.parse(acceptedInstanceInfo.restrictions)
       : undefined
-  } catch (error) {
-    throw new Error(
-      `Invalid response restrictions for live quiz ${request.liveQuizId}, instance ${request.instanceId}: ${String(error)}`
-    )
+  } catch {
+    return {
+      status: 400,
+      body: { error: 'Invalid correlated response metadata' },
+    }
   }
 
   const validation = validateStudentResponse({
     type: acceptedInstanceInfo.type,
     response: request.response,
     instanceInfo: acceptedInstanceInfo,
-    restrictions:
-      typeof restrictions === 'object' && restrictions !== null
-        ? restrictions
-        : undefined,
+    restrictions,
   })
   if (!validation.valid) {
     return { status: 400, body: { error: validation.message } }

--- a/apps/response-api/src/correlatedResponseHandler.ts
+++ b/apps/response-api/src/correlatedResponseHandler.ts
@@ -52,6 +52,12 @@ export async function handleCorrelatedResponse({
       body: { error: 'Live quiz response identity required' },
     }
   }
+  if (identity.kind === 'temporary') {
+    return {
+      status: 401,
+      body: { error: 'Live quiz response identity is no longer active' },
+    }
+  }
 
   const acceptedInstanceInfo = parseCorrelatedResponseInstanceInfo(instanceInfo)
   if (!acceptedInstanceInfo) {

--- a/apps/response-api/src/correlatedResponseHandler.ts
+++ b/apps/response-api/src/correlatedResponseHandler.ts
@@ -67,6 +67,16 @@ export async function handleCorrelatedResponse({
     }
   }
 
+  if (acceptedInstanceInfo.type === 'FREE_TEXT') {
+    return {
+      status: 400,
+      body: {
+        error:
+          'Free-text responses are not retained for correlated teaching exports',
+      },
+    }
+  }
+
   let restrictions: unknown
   try {
     restrictions = acceptedInstanceInfo.restrictions

--- a/apps/response-api/src/correlatedResponseOutbox.ts
+++ b/apps/response-api/src/correlatedResponseOutbox.ts
@@ -1,0 +1,66 @@
+import type { PrismaClient } from '@klicker-uzh/prisma/client'
+import {
+  CORRELATED_RESPONSE_EVENT,
+  type CorrelatedResponseDeliveryMessage,
+} from '@klicker-uzh/util'
+
+const CORRELATED_OUTBOX_RETRY_MS = 30_000
+const CORRELATED_OUTBOX_BATCH_SIZE = 50
+
+export async function reservePendingCorrelatedResponses({
+  database,
+  now = new Date(),
+  nextDeliveryAt = new Date(now.getTime() + CORRELATED_OUTBOX_RETRY_MS),
+  batchSize = CORRELATED_OUTBOX_BATCH_SIZE,
+}: {
+  database: Pick<PrismaClient, '$queryRaw'>
+  now?: Date
+  nextDeliveryAt?: Date
+  batchSize?: number
+}) {
+  return database.$queryRaw<{ id: string }[]>`
+    WITH due AS (
+      SELECT "id"
+      FROM "public"."LiveQuizPendingResponse"
+      WHERE "settledAt" IS NULL AND "nextDeliveryAt" <= ${now}
+      ORDER BY "nextDeliveryAt" ASC, "createdAt" ASC
+      LIMIT ${batchSize}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE "public"."LiveQuizPendingResponse" AS pending
+    SET
+      "nextDeliveryAt" = ${nextDeliveryAt},
+      "deliveryAttempts" = pending."deliveryAttempts" + 1
+    FROM due
+    WHERE pending."id" = due."id"
+    RETURNING pending."id"
+  `
+}
+
+export async function dispatchPendingCorrelatedResponses({
+  database,
+  pushEvent,
+  now,
+}: {
+  database: Pick<PrismaClient, '$queryRaw'>
+  pushEvent: (
+    eventName: string,
+    message: CorrelatedResponseDeliveryMessage
+  ) => Promise<unknown>
+  now?: Date
+}) {
+  const pendingResponses = await reservePendingCorrelatedResponses({
+    database,
+    now,
+  })
+  const results = await Promise.allSettled(
+    pendingResponses.map(({ id }) =>
+      pushEvent(CORRELATED_RESPONSE_EVENT, { messageId: id })
+    )
+  )
+
+  return {
+    attempted: results.length,
+    failed: results.filter((result) => result.status === 'rejected').length,
+  }
+}

--- a/apps/response-api/src/index.ts
+++ b/apps/response-api/src/index.ts
@@ -1,10 +1,31 @@
 import { hatchetClient } from '@klicker-uzh/hatchet'
+import { prisma } from '@klicker-uzh/prisma'
 import { UserLoginScope } from '@klicker-uzh/prisma/client'
-import { verifyJWT, type JWTPayload } from '@klicker-uzh/util'
+import {
+  createLiveQuizRespondentToken,
+  getLiveQuizRespondentCookieName,
+  resolveLiveQuizResponseIdentity,
+  verifyJWT,
+  type JWTPayload,
+  type LiveQuizResponseIdentity,
+} from '@klicker-uzh/util'
 import { randomUUID } from 'crypto'
-import { createServer, IncomingMessage, ServerResponse } from 'http'
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
 import { Redis } from 'ioredis'
 import { createHash } from 'node:crypto'
+import { handleAggregateResponse } from './aggregateResponse.js'
+import {
+  getCorrelatedResponseAdmission,
+  serializeLiveQuizRespondentCookie,
+} from './correlatedResponseAdmission.js'
+import { handleCorrelatedResponse } from './correlatedResponseHandler.js'
+import { dispatchPendingCorrelatedResponses } from './correlatedResponseOutbox.js'
+import {
+  hasJsonContentType,
+  isAllowedCorsOrigin,
+  loadLiveQuizResponseInstance,
+  parseLiveQuizResponseRequest,
+} from './liveQuizResponseRequest.js'
 
 const redis = new Redis({
   family: 4,
@@ -27,11 +48,14 @@ const CORS_ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || '')
   .split(',')
   .map((o) => o.trim())
   .filter(Boolean)
+const CORRELATED_OUTBOX_POLL_INTERVAL_MS = 5_000
 
 function setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
   const origin = req.headers.origin
-  // Only allow explicitly whitelisted origins, and never allow "null"
-  if (origin && origin !== 'null' && CORS_ALLOWED_ORIGINS.includes(origin)) {
+  if (
+    origin &&
+    isAllowedCorsOrigin({ origin, allowedOrigins: CORS_ALLOWED_ORIGINS })
+  ) {
     res.setHeader('Access-Control-Allow-Origin', origin)
     res.setHeader('Vary', 'Origin')
     res.setHeader('Access-Control-Allow-Credentials', 'true')
@@ -90,7 +114,108 @@ async function readBody(req: IncomingMessage): Promise<any> {
   }
 }
 
-async function handleAddResponse(req: IncomingMessage, res: ServerResponse) {
+function getResponseIdentityConfig() {
+  const secret = process.env.APP_SECRET
+  const issuer = process.env.APP_ORIGIN_API
+  if (!secret || !issuer) {
+    throw new Error(
+      'APP_SECRET and APP_ORIGIN_API are required for correlated live quiz responses'
+    )
+  }
+
+  return { secret, issuer }
+}
+
+async function ensureCorrelatedResponseIdentity({
+  req,
+  res,
+  liveQuizId,
+}: {
+  req: IncomingMessage
+  res: ServerResponse
+  liveQuizId: string
+}): Promise<LiveQuizResponseIdentity> {
+  const { secret, issuer } = getResponseIdentityConfig()
+  const cookieHeader =
+    typeof req.headers.cookie === 'string' ? req.headers.cookie : undefined
+  const existingIdentity = await resolveLiveQuizResponseIdentity({
+    cookieHeader,
+    liveQuizId,
+    secret,
+    issuer,
+  })
+  if (existingIdentity) {
+    return existingIdentity
+  }
+
+  const respondentId = randomUUID()
+  const token = await createLiveQuizRespondentToken({
+    respondentId,
+    liveQuizId,
+    secret,
+    issuer,
+  })
+  const identity: LiveQuizResponseIdentity = {
+    kind: 'anonymous',
+    id: respondentId,
+    liveQuizId,
+    token,
+    cookieName: getLiveQuizRespondentCookieName(liveQuizId),
+  }
+
+  res.setHeader(
+    'Set-Cookie',
+    serializeLiveQuizRespondentCookie({
+      token,
+      liveQuizId,
+      secure:
+        process.env.NODE_ENV === 'production' &&
+        process.env.COOKIE_DOMAIN !== '127.0.0.1',
+    })
+  )
+  return identity
+}
+
+async function handleInitializeLiveQuizResponseIdentity(
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  if (process.env.ASSESSMENT_MODE === 'true') {
+    return sendJson(req, res, 200, { status: 'not_required' })
+  }
+
+  const payload = await readBody(req)
+  if (!payload || typeof payload.liveQuizId !== 'string') {
+    return badRequest(req, res, 'Missing required field: liveQuizId')
+  }
+
+  const admission = await getCorrelatedResponseAdmission({
+    database: prisma,
+    liveQuizId: payload.liveQuizId,
+    cookieHeader:
+      typeof req.headers.cookie === 'string' ? req.headers.cookie : undefined,
+  })
+  if (admission === 'not_found') {
+    return sendJson(req, res, 404, { error: 'Live quiz not found' })
+  }
+  if (admission === 'not_required') {
+    return sendJson(req, res, 200, { status: 'not_required' })
+  }
+  if (admission === 'pin_required') {
+    return sendJson(req, res, 403, { error: 'Live quiz PIN required' })
+  }
+  await ensureCorrelatedResponseIdentity({
+    req,
+    res,
+    liveQuizId: payload.liveQuizId,
+  })
+  return sendJson(req, res, 200, { status: 'ready' })
+}
+
+async function readLiveQuizResponseRequest(
+  req: IncomingMessage,
+  res: ServerResponse
+) {
   let payload: any
   try {
     payload = await readBody(req)
@@ -98,62 +223,63 @@ async function handleAddResponse(req: IncomingMessage, res: ServerResponse) {
     return badRequest(req, res, err.message)
   }
 
-  if (!payload || typeof payload !== 'object') {
-    return badRequest(req, res, 'Body must be a JSON object')
+  const parsed = parseLiveQuizResponseRequest({
+    payload,
+    cookieHeader:
+      typeof req.headers.cookie === 'string' ? req.headers.cookie : undefined,
+  })
+  if (!parsed.ok) {
+    badRequest(req, res, parsed.message)
+    return null
   }
 
-  const { response, liveQuizId, instanceId } = payload
-  if (!response || !liveQuizId || typeof instanceId === 'undefined') {
-    return badRequest(
-      req,
-      res,
-      'Missing required fields: response, liveQuizId, instanceId'
-    )
-  }
+  return parsed.request
+}
 
-  // Only forward participant-related cookies. If both exist, include both.
-  let cookie: string | undefined
-  if (typeof req.headers['cookie'] === 'string') {
-    const raw = req.headers['cookie']
-    const parts = raw.split(';').map((s) => s.trim())
-    const participantPair = parts.find((p) =>
-      p.startsWith('participant_token=')
-    )
-    const temporaryPair = parts.find((p) =>
-      p.startsWith('temporary_participant_token=')
-    )
-    const forwarded: string[] = []
-    if (participantPair) forwarded.push(participantPair)
-    if (temporaryPair) forwarded.push(temporaryPair)
-    if (forwarded.length > 0) {
-      cookie = forwarded.join('; ')
-    }
-  }
+async function handleAddAggregateResponse(
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  const request = await readLiveQuizResponseRequest(req, res)
+  if (!request) return
 
-  const responseTimestamp = Date.now()
-  const message = {
-    messageId: randomUUID(),
-    sessionId: String(liveQuizId),
-    instanceId: String(instanceId),
-    response, // pass through as-is; worker validates
-    cookie,
-    responseTimestamp,
-  }
+  const { responseCollectionMode } = await loadLiveQuizResponseInstance({
+    database: prisma,
+    redis,
+    request,
+  })
+  const result = await handleAggregateResponse({
+    request,
+    responseCollectionMode,
+    pushEvent: (eventName, message) =>
+      hatchetClient.events.push(eventName, message),
+  })
+  return sendJson(req, res, result.status, result.body)
+}
 
-  // determine if the participant is logged in with a valid student cookie (temporary or standard)
-  const isAuthenticatedParticipant =
-    cookie &&
-    (cookie.includes('participant_token=') ||
-      cookie.includes('temporary_participant_token='))
+async function handleAddCorrelatedResponse(
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  const request = await readLiveQuizResponseRequest(req, res)
+  if (!request) return
 
-  // depending on the authentication state, add the response to the correct hatchet event queue
-  const eventName = isAuthenticatedParticipant
-    ? 'response-received:authenticated'
-    : 'response-received:anonymous'
-  console.log(`Pushing event ${eventName} with payload`, message)
-
-  await hatchetClient.events.push(eventName, message)
-  return sendJson(req, res, 200, { status: 'ok', responseTimestamp })
+  const { instanceInfo, responseCollectionMode } =
+    await loadLiveQuizResponseInstance({
+      database: prisma,
+      redis,
+      request,
+    })
+  const result = await handleCorrelatedResponse({
+    request,
+    instanceInfo,
+    responseCollectionMode,
+    database: prisma,
+    getIdentityConfig: getResponseIdentityConfig,
+    pushEvent: (eventName, message) =>
+      hatchetClient.events.push(eventName, message),
+  })
+  return sendJson(req, res, result.status, result.body)
 }
 
 async function handleAddAssessmentResponse(
@@ -343,6 +469,15 @@ async function handleAddAssessmentResponse(
 
 const server = createServer(async (req, res) => {
   try {
+    if (
+      !isAllowedCorsOrigin({
+        origin: req.headers.origin,
+        allowedOrigins: CORS_ALLOWED_ORIGINS,
+      })
+    ) {
+      return sendJson(req, res, 403, { error: 'Origin not allowed' })
+    }
+
     // handle CORS preflight requests
     if (req.method === 'OPTIONS') {
       setCorsHeaders(req, res)
@@ -360,16 +495,40 @@ const server = createServer(async (req, res) => {
       return sendJson(req, res, 200, { status: 'ok' })
     }
 
+    if (
+      req.method === 'POST' &&
+      !hasJsonContentType(
+        typeof req.headers['content-type'] === 'string'
+          ? req.headers['content-type']
+          : undefined
+      )
+    ) {
+      return sendJson(req, res, 415, {
+        error: 'Content-Type must be application/json',
+      })
+    }
+
     // add response endpoint
     if (url.pathname === '/AddResponse' && req.method === 'POST') {
-      // if not in assessment mode, call standard processing logic
       if (process.env.ASSESSMENT_MODE === 'true') {
         return await handleAddAssessmentResponse(req, res)
-      } else {
-        // call the standard processing function, which will distinguish between authenticated and anonymous modes
-        // if a valid cookie exists is not relevant at this point -> otherwise answers are simply treated as anonymous
-        return await handleAddResponse(req, res)
       }
+      return await handleAddAggregateResponse(req, res)
+    }
+
+    if (
+      url.pathname === '/AddCorrelatedResponse' &&
+      req.method === 'POST' &&
+      process.env.ASSESSMENT_MODE !== 'true'
+    ) {
+      return await handleAddCorrelatedResponse(req, res)
+    }
+
+    if (
+      url.pathname === '/InitializeLiveQuizResponseIdentity' &&
+      req.method === 'POST'
+    ) {
+      return await handleInitializeLiveQuizResponseIdentity(req, res)
     }
 
     // fallback to 404 Not Found
@@ -406,6 +565,36 @@ async function initializeService() {
   } catch (error) {
     console.error('Failed to connect to assessment Redis:', error)
     throw error
+  }
+
+  if (process.env.ASSESSMENT_MODE !== 'true') {
+    const dispatchPending = async () => {
+      const result = await dispatchPendingCorrelatedResponses({
+        database: prisma,
+        pushEvent: (eventName, message) =>
+          hatchetClient.events.push(eventName, message),
+      })
+      if (result.failed > 0) {
+        console.error('Correlated response outbox delivery failures', result)
+      }
+    }
+
+    const scheduleNextDispatch = () => {
+      const outboxTimer = setTimeout(() => {
+        void dispatchPending()
+          .catch((error) => {
+            console.error('Correlated response outbox dispatch failed', error)
+          })
+          .finally(scheduleNextDispatch)
+      }, CORRELATED_OUTBOX_POLL_INTERVAL_MS)
+      outboxTimer.unref()
+    }
+
+    void dispatchPending()
+      .catch((error) => {
+        console.error('Correlated response outbox dispatch failed', error)
+      })
+      .finally(scheduleNextDispatch)
   }
 
   console.log('All connections established successfully')

--- a/apps/response-api/src/index.ts
+++ b/apps/response-api/src/index.ts
@@ -130,10 +130,12 @@ async function ensureCorrelatedResponseIdentity({
   req,
   res,
   liveQuizId,
+  publicationGeneration,
 }: {
   req: IncomingMessage
   res: ServerResponse
   liveQuizId: string
+  publicationGeneration: number
 }): Promise<LiveQuizResponseIdentity> {
   const { secret, issuer } = getResponseIdentityConfig()
   const cookieHeader =
@@ -144,7 +146,11 @@ async function ensureCorrelatedResponseIdentity({
     secret,
     issuer,
   })
-  if (existingIdentity) {
+  if (
+    existingIdentity &&
+    (existingIdentity.kind !== 'anonymous' ||
+      existingIdentity.publicationGeneration === publicationGeneration)
+  ) {
     return existingIdentity
   }
 
@@ -152,6 +158,7 @@ async function ensureCorrelatedResponseIdentity({
   const token = await createLiveQuizRespondentToken({
     respondentId,
     liveQuizId,
+    publicationGeneration,
     secret,
     issuer,
   })
@@ -159,6 +166,7 @@ async function ensureCorrelatedResponseIdentity({
     kind: 'anonymous',
     id: respondentId,
     liveQuizId,
+    publicationGeneration,
     token,
     cookieName: getLiveQuizRespondentCookieName(liveQuizId),
   }
@@ -195,19 +203,20 @@ async function handleInitializeLiveQuizResponseIdentity(
     cookieHeader:
       typeof req.headers.cookie === 'string' ? req.headers.cookie : undefined,
   })
-  if (admission === 'not_found') {
+  if (admission.status === 'not_found') {
     return sendJson(req, res, 404, { error: 'Live quiz not found' })
   }
-  if (admission === 'not_required') {
+  if (admission.status === 'not_required') {
     return sendJson(req, res, 200, { status: 'not_required' })
   }
-  if (admission === 'pin_required') {
+  if (admission.status === 'pin_required') {
     return sendJson(req, res, 403, { error: 'Live quiz PIN required' })
   }
   await ensureCorrelatedResponseIdentity({
     req,
     res,
     liveQuizId: payload.liveQuizId,
+    publicationGeneration: admission.publicationGeneration,
   })
   return sendJson(req, res, 200, { status: 'ready' })
 }

--- a/apps/response-api/src/liveQuizResponseRequest.ts
+++ b/apps/response-api/src/liveQuizResponseRequest.ts
@@ -1,10 +1,10 @@
+import { randomUUID } from 'node:crypto'
 import {
   LiveQuizResponseCollectionMode,
   type PrismaClient,
 } from '@klicker-uzh/prisma/client'
 import type { LiveQuizResponseInput } from '@klicker-uzh/types'
 import type { Redis } from 'ioredis'
-import { randomUUID } from 'node:crypto'
 
 export function isAllowedCorsOrigin({
   origin,
@@ -23,6 +23,140 @@ export function hasJsonContentType(contentType: string | undefined) {
   return (
     contentType?.split(';', 1)[0]?.trim().toLowerCase() === 'application/json'
   )
+}
+
+const CORRELATED_INSTANCE_INFO_FIELDS = [
+  'type',
+  'blockExecution',
+  'sessionBlockId',
+  'basePoints',
+  'blockClosedAt',
+  'defaultCorrectPoints',
+  'defaultPoints',
+  'firstResponseReceivedAt',
+  'maxBonusPoints',
+  'pointsMultiplier',
+  'restrictions',
+  'solutions',
+  'timeToZeroBonus',
+] as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function deriveCaseStudyResponseShape(solutions: string | undefined) {
+  if (!solutions) return undefined
+
+  try {
+    const parsed: unknown = JSON.parse(solutions)
+    if (!Array.isArray(parsed)) return undefined
+
+    const cases: string[] = []
+    const items = new Set<number>()
+    const criteria = new Map<string, { min: number; max: number }>()
+
+    for (const caseEntry of parsed) {
+      if (
+        !isRecord(caseEntry) ||
+        typeof caseEntry.caseId !== 'string' ||
+        !Array.isArray(caseEntry.itemSolutions)
+      ) {
+        return undefined
+      }
+
+      cases.push(caseEntry.caseId)
+      for (const itemSolution of caseEntry.itemSolutions) {
+        if (
+          !isRecord(itemSolution) ||
+          typeof itemSolution.itemId !== 'number' ||
+          !Number.isInteger(itemSolution.itemId) ||
+          itemSolution.itemId <= 0 ||
+          !Array.isArray(itemSolution.criteriaSolutions)
+        ) {
+          return undefined
+        }
+
+        items.add(itemSolution.itemId)
+        for (const criterionSolution of itemSolution.criteriaSolutions) {
+          if (
+            !isRecord(criterionSolution) ||
+            typeof criterionSolution.criterionId !== 'string' ||
+            !criterionSolution.criterionId ||
+            typeof criterionSolution.min !== 'number' ||
+            !Number.isFinite(criterionSolution.min) ||
+            typeof criterionSolution.max !== 'number' ||
+            !Number.isFinite(criterionSolution.max) ||
+            criterionSolution.min > criterionSolution.max
+          ) {
+            return undefined
+          }
+
+          const existingBounds = criteria.get(criterionSolution.criterionId)
+          if (
+            existingBounds &&
+            (existingBounds.min !== criterionSolution.min ||
+              existingBounds.max !== criterionSolution.max)
+          ) {
+            return undefined
+          }
+          criteria.set(criterionSolution.criterionId, {
+            min: criterionSolution.min,
+            max: criterionSolution.max,
+          })
+        }
+      }
+    }
+
+    return JSON.stringify({
+      cases,
+      items: [...items],
+      criteria: [...criteria].map(([id, bounds]) => ({ id, ...bounds })),
+    })
+  } catch {
+    return undefined
+  }
+}
+
+export function adaptLiveQuizResponseInstanceInfo(
+  operationalInfo: Record<string, string>
+) {
+  const instanceInfo: Record<string, string> = {}
+
+  for (const field of CORRELATED_INSTANCE_INFO_FIELDS) {
+    const value = operationalInfo[field]
+    if (typeof value === 'string') {
+      instanceInfo[field] = value
+    }
+  }
+
+  if (
+    operationalInfo.type === 'SC' ||
+    operationalInfo.type === 'MC' ||
+    operationalInfo.type === 'KPRIM'
+  ) {
+    if (typeof operationalInfo.choiceCount === 'string') {
+      instanceInfo.choiceCount = operationalInfo.choiceCount
+    }
+  } else if (operationalInfo.type === 'SELECTION') {
+    if (typeof operationalInfo.numberOfInputs === 'string') {
+      instanceInfo.numberOfInputs = operationalInfo.numberOfInputs
+    }
+    const selectionAnswerIds =
+      operationalInfo.selectionAnswerIds ?? operationalInfo.solutions
+    if (typeof selectionAnswerIds === 'string') {
+      instanceInfo.selectionAnswerIds = selectionAnswerIds
+    }
+  } else if (operationalInfo.type === 'CASE_STUDY') {
+    const responseShape =
+      operationalInfo.caseStudyResponseShape ??
+      deriveCaseStudyResponseShape(operationalInfo.solutions)
+    if (typeof responseShape === 'string') {
+      instanceInfo.caseStudyResponseShape = responseShape
+    }
+  }
+
+  return instanceInfo
 }
 
 export async function resolveResponseCollectionMode({
@@ -113,11 +247,12 @@ export async function loadLiveQuizResponseInstance({
   redis: Pick<Redis, 'hgetall'>
   request: LiveQuizResponseRequest
 }) {
-  const instanceInfo = await redis.hgetall(
+  const operationalInfo = await redis.hgetall(
     `lq:${request.liveQuizId}:i:${request.instanceId}:info`
   )
+  const instanceInfo = adaptLiveQuizResponseInstanceInfo(operationalInfo)
   const responseCollectionMode = await resolveResponseCollectionMode({
-    cachedMode: instanceInfo.responseCollectionMode,
+    cachedMode: operationalInfo.responseCollectionMode,
     liveQuizId: request.liveQuizId,
     lookupMode: async (id) =>
       (

--- a/apps/response-api/src/liveQuizResponseRequest.ts
+++ b/apps/response-api/src/liveQuizResponseRequest.ts
@@ -1,0 +1,132 @@
+import {
+  LiveQuizResponseCollectionMode,
+  type PrismaClient,
+} from '@klicker-uzh/prisma/client'
+import type { LiveQuizResponseInput } from '@klicker-uzh/types'
+import type { Redis } from 'ioredis'
+import { randomUUID } from 'node:crypto'
+
+export function isAllowedCorsOrigin({
+  origin,
+  allowedOrigins,
+}: {
+  origin: string | undefined
+  allowedOrigins: string[]
+}) {
+  return (
+    origin === undefined ||
+    (origin !== 'null' && allowedOrigins.includes(origin))
+  )
+}
+
+export function hasJsonContentType(contentType: string | undefined) {
+  return (
+    contentType?.split(';', 1)[0]?.trim().toLowerCase() === 'application/json'
+  )
+}
+
+export async function resolveResponseCollectionMode({
+  cachedMode,
+  liveQuizId,
+  lookupMode,
+}: {
+  cachedMode: string | undefined
+  liveQuizId: string
+  lookupMode: (
+    liveQuizId: string
+  ) => Promise<LiveQuizResponseCollectionMode | string | null>
+}) {
+  if (
+    cachedMode === LiveQuizResponseCollectionMode.AGGREGATED_ANONYMOUS ||
+    cachedMode === LiveQuizResponseCollectionMode.CORRELATED_EXPORT
+  ) {
+    return cachedMode
+  }
+
+  const storedMode = await lookupMode(liveQuizId)
+  if (
+    storedMode === LiveQuizResponseCollectionMode.AGGREGATED_ANONYMOUS ||
+    storedMode === LiveQuizResponseCollectionMode.CORRELATED_EXPORT
+  ) {
+    return storedMode
+  }
+
+  throw new Error(
+    `Response collection mode for live quiz ${liveQuizId} is unavailable`
+  )
+}
+
+export type LiveQuizResponseRequest = {
+  messageId: string
+  liveQuizId: string
+  instanceId: string
+  response: LiveQuizResponseInput
+  responseTimestamp: number
+  cookieHeader: string | undefined
+}
+
+export function parseLiveQuizResponseRequest({
+  payload,
+  cookieHeader,
+  now = Date.now,
+}: {
+  payload: unknown
+  cookieHeader: string | undefined
+  now?: () => number
+}):
+  | { ok: true; request: LiveQuizResponseRequest }
+  | { ok: false; message: string } {
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, message: 'Body must be a JSON object' }
+  }
+
+  const { response, liveQuizId, instanceId } = payload as Record<
+    string,
+    unknown
+  >
+  if (!response || !liveQuizId || typeof instanceId === 'undefined') {
+    return {
+      ok: false,
+      message: 'Missing required fields: response, liveQuizId, instanceId',
+    }
+  }
+
+  return {
+    ok: true,
+    request: {
+      messageId: randomUUID(),
+      liveQuizId: String(liveQuizId),
+      instanceId: String(instanceId),
+      response: response as LiveQuizResponseInput,
+      responseTimestamp: now(),
+      cookieHeader,
+    },
+  }
+}
+
+export async function loadLiveQuizResponseInstance({
+  database,
+  redis,
+  request,
+}: {
+  database: Pick<PrismaClient, 'liveQuiz'>
+  redis: Pick<Redis, 'hgetall'>
+  request: LiveQuizResponseRequest
+}) {
+  const instanceInfo = await redis.hgetall(
+    `lq:${request.liveQuizId}:i:${request.instanceId}:info`
+  )
+  const responseCollectionMode = await resolveResponseCollectionMode({
+    cachedMode: instanceInfo.responseCollectionMode,
+    liveQuizId: request.liveQuizId,
+    lookupMode: async (id) =>
+      (
+        await database.liveQuiz.findUnique({
+          where: { id },
+          select: { responseCollectionMode: true },
+        })
+      )?.responseCollectionMode ?? null,
+  })
+
+  return { instanceInfo, responseCollectionMode }
+}

--- a/apps/response-api/test/correlatedResponses.test.ts
+++ b/apps/response-api/test/correlatedResponses.test.ts
@@ -292,6 +292,7 @@ describe('correlated response request safeguards', () => {
               }),
             },
             liveQuizPendingResponse: {
+              findUnique: async () => null,
               create: async (args: any) => {
                 createCalls.push(args)
                 return args.data
@@ -448,36 +449,180 @@ describe('correlated response request safeguards', () => {
   })
 
   it('rejects a second pending response for the same respondent execution', async () => {
-    assert.equal(
-      (
-        await admitCorrelatedResponse({
-          identity: {
-            kind: 'participant',
-            id: '33333333-3333-4333-8333-333333333333',
-            token: 'signed-token',
-            cookieName: 'participant_token',
-          },
-          database: {
-            $transaction: async () => {
-              throw { code: 'P2002' }
+    const liveQuizId = '11111111-1111-4111-8111-111111111111'
+    const participantId = '33333333-3333-4333-8333-333333333333'
+    let attempts = 0
+    let receiptCreated = false
+    const result = await admitCorrelatedResponse({
+      identity: {
+        kind: 'participant',
+        id: participantId,
+        token: 'signed-token',
+        cookieName: 'participant_token',
+      },
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) => {
+          attempts += 1
+          return callback({
+            $queryRaw: async () => [
+              {
+                activeBlockId: 7,
+                blockExecution: 3,
+                blockId: 7,
+                blockStatus: 'ACTIVE',
+                isAssessmentEnabled: false,
+                pinCode: null,
+                responseCollectionMode: 'CORRELATED_EXPORT',
+                publicationGeneration: 3,
+                status: 'PUBLISHED',
+              },
+            ],
+            participant: {
+              findUnique: async () => ({ id: participantId }),
             },
-          } as any,
-          liveQuizId: '11111111-1111-4111-8111-111111111111',
-          instanceId: '42',
-          messageId: '22222222-2222-4222-8222-222222222222',
-          response: { value: 'private response' },
-          responseTimestamp: 1_000,
-          instanceInfo: {
-            type: 'FREE_TEXT',
-            blockExecution: '3',
-            sessionBlockId: '7',
-          },
-          cookieHeader: undefined,
-          secret: 'app-secret',
-        })
-      ).status,
-      'duplicate'
-    )
+            liveQuizRespondentBinding: {
+              findUnique: async () => ({
+                respondentId: participantId,
+                liveQuizId,
+                publicationGeneration: 3,
+                participantId,
+                verificationSecretHash: null,
+                expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+              }),
+              update: async () => ({
+                respondentId: participantId,
+                liveQuizId,
+                publicationGeneration: 3,
+                participantId,
+                verificationSecretHash: null,
+                expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+              }),
+            },
+            liveQuizRespondent: {
+              findUnique: async () => ({
+                finalizedAt: null,
+                liveQuizId,
+                publicationGeneration: 3,
+              }),
+            },
+            liveQuizPendingResponse: {
+              findUnique: async () => ({
+                id: '11111111-1111-4111-8111-111111111112',
+              }),
+              create: async () => {
+                receiptCreated = true
+              },
+            },
+          })
+        },
+      } as any,
+      liveQuizId,
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+    })
+
+    assert.deepEqual(result, { status: 'duplicate' })
+    assert.equal(attempts, 1)
+    assert.equal(receiptCreated, false)
+  })
+
+  it('resolves concurrent first-submission races into distinct receipts', async () => {
+    const liveQuizId = '11111111-1111-4111-8111-111111111111'
+    const respondentId = '33333333-3333-4333-8333-333333333333'
+    const token = 'signed-token'
+    const createCalls: any[] = []
+    let attempts = 0
+    const result = await admitCorrelatedResponse({
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) => {
+          attempts += 1
+          if (attempts === 1) {
+            // the concurrent sibling won the respondent/binding insert race
+            throw { code: 'P2002' }
+          }
+          return callback({
+            $queryRaw: async () => [
+              {
+                activeBlockId: 7,
+                blockExecution: 3,
+                blockId: 7,
+                blockStatus: 'ACTIVE',
+                isAssessmentEnabled: false,
+                pinCode: null,
+                responseCollectionMode: 'CORRELATED_EXPORT',
+                publicationGeneration: 3,
+                status: 'PUBLISHED',
+              },
+            ],
+            liveQuizRespondentBinding: {
+              findUnique: async () => ({
+                respondentId,
+                liveQuizId,
+                publicationGeneration: 3,
+                participantId: null,
+                verificationSecretHash: hashLiveQuizRespondentToken(token),
+                expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+              }),
+              update: async () => ({
+                respondentId,
+                liveQuizId,
+                publicationGeneration: 3,
+                participantId: null,
+                verificationSecretHash: hashLiveQuizRespondentToken(token),
+                expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+              }),
+            },
+            liveQuizRespondent: {
+              findUnique: async () => ({
+                finalizedAt: null,
+                liveQuizId,
+                publicationGeneration: 3,
+              }),
+            },
+            liveQuizPendingResponse: {
+              findUnique: async () => null,
+              create: async (args: any) => {
+                createCalls.push(args)
+                return args.data
+              },
+            },
+          })
+        },
+      } as any,
+      identity: {
+        kind: 'anonymous',
+        id: respondentId,
+        liveQuizId,
+        publicationGeneration: 3,
+        token,
+        cookieName: `live_quiz_respondent_token_${liveQuizId}`,
+      },
+      liveQuizId,
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'race answer' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+    })
+
+    assert.equal(result.status, 'registered')
+    assert.equal(attempts, 2)
+    assert.equal(createCalls.length, 1)
   })
 
   it('checks PIN access inside the locked admission transaction', async () => {

--- a/apps/response-api/test/correlatedResponses.test.ts
+++ b/apps/response-api/test/correlatedResponses.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { LiveQuizRespondentType } from '@klicker-uzh/prisma/client'
 import {
   buildCorrelatedResponseKey,
   decryptCorrelatedResponseEvent,
   encryptCorrelatedResponseEvent,
+  hashLiveQuizRespondentToken,
 } from '@klicker-uzh/util'
 import {
   admitCorrelatedResponse,
@@ -25,6 +25,7 @@ describe('correlated response key', () => {
   it('is stable for one identity and block execution', () => {
     const key = buildCorrelatedResponseKey({
       liveQuizId: 'quiz-1',
+      publicationGeneration: 3,
       instanceId: '42',
       blockExecution: '3',
       identityKey: 'respondent:abc',
@@ -32,7 +33,7 @@ describe('correlated response key', () => {
 
     assert.equal(
       key,
-      'lq:quiz-1:i:42:correlatedVotes:3:085bf40ef25fbf989488342d89d5669f7bf03aca4968dc220af108593e093de4'
+      'lq:quiz-1:g:3:i:42:correlatedVotes:3:085bf40ef25fbf989488342d89d5669f7bf03aca4968dc220af108593e093de4'
     )
   })
 })
@@ -161,69 +162,58 @@ describe('correlated response request safeguards', () => {
           pinCode: 'ABC123',
           responseCollectionMode: 'CORRELATED_EXPORT',
           status: 'PUBLISHED',
+          publicationGeneration: 3,
         }),
       },
     } as any
 
-    assert.equal(
+    assert.deepEqual(
       await getCorrelatedResponseAdmission({
         database,
         liveQuizId: 'quiz-1',
         cookieHeader: 'live-quiz-pin-quiz-1=ABC123',
       }),
-      'ready'
+      { status: 'ready', publicationGeneration: 3 }
     )
-    assert.equal(
+    assert.deepEqual(
       await getCorrelatedResponseAdmission({
         database,
         liveQuizId: 'quiz-1',
         cookieHeader: undefined,
       }),
-      'pin_required'
+      { status: 'pin_required' }
     )
   })
 
-  it('atomically bridges an active temporary identity and registers its outbox event', async () => {
+  it('rejects gamification-only temporary identities before persistence', async () => {
     const respondentId = '33333333-3333-4333-8333-333333333333'
-    let respondentCreated = false
-    const createCalls: any[] = []
-    let lockQuery = ''
+    let bindingCreated = false
+    let outboxCreated = false
     const result = await admitCorrelatedResponse({
       database: {
         $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
           callback({
-            $queryRaw: async (strings: TemplateStringsArray) => {
-              lockQuery = strings.join('?')
-              return [
-                {
-                  activeBlockId: 7,
-                  blockExecution: 3,
-                  blockId: 7,
-                  blockStatus: 'ACTIVE',
-                  isAssessmentEnabled: false,
-                  pinCode: null,
-                  responseCollectionMode: 'CORRELATED_EXPORT',
-                  status: 'PUBLISHED',
-                },
-              ]
-            },
-            temporaryLeaderboardEntry: {
-              findUnique: async () => ({ id: respondentId }),
-            },
-            liveQuizRespondent: {
+            $queryRaw: async () => [
+              {
+                activeBlockId: 7,
+                blockExecution: 3,
+                blockId: 7,
+                blockStatus: 'ACTIVE',
+                isAssessmentEnabled: false,
+                pinCode: null,
+                responseCollectionMode: 'CORRELATED_EXPORT',
+                publicationGeneration: 3,
+                status: 'PUBLISHED',
+              },
+            ],
+            liveQuizRespondentBinding: {
               upsert: async () => {
-                respondentCreated = true
-                return {
-                  id: respondentId,
-                  liveQuizId: '11111111-1111-4111-8111-111111111111',
-                  type: LiveQuizRespondentType.TEMPORARY_PSEUDONYM,
-                }
+                bindingCreated = true
               },
             },
             liveQuizPendingResponse: {
-              create: async (args: any) => {
-                createCalls.push(args)
-                return args.data
+              create: async () => {
+                outboxCreated = true
               },
             },
           }),
@@ -250,8 +240,90 @@ describe('correlated response request safeguards', () => {
       nextDeliveryAt: new Date('2026-07-29T12:00:00.000Z'),
     })
 
+    assert.deepEqual(result, { status: 'invalid_identity' })
+    assert.equal(bindingCreated, false)
+    assert.equal(outboxCreated, false)
+  })
+
+  it('binds an anonymous identity to the generation-scoped respondent', async () => {
+    const liveQuizId = '11111111-1111-4111-8111-111111111111'
+    const respondentId = '33333333-3333-4333-8333-333333333333'
+    const token = 'signed-token'
+    const createCalls: any[] = []
+    let lockQuery = ''
+    const result = await admitCorrelatedResponse({
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
+          callback({
+            $queryRaw: async (strings: TemplateStringsArray) => {
+              lockQuery = strings.join('?')
+              return [
+                {
+                  activeBlockId: 7,
+                  blockExecution: 3,
+                  blockId: 7,
+                  blockStatus: 'ACTIVE',
+                  isAssessmentEnabled: false,
+                  pinCode: null,
+                  responseCollectionMode: 'CORRELATED_EXPORT',
+                  publicationGeneration: 3,
+                  status: 'PUBLISHED',
+                },
+              ]
+            },
+            liveQuizRespondentBinding: {
+              findUnique: async () => null,
+              create: async () => ({
+                respondentId,
+                liveQuizId,
+                publicationGeneration: 3,
+                participantId: null,
+                verificationSecretHash: hashLiveQuizRespondentToken(token),
+                expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+                respondent: { finalizedAt: null },
+              }),
+            },
+            liveQuizRespondent: {
+              create: async () => ({ id: respondentId }),
+              findUnique: async () => ({
+                finalizedAt: null,
+                liveQuizId,
+                publicationGeneration: 3,
+              }),
+            },
+            liveQuizPendingResponse: {
+              create: async (args: any) => {
+                createCalls.push(args)
+                return args.data
+              },
+            },
+          }),
+      } as any,
+      identity: {
+        kind: 'anonymous',
+        id: respondentId,
+        liveQuizId,
+        publicationGeneration: 3,
+        token,
+        cookieName:
+          'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
+      },
+      liveQuizId,
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+      nextDeliveryAt: new Date('2026-07-29T12:00:00.000Z'),
+    })
+
     assert.equal(result.status, 'registered')
-    assert.equal(respondentCreated, true)
     assert.match(lockQuery, /FOR SHARE OF quiz, block/)
     assert.equal(createCalls.length, 1)
     assert.deepEqual(
@@ -261,11 +333,12 @@ describe('correlated response request safeguards', () => {
       }),
       {
         messageId: '22222222-2222-4222-8222-222222222222',
-        sessionId: '11111111-1111-4111-8111-111111111111',
+        sessionId: liveQuizId,
         instanceId: '42',
+        publicationGeneration: 3,
         response: { value: 'private response' },
         responseTimestamp: 1_000,
-        acceptedIdentity: { kind: 'temporary', id: respondentId },
+        acceptedIdentity: { kind: 'anonymous', id: respondentId },
         instanceInfo: {
           type: 'FREE_TEXT',
           blockExecution: '3',
@@ -276,12 +349,14 @@ describe('correlated response request safeguards', () => {
     assert.equal(
       createCalls[0].data.responseKey,
       buildCorrelatedResponseKey({
-        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        liveQuizId,
+        publicationGeneration: 3,
         instanceId: '42',
         blockExecution: '3',
         identityKey: `respondent:${respondentId}`,
       })
     )
+    assert.equal(createCalls[0].data.publicationGeneration, 3)
   })
 
   it('does not create identities or outbox entries after the quiz has ended', async () => {
@@ -319,6 +394,7 @@ describe('correlated response request safeguards', () => {
         kind: 'anonymous',
         id: '33333333-3333-4333-8333-333333333333',
         liveQuizId: '11111111-1111-4111-8111-111111111111',
+        publicationGeneration: 3,
         token: 'signed-token',
         cookieName:
           'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
@@ -349,6 +425,7 @@ describe('correlated response request safeguards', () => {
         kind: 'anonymous',
         id: '33333333-3333-4333-8333-333333333333',
         liveQuizId: '11111111-1111-4111-8111-111111111111',
+        publicationGeneration: 3,
         token: 'signed-token',
         cookieName:
           'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
@@ -419,6 +496,7 @@ describe('correlated response request safeguards', () => {
                 isAssessmentEnabled: false,
                 pinCode: 'ABC123',
                 responseCollectionMode: 'CORRELATED_EXPORT',
+                publicationGeneration: 3,
                 status: 'PUBLISHED',
               },
             ],
@@ -438,6 +516,7 @@ describe('correlated response request safeguards', () => {
         kind: 'anonymous',
         id: '33333333-3333-4333-8333-333333333333',
         liveQuizId: '11111111-1111-4111-8111-111111111111',
+        publicationGeneration: 3,
         token: 'signed-token',
         cookieName:
           'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
@@ -466,6 +545,7 @@ describe('correlated response request safeguards', () => {
       messageId: '22222222-2222-4222-8222-222222222222',
       sessionId: '11111111-1111-4111-8111-111111111111',
       instanceId: '42',
+      publicationGeneration: 3,
       response: { value: 'private response' },
       responseTimestamp: 1_000,
       instanceInfo: {
@@ -515,6 +595,7 @@ describe('correlated response request safeguards', () => {
       messageId: '22222222-2222-4222-8222-222222222222',
       sessionId: '11111111-1111-4111-8111-111111111111',
       instanceId: '42',
+      publicationGeneration: 3,
       response: { value: 'response' },
       responseTimestamp: 1_000,
       instanceInfo: {

--- a/apps/response-api/test/correlatedResponses.test.ts
+++ b/apps/response-api/test/correlatedResponses.test.ts
@@ -1,0 +1,552 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { LiveQuizRespondentType } from '@klicker-uzh/prisma/client'
+import {
+  buildCorrelatedResponseKey,
+  decryptCorrelatedResponseEvent,
+  encryptCorrelatedResponseEvent,
+} from '@klicker-uzh/util'
+import {
+  admitCorrelatedResponse,
+  getCorrelatedResponseAdmission,
+  hasValidLiveQuizPin,
+  serializeLiveQuizRespondentCookie,
+} from '../src/correlatedResponseAdmission.js'
+import { dispatchPendingCorrelatedResponses } from '../src/correlatedResponseOutbox.js'
+import {
+  hasJsonContentType,
+  isAllowedCorsOrigin,
+  resolveResponseCollectionMode,
+} from '../src/liveQuizResponseRequest.js'
+
+describe('correlated response key', () => {
+  it('is stable for one identity and block execution', () => {
+    const key = buildCorrelatedResponseKey({
+      liveQuizId: 'quiz-1',
+      instanceId: '42',
+      blockExecution: '3',
+      identityKey: 'respondent:abc',
+    })
+
+    assert.equal(
+      key,
+      'lq:quiz-1:i:42:correlatedVotes:3:085bf40ef25fbf989488342d89d5669f7bf03aca4968dc220af108593e093de4'
+    )
+  })
+})
+
+describe('correlated response request safeguards', () => {
+  it('requires allowlisted browser origins while permitting non-browser clients', () => {
+    assert.equal(
+      isAllowedCorsOrigin({
+        origin: undefined,
+        allowedOrigins: ['https://pwa.klicker.test'],
+      }),
+      true
+    )
+    assert.equal(
+      isAllowedCorsOrigin({
+        origin: 'https://pwa.klicker.test',
+        allowedOrigins: ['https://pwa.klicker.test'],
+      }),
+      true
+    )
+    assert.equal(
+      isAllowedCorsOrigin({
+        origin: 'https://attacker.test',
+        allowedOrigins: ['https://pwa.klicker.test'],
+      }),
+      false
+    )
+  })
+
+  it('accepts only JSON request content types', () => {
+    assert.equal(hasJsonContentType('application/json'), true)
+    assert.equal(hasJsonContentType('application/json; charset=utf-8'), true)
+    assert.equal(hasJsonContentType('text/plain'), false)
+    assert.equal(hasJsonContentType(undefined), false)
+  })
+
+  it('centralizes correlated quiz and PIN admission', async () => {
+    const database = {
+      liveQuiz: {
+        findUnique: async () => ({
+          isAssessmentEnabled: false,
+          pinCode: 'ABC123',
+          responseCollectionMode: 'CORRELATED_EXPORT',
+          status: 'PUBLISHED',
+        }),
+      },
+    } as any
+
+    assert.equal(
+      await getCorrelatedResponseAdmission({
+        database,
+        liveQuizId: 'quiz-1',
+        cookieHeader: 'live-quiz-pin-quiz-1=ABC123',
+      }),
+      'ready'
+    )
+    assert.equal(
+      await getCorrelatedResponseAdmission({
+        database,
+        liveQuizId: 'quiz-1',
+        cookieHeader: undefined,
+      }),
+      'pin_required'
+    )
+  })
+
+  it('atomically bridges an active temporary identity and registers its outbox event', async () => {
+    const respondentId = '33333333-3333-4333-8333-333333333333'
+    let respondentCreated = false
+    const createCalls: any[] = []
+    let lockQuery = ''
+    const result = await admitCorrelatedResponse({
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
+          callback({
+            $queryRaw: async (strings: TemplateStringsArray) => {
+              lockQuery = strings.join('?')
+              return [
+                {
+                  activeBlockId: 7,
+                  blockExecution: 3,
+                  blockId: 7,
+                  blockStatus: 'ACTIVE',
+                  isAssessmentEnabled: false,
+                  pinCode: null,
+                  responseCollectionMode: 'CORRELATED_EXPORT',
+                  status: 'PUBLISHED',
+                },
+              ]
+            },
+            temporaryLeaderboardEntry: {
+              findUnique: async () => ({ id: respondentId }),
+            },
+            liveQuizRespondent: {
+              upsert: async () => {
+                respondentCreated = true
+                return {
+                  id: respondentId,
+                  liveQuizId: '11111111-1111-4111-8111-111111111111',
+                  type: LiveQuizRespondentType.TEMPORARY_PSEUDONYM,
+                }
+              },
+            },
+            liveQuizPendingResponse: {
+              create: async (args: any) => {
+                createCalls.push(args)
+                return args.data
+              },
+            },
+          }),
+      } as any,
+      identity: {
+        kind: 'temporary',
+        id: respondentId,
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        token: 'signed-token',
+        cookieName: 'temporary_participant_token',
+      },
+      liveQuizId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+      nextDeliveryAt: new Date('2026-07-29T12:00:00.000Z'),
+    })
+
+    assert.equal(result.status, 'registered')
+    assert.equal(respondentCreated, true)
+    assert.match(lockQuery, /FOR SHARE OF quiz, block/)
+    assert.equal(createCalls.length, 1)
+    assert.deepEqual(
+      decryptCorrelatedResponseEvent({
+        encryptedPayload: createCalls[0].data.eventPayload,
+        secret: 'app-secret',
+      }),
+      {
+        messageId: '22222222-2222-4222-8222-222222222222',
+        sessionId: '11111111-1111-4111-8111-111111111111',
+        instanceId: '42',
+        response: { value: 'private response' },
+        responseTimestamp: 1_000,
+        acceptedIdentity: { kind: 'temporary', id: respondentId },
+        instanceInfo: {
+          type: 'FREE_TEXT',
+          blockExecution: '3',
+          sessionBlockId: '7',
+        },
+      }
+    )
+    assert.equal(
+      createCalls[0].data.responseKey,
+      buildCorrelatedResponseKey({
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        instanceId: '42',
+        blockExecution: '3',
+        identityKey: `respondent:${respondentId}`,
+      })
+    )
+  })
+
+  it('does not create identities or outbox entries after the quiz has ended', async () => {
+    let respondentCreated = false
+    let createCalled = false
+    const result = await admitCorrelatedResponse({
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
+          callback({
+            $queryRaw: async () => [
+              {
+                activeBlockId: null,
+                blockExecution: 3,
+                blockId: 7,
+                blockStatus: 'EXECUTED',
+                isAssessmentEnabled: false,
+                pinCode: null,
+                responseCollectionMode: 'CORRELATED_EXPORT',
+                status: 'ENDED',
+              },
+            ],
+            liveQuizRespondent: {
+              upsert: async () => {
+                respondentCreated = true
+              },
+            },
+            liveQuizPendingResponse: {
+              create: async () => {
+                createCalled = true
+              },
+            },
+          }),
+      } as any,
+      identity: {
+        kind: 'anonymous',
+        id: '33333333-3333-4333-8333-333333333333',
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        token: 'signed-token',
+        cookieName:
+          'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
+      },
+      liveQuizId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+    })
+
+    assert.equal(result.status, 'not_found')
+    assert.equal(respondentCreated, false)
+    assert.equal(createCalled, false)
+  })
+
+  it('rejects empty correlated metadata identifiers before persistence', async () => {
+    const result = await admitCorrelatedResponse({
+      database: {} as any,
+      identity: {
+        kind: 'anonymous',
+        id: '33333333-3333-4333-8333-333333333333',
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        token: 'signed-token',
+        cookieName:
+          'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
+      },
+      liveQuizId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '',
+        sessionBlockId: '7',
+      },
+      cookieHeader: undefined,
+      secret: 'app-secret',
+    })
+
+    assert.equal(result.status, 'invalid_metadata')
+  })
+
+  it('rejects a second pending response for the same respondent execution', async () => {
+    assert.equal(
+      (
+        await admitCorrelatedResponse({
+          identity: {
+            kind: 'participant',
+            id: '33333333-3333-4333-8333-333333333333',
+            token: 'signed-token',
+            cookieName: 'participant_token',
+          },
+          database: {
+            $transaction: async () => {
+              throw { code: 'P2002' }
+            },
+          } as any,
+          liveQuizId: '11111111-1111-4111-8111-111111111111',
+          instanceId: '42',
+          messageId: '22222222-2222-4222-8222-222222222222',
+          response: { value: 'private response' },
+          responseTimestamp: 1_000,
+          instanceInfo: {
+            type: 'FREE_TEXT',
+            blockExecution: '3',
+            sessionBlockId: '7',
+          },
+          cookieHeader: undefined,
+          secret: 'app-secret',
+        })
+      ).status,
+      'duplicate'
+    )
+  })
+
+  it('checks PIN access inside the locked admission transaction', async () => {
+    let identityCreated = false
+    let outboxCreated = false
+    const result = await admitCorrelatedResponse({
+      database: {
+        $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
+          callback({
+            $queryRaw: async () => [
+              {
+                activeBlockId: 7,
+                blockExecution: 3,
+                blockId: 7,
+                blockStatus: 'ACTIVE',
+                isAssessmentEnabled: false,
+                pinCode: 'ABC123',
+                responseCollectionMode: 'CORRELATED_EXPORT',
+                status: 'PUBLISHED',
+              },
+            ],
+            liveQuizRespondent: {
+              upsert: async () => {
+                identityCreated = true
+              },
+            },
+            liveQuizPendingResponse: {
+              create: async () => {
+                outboxCreated = true
+              },
+            },
+          }),
+      } as any,
+      identity: {
+        kind: 'anonymous',
+        id: '33333333-3333-4333-8333-333333333333',
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        token: 'signed-token',
+        cookieName:
+          'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111',
+      },
+      liveQuizId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      messageId: '22222222-2222-4222-8222-222222222222',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      cookieHeader: 'live-quiz-pin-11111111-1111-4111-8111-111111111111=WRONG',
+      secret: 'app-secret',
+    })
+
+    assert.deepEqual(result, { status: 'pin_required' })
+    assert.equal(identityCreated, false)
+    assert.equal(outboxCreated, false)
+  })
+
+  it('encrypts outbox events and rejects tampering', () => {
+    const message = {
+      messageId: '22222222-2222-4222-8222-222222222222',
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      response: { value: 'private response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT' as const,
+        blockExecution: '1',
+        sessionBlockId: '7',
+      },
+      acceptedIdentity: {
+        kind: 'anonymous' as const,
+        id: '33333333-3333-4333-8333-333333333333',
+      },
+    }
+    const eventPayload = encryptCorrelatedResponseEvent({
+      message,
+      secret: 'app-secret',
+    })
+
+    assert.equal(eventPayload.includes('private response'), false)
+    assert.deepEqual(
+      decryptCorrelatedResponseEvent({
+        encryptedPayload: eventPayload,
+        secret: 'app-secret',
+      }),
+      message
+    )
+    const payloadParts = eventPayload.split('.')
+    const tamperedCiphertext = Buffer.from(payloadParts[3]!, 'base64url')
+    tamperedCiphertext[0] ^= 1
+    payloadParts[3] = tamperedCiphertext.toString('base64url')
+    assert.throws(() =>
+      decryptCorrelatedResponseEvent({
+        encryptedPayload: payloadParts.join('.'),
+        secret: 'app-secret',
+      })
+    )
+
+    assert.throws(() =>
+      encryptCorrelatedResponseEvent({
+        message: { ...message, response: null } as any,
+        secret: 'app-secret',
+      })
+    )
+  })
+
+  it('reserves and republishes outbox events by stable message id', async () => {
+    const message = {
+      messageId: '22222222-2222-4222-8222-222222222222',
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      instanceId: '42',
+      response: { value: 'response' },
+      responseTimestamp: 1_000,
+      instanceInfo: {
+        type: 'FREE_TEXT' as const,
+        blockExecution: '1',
+        sessionBlockId: '7',
+      },
+      acceptedIdentity: {
+        kind: 'participant' as const,
+        id: '33333333-3333-4333-8333-333333333333',
+      },
+    }
+    const pushes: unknown[] = []
+    const result = await dispatchPendingCorrelatedResponses({
+      database: {
+        $queryRaw: async () => [{ id: message.messageId }],
+      } as any,
+      pushEvent: async (eventName, eventMessage) => {
+        pushes.push({ eventName, eventMessage })
+      },
+      now: new Date('2026-07-29T12:00:00.000Z'),
+    })
+
+    assert.deepEqual(result, { attempted: 1, failed: 0 })
+    assert.deepEqual(pushes, [
+      {
+        eventName: 'response-received:correlated-v1',
+        eventMessage: { messageId: message.messageId },
+      },
+    ])
+  })
+
+  it('retains failed outbox events for a later reservation', async () => {
+    const messageId = '22222222-2222-4222-8222-222222222222'
+    const result = await dispatchPendingCorrelatedResponses({
+      database: {
+        $queryRaw: async () => [{ id: messageId }],
+      } as any,
+      pushEvent: async () => {
+        throw new Error('ambiguous publication failure')
+      },
+    })
+
+    assert.deepEqual(result, { attempted: 1, failed: 1 })
+  })
+})
+
+describe('live quiz respondent cookie', () => {
+  it('uses a host-only cookie with the same lifetime as the signed token', () => {
+    assert.equal(
+      serializeLiveQuizRespondentCookie({
+        token: 'signed-token',
+        liveQuizId: '11111111-1111-4111-8111-111111111111',
+        secure: true,
+      }),
+      'live_quiz_respondent_token_11111111-1111-4111-8111-111111111111=signed-token; Max-Age=1209600; Path=/; HttpOnly; Secure; SameSite=Lax'
+    )
+  })
+})
+
+describe('live quiz PIN access', () => {
+  it('allows quizzes without PIN protection', () => {
+    assert.equal(
+      hasValidLiveQuizPin({
+        cookieHeader: undefined,
+        liveQuizId: 'quiz-1',
+        pinCode: null,
+      }),
+      true
+    )
+  })
+
+  it('requires the quiz-scoped PIN cookie', () => {
+    assert.equal(
+      hasValidLiveQuizPin({
+        cookieHeader: 'live-quiz-pin-other=ABC123; live-quiz-pin-quiz-1=DEF456',
+        liveQuizId: 'quiz-1',
+        pinCode: 'DEF456',
+      }),
+      true
+    )
+    assert.equal(
+      hasValidLiveQuizPin({
+        cookieHeader: 'live-quiz-pin-quiz-1=WRONG1',
+        liveQuizId: 'quiz-1',
+        pinCode: 'DEF456',
+      }),
+      false
+    )
+  })
+})
+
+describe('response collection mode', () => {
+  it('uses cached correlated mode without a database lookup', async () => {
+    let lookupCalled = false
+
+    assert.equal(
+      await resolveResponseCollectionMode({
+        cachedMode: 'CORRELATED_EXPORT',
+        liveQuizId: 'quiz-1',
+        lookupMode: async () => {
+          lookupCalled = true
+          return 'AGGREGATED_ANONYMOUS'
+        },
+      }),
+      'CORRELATED_EXPORT'
+    )
+    assert.equal(lookupCalled, false)
+  })
+
+  it('falls back to the stored mode for rolling deployments', async () => {
+    assert.equal(
+      await resolveResponseCollectionMode({
+        cachedMode: undefined,
+        liveQuizId: 'quiz-1',
+        lookupMode: async () => 'CORRELATED_EXPORT',
+      }),
+      'CORRELATED_EXPORT'
+    )
+  })
+})

--- a/apps/response-api/test/correlatedResponses.test.ts
+++ b/apps/response-api/test/correlatedResponses.test.ts
@@ -87,7 +87,8 @@ describe('correlated response request safeguards', () => {
       blockStartedAt: '1754000000000',
       responseCollectionMode: 'CORRELATED_EXPORT',
       numberOfInputs: '2',
-      solutions: '[11,12]',
+      selectionAnswerIds: '[11,12]',
+      solutions: '[11]',
     }
 
     const loaded = await loadLiveQuizResponseInstance({
@@ -121,10 +122,10 @@ describe('correlated response request safeguards', () => {
       defaultPoints: '10',
       maxBonusPoints: '45',
       pointsMultiplier: '1',
-      solutions: '[11,12]',
+      selectionAnswerIds: '[11,12]',
+      solutions: '[11]',
       timeToZeroBonus: '20',
       numberOfInputs: '2',
-      selectionAnswerIds: '[11,12]',
     })
 
     const caseStudyInfo = adaptLiveQuizResponseInstanceInfo({

--- a/apps/response-api/test/correlatedResponses.test.ts
+++ b/apps/response-api/test/correlatedResponses.test.ts
@@ -14,8 +14,10 @@ import {
 } from '../src/correlatedResponseAdmission.js'
 import { dispatchPendingCorrelatedResponses } from '../src/correlatedResponseOutbox.js'
 import {
+  adaptLiveQuizResponseInstanceInfo,
   hasJsonContentType,
   isAllowedCorsOrigin,
+  loadLiveQuizResponseInstance,
   resolveResponseCollectionMode,
 } from '../src/liveQuizResponseRequest.js'
 
@@ -65,6 +67,89 @@ describe('correlated response request safeguards', () => {
     assert.equal(hasJsonContentType('application/json; charset=utf-8'), true)
     assert.equal(hasJsonContentType('text/plain'), false)
     assert.equal(hasJsonContentType(undefined), false)
+  })
+
+  it('adapts the operational Redis hash before strict response validation', async () => {
+    const rawInstanceInfo = {
+      namespace: 'quiz-namespace',
+      startedAt: '1754000000000',
+      sessionBlockId: '7',
+      liveQuizId: 'quiz-1',
+      courseId: 'course-1',
+      type: 'SELECTION',
+      basePoints: 'true',
+      pointsMultiplier: '1',
+      defaultPoints: '10',
+      defaultCorrectPoints: '5',
+      maxBonusPoints: '45',
+      timeToZeroBonus: '20',
+      blockExecution: '3',
+      blockStartedAt: '1754000000000',
+      responseCollectionMode: 'CORRELATED_EXPORT',
+      numberOfInputs: '2',
+      solutions: '[11,12]',
+    }
+
+    const loaded = await loadLiveQuizResponseInstance({
+      database: {
+        liveQuiz: {
+          findUnique: async () => {
+            throw new Error('database mode lookup should not be needed')
+          },
+        },
+      } as any,
+      redis: {
+        hgetall: async () => rawInstanceInfo,
+      },
+      request: {
+        messageId: 'message-1',
+        liveQuizId: 'quiz-1',
+        instanceId: '42',
+        response: { selection: [11, 12] },
+        responseTimestamp: 1_000,
+        cookieHeader: undefined,
+      },
+    })
+
+    assert.equal(loaded.responseCollectionMode, 'CORRELATED_EXPORT')
+    assert.deepEqual(loaded.instanceInfo, {
+      type: 'SELECTION',
+      blockExecution: '3',
+      sessionBlockId: '7',
+      basePoints: 'true',
+      defaultCorrectPoints: '5',
+      defaultPoints: '10',
+      maxBonusPoints: '45',
+      pointsMultiplier: '1',
+      solutions: '[11,12]',
+      timeToZeroBonus: '20',
+      numberOfInputs: '2',
+      selectionAnswerIds: '[11,12]',
+    })
+
+    const caseStudyInfo = adaptLiveQuizResponseInstanceInfo({
+      type: 'CASE_STUDY',
+      blockExecution: '3',
+      sessionBlockId: '7',
+      solutions: JSON.stringify([
+        {
+          caseId: 'case-a',
+          itemSolutions: [
+            {
+              itemId: 11,
+              criteriaSolutions: [
+                { criterionId: 'criterion-a', min: 0, max: 5 },
+              ],
+            },
+          ],
+        },
+      ]),
+    })
+    assert.deepEqual(JSON.parse(caseStudyInfo.caseStudyResponseShape!), {
+      cases: ['case-a'],
+      items: [11],
+      criteria: [{ id: 'criterion-a', min: 0, max: 5 }],
+    })
   })
 
   it('centralizes correlated quiz and PIN admission', async () => {

--- a/apps/response-api/test/responseHandlers.test.ts
+++ b/apps/response-api/test/responseHandlers.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
-  LiveQuizRespondentType,
   LiveQuizResponseCollectionMode,
   PublicationStatus,
 } from '@klicker-uzh/prisma/client'
@@ -107,6 +106,7 @@ describe('standard live quiz response handlers', () => {
     const token = await createLiveQuizRespondentToken({
       respondentId: '33333333-3333-4333-8333-333333333333',
       liveQuizId: request.liveQuizId,
+      publicationGeneration: 3,
       secret,
       issuer,
     })
@@ -145,6 +145,7 @@ describe('standard live quiz response handlers', () => {
     const token = await createLiveQuizRespondentToken({
       respondentId,
       liveQuizId: request.liveQuizId,
+      publicationGeneration: 3,
       secret,
       issuer,
     })
@@ -162,6 +163,7 @@ describe('standard live quiz response handlers', () => {
           pinCode: null,
           responseCollectionMode:
             LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+          publicationGeneration: 3,
           status: PublicationStatus.PUBLISHED,
         }),
       },
@@ -177,15 +179,27 @@ describe('standard live quiz response handlers', () => {
               pinCode: null,
               responseCollectionMode:
                 LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+              publicationGeneration: 3,
               status: PublicationStatus.PUBLISHED,
             },
           ],
-          liveQuizRespondent: {
-            upsert: async () => ({
-              id: respondentId,
+          liveQuizRespondentBinding: {
+            findUnique: async () => null,
+            create: async () => ({
+              respondentId,
               liveQuizId: request.liveQuizId,
-              type: LiveQuizRespondentType.ANONYMOUS_CORRELATED,
+              publicationGeneration: 3,
+              participantId: null,
               verificationSecretHash: hashLiveQuizRespondentToken(token),
+              expiresAt: new Date('2026-07-29T12:20:00.000Z'),
+            }),
+          },
+          liveQuizRespondent: {
+            create: async () => ({ id: respondentId }),
+            findUnique: async () => ({
+              finalizedAt: null,
+              liveQuizId: request.liveQuizId,
+              publicationGeneration: 3,
             }),
           },
           liveQuizPendingResponse: {

--- a/apps/response-api/test/responseHandlers.test.ts
+++ b/apps/response-api/test/responseHandlers.test.ts
@@ -138,6 +138,47 @@ describe('standard live quiz response handlers', () => {
     assert.equal(pushed, false)
   })
 
+  it('rejects free-text correlated responses before identity admission', async () => {
+    const secret = 'test-secret'
+    const issuer = 'https://api.test'
+    const token = await createLiveQuizRespondentToken({
+      respondentId: '33333333-3333-4333-8333-333333333333',
+      liveQuizId: request.liveQuizId,
+      publicationGeneration: 3,
+      secret,
+      issuer,
+    })
+    let pushed = false
+
+    const result = await handleCorrelatedResponse({
+      request: {
+        ...request,
+        response: { value: 'identifying free-text' },
+        cookieHeader: `${getLiveQuizRespondentCookieName(request.liveQuizId)}=${token}`,
+      },
+      instanceInfo: {
+        type: 'FREE_TEXT',
+        blockExecution: '3',
+        sessionBlockId: '7',
+      },
+      responseCollectionMode: LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+      database: {} as any,
+      getIdentityConfig: () => ({ secret, issuer }),
+      pushEvent: async () => {
+        pushed = true
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 400,
+      body: {
+        error:
+          'Free-text responses are not retained for correlated teaching exports',
+      },
+    })
+    assert.equal(pushed, false)
+  })
+
   it('registers and publishes only an outbox id for correlated responses', async () => {
     const secret = 'test-secret'
     const issuer = 'https://api.test'

--- a/apps/response-api/test/responseHandlers.test.ts
+++ b/apps/response-api/test/responseHandlers.test.ts
@@ -244,6 +244,7 @@ describe('standard live quiz response handlers', () => {
             }),
           },
           liveQuizPendingResponse: {
+            findUnique: async () => null,
             create: async ({ data }: { data: unknown }) => {
               pendingResponses.push(data)
             },

--- a/apps/response-api/test/responseHandlers.test.ts
+++ b/apps/response-api/test/responseHandlers.test.ts
@@ -101,6 +101,43 @@ describe('standard live quiz response handlers', () => {
     })
   })
 
+  it('rejects malformed restrictions before creating a pending response', async () => {
+    const secret = 'test-secret'
+    const issuer = 'https://api.test'
+    const token = await createLiveQuizRespondentToken({
+      respondentId: '33333333-3333-4333-8333-333333333333',
+      liveQuizId: request.liveQuizId,
+      secret,
+      issuer,
+    })
+    let pushed = false
+
+    const result = await handleCorrelatedResponse({
+      request: {
+        ...request,
+        cookieHeader: `${getLiveQuizRespondentCookieName(request.liveQuizId)}=${token}`,
+      },
+      instanceInfo: {
+        type: 'NUMERICAL',
+        blockExecution: '3',
+        sessionBlockId: '7',
+        restrictions: '{not-json',
+      },
+      responseCollectionMode: LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+      database: {} as any,
+      getIdentityConfig: () => ({ secret, issuer }),
+      pushEvent: async () => {
+        pushed = true
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 400,
+      body: { error: 'Invalid correlated response metadata' },
+    })
+    assert.equal(pushed, false)
+  })
+
   it('registers and publishes only an outbox id for correlated responses', async () => {
     const secret = 'test-secret'
     const issuer = 'https://api.test'

--- a/apps/response-api/test/responseHandlers.test.ts
+++ b/apps/response-api/test/responseHandlers.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  LiveQuizRespondentType,
+  LiveQuizResponseCollectionMode,
+  PublicationStatus,
+} from '@klicker-uzh/prisma/client'
+import {
+  CORRELATED_RESPONSE_EVENT,
+  createLiveQuizRespondentToken,
+  decryptCorrelatedResponseEvent,
+  getLiveQuizRespondentCookieName,
+  hashLiveQuizRespondentToken,
+} from '@klicker-uzh/util'
+import { handleAggregateResponse } from '../src/aggregateResponse.js'
+import { handleCorrelatedResponse } from '../src/correlatedResponseHandler.js'
+import type { LiveQuizResponseRequest } from '../src/liveQuizResponseRequest.js'
+
+const request: LiveQuizResponseRequest = {
+  messageId: '11111111-1111-4111-8111-111111111111',
+  liveQuizId: '22222222-2222-4222-8222-222222222222',
+  instanceId: '42',
+  response: { choices: [{ ix: 0, selected: true }] },
+  responseTimestamp: 1_754_000_000_000,
+  cookieHeader: undefined,
+}
+
+describe('standard live quiz response handlers', () => {
+  it('rejects correlated collection on the aggregate endpoint', async () => {
+    let pushed = false
+    const result = await handleAggregateResponse({
+      request,
+      responseCollectionMode: LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+      pushEvent: async () => {
+        pushed = true
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 409,
+      body: {
+        error: 'Response endpoint does not match live quiz collection mode',
+      },
+    })
+    assert.equal(pushed, false)
+  })
+
+  it('rejects aggregate collection on the correlated endpoint', async () => {
+    let pushed = false
+    const result = await handleCorrelatedResponse({
+      request,
+      instanceInfo: {},
+      responseCollectionMode:
+        LiveQuizResponseCollectionMode.AGGREGATED_ANONYMOUS,
+      database: {} as any,
+      getIdentityConfig: () => {
+        throw new Error('Identity configuration should not be read')
+      },
+      pushEvent: async () => {
+        pushed = true
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 409,
+      body: {
+        error: 'Response endpoint does not match live quiz collection mode',
+      },
+    })
+    assert.equal(pushed, false)
+  })
+
+  it('forwards only participant cookies through the aggregate handler', async () => {
+    let event:
+      | {
+          name: string
+          cookie: string | undefined
+        }
+      | undefined
+    const result = await handleAggregateResponse({
+      request: {
+        ...request,
+        cookieHeader:
+          'unrelated=value; participant_token=participant; temporary_participant_token=temporary',
+      },
+      responseCollectionMode:
+        LiveQuizResponseCollectionMode.AGGREGATED_ANONYMOUS,
+      pushEvent: async (name, message) => {
+        event = { name, cookie: message.cookie }
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 200,
+      body: { status: 'ok', responseTimestamp: request.responseTimestamp },
+    })
+    assert.deepEqual(event, {
+      name: 'response-received:authenticated',
+      cookie:
+        'participant_token=participant; temporary_participant_token=temporary',
+    })
+  })
+
+  it('registers and publishes only an outbox id for correlated responses', async () => {
+    const secret = 'test-secret'
+    const issuer = 'https://api.test'
+    const respondentId = '33333333-3333-4333-8333-333333333333'
+    const token = await createLiveQuizRespondentToken({
+      respondentId,
+      liveQuizId: request.liveQuizId,
+      secret,
+      issuer,
+    })
+    const pendingResponses: any[] = []
+    let pushed:
+      | {
+          eventName: string
+          message: unknown
+        }
+      | undefined
+    const database = {
+      liveQuiz: {
+        findUnique: async () => ({
+          isAssessmentEnabled: false,
+          pinCode: null,
+          responseCollectionMode:
+            LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+          status: PublicationStatus.PUBLISHED,
+        }),
+      },
+      $transaction: async (callback: (prisma: any) => Promise<unknown>) =>
+        callback({
+          $queryRaw: async () => [
+            {
+              activeBlockId: 7,
+              blockExecution: 3,
+              blockId: 7,
+              blockStatus: 'ACTIVE',
+              isAssessmentEnabled: false,
+              pinCode: null,
+              responseCollectionMode:
+                LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+              status: PublicationStatus.PUBLISHED,
+            },
+          ],
+          liveQuizRespondent: {
+            upsert: async () => ({
+              id: respondentId,
+              liveQuizId: request.liveQuizId,
+              type: LiveQuizRespondentType.ANONYMOUS_CORRELATED,
+              verificationSecretHash: hashLiveQuizRespondentToken(token),
+            }),
+          },
+          liveQuizPendingResponse: {
+            create: async ({ data }: { data: unknown }) => {
+              pendingResponses.push(data)
+            },
+          },
+        }),
+    } as any
+
+    const result = await handleCorrelatedResponse({
+      request: {
+        ...request,
+        cookieHeader: `${getLiveQuizRespondentCookieName(request.liveQuizId)}=${token}`,
+      },
+      instanceInfo: {
+        type: 'SC',
+        blockExecution: '3',
+        sessionBlockId: '7',
+        choiceCount: '1',
+      },
+      responseCollectionMode: LiveQuizResponseCollectionMode.CORRELATED_EXPORT,
+      database,
+      getIdentityConfig: () => ({ secret, issuer }),
+      pushEvent: async (eventName, message) => {
+        pushed = { eventName, message }
+      },
+    })
+
+    assert.deepEqual(result, {
+      status: 200,
+      body: { status: 'ok', responseTimestamp: request.responseTimestamp },
+    })
+    assert.deepEqual(pushed, {
+      eventName: CORRELATED_RESPONSE_EVENT,
+      message: { messageId: request.messageId },
+    })
+    assert.equal(pendingResponses.length, 1)
+    const pendingResponse = pendingResponses[0]
+    assert.equal(pendingResponse.id, request.messageId)
+    assert.equal(
+      decryptCorrelatedResponseEvent({
+        encryptedPayload: pendingResponse.eventPayload,
+        secret,
+      }).acceptedIdentity.id,
+      respondentId
+    )
+  })
+})

--- a/docs/solutions/runtime-error/live-quiz-correlated-cache-metadata-contract.md
+++ b/docs/solutions/runtime-error/live-quiz-correlated-cache-metadata-contract.md
@@ -1,0 +1,42 @@
+---
+module: live-quiz-response
+date: 2026-08-12
+problem_type: runtime_error
+severity: high
+symptoms:
+  - 'Correlated submissions returned 400 Invalid correlated response metadata in production-shaped Redis hashes.'
+  - 'Valid selection answers were rejected when their IDs were not correct solution IDs.'
+  - 'Malformed restrictions could reach encrypted outbox validation and surface as a 500.'
+root_cause: "The Redis producer's operational hash was passed directly to a stricter response contract, and selectable IDs were conflated with grading solution IDs."
+tags: [live-quiz, response-api, redis, metadata, outbox]
+---
+
+# Correlated response metadata has a producer contract
+
+## Problem
+
+The live-quiz response API consumes Redis hashes that serve several purposes: routing, grading, timing, and response validation. The correlated-response contract only accepts a narrow subset of those fields. Passing the complete operational hash directly to the strict parser caused production-shaped submissions to fail before admission.
+
+Selection questions also have two different ID sets: every selectable answer and the subset that is correct for grading. Treating the correct subset as the complete selectable set rejects legitimate answers.
+
+## Symptoms
+
+The strict parser rejected operational fields such as namespace and timestamps. Selection responses using a valid non-solution option were rejected. Invalid JSON restrictions were converted into absent restrictions and then failed later during outbox validation.
+
+## What Didn't Work
+
+Passing `hgetall` output directly to `parseCorrelatedResponseInstanceInfo` coupled a broad operational cache shape to a narrow response contract. Reusing the grading solution IDs for `selectionAnswerIds` looked convenient but changed the meaning of the field. Filtering malformed parsed restrictions to `undefined` made malformed metadata indistinguishable from omitted metadata.
+
+## Solution
+
+`adaptLiveQuizResponseInstanceInfo` now whitelists the contract fields, maps legacy selection metadata, and derives legacy case-study shape only when it can be validated ([`apps/response-api/src/liveQuizResponseRequest.ts:121-159`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:121), [`apps/response-api/src/liveQuizResponseRequest.ts:250-266`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:250)). The loader keeps routing mode lookup on the operational hash while passing only adapted metadata to correlated admission.
+
+The GraphQL cache writer emits canonical selection and case-study metadata ([`packages/graphql/src/services/liveQuizzes.ts:1282-1337`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:1282)). The pure helper keeps all selectable answer IDs separate from correct solution IDs ([`packages/graphql/src/services/liveQuizResponseCacheMetadata.ts:1-14`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:1)), with a regression test for that distinction ([`packages/graphql/test/liveQuizResponseCacheMetadata.test.ts:5-14`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:5)). Malformed restriction JSON is rejected as a 400 and passed through to fail-closed validation rather than being treated as absent ([`apps/response-api/src/correlatedResponseHandler.ts:64-83`](/Users/rschlae/Git/klicker/klicker-uzh/trees/pr5134-stack-a:64)).
+
+## Why This Works
+
+The producer may retain operational fields without expanding the public response contract. The adapter is the compatibility boundary, so strict validation sees only fields it understands. Selection validation can accept every answer entry while the worker still receives the correct-only solution list for grading. Invalid metadata remains distinguishable from omitted optional metadata and cannot be durably acknowledged.
+
+## Prevention
+
+Test the adapter with the actual Redis `hgetall` shape, including unrelated operational fields and each question variant. Keep producer metadata helpers pure where possible so field-semantics regressions can be tested without a live Redis or GraphQL service. Treat legacy cache fallbacks as compatibility behavior with an explicit sunset or rejection path; do not infer complete selectable metadata from grading solutions.

--- a/packages/graphql/src/services/liveQuizResponseCacheMetadata.ts
+++ b/packages/graphql/src/services/liveQuizResponseCacheMetadata.ts
@@ -1,0 +1,15 @@
+export function buildLiveQuizSelectionResponseMetadata({
+  answerCollectionEntries,
+  solutionIds,
+}: {
+  answerCollectionEntries?: { id: number }[] | null
+  solutionIds?: number[] | null
+}) {
+  const selectableIds =
+    answerCollectionEntries?.map((entry) => entry.id) ?? solutionIds ?? []
+
+  return {
+    selectionAnswerIds: JSON.stringify(selectableIds),
+    solutions: JSON.stringify(solutionIds),
+  }
+}

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -47,6 +47,7 @@ import {
   lockCourseLiveQuizResponseCollectionSettings,
   lockLiveQuizResponseCollectionState,
 } from './liveQuizResponseCollection.js'
+import { buildLiveQuizSelectionResponseMetadata } from './liveQuizResponseCacheMetadata.js'
 import { sendTeamsNotification } from './notifications.js'
 import { upsertDailyTimelineEntry } from './participants.js'
 import { computeStackEvaluation } from './stacks.js'
@@ -1277,15 +1278,16 @@ export async function activateLiveQuizBlock(
       }
 
       case DB.ElementType.SELECTION: {
-        const selectionAnswerIds = JSON.stringify(
-          elementData.options.answerCollection?.entries.map(
-            (entry) => entry.id
-          ) ?? elementData.options.answerCollectionSolutionIds
-        )
+        const { selectionAnswerIds, solutions } =
+          buildLiveQuizSelectionResponseMetadata({
+            answerCollectionEntries:
+              elementData.options.answerCollection?.entries,
+            solutionIds: elementData.options.answerCollectionSolutionIds,
+          })
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,
           selectionAnswerIds,
-          solutions: selectionAnswerIds,
+          solutions,
           numberOfInputs: elementData.options.numberOfInputs,
         })
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:results`, {

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1278,7 +1278,9 @@ export async function activateLiveQuizBlock(
 
       case DB.ElementType.SELECTION: {
         const selectionAnswerIds = JSON.stringify(
-          elementData.options.answerCollectionSolutionIds
+          elementData.options.answerCollection?.entries.map(
+            (entry) => entry.id
+          ) ?? elementData.options.answerCollectionSolutionIds
         )
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1209,6 +1209,7 @@ export async function activateLiveQuizBlock(
       timeToZeroBonus: updatedQuiz.timeToZeroBonus,
       blockExecution: updatedQuiz.activeBlock!.execution,
       blockStartedAt: Number(updatedQuiz.activeBlock!.startedAt),
+      responseCollectionMode: updatedQuiz.responseCollectionMode,
     }
 
     switch (elementData.type) {
@@ -1276,11 +1277,13 @@ export async function activateLiveQuizBlock(
       }
 
       case DB.ElementType.SELECTION: {
+        const selectionAnswerIds = JSON.stringify(
+          elementData.options.answerCollectionSolutionIds
+        )
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,
-          solutions: JSON.stringify(
-            elementData.options.answerCollectionSolutionIds
-          ),
+          selectionAnswerIds,
+          solutions: selectionAnswerIds,
           numberOfInputs: elementData.options.numberOfInputs,
         })
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:results`, {
@@ -1292,6 +1295,24 @@ export async function activateLiveQuizBlock(
       }
 
       case DB.ElementType.CASE_STUDY: {
+        const caseStudyResponseShape = JSON.stringify({
+          cases: elementData.options.cases.map((caseItem) => caseItem.id),
+          items:
+            elementData.options.items?.map((item) => item.id) ??
+            Array.from(
+              new Set(
+                elementData.options.cases.flatMap(
+                  (caseItem) =>
+                    caseItem.solutions?.map((solution) => solution.itemId) ?? []
+                )
+              )
+            ),
+          criteria: elementData.options.criteria.map((criterion) => ({
+            id: criterion.id,
+            min: criterion.min,
+            max: criterion.max,
+          })),
+        })
         // convert solutions to object for faster access
         const validSolutions = elementData.options.cases.every(
           (caseItem) => caseItem.solutions
@@ -1306,6 +1327,7 @@ export async function activateLiveQuizBlock(
 
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,
+          caseStudyResponseShape,
           solutions: solutions ? JSON.stringify(solutions) : undefined,
         })
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:results`, {

--- a/packages/graphql/test/liveQuizResponseCacheMetadata.test.ts
+++ b/packages/graphql/test/liveQuizResponseCacheMetadata.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { buildLiveQuizSelectionResponseMetadata } from '../src/services/liveQuizResponseCacheMetadata.js'
+
+describe('live quiz response cache metadata', () => {
+  it('keeps all selectable IDs separate from correct solution IDs', () => {
+    expect(
+      buildLiveQuizSelectionResponseMetadata({
+        answerCollectionEntries: [{ id: 11 }, { id: 12 }, { id: 13 }],
+        solutionIds: [11],
+      })
+    ).toEqual({
+      selectionAnswerIds: '[11,12,13]',
+      solutions: '[11]',
+    })
+  })
+})

--- a/packages/prisma/src/prisma/schema/migrations/20260729120000_live_quiz_pending_responses/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260729120000_live_quiz_pending_responses/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "public"."LiveQuizPendingResponse" (
+    "id" UUID NOT NULL,
+    "responseKey" TEXT NOT NULL,
+    "eventPayload" TEXT,
+    "nextDeliveryAt" TIMESTAMP(3),
+    "deliveryAttempts" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "settledAt" TIMESTAMP(3),
+    "liveQuizId" UUID NOT NULL,
+
+    CONSTRAINT "LiveQuizPendingResponse_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "LiveQuizPendingResponse_liveQuizId_idx"
+ON "public"."LiveQuizPendingResponse"("liveQuizId");
+
+CREATE UNIQUE INDEX "LiveQuizPendingResponse_responseKey_key"
+ON "public"."LiveQuizPendingResponse"("responseKey");
+
+CREATE INDEX "LiveQuizPendingResponse_nextDeliveryAt_idx"
+ON "public"."LiveQuizPendingResponse"("nextDeliveryAt");
+
+ALTER TABLE "public"."LiveQuizPendingResponse"
+ADD CONSTRAINT "LiveQuizPendingResponse_liveQuizId_fkey"
+FOREIGN KEY ("liveQuizId") REFERENCES "public"."LiveQuiz"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/src/prisma/schema/migrations/20260815180000_live_quiz_pending_response_generation/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260815180000_live_quiz_pending_response_generation/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "public"."LiveQuizPendingResponse"
+ADD COLUMN "publicationGeneration" INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX "LiveQuizPendingResponse_liveQuizId_publicationGeneration_settledAt_idx"
+ON "public"."LiveQuizPendingResponse"("liveQuizId", "publicationGeneration", "settledAt");

--- a/packages/prisma/src/prisma/schema/quiz.prisma
+++ b/packages/prisma/src/prisma/schema/quiz.prisma
@@ -128,6 +128,7 @@ model LiveQuiz {
   temporaryLeaderboard TemporaryLeaderboardEntry[]
   respondents          LiveQuizRespondent[]
   respondentBindings   LiveQuizRespondentBinding[]
+  pendingResponses     LiveQuizPendingResponse[]
 
   feedbacks          Feedback[]
   confusionFeedbacks ConfusionTimestep[]

--- a/packages/prisma/src/prisma/schema/response.prisma
+++ b/packages/prisma/src/prisma/schema/response.prisma
@@ -146,6 +146,22 @@ model LiveQuizResponse {
   @@index([instanceId, elementBlockExecution])
 }
 
+model LiveQuizPendingResponse {
+  id               String   @id @db.Uuid
+  responseKey      String   @unique
+  eventPayload     String?
+  nextDeliveryAt   DateTime?
+  deliveryAttempts Int      @default(0)
+  createdAt        DateTime @default(now())
+  settledAt        DateTime?
+
+  liveQuiz   LiveQuiz @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  liveQuizId String   @db.Uuid
+
+  @@index([liveQuizId])
+  @@index([nextDeliveryAt])
+}
+
 enum PointCorrectionType {
   ALL_COURSE
   PARTICIPATING

--- a/packages/prisma/src/prisma/schema/response.prisma
+++ b/packages/prisma/src/prisma/schema/response.prisma
@@ -157,8 +157,10 @@ model LiveQuizPendingResponse {
 
   liveQuiz   LiveQuiz @relation(fields: [liveQuizId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   liveQuizId String   @db.Uuid
+  publicationGeneration Int @default(0)
 
   @@index([liveQuizId])
+  @@index([liveQuizId, publicationGeneration, settledAt])
   @@index([nextDeliveryAt])
 }
 


### PR DESCRIPTION
## What This Adds

A3 implements durable correlated-response admission at the response API boundary.

- Adds the correlated response request, admission, outbox, and aggregate-effect paths.
- Adds PostgreSQL uniqueness and transactional admission behavior so duplicate submissions return recorded-before without admitting a second durable response.
- Resolves concurrent first-submission identity races with a bounded retry that only re-runs on the respondent/binding uniqueness conflict, and derives duplicate status from the response-key receipt instead of treating every constraint violation as a duplicate.
- Rejects free-text correlated admission before identity admission (worker rejection remains defense-in-depth).
- Scopes respondent admission by publication generation and keeps selectable/solution answer IDs separated.
- Adds Redis cache metadata and the response-api/GraphQL integration needed to select the correlated path without changing aggregate-only quizzes.
- Records the cache-metadata contract in `docs/solutions/runtime-error/live-quiz-correlated-cache-metadata-contract.md` and adds focused response-api and metadata tests.

## How It Works

The response API validates the quiz mode, identity, PIN, response metadata, and correlation scope before creating the encrypted outbox admission event. Redis remains the live aggregate path; the durable outbox and database uniqueness are the authoritative persistence boundary for correlated responses. Aggregate-only requests continue through the existing path.

## Branch Coverage

- Base: `rs/pr5134-a2-contracts` at `3f768a761`.
- Head: `1d4b263ed`.
- Reviewed: 8 commits; 2,587 additions and 65 deletions across 19 substantive files, excluding generated output and project artifacts.
- Covered: response-api admission, transactional outbox wiring, cache metadata, schema mirrors/migrations, GraphQL integration, tests, and the runtime-error solution note.

## Review Focus

- Confirm duplicate admission is atomic and idempotent under concurrent submissions, and that a distinct concurrent first response is never discarded by the uniqueness retry.
- Confirm cache keys include quiz, instance, execution, and identity scope, and cannot cross quiz boundaries.
- Confirm the aggregate path and assessment path retain their existing behavior.
- Confirm free-text rejection happens before identity admission.

## Verification

Current head:

- `pnpm --filter @klicker-uzh/response-api run test:run -- --test-reporter=spec` -> 26/26 passed on this commit (host), including the race-retry and receipt-based duplicate tests.
- `pnpm run check:all` -> 24/24 turbo tasks green at this commit.
- Full host `pnpm run build` -> 22 tasks, 0 failures.
- Code Quality (org-level CodeQL + GitGuardian, run 31975958241) -> success.

Earlier branch verification:

- GraphQL and Prisma-dependent checks were run on the integrated stack.

Failed/Warning:

- The repo-native CI workflows have no runs on this head (see the A1 description for the trigger investigation); the last repo-native run on this branch is from 2026-08-12 on a superseded head. Only the org-level Code Quality workflow ran on the current head.
- The full local GraphQL suite was separately blocked by unavailable Redis on ports 6379/6380.

## Security / Privacy

- Admission accepts only validated, quiz- and generation-scoped identities and stores event data through the encrypted outbox boundary.
- No raw tokens, credentials, production payloads, or real participant data are committed.

## Blocking Before Merge

- [ ] Repo-native CI green on the current head.
- [ ] Keep the stack draft until the integrated B2 browser and staged rollout gates are green.

## Follow-Up After Merge

- Verify the two-phase rollout in staging before enabling correlated publication.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch:

- Machine: `MacBook-Pro`
- Worktree: `trees/pr5134-stack-a` in repository `klicker-uzh`.
- Solution note: `docs/solutions/runtime-error/live-quiz-correlated-cache-metadata-contract.md` (committed on this branch).
- Handoff: `~/.handoffs/klicker-uzh/2026-08-17-pr5134-review-corrections-handoff.md` on `MacBook-Pro`.
