### PR TITLE
chore(chat): add local MCP and Auto Mode fixture

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -63,6 +63,15 @@ routing as production behaviour ([docs/chat-platform.md](../../../docs/chat-plat
 Without `UPSTREAM_OPENAI_API_KEY`, stop at picker/error-state verification and
 report the live-answer gap explicitly.
 
+For the seeded local MCP smoke test, verify
+`http://localhost:1417/health`, select the direct `GPT-5.6 Luna` model in
+Benibot, and send the prompt recorded in `AGENTS.md`. Require a completed
+`KB_doc_query` chip, the `KLICKER_LOCAL_MCP_OK` marker, and the synthetic source
+card both before and after reloading the thread. Auto Mode currently proves
+tool discovery, invocation, persistence, and rendering locally, but its
+OpenRouter follow-up step can be empty after a tool result; do not use that
+path as proof of final-answer synthesis.
+
 ## Pre-PR verification checklist
 
 Every item, in order; paste evidence (command + tail of output, screenshots) into the PR or task report:

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -57,20 +57,22 @@ CI runs Playwright (8-way shard) on almost every code PR — CI is the real e2e 
 For Chat model-picker or LiteLLM routing changes, treat the local proxy as a
 separate proof gate: after `devrouter ensure .`, check LiteLLM liveness and the
 chat credits payload before browser interaction. The local Auto Mode maps to
-LiteLLM's `complexity-router` and routes through the GPT-5.6 Luna/Sol aliases —
-a local-only tier map that the deployments do not ship, so never report local
-routing as production behaviour ([docs/chat-platform.md](../../../docs/chat-platform.md)).
+LiteLLM's Auto V2 `complexity-router`: require direct embedding and target-model
+probes, then inspect logs for the expected `semantic_keyword_match` or
+`llm_classifier` cause and routed model. A successful answer after a classifier
+or embedding failure is only heuristic fallback and does not prove Auto V2.
+The local aliases and generic upstream differ from deployment infrastructure,
+so never report local routing as live production behaviour
+([docs/chat-platform.md](../../../docs/chat-platform.md)).
 Without `UPSTREAM_OPENAI_API_KEY`, stop at picker/error-state verification and
 report the live-answer gap explicitly.
 
 For the seeded local MCP smoke test, verify
-`http://localhost:1417/health`, select the direct `GPT-5.6 Luna` model in
-Benibot, and send the prompt recorded in `AGENTS.md`. Require a completed
+`http://localhost:1417/health`, keep `Auto Mode` selected in Benibot, and send
+the prompt recorded in `AGENTS.md`. Require a completed
 `KB_doc_query` chip, the `KLICKER_LOCAL_MCP_OK` marker, and the synthetic source
-card both before and after reloading the thread. Auto Mode currently proves
-tool discovery, invocation, persistence, and rendering locally, but its
-OpenRouter follow-up step can be empty after a tool result; do not use that
-path as proof of final-answer synthesis.
+card in a non-empty final answer both before and after reloading the thread.
+Use direct `GPT-5.6 Luna` only to isolate the router from the model/tool path.
 
 ## Pre-PR verification checklist
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -134,7 +134,9 @@ host-side `devrouter ensure` delivers its matching process helper and invokes
 `/tmp/devrouter-process-klicker-local-mcp.state` for the seeded local MCP
 fixture. Exact workspace, command, adapter bytes, and declared non-secret
 runtime-origin values are fingerprinted for reuse; stale owned groups are
-replaced boundedly, and unknown processes are never killed. HTTP readiness remains in
+replaced boundedly, and unknown processes are never killed. The MCP command
+also carries the fixture source hash so a source edit forces managed
+replacement. HTTP readiness remains in
 `devrouter ensure .`; the root build script forces production mode even though
 the live container exports `NODE_ENV=development`. Rerun ensure after
 `pnpm run build` so stale Next.js dev output can trigger the single

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -117,14 +117,14 @@ the hardcoded defaults only know `klicker.com`.
 
 ## What's inside
 
-| Service                             | Image                                      | Purpose                                                      |
-| ----------------------------------- | ------------------------------------------ | ------------------------------------------------------------ |
-| `app`                               | local `Dockerfile` (Node 24 + pnpm 11.5.0) | runs every routed app plus the two Hatchet workers           |
-| `postgres`                          | `postgres:15`                              | DB (klicker-prod + shadow/lti/qa/hatchet via init.sql)       |
-| `redis_exec`/`_assessment`/`_cache` | `redis:7`                                  | live-quiz exec / assessment / cache + pub/sub                |
-| `mailhog`                           | `mailhog/mailhog`                          | dev SMTP sink                                                |
-| `hatchet`                           | `hatchet-lite-dev:v0.101.0`                | workflow engine (gRPC :7077, no UI auth)                     |
-| `litellm`                           | `ghcr.io/berriai/litellm-database:v1.88.1` | LLM proxy + complexity router for chat (port 4000 intra-net) |
+| Service                             | Image                                      | Purpose                                                              |
+| ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `app`                               | local `Dockerfile` (Node 24 + pnpm 11.5.0) | runs every routed app plus the two Hatchet workers                   |
+| `postgres`                          | `postgres:15`                              | DB (klicker-prod + shadow/lti/qa/hatchet via init.sql)               |
+| `redis_exec`/`_assessment`/`_cache` | `redis:7`                                  | live-quiz exec / assessment / cache + pub/sub                        |
+| `mailhog`                           | `mailhog/mailhog`                          | dev SMTP sink                                                        |
+| `hatchet`                           | `hatchet-lite-dev:v0.101.0`                | workflow engine (gRPC :7077, no UI auth)                             |
+| `litellm`                           | `ghcr.io/berriai/litellm-database:v1.96.2` | LLM proxy + Auto V2 complexity router for chat (port 4000 intra-net) |
 
 Environment lives in `devcontainer.env` (committed, dev-only). Lifecycle:
 `post-create.sh` (install + build packages + prisma reset/push/seed + token) then
@@ -154,5 +154,8 @@ analytics image and lint CI so the root quality gate runs inside the container.
   if `.env` is missing, so `post-create` seeds an **empty** `.env` in each dir
   (the container env from `devcontainer.env` is what actually applies).
 - Tier 3 (`chat`) needs an upstream LLM key: set `UPSTREAM_OPENAI_API_KEY`.
+- Auto V2 sends its Luna-low classification and semantic embedding requests to
+  the same upstream as the selected answer model. With OpenRouter, use only
+  seeded or synthetic content and expect the extra calls to add latency/cost.
 - Benibot's seeded Tutor and Explainer modes use the read-only `doc_query`
   fixture at `http://localhost:1417/mcp`. Its log is `/tmp/local-mcp.log`.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -130,10 +130,11 @@ Environment lives in `devcontainer.env` (committed, dev-only). Lifecycle:
 `post-create.sh` (install + build packages + prisma reset/push/seed + token) then
 host-side `devrouter ensure` delivers its matching process helper and invokes
 `post-start.sh` (set Klicker origins and call that helper). Runtime state is
-`/tmp/devrouter-process-klicker-dev.state`: exact workspace, command, adapter
-bytes, and declared non-secret runtime-origin values are fingerprinted for
-reuse; stale owned groups are replaced boundedly, and unknown processes are
-never killed. HTTP readiness remains in
+`/tmp/devrouter-process-klicker-dev.state` for the app stack and
+`/tmp/devrouter-process-klicker-local-mcp.state` for the seeded local MCP
+fixture. Exact workspace, command, adapter bytes, and declared non-secret
+runtime-origin values are fingerprinted for reuse; stale owned groups are
+replaced boundedly, and unknown processes are never killed. HTTP readiness remains in
 `devrouter ensure .`; the root build script forces production mode even though
 the live container exports `NODE_ENV=development`. Rerun ensure after
 `pnpm run build` so stale Next.js dev output can trigger the single
@@ -151,3 +152,5 @@ analytics image and lint CI so the root quality gate runs inside the container.
   if `.env` is missing, so `post-create` seeds an **empty** `.env` in each dir
   (the container env from `devcontainer.env` is what actually applies).
 - Tier 3 (`chat`) needs an upstream LLM key: set `UPSTREAM_OPENAI_API_KEY`.
+- Benibot's seeded Tutor and Explainer modes use the read-only `doc_query`
+  fixture at `http://localhost:1417/mcp`. Its log is `/tmp/local-mcp.log`.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -113,7 +113,7 @@ services:
 
   # --- LiteLLM for Chat (Tier 3) ---
   litellm:
-    image: ghcr.io/berriai/litellm-database:v1.88.1
+    image: ghcr.io/berriai/litellm-database:v1.96.2@sha256:80e5e92bdcca246cd4153d451e5f75b65e19c7e39c46cc88a38bed4b65cc5836
     volumes:
       - ../util/litellm/config.yaml:/app/config.yaml:ro
     command:
@@ -125,6 +125,7 @@ services:
       # Supplied by the user in their local env or .devcontainer.env to enable chat
       - UPSTREAM_OPENAI_API_KEY=${UPSTREAM_OPENAI_API_KEY:-}
       - UPSTREAM_OPENAI_BASE_URL=${UPSTREAM_OPENAI_BASE_URL:-https://api.openai.com/v1}
+      - LITELLM_LOG=INFO
     healthcheck:
       test:
         - CMD

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -75,6 +75,27 @@ export npm_config_verify_deps_before_run=false
 
 export DEVROUTER_PROCESS_FINGERPRINT_ENV='APP_ORIGIN_API,APP_ORIGIN_AUTH,APP_ORIGIN_PWA,APP_ORIGIN_MANAGE,APP_ORIGIN_CONTROL,APP_ORIGIN_ASSESSMENT_API,APP_ORIGIN_ASSESSMENT_PWA,APP_ORIGIN_LTI,APP_ORIGIN_CHAT,APP_MANAGE_SUBDOMAIN,APP_STUDENT_SUBDOMAIN,APP_CONTROL_SUBDOMAIN,NEXTAUTH_URL,COOKIE_DOMAIN,NEXT_PUBLIC_API_URL,NEXT_PUBLIC_AUTH_URL,NEXT_PUBLIC_MANAGE_URL,NEXT_PUBLIC_PWA_URL,NEXT_PUBLIC_ASSESSMENT_URL,NEXT_PUBLIC_CONTROL_URL,NEXT_PUBLIC_ADD_RESPONSE_URL,NEXT_PUBLIC_CHAT_URL,CORS_ALLOWED_ORIGINS,AUTH_LECTURER_ALLOWED_HOSTS,AUTH_STUDENT_ALLOWED_HOSTS,NODE_EXTRA_CA_CERTS'
 
+# The test seed connects Benibot's Tutor and Explainer modes to this local,
+# read-only MCP fixture. Keep it in the app container so the seeded
+# http://localhost:1417/mcp endpoint remains valid in every workspace. Prove
+# readiness before starting Chat so its first request cannot miss the fixture.
+"$DEVROUTER_PROCESS_HELPER" ensure \
+  --name klicker-local-mcp \
+  --match 'apps/chat/scripts/local-mcp-server.mjs' \
+  --log /tmp/local-mcp.log \
+  -- node apps/chat/scripts/local-mcp-server.mjs
+
+for attempt in $(seq 1 20); do
+  if curl --fail --silent --show-error http://localhost:1417/health >/dev/null; then
+    break
+  fi
+  if [ "$attempt" -eq 20 ]; then
+    echo '[post-start] ERROR: local MCP fixture did not become healthy.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
 # Run every routed app plus both Hatchet workers without Infisical. Devrouter
 # owns generic locking, process-group identity, and bounded replacement; this
 # repository owns only the application command and environment above.
@@ -96,6 +117,7 @@ if [ -s /etc/devrouter/mkcert-rootCA.pem ]; then
 [post-start]   Response API -> ${NEXT_PUBLIC_ADD_RESPONSE_URL}
 [post-start]   LTI Service  -> ${APP_ORIGIN_LTI}
 [post-start]   Chat         -> ${NEXT_PUBLIC_CHAT_URL} (requires UPSTREAM_OPENAI_API_KEY)
+[post-start]   MCP fixture  -> http://localhost:1417/mcp (Benibot Tutor/Explainer)
 [post-start]   Workers      -> hatchet-worker-general + -response-processor (no URL; consume hatchet queue)
 [post-start] Lifecycle -> on the host: devrouter ensure <this-checkout>
 [post-start] Logs    -> devrouter exec <this-checkout> -- tail -f /tmp/dev.log
@@ -112,6 +134,7 @@ else
 [post-start]   Response API -> http://localhost:7078
 [post-start]   LTI Service  -> http://localhost:4000
 [post-start]   Chat         -> http://localhost:3004 (requires UPSTREAM_OPENAI_API_KEY)
+[post-start]   MCP fixture  -> http://localhost:1417/mcp (Benibot Tutor/Explainer)
 [post-start]   Workers      -> hatchet-worker-general + -response-processor (no URL; consume hatchet queue)
 [post-start] Logs    -> devrouter exec <this-checkout> -- tail -f /tmp/dev.log
 EOF

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -79,11 +79,13 @@ export DEVROUTER_PROCESS_FINGERPRINT_ENV='APP_ORIGIN_API,APP_ORIGIN_AUTH,APP_ORI
 # read-only MCP fixture. Keep it in the app container so the seeded
 # http://localhost:1417/mcp endpoint remains valid in every workspace. Prove
 # readiness before starting Chat so its first request cannot miss the fixture.
+MCP_FIXTURE_SHA256=$(sha256sum apps/chat/scripts/local-mcp-server.mjs)
+MCP_FIXTURE_SHA256=${MCP_FIXTURE_SHA256%% *}
 "$DEVROUTER_PROCESS_HELPER" ensure \
   --name klicker-local-mcp \
   --match 'apps/chat/scripts/local-mcp-server.mjs' \
   --log /tmp/local-mcp.log \
-  -- node apps/chat/scripts/local-mcp-server.mjs
+  -- node apps/chat/scripts/local-mcp-server.mjs "$MCP_FIXTURE_SHA256"
 
 for attempt in $(seq 1 20); do
   if curl --fail --silent --show-error http://localhost:1417/health >/dev/null; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,45 @@ The same command starts and proves primary and linked checkouts. Use `devrouter 
 
 The dev servers auto-start in the background (`devrouter exec . -- tail -f /tmp/dev.log`; first compile takes ~1min). Host-side `devrouter ensure` owns lifecycle reconciliation and delivers its matching process helper to the exact validated container. The stack runs every routed app plus the two Hatchet workers (no worker route); analytics, Office add-in, and docs remain outside it. See `.devcontainer/README.md`.
 
+**OpenRouter-backed local chat:** Start a new or stopped environment through
+Infisical so the local LiteLLM container receives the OpenRouter key without
+writing it to disk:
+
+```bash
+infisical run \
+  --projectId f855faee-8a7f-4615-86a8-dbe7ae7c7d30 \
+  -- sh -c 'UPSTREAM_OPENAI_API_KEY="$OPENROUTER_API_KEY" UPSTREAM_OPENAI_BASE_URL=https://openrouter.ai/api/v1 devrouter ensure .'
+```
+
+If LiteLLM is already running without those variables, stop the workspace with
+`devrouter workspace stop <workspace>` and rerun the command; `ensure` does not
+replace environment variables inside an existing service container. Use only
+seeded or synthetic test content because OpenRouter is an external upstream and
+the Azure-specific chatbot disclaimer does not describe this local path.
+
+Local Auto Mode is selected by `CHAT_PRIMARY_MODEL_ID=auto`. Chat sends the
+`auto-router` deployment to LiteLLM at `http://litellm:4000`; LiteLLM classifies
+the request and chooses the configured target in `util/litellm/config.yaml`:
+simple/default requests use `gpt-5.6-luna` with medium effort,
+medium/complex requests use Luna with xhigh effort, and reasoning requests use
+`gpt-5.6-sol` with low effort. LiteLLM then forwards that target through
+OpenRouter's OpenAI-compatible endpoint; OpenRouter supplies the selected model
+but does not perform the classification. LiteLLM falls back from the Sol target
+to `gpt-5.1` on an upstream failure. Separately, when Chat credits reach zero,
+Chat selects `gpt-4.1-mini` before calling LiteLLM and bypasses Auto Mode.
+
+The seeded Benibot exposes a deterministic local `doc_query` MCP tool in Tutor
+and Explainer modes. `post-start.sh` runs it at `http://localhost:1417/mcp`;
+its source is `apps/chat/scripts/local-mcp-server.mjs` and its log is
+`/tmp/local-mcp.log`. Select the direct `GPT-5.6 Luna` model, then test the
+complete path in Chat with: “Use the local MCP tool to test the integration.
+Search for `portfolio diversification` and tell me the exact marker it
+returns.” A successful turn calls `KB_doc_query` and shows
+`KLICKER_LOCAL_MCP_OK` plus the synthetic source card. Local Auto Mode currently
+completes and renders the tool result but OpenRouter returns an empty follow-up
+assistant step, so use the direct model when the final marker text is part of
+the test.
+
 **Routing:** [devrouter](https://github.com/rschlaefli/devrouter) ≥ 0.0.35 fronts the stack over the shared `devnet` network. One-time host setup must happen **before** the container starts:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,26 +158,29 @@ the Azure-specific chatbot disclaimer does not describe this local path.
 
 Local Auto Mode is selected by `CHAT_PRIMARY_MODEL_ID=auto`. Chat sends the
 `auto-router` deployment to LiteLLM at `http://litellm:4000`; LiteLLM classifies
-the request and chooses the configured target in `util/litellm/config.yaml`:
-simple/default requests use `gpt-5.6-luna` with medium effort,
-medium/complex requests use Luna with xhigh effort, and reasoning requests use
-`gpt-5.6-sol` with low effort. LiteLLM then forwards that target through
-OpenRouter's OpenAI-compatible endpoint; OpenRouter supplies the selected model
-but does not perform the classification. LiteLLM falls back from the Sol target
-to `gpt-5.1` on an upstream failure. Separately, when Chat credits reach zero,
-Chat selects `gpt-4.1-mini` before calling LiteLLM and bypasses Auto Mode.
+the request with the current Auto V2 policy in `util/litellm/config.yaml`.
+Classification uses Luna low; semantic corpus matching uses
+`openai/text-embedding-3-small`; SIMPLE, MEDIUM, and COMPLEX route to Luna
+medium, high, and xhigh; REASONING routes to Sol medium. LiteLLM then forwards
+all three request types through OpenRouter's OpenAI-compatible endpoint;
+OpenRouter supplies the selected models but does not make the routing decision.
+This adds one classifier request and, for semantic matching, one embedding
+request to the same external OpenRouter data boundary. It therefore adds local
+latency and usage cost. LiteLLM falls back from Sol medium to `gpt-5.1` on an
+upstream failure. Separately, when Chat credits reach zero, Chat selects
+`gpt-4.1-mini` before calling LiteLLM and bypasses Auto Mode.
 
 The seeded Benibot exposes a deterministic local `doc_query` MCP tool in Tutor
 and Explainer modes. `post-start.sh` runs it at `http://localhost:1417/mcp`;
 its source is `apps/chat/scripts/local-mcp-server.mjs` and its log is
-`/tmp/local-mcp.log`. Select the direct `GPT-5.6 Luna` model, then test the
-complete path in Chat with: “Use the local MCP tool to test the integration.
+`/tmp/local-mcp.log`. Keep `Auto Mode` selected, then test the complete path in
+Chat with: “Use the local MCP tool to test the integration.
 Search for `portfolio diversification` and tell me the exact marker it
 returns.” A successful turn calls `KB_doc_query` and shows
-`KLICKER_LOCAL_MCP_OK` plus the synthetic source card. Local Auto Mode currently
-completes and renders the tool result but OpenRouter returns an empty follow-up
-assistant step, so use the direct model when the final marker text is part of
-the test.
+`KLICKER_LOCAL_MCP_OK` in a non-empty final answer plus the synthetic source
+card. Reload the thread and require the tool result, answer, and source to
+remain visible. Use the direct `GPT-5.6 Luna` option only when isolating the
+router from the model/tool integration.
 
 **Routing:** [devrouter](https://github.com/rschlaefli/devrouter) ≥ 0.0.35 fronts the stack over the shared `devnet` network. One-time host setup must happen **before** the container starts:
 

--- a/apps/chat/scripts/local-mcp-server.mjs
+++ b/apps/chat/scripts/local-mcp-server.mjs
@@ -1,0 +1,135 @@
+import { createServer } from 'node:http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { z } from 'zod'
+
+const HOST = '127.0.0.1'
+const PORT = 1417
+const MAX_BODY_BYTES = 1024 * 1024
+
+function createMcpServer() {
+  const server = new McpServer({
+    name: 'klicker-local-test-mcp',
+    version: '1.0.0',
+  })
+
+  server.registerTool(
+    'doc_query',
+    {
+      title: 'Search synthetic course material',
+      description:
+        'Search deterministic synthetic course material. Use this tool whenever the user asks to test the local MCP integration.',
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .max(500)
+          .describe('The synthetic course-material search query'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ query }) => {
+      const payload = {
+        answer: `KLICKER_LOCAL_MCP_OK: the local MCP server received "${query}".`,
+        sources_used: 1,
+        sources: [
+          {
+            expert: 'KlickerUZH local development fixture',
+            source_type: 'pdf',
+            file_name: 'synthetic-course-material.pdf',
+            page_number: 1,
+          },
+        ],
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+        structuredContent: payload,
+      }
+    }
+  )
+
+  return server
+}
+
+async function readJsonBody(request) {
+  const chunks = []
+  let size = 0
+
+  for await (const chunk of request) {
+    size += chunk.length
+    if (size > MAX_BODY_BYTES) {
+      throw new Error('Request body is too large')
+    }
+    chunks.push(chunk)
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+function sendJson(response, status, body) {
+  response.writeHead(status, { 'Content-Type': 'application/json' })
+  response.end(JSON.stringify(body))
+}
+
+const httpServer = createServer(async (request, response) => {
+  if (request.url === '/health' && request.method === 'GET') {
+    sendJson(response, 200, { status: 'ok' })
+    return
+  }
+
+  if (request.url !== '/mcp') {
+    sendJson(response, 404, { error: 'Not found' })
+    return
+  }
+
+  if (request.method !== 'POST') {
+    response.writeHead(405, { Allow: 'POST' })
+    response.end()
+    return
+  }
+
+  const mcpServer = createMcpServer()
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+    enableDnsRebindingProtection: true,
+    allowedHosts: [`${HOST}:${PORT}`, `localhost:${PORT}`],
+  })
+
+  response.on('close', () => {
+    void transport.close()
+    void mcpServer.close()
+  })
+
+  try {
+    const body = await readJsonBody(request)
+    await mcpServer.connect(transport)
+    await transport.handleRequest(request, response, body)
+  } catch (error) {
+    console.error('[local-mcp] Request failed:', error)
+    if (!response.headersSent) {
+      sendJson(response, 400, {
+        jsonrpc: '2.0',
+        error: { code: -32700, message: 'Invalid JSON-RPC request' },
+        id: null,
+      })
+    }
+  }
+})
+
+httpServer.listen(PORT, HOST, () => {
+  console.log(`[local-mcp] Listening on http://${HOST}:${PORT}/mcp`)
+})
+
+function shutdown() {
+  httpServer.close(() => process.exit(0))
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -85,24 +85,31 @@ Both staging and production now use `auto` as the global automatic-model
 primary, so chatbots using automatic model selection use Auto by default.
 Chatbots with an explicit model selection can continue using that selection.
 
-The local devcontainer simulation in `util/litellm/config.yaml` is deliberately
-**not** a copy of that map: it uses different model names (GPT-5.6 Luna/Sol),
-its own tier assignment, and the generic
+The local devcontainer simulation in `util/litellm/config.yaml` mirrors the
+deployed Klicker Auto V2 policy and semantic corpus with local, unprefixed model
+aliases: Luna medium/high/xhigh for SIMPLE/MEDIUM/COMPLEX and Sol medium for
+REASONING. It deliberately retains the generic
 `UPSTREAM_OPENAI_BASE_URL`/`UPSTREAM_OPENAI_API_KEY` boundary instead of
-production Azure URLs or secret names. Local Auto Mode behaviour is therefore
-evidence about the wiring only, never about production routing. The local chat
-registry maps the user-facing `auto` model id to the `auto-router`
-LiteLLM deployment and exposes `gpt-5.6-luna` for a direct comparison. The
-seeded Benibot fixture allow-lists all three of `auto`, `gpt-5.6-luna` and
-`gpt-4.1-mini` explicitly, so it satisfies the fallback invariant below without
-relying on the `|| m.fallback` exemption that the runtime filters apply anyway.
+production Azure URLs, model prefixes, secrets, or failover topology. Local
+Auto Mode is therefore evidence about the wiring and policy simulation, never
+live production routing. The local chat registry maps the user-facing `auto`
+model id to the `auto-router` LiteLLM deployment and exposes `gpt-5.6-luna` for
+a direct comparison. The seeded Benibot fixture allow-lists all three of
+`auto`, `gpt-5.6-luna` and `gpt-4.1-mini` explicitly, so it satisfies the
+fallback invariant below without relying on the `|| m.fallback` exemption that
+the runtime filters apply anyway.
 
-The local LiteLLM service uses the deployed semantic-router-compatible image
-`ghcr.io/berriai/litellm-database:v1.88.1`, has a healthcheck, and is included
-in `.devcontainer/devcontainer.json:runServices`. A model call still requires
-the operator's local `UPSTREAM_OPENAI_API_KEY`; without it, verify service
-health, model exposure, picker state, and request error handling, but do not
-claim an end-to-end answer stream.
+The local LiteLLM service pins
+`ghcr.io/berriai/litellm-database:v1.96.2` by immutable multi-platform digest,
+has a healthcheck, and is included in
+`.devcontainer/devcontainer.json:runServices`. Auto V2 uses Luna low for its LLM
+classifier and `openai/text-embedding-3-small` for semantic corpus matching,
+then invokes the selected answer model. With an OpenRouter upstream, all of
+those requests cross the same external provider boundary and add latency and
+usage cost. A model call still requires the operator's local
+`UPSTREAM_OPENAI_API_KEY`; without it, verify service health, model exposure,
+picker state, and request error handling, but do not claim an end-to-end answer
+stream.
 
 - Omitted `supportsImageAttachments` defaults to **false** — every image-capable model must set it explicitly in deployment values or the attach button disappears.
 - Zero-credit course chatbots need a usable fallback model (`CHAT_FALLBACK_MODEL_ID`, default `gpt-4.1-mini`) AND explicit chatbot `allowedModelIds` must include it. Audit/fix with `packages/prisma-data/src/scripts/2026-06-15_ensure_chatbot_fallback_model.ts`.

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -2,7 +2,7 @@
 type: App Guide
 title: Chat Platform
 description: The apps/chat island — app router, zustand, assistant-ui, route-handler auth guards, and the model registry.
-timestamp: '2026-08-10'
+timestamp: '2026-08-12'
 tags:
   - frontend
   - chat
@@ -40,6 +40,8 @@ Chatbot route recovery is intentionally split by cause. `src/app/[chatbotId]/lay
 - `src/lib/toolOutput.ts` — live-SSE tool-result normalization (the streaming half of the provider-error redaction boundary).
 - `src/lib/attachments/` — image attachment adapter plus attachment state and UI helpers.
 - Local model proxy: the `litellm` compose service (port 4000).
+- Local MCP fixture: `scripts/local-mcp-server.mjs` exposes a deterministic,
+  read-only `doc_query` tool on port 1417 for the seeded Benibot.
 
 The chat route returns an AI SDK UI message stream and passes
 `consumeSseStream: consumeStream` to `toUIMessageStreamResponse`. Keep this
@@ -407,6 +409,20 @@ PostgreSQL is the only rating store. Do not mirror votes to Langfuse while the t
 - **Message edits must go through the edit composer's own send** — `messageRuntime.composer.send({ startRun: true })` in `thread.tsx:EditComposer`. The public `threadRuntime.append()` normalizes a `null` parentId to "last message in the current path" (vendor `toAppendMessage`), so submitting an edit through it turns a root-message edit into a brand-new turn instead of a sibling branch and the branch pager (`branch-picker.tsx`) never shows. `startRun: true` is required because the vendor's own change gate compares only composer text/attachments and cannot see the kept-original-attachment state this app tracks outside the composer; the app-side `canSubmit` is the real change gate.
 
 ## Testing
+
+The self-contained devcontainer starts the seeded local MCP fixture through
+`post-start.sh`. Benibot's Tutor and Explainer configurations already point to
+`http://localhost:1417/mcp` and allow `doc_query`; the runtime namespaces the
+tool as `KB_doc_query`. Select the direct `GPT-5.6 Luna` model, then prompt
+Benibot with “Use the local MCP tool to test the integration. Search for
+`portfolio diversification` and tell me the exact marker it returns.” The
+end-to-end pass requires a completed tool call, `KLICKER_LOCAL_MCP_OK` in the
+answer, and the `synthetic-course-material.pdf` source card. Local Auto Mode
+discovers, calls, persists, and renders the same tool result, but the current
+OpenRouter path returns an empty second assistant step after that result; use
+the direct model when checking final answer synthesis. The fixture is synthetic
+wiring evidence only; it does not validate retrieval quality or a deployed MCP
+server.
 
 Pure-logic vitest lives in `apps/chat/test/` (safe without services); `apps/chat/vitest.config.ts` mirrors the `@/*` alias from the app tsconfig — keep them in sync. The runner is `environment: 'node'` with no jsdom/testing-library, so component behavior is tested by extracting the decision logic into pure modules next to the component (`message-parts-state.ts`, `thread-list-state.ts`) — follow that pattern rather than adding a DOM environment. The whole suite shares **one fork** (`singleFork: true`), so a `vi.stubGlobal` is process-global: the config sets `unstubGlobals: true`, but that only restores before each _test_ — the next file's module **import** still sees whatever the previous file's last test left stubbed (a leaked `window`/`URL` once broke zustand-persist feature detection and `new URL` in unrelated files, order-dependently). Any file stubbing environment-shaped globals (`window`, `URL`, `document`) must also clean up itself with `afterEach(() => vi.unstubAllGlobals())`. `message-parts.test.ts` owns disclosure-state rules, while `persisted-assistant-content.test.ts` owns the provider-error redaction boundary. E2E coverage is Playwright-only (`playwright/tests/Y-chat.spec.ts`).
 

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -420,8 +420,8 @@ PostgreSQL is the only rating store. Do not mirror votes to Langfuse while the t
 The self-contained devcontainer starts the seeded local MCP fixture through
 `post-start.sh`. Benibot's Tutor and Explainer configurations already point to
 `http://localhost:1417/mcp` and allow `doc_query`; the runtime namespaces the
-tool as `KB_doc_query`. Select the direct `GPT-5.6 Luna` model, then prompt
-Benibot with “Use the local MCP tool to test the integration. Search for
+tool as `KB_doc_query`. Keep Auto Mode selected, then prompt Benibot with “Use
+the local MCP tool to test the integration. Search for
 `portfolio diversification` and tell me the exact marker it returns.” The
 end-to-end pass requires a completed tool call, `KLICKER_LOCAL_MCP_OK` in the
 non-empty answer, and the `synthetic-course-material.pdf` source card. Keep

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -424,12 +424,11 @@ tool as `KB_doc_query`. Select the direct `GPT-5.6 Luna` model, then prompt
 Benibot with “Use the local MCP tool to test the integration. Search for
 `portfolio diversification` and tell me the exact marker it returns.” The
 end-to-end pass requires a completed tool call, `KLICKER_LOCAL_MCP_OK` in the
-answer, and the `synthetic-course-material.pdf` source card. Local Auto Mode
-discovers, calls, persists, and renders the same tool result, but the current
-OpenRouter path returns an empty second assistant step after that result; use
-the direct model when checking final answer synthesis. The fixture is synthetic
-wiring evidence only; it does not validate retrieval quality or a deployed MCP
-server.
+non-empty answer, and the `synthetic-course-material.pdf` source card. Keep
+Auto Mode selected and require the tool result, answer, and source to remain
+after reloading the thread. Use direct GPT-5.6 Luna only to isolate the router
+from the model/tool path. The fixture is synthetic wiring evidence only; it
+does not validate retrieval quality or a deployed MCP server.
 
 Pure-logic vitest lives in `apps/chat/test/` (safe without services); `apps/chat/vitest.config.ts` mirrors the `@/*` alias from the app tsconfig — keep them in sync. The runner is `environment: 'node'` with no jsdom/testing-library, so component behavior is tested by extracting the decision logic into pure modules next to the component (`message-parts-state.ts`, `thread-list-state.ts`) — follow that pattern rather than adding a DOM environment. The whole suite shares **one fork** (`singleFork: true`), so a `vi.stubGlobal` is process-global: the config sets `unstubGlobals: true`, but that only restores before each _test_ — the next file's module **import** still sees whatever the previous file's last test left stubbed (a leaked `window`/`URL` once broke zustand-persist feature detection and `new URL` in unrelated files, order-dependently). Any file stubbing environment-shaped globals (`window`, `URL`, `document`) must also clean up itself with `afterEach(() => vi.unstubAllGlobals())`. `message-parts.test.ts` owns disclosure-state rules, while `persisted-assistant-content.test.ts` owns the provider-error redaction boundary. E2E coverage is Playwright-only (`playwright/tests/Y-chat.spec.ts`).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 type: Guide
 title: Getting Started
 description: Toolchain, first-time setup, infrastructure bring-up, dev-server paths, and the exact failure signatures a fresh clone produces.
-timestamp: '2026-08-03'
+timestamp: '2026-08-12'
 tags:
   - environment
   - onboarding
@@ -56,6 +56,21 @@ Clone-and-run via a self-contained devcontainer — no Infisical, no external Ed
         Use `devrouter workspace up <branch-name>` from the main repository to create a new worktree. Do not use bare `devpod up` or manual route-token loops; `ensure` owns the persisted identity, Git mount, overlay, aliases, runtime proof, and routes together.
      3. Those namespaced hosts only work because `allowedDevOrigins` in `packages/next-config/index.js` is `['**.localhost']` in development (and `undefined` in production) — Next's implicit `*.localhost` matches a single label only. If that glob ever stops covering a worktree host, the symptom is an app that serves HTML but never hydrates, with no obvious error.
 3. **Logs:** The dev servers auto-start inside the container. View logs via `devrouter exec . -- tail -f /tmp/dev.log`.
+
+For OpenRouter-backed Chat, inject the shared prototyping key when starting the
+workspace; never write it into the repository:
+
+```bash
+infisical run \
+  --projectId f855faee-8a7f-4615-86a8-dbe7ae7c7d30 \
+  -- sh -c 'UPSTREAM_OPENAI_API_KEY="$OPENROUTER_API_KEY" UPSTREAM_OPENAI_BASE_URL=https://openrouter.ai/api/v1 devrouter ensure .'
+```
+
+The local LiteLLM Auto V2 router sends classification, semantic embedding, and
+answer requests through that same external upstream. Use seeded or synthetic
+content. If the workspace was already started without the variables, stop it
+before rerunning the command because `ensure` does not replace a running
+container's environment.
 
 `post-start.sh` keeps Klicker's environment and origin setup local. Host-side `devrouter ensure` delivers its matching process helper to the exact validated container, then invokes the adapter. Released devrouter `0.0.35` records its owned process group and fingerprints the workspace, command, adapter bytes, and declared non-secret origin environment in `/tmp/devrouter-process-klicker-dev.state`; an exact repeat is idempotent, stale owned groups are replaced boundedly, and unknown processes are never killed.
 

--- a/docs/log/2026-08-12-local-chat-mcp-fixture.md
+++ b/docs/log/2026-08-12-local-chat-mcp-fixture.md
@@ -1,6 +1,7 @@
 ---
 type: Change Log
 title: Local Chat MCP Fixture
+description: Local deterministic MCP testing and Auto V2 routing through the OpenRouter-backed devcontainer.
 timestamp: '2026-08-12'
 tags:
   - chat
@@ -21,7 +22,16 @@ discovery, invocation, streaming, result rendering, and persistence without
 depending on a deployed retrieval service. It does not validate retrieval
 quality or production MCP configuration.
 
+The same local test package now pins LiteLLM 1.96.2 and mirrors the deployed
+Klicker Auto V2 policy: Luna low classifies, an OpenRouter-backed
+`text-embedding-3-small` matches the semantic corpus, Luna handles SIMPLE
+through COMPLEX at increasing effort, and Sol medium handles REASONING. The
+local generic upstream and GPT-5.1 fallback remain deliberate differences from
+the production Azure and failover topology. Classifier, embedding, and answer
+requests all use the same external OpenRouter boundary, adding local latency
+and usage cost.
+
 `post-start.sh` owns the fixture process separately from the main application
 stack, waits for `/health`, and writes its output to `/tmp/local-mcp.log`. The
-copy-paste browser test and the current Auto Mode limitation are documented in
-`AGENTS.md` and the Chat Platform testing section.
+copy-paste Auto Mode browser test and fail-closed routing checks are documented
+in `AGENTS.md` and the Chat Platform testing section.

--- a/docs/log/2026-08-12-local-chat-mcp-fixture.md
+++ b/docs/log/2026-08-12-local-chat-mcp-fixture.md
@@ -1,0 +1,27 @@
+---
+type: Change Log
+title: Local Chat MCP Fixture
+timestamp: '2026-08-12'
+tags:
+  - chat
+  - mcp
+  - development
+---
+
+# Local Chat MCP Fixture
+
+The self-contained devcontainer now runs a deterministic, read-only MCP server
+for the seeded Benibot. The existing Tutor and Explainer seed configurations
+connect to `http://localhost:1417/mcp` and expose its `doc_query` tool as
+`KB_doc_query` in Chat.
+
+The fixture returns only synthetic content with a stable
+`KLICKER_LOCAL_MCP_OK` marker and one synthetic source. It verifies local MCP
+discovery, invocation, streaming, result rendering, and persistence without
+depending on a deployed retrieval service. It does not validate retrieval
+quality or production MCP configuration.
+
+`post-start.sh` owns the fixture process separately from the main application
+stack, waits for `/health`, and writes its output to `/tmp/local-mcp.log`. The
+copy-paste browser test and the current Auto Mode limitation are documented in
+`AGENTS.md` and the Chat Platform testing section.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,10 +62,11 @@ For authoring specifics, helper patterns, and failure triage, use the `klicker-p
 
 - The local Chat model simulation includes LiteLLM's `auto-router` and
   the GPT-5.6 Luna/Sol target aliases. After `devrouter ensure .`, verify the
-  LiteLLM liveness endpoint and the chat credits response before browser
-  testing the `Auto Mode`/`GPT-5.6 Luna` picker. A real
-  `UPSTREAM_OPENAI_API_KEY` is required for a streamed answer; service health
-  alone is not model-call evidence.
+  LiteLLM liveness endpoint, direct embedding/model probes, expected Auto V2
+  routing decisions in LiteLLM logs, and the chat credits response before
+  browser testing the `Auto Mode`/`GPT-5.6 Luna` picker. A real
+  `UPSTREAM_OPENAI_API_KEY` is required for these calls; service health alone is
+  not classification or answer-stream evidence.
 - Tests that **publish, schedule, or end activities** need the Hatchet **general worker** running on top of the test stack — otherwise mutations fail with `workflow not found`. The worker needs `DATABASE_URL` pointed at the test DB ([Async & Workers](./async-and-workers.md)).
 - **Live-quiz response tests** additionally need `response-api` + the response processor with the same `APP_SECRET`/Redis/Postgres settings — otherwise the UI accepts answers that never reach cockpit/evaluation.
 - Markdown video integration is covered on genuine Manage element-editor and mobile PWA live-quiz surfaces in `playwright/tests/0-video-embed.spec.ts`. The spec verifies immediate YouTube/Kaltura iframes, ordinary-link behavior, and the absence of horizontal overflow.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -7,7 +7,9 @@
   starts nothing there.
 - Decision: Add one deterministic, read-only MCP fixture to the existing Chat
   package and start it inside the app container. Keep the existing seeded URL,
-  add no dependency, and make no production configuration change.
+  add no dependency, and make no production configuration change. Complete the
+  same local test package by upgrading its LiteLLM simulation to the current
+  Auto V2 router used for Klicker in the AI deployment repository.
 - Package: Full-path stacked package on `rs/chat-local-mcp-fixture-clean`, based
   on `rs/chat-ux-conversation-polish` while draft PR #5363 remains open.
 
@@ -17,6 +19,10 @@
 - Accepted: start and health-check MCP before Chat; add read-only annotations;
   keep this package separate from PR #5363; document the direct-model smoke
   test and Auto Mode limitation.
+- Follow-up review: the widened Auto V2 slice received a planning-stage review
+  on 2026-08-12. The correction pass approved the explicit target mapping,
+  fallback, fail-closed routing matrix, OpenRouter trust boundary, and browser
+  completion gate.
 
 ## Slice: Local MCP tracer bullet
 
@@ -48,11 +54,51 @@
     claiming final synthesis when its second step is empty.
 - Commit: `chore(chat): add local MCP test fixture`.
 
+## Slice: Local Auto V2 routing
+
+- Route: main.
+- Budget skip reason: critical-path coupling across LiteLLM configuration,
+  OpenRouter model capabilities, the live Chat tool loop, and runtime log
+  evidence.
+- Test obligation: no new automated test. Configuration validation, controlled
+  runtime routing probes, and the real Browser tool journey exercise the
+  consequential seams without adding a mock of LiteLLM internals.
+- Do:
+  - Pin
+    `ghcr.io/berriai/litellm-database:v1.96.2@sha256:80e5e92bdcca246cd4153d451e5f75b65e19c7e39c46cc88a38bed4b65cc5836`.
+  - Mirror the deployed Klicker Auto V2 policy through the local generic
+    OpenRouter boundary: Luna low classifier, Luna medium/high/xhigh for
+    SIMPLE/MEDIUM/COMPLEX, Sol medium for REASONING, and
+    `openai/text-embedding-3-small` for semantic matching.
+  - Set `session_affinity: false`, `adaptive: false`, no escalation keywords,
+    a four-second classifier timeout, semantic keyword matching with threshold
+    `0.55`, and the exact deployed Klicker SIMPLE/COMPLEX/REASONING corpus.
+  - Keep Auto on Chat Completions, retain the existing generic upstream
+    credential boundary, and retarget the local Sol fallback from the removed
+    low-effort alias to Sol medium -> GPT-5.1.
+  - Document the extra classifier and embedding requests, latency/cost, and
+    OpenRouter data boundary in the runbook, devcontainer docs, wiki, testing
+    guidance, and this package's existing change log.
+- Check:
+  - Resolve the pinned image for the host architecture and validate Compose,
+    YAML, formatting, wiki, agent instructions, and secret hygiene.
+  - Call the embedding alias and every Luna/Sol target alias directly with its
+    configured effort.
+  - Send exact SIMPLE, COMPLEX, and REASONING corpus prompts and require
+    `cause=semantic_keyword_match` with the expected target in LiteLLM logs.
+  - Send a non-corpus prompt and require `cause=llm_classifier` with the
+    expected tier. Classifier or embedding failure, heuristic fallback, or a
+    mismatched model fails this gate even if an answer is returned.
+  - Browser: Auto invokes `KB_doc_query`, renders a non-empty final answer and
+    source, and preserves the tool result, answer, and source after reload. An
+    empty post-tool step fails the package.
+- Commit: `chore(chat): align local Auto Mode routing`.
+
 ## Progress
 
 - Planning-stage review: done.
-- Implementation: complete locally.
-- Verification: protocol, managed lifecycle, Chat suite, root checks, build,
+- MCP implementation: complete locally.
+- MCP verification: protocol, managed lifecycle, Chat suite, root checks, build,
   direct-model browser path, Auto Mode behavior, and reload persistence passed
   or were characterized as described above.
 - Plan commit: `939ec6dd7`.
@@ -65,4 +111,10 @@
   and one low history-ordering finding. Both were fixed before publication:
   the fixture source hash now forces managed replacement, and this clean stack
   commits the reviewed plan first.
-- Remaining: final verification readback and publication only when requested.
+- Auto V2 implementation: pending.
+- Auto V2 simplifier and intermediate review: pending; both run in parallel on
+  the immutable implementation range because model routing is a cross-system
+  seam.
+- Integrated final review: reopened for the widened exact branch head.
+- Remaining: implement and verify Auto V2, complete its reviews, then stop
+  before push or PR update unless separately authorized.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -124,6 +124,8 @@
   `def434085`. Both approved the implementation after identifying this stale
   remaining-work line; no config, runtime, security, or maintainability change
   was requested.
-- Integrated final review: reopened for the widened exact branch head.
-- Remaining: complete exact-head integrated final review, then stop before push
-  or PR update unless separately authorized.
+- Integrated final review: done for `b6eeb6a63..1f6817bd7`. The correction pass
+  found one stale Chat runbook paragraph and no implementation, security,
+  architecture, test, or ADR issue. The documentation-only correction is
+  committed and verified through focused main-session checks.
+- Remaining: stop before push or PR update unless separately authorized.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -8,8 +8,8 @@
 - Decision: Add one deterministic, read-only MCP fixture to the existing Chat
   package and start it inside the app container. Keep the existing seeded URL,
   add no dependency, and make no production configuration change.
-- Package: Full-path stacked package on `rs/chat-local-mcp-fixture`, based on
-  `rs/chat-ux-conversation-polish` while draft PR #5363 remains open.
+- Package: Full-path stacked package on `rs/chat-local-mcp-fixture-clean`, based
+  on `rs/chat-ux-conversation-polish` while draft PR #5363 remains open.
 
 ## Planning Review
 
@@ -55,8 +55,14 @@
 - Verification: protocol, managed lifecycle, Chat suite, root checks, build,
   direct-model browser path, Auto Mode behavior, and reload persistence passed
   or were characterized as described above.
-- Commit: `48c9a3f72`.
+- Plan commit: `939ec6dd7`.
+- Implementation commit: `b854a3bcb`.
+- Review-fix commit: `ed14f51d6`.
 - Simplifier: done — approved with no justified net reduction.
 - Intermediate review: done — no actionable correctness, security, lifecycle,
   cross-system, or verification findings.
-- Remaining: integrated final review before publication.
+- Integrated final review: completed with one medium runtime-identity finding
+  and one low history-ordering finding. Both were fixed before publication:
+  the fixture source hash now forces managed replacement, and this clean stack
+  commits the reviewed plan first.
+- Remaining: final verification readback and publication only when requested.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -120,9 +120,10 @@
   Browser, Auto called `KB_doc_query`, rendered a non-empty answer containing
   `KLICKER_LOCAL_MCP_OK` and the source card, and preserved all three after
   reload.
-- Auto V2 simplifier and intermediate review: pending; both run in parallel on
-  the immutable implementation range because model routing is a cross-system
-  seam.
+- Auto V2 simplifier and intermediate review: done in parallel on commit
+  `def434085`. Both approved the implementation after identifying this stale
+  remaining-work line; no config, runtime, security, or maintainability change
+  was requested.
 - Integrated final review: reopened for the widened exact branch head.
-- Remaining: implement and verify Auto V2, complete its reviews, then stop
-  before push or PR update unless separately authorized.
+- Remaining: complete exact-head integrated final review, then stop before push
+  or PR update unless separately authorized.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -111,7 +111,15 @@
   and one low history-ordering finding. Both were fixed before publication:
   the fixture source hash now forces managed replacement, and this clean stack
   commits the reviewed plan first.
-- Auto V2 implementation: pending.
+- Auto V2 implementation: complete locally. LiteLLM 1.96.2 runs from the pinned
+  multi-platform digest and exposes every classifier, embedding, and tier alias.
+- Auto V2 verification: direct target calls and the 1,536-dimension embedding
+  call passed. Runtime logs proved semantic SIMPLE -> Luna medium, COMPLEX ->
+  Luna xhigh, REASONING -> Sol medium, and LLM-classified MEDIUM -> Luna high,
+  with no classifier, embedding, or heuristic-fallback warning. In the real
+  Browser, Auto called `KB_doc_query`, rendered a non-empty answer containing
+  `KLICKER_LOCAL_MCP_OK` and the source card, and preserved all three after
+  reload.
 - Auto V2 simplifier and intermediate review: pending; both run in parallel on
   the immutable implementation range because model routing is a cross-system
   seam.

--- a/project/2026-08-12-local-chat-mcp-fixture-plan.md
+++ b/project/2026-08-12-local-chat-mcp-fixture-plan.md
@@ -1,0 +1,62 @@
+# Local Chat MCP Fixture
+
+## Goal
+
+- Problem: Benibot's test seed enables a `doc_query` MCP server at
+  `http://localhost:1417/mcp`, but the self-contained development environment
+  starts nothing there.
+- Decision: Add one deterministic, read-only MCP fixture to the existing Chat
+  package and start it inside the app container. Keep the existing seeded URL,
+  add no dependency, and make no production configuration change.
+- Package: Full-path stacked package on `rs/chat-local-mcp-fixture`, based on
+  `rs/chat-ux-conversation-polish` while draft PR #5363 remains open.
+
+## Planning Review
+
+- Review: capable read-only planner completed on 2026-08-12.
+- Accepted: start and health-check MCP before Chat; add read-only annotations;
+  keep this package separate from PR #5363; document the direct-model smoke
+  test and Auto Mode limitation.
+
+## Slice: Local MCP tracer bullet
+
+- Route: main.
+- Budget skip reason: critical-path coupling across MCP transport, devcontainer
+  lifecycle, seeded chatbot configuration, OpenRouter/LiteLLM, and browser
+  proof.
+- Test obligation: no new automated test. The existing source normalization,
+  tool rendering, and persistence suites cover the stable application seams;
+  this package adds direct MCP protocol and real-browser integration evidence.
+- Do:
+  - Add one stateless Streamable HTTP MCP server exposing only `doc_query`.
+  - Return deterministic synthetic content with `KLICKER_LOCAL_MCP_OK` and one
+    source in both text and structured MCP output.
+  - Bind to loopback, bound request/query size, validate Host, and declare the
+    tool read-only, non-destructive, idempotent, and closed-world.
+  - Start it through the delivered devrouter process helper, prove `/health`,
+    then start the application stack.
+  - Update agent instructions, environment docs, Chat wiki, testing skill, and
+    change log.
+- Check:
+  - Syntax, formatting, shell syntax, AGENTS validation, and secret scan.
+  - SDK-client initialize/list/call plus invalid-input rejection.
+  - Managed process start/reuse and health.
+  - Full Chat Vitest suite, root `check:all`, and root build.
+  - Browser: direct GPT-5.6 Luna calls `KB_doc_query`, renders the exact marker
+    and source card, and preserves all three after reload.
+  - Browser: record Auto Mode's actual tool-call and follow-up behavior without
+    claiming final synthesis when its second step is empty.
+- Commit: `chore(chat): add local MCP test fixture`.
+
+## Progress
+
+- Planning-stage review: done.
+- Implementation: complete locally.
+- Verification: protocol, managed lifecycle, Chat suite, root checks, build,
+  direct-model browser path, Auto Mode behavior, and reload persistence passed
+  or were characterized as described above.
+- Commit: `48c9a3f72`.
+- Simplifier: done — approved with no justified net reduction.
+- Intermediate review: done — no actionable correctness, security, lifecycle,
+  cross-system, or verification findings.
+- Remaining: integrated final review before publication.

--- a/util/litellm/config.yaml
+++ b/util/litellm/config.yaml
@@ -1,18 +1,80 @@
 # LiteLLM Proxy Configuration
 
 model_list:
-  # Production's Auto model is a LiteLLM auto-router endpoint. The
-  # local names intentionally omit the production Azure/product prefix; the
-  # chat registry maps its `auto` model id to `auto-router` below.
+  # This mirrors the deployed Klicker Auto V2 policy while keeping local model
+  # names and the generic upstream boundary. The chat registry maps its `auto`
+  # model id to `auto-router`.
   - model_name: 'auto-router'
     litellm_params:
       model: 'auto_router/complexity_router'
       complexity_router_config:
+        session_affinity: false
+        adaptive: false
+        escalation_keywords: []
+        classifier_type: 'llm'
+        classifier_llm_config:
+          model: 'gpt-5.6-luna-low'
+          timeout_ms: 4000
+        semantic_keyword_matching: true
+        embedding_model: 'text-embedding-3-small'
+        match_threshold: 0.55
         tiers:
           SIMPLE: 'gpt-5.6-luna-medium'
-          MEDIUM: 'gpt-5.6-luna-xhigh'
+          MEDIUM: 'gpt-5.6-luna-high'
           COMPLEX: 'gpt-5.6-luna-xhigh'
-          REASONING: 'gpt-5.6-sol-low'
+          REASONING: 'gpt-5.6-sol-medium'
+        keyword_tier_rules:
+          - tier: 'SIMPLE'
+            keywords:
+              - 'What is the definition of opportunity cost?'
+              - 'What does CAPM stand for?'
+              - 'When is the final exam for this course?'
+              - 'What topics are covered in chapter 4?'
+              - 'What is a confidence interval?'
+              - 'List the assumptions of linear regression.'
+              - 'What is the formula for present value?'
+              - 'Summarize the key points of lecture 5.'
+              - 'Explain what a p-value means in simple terms.'
+              - 'Can you explain the concept of price elasticity?'
+              - 'What is the difference between a stock and a bond?'
+              - 'Explain the difference between correlation and causation.'
+              - 'Give me an overview of supply and demand.'
+              - 'Why do we use a logarithm in this formula?'
+              - 'What does this term in the lecture slides mean?'
+          - tier: 'COMPLEX'
+            keywords:
+              - 'Calculate the NPV of a project with cash flows -100, 40, 40, and 40 at the course discount rate.'
+              - 'Solve for x in 3x^2 + 2x - 5 = 0 and explain which root is relevant.'
+              - 'Compute the standard deviation of the dataset 4, 8, 15, 16, 23, 42.'
+              - 'Find the equilibrium price and quantity from these supply and demand functions.'
+              - 'Work through this constrained optimization problem step by step.'
+              - 'Given this balance sheet, calculate the current ratio and interpret it.'
+              - 'Determine the Nash equilibrium of this 2x2 game.'
+              - 'Compute the duration of this bond from its cash flows.'
+              - 'Run a hypothesis test for these two sample means and state the conclusion.'
+              - 'Derive the demand function from this utility function.'
+              - 'Work out the marginal cost from this total cost function.'
+              - 'Calculate the expected return and variance of this portfolio.'
+              - "Use Bayes' rule to compute the posterior probability from these test results."
+              - 'Estimate the regression coefficient from this small dataset and interpret the sign.'
+          - tier: 'REASONING'
+            keywords:
+              - 'Prove that the square root of 2 is irrational and identify where the contradiction enters.'
+              - 'Derive the Black-Scholes partial differential equation from no-arbitrage assumptions and discuss which assumptions fail in illiquid markets.'
+              - 'Explain why increasing the money supply can lead to inflation in the long run, including the transmission mechanism and limiting assumptions.'
+              - 'Critically evaluate the efficient market hypothesis using both theoretical assumptions and empirical anomalies.'
+              - 'Design an experiment to test whether this intervention causes the observed effect, including identification strategy and threats to validity.'
+              - 'Explain why the central limit theorem holds and what its assumptions imply for small, skewed samples.'
+              - 'Compare Keynesian and monetarist explanations of stagflation and argue which explanation is stronger under different evidence patterns.'
+              - 'Discuss the trade-off between bias and variance and use it to justify a model-selection strategy.'
+              - 'Prove that this function is convex and explain why that matters for finding a global optimum.'
+              - 'Analyze the welfare effects of a tax in this market, separating consumer surplus, producer surplus, government revenue, and deadweight loss.'
+              - 'Assess whether a statistically significant regression result supports a causal claim, considering confounding, selection bias, and external validity.'
+              - 'Critique this survey design for non-response bias, measurement error, and sampling bias, then propose a stronger design.'
+              - 'Choose between two competing economic models for this scenario and justify the choice from assumptions, predictive power, and limitations.'
+              - 'Explain how an omitted variable can reverse a regression coefficient and construct a concrete example.'
+              - 'Develop a proof strategy for this theorem before carrying out the proof.'
+              - 'Evaluate whether a price ceiling improves welfare when the market also has an externality.'
       complexity_router_default_model: 'gpt-5.6-luna-medium'
 
   - model_name: 'gpt-4.1'
@@ -45,6 +107,22 @@ model_list:
       api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
       timeout: 600
 
+  - model_name: 'gpt-5.6-luna-low'
+    litellm_params:
+      model: 'openai/gpt-5.6-luna'
+      reasoning_effort: 'low'
+      api_base: 'os.environ/UPSTREAM_OPENAI_BASE_URL'
+      api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
+      timeout: 600
+
+  - model_name: 'gpt-5.6-luna-high'
+    litellm_params:
+      model: 'openai/gpt-5.6-luna'
+      reasoning_effort: 'high'
+      api_base: 'os.environ/UPSTREAM_OPENAI_BASE_URL'
+      api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
+      timeout: 600
+
   - model_name: 'gpt-5.6-luna-xhigh'
     litellm_params:
       model: 'openai/gpt-5.6-luna'
@@ -53,13 +131,22 @@ model_list:
       api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
       timeout: 600
 
-  - model_name: 'gpt-5.6-sol-low'
+  - model_name: 'gpt-5.6-sol-medium'
     litellm_params:
       model: 'openai/gpt-5.6-sol'
-      reasoning_effort: 'low'
+      reasoning_effort: 'medium'
       api_base: 'os.environ/UPSTREAM_OPENAI_BASE_URL'
       api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
       timeout: 600
+
+  # The first `openai/` selects LiteLLM's OpenAI-compatible provider. The
+  # second remains in the model id sent to OpenRouter.
+  - model_name: 'text-embedding-3-small'
+    litellm_params:
+      model: 'openai/openai/text-embedding-3-small'
+      api_base: 'os.environ/UPSTREAM_OPENAI_BASE_URL'
+      api_key: 'os.environ/UPSTREAM_OPENAI_API_KEY'
+      timeout: 60
 
   - model_name: 'gpt-4.1-mini'
     litellm_params:
@@ -72,4 +159,4 @@ request_timeout: 600
 router_settings:
   routing_strategy: 'simple-shuffle'
   fallbacks:
-    - 'gpt-5.6-sol-low': ['gpt-5.1']
+    - 'gpt-5.6-sol-medium': ['gpt-5.1']


### PR DESCRIPTION
## Summary

Add a deterministic local MCP fixture and the local Auto Mode/LiteLLM routing needed to exercise chat tool calls without depending on a production MCP server.

## What changed

- Add a local Streamable HTTP MCP server with a stable `KLICKER_LOCAL_MCP_OK` response, health checks, and restart-on-change behavior.
- Wire the fixture into the self-contained devcontainer and document the exact local startup, health-check, and test flow in `AGENTS.md` and the chat/testing docs.
- Add the local LiteLLM complexity-router configuration, with Luna aliases for the ordinary complexity levels and Sol for reasoning.
- Extend the testing skill and committed local verification log so the fixture is usable by both developers and automated browser tests.

## Scope and size

This branch contains the complete local fixture package. The computed substantive diff against `rs/chat-ux-conversation-polish` is 11 files, 431 additions, and 47 deletions (478 lines total), excluding project-artifact docs and lockfiles.

## Verification

- `pnpm run check:all` in the self-contained container: 24/24 tasks passed.
- Root build in the self-contained container: 22/22 tasks passed.
- Helm rendering and gitleaks checks passed.
- Real devrouter/browser verification reached the local chat route, accepted the disclaimer, selected Auto, exercised the MCP query, observed `KLICKER_LOCAL_MCP_OK`, and confirmed source persistence after reload.
- Local MCP health and LiteLLM health were checked directly; the local LiteLLM container used the pinned v1.96.2 image for the browser run.

## Review status and limits

This PR is intentionally still a draft. The configured integrated-final reviewer was unavailable at runtime; the local review record is `project/_local/reviews/2026-08-12-chat-stream-transparency-integrated-final-runtime-blocked.md` (ignored and not part of the PR). The LiteLLM/OpenRouter route is local-development plumbing only and is not a production deployment change.

