### PR TITLE
enhance(chat): make streamed sources and reasoning visible

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -64,6 +64,12 @@ or embedding failure is only heuristic fallback and does not prove Auto V2.
 The local aliases and generic upstream differ from deployment infrastructure,
 so never report local routing as live production behaviour
 ([docs/chat-platform.md](../../../docs/chat-platform.md)).
+For Auto reasoning, use the Responses endpoint and omit a request-level effort:
+require the routed target alias to retain its configured effort, a reasoning
+summary part to reach the Chat stream, and the reasoning-effort selector to
+remain absent for Auto. Staging/production compatibility remains unproven until
+an authorized staging smoke covers Responses storage, tool continuation, and
+reasoning against the deployed LiteLLM router.
 Without `UPSTREAM_OPENAI_API_KEY`, stop at picker/error-state verification and
 report the live-answer gap explicitly.
 
@@ -72,6 +78,8 @@ For the seeded local MCP smoke test, verify
 the prompt recorded in `AGENTS.md`. Require a completed
 `KB_doc_query` chip, the `KLICKER_LOCAL_MCP_OK` marker, and the synthetic source
 card in a non-empty final answer both before and after reloading the thread.
+During the live stream, a completed tool chip may precede answer text, but the
+source section must stay absent until the first non-whitespace answer delta.
 Use direct `GPT-5.6 Luna` only to isolate the router from the model/tool path.
 
 ## Pre-PR verification checklist

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -126,6 +126,9 @@ services:
       - UPSTREAM_OPENAI_API_KEY=${UPSTREAM_OPENAI_API_KEY:-}
       - UPSTREAM_OPENAI_BASE_URL=${UPSTREAM_OPENAI_BASE_URL:-https://api.openai.com/v1}
       - LITELLM_LOG=INFO
+      # Responses API callers opt into a visible reasoning summary while each
+      # routed alias keeps its own fixed reasoning effort.
+      - LITELLM_REASONING_AUTO_SUMMARY=true
     healthcheck:
       test:
         - CMD

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -119,7 +119,7 @@ function getOpenAIModel(
   provider: ReturnType<typeof createOpenAI>,
   modelConfig: ChatModelConfig
 ) {
-  return modelConfig.supportsReasoning
+  return modelConfig.usesResponsesApi
     ? provider.responses(modelConfig.deploymentId)
     : provider.chat(modelConfig.deploymentId)
 }
@@ -1214,7 +1214,7 @@ export async function POST(
       telemetry: { isEnabled: isAiTelemetryEnabled },
       providerOptions: {
         openai: {
-          ...(selectedModelConfig.supportsReasoning && {
+          ...(selectedModelConfig.usesResponsesApi && {
             store: getOpenAIResponsesStore(),
           }),
           ...(providerReasoningEffort && {

--- a/apps/chat/src/components/thread.tsx
+++ b/apps/chat/src/components/thread.tsx
@@ -1363,6 +1363,11 @@ const AssistantMessage: FC = () => {
       m.status?.type === 'running' &&
       m.content.length === 0
   )
+  const hasAnswerText = useMessage((message) =>
+    message.content.some(
+      (part) => part.type === 'text' && part.text.trim().length > 0
+    )
+  )
   // Computed once here (not inside SourcesSection/MarkdownText) and shared
   // via context, so the sources grid and the inline `[n]` citation chips
   // read the same normalized list instead of each re-parsing the tool JSON.
@@ -1423,7 +1428,7 @@ const AssistantMessage: FC = () => {
         <ImageAnalyzedChip />
         <MessageSourcesProvider value={messageSources}>
           <AssistantMessageParts />
-          <SourcesSection />
+          {hasAnswerText && <SourcesSection />}
         </MessageSourcesProvider>
         <MessageMetadata includeCredits />
       </div>

--- a/apps/chat/src/lib/server/chatModelRegistry.ts
+++ b/apps/chat/src/lib/server/chatModelRegistry.ts
@@ -9,6 +9,7 @@ const chatModelSchema = z
     description: z.string().default(''),
     fallback: z.boolean().default(false),
     supportsReasoning: z.boolean().default(false),
+    usesResponsesApi: z.boolean().optional(),
     supportsImageAttachments: z.boolean().default(false),
     supportedReasoningEfforts: z.array(z.string().min(1)).optional(),
     maxOutputTokens: z.number().positive().optional(),
@@ -67,8 +68,9 @@ type RawChatModelConfig = z.infer<typeof chatModelSchema>
 export type ReasoningEffortByModel = Record<string, ReasoningEffort[]>
 export type ChatModelConfig = Omit<
   RawChatModelConfig,
-  'supportedReasoningEfforts'
+  'supportedReasoningEfforts' | 'usesResponsesApi'
 > & {
+  usesResponsesApi: boolean
   supportedReasoningEfforts: ReasoningEffort[]
 }
 
@@ -77,15 +79,19 @@ function dedupeStrings(values: readonly string[]) {
 }
 
 function normalizeChatModelConfig(model: RawChatModelConfig): ChatModelConfig {
+  const usesResponsesApi = model.usesResponsesApi ?? model.supportsReasoning
+
   if (!model.supportsReasoning) {
     return {
       ...model,
+      usesResponsesApi,
       supportedReasoningEfforts: [],
     }
   }
 
   return {
     ...model,
+    usesResponsesApi,
     supportedReasoningEfforts: dedupeStrings(
       model.supportedReasoningEfforts ?? []
     ),
@@ -106,6 +112,7 @@ export const DEFAULT_MODEL_REGISTRY: ChatModelConfig[] = [
     description: 'Automatic model selection through the LiteLLM auto router',
     fallback: false,
     supportsReasoning: false,
+    usesResponsesApi: true,
     supportsImageAttachments: true,
     supportedReasoningEfforts: [],
     cost: { input: 1.25, output: 10.0 },
@@ -117,6 +124,7 @@ export const DEFAULT_MODEL_REGISTRY: ChatModelConfig[] = [
     description: 'OpenAI reasoning model',
     fallback: false,
     supportsReasoning: true,
+    usesResponsesApi: true,
     supportsImageAttachments: true,
     supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
     cost: { input: 1.25, output: 10.0 },
@@ -128,6 +136,7 @@ export const DEFAULT_MODEL_REGISTRY: ChatModelConfig[] = [
     description: 'OpenAI model',
     fallback: false,
     supportsReasoning: false,
+    usesResponsesApi: false,
     supportsImageAttachments: true,
     supportedReasoningEfforts: [],
     cost: { input: 2.0, output: 8.0 },
@@ -139,6 +148,7 @@ export const DEFAULT_MODEL_REGISTRY: ChatModelConfig[] = [
     description: 'Small OpenAI model',
     fallback: true,
     supportsReasoning: false,
+    usesResponsesApi: false,
     supportsImageAttachments: true,
     supportedReasoningEfforts: [],
     cost: { input: 0.4, output: 1.6 },

--- a/apps/chat/test/chatModelRegistry.test.ts
+++ b/apps/chat/test/chatModelRegistry.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('chat model registry provider protocol', () => {
+  test('preserves the legacy reasoning-based Responses default while allowing Auto to opt in', async () => {
+    vi.stubEnv(
+      'CHAT_MODEL_REGISTRY_JSON',
+      JSON.stringify([
+        {
+          id: 'auto',
+          deploymentId: 'auto-router',
+          name: 'Auto',
+          supportsReasoning: false,
+          usesResponsesApi: true,
+          cost: { input: 1, output: 1 },
+        },
+        {
+          id: 'reasoning',
+          deploymentId: 'reasoning',
+          name: 'Reasoning',
+          supportsReasoning: true,
+          supportedReasoningEfforts: ['medium'],
+          cost: { input: 1, output: 1 },
+        },
+        {
+          id: 'fallback',
+          deploymentId: 'fallback',
+          name: 'Fallback',
+          fallback: true,
+          cost: { input: 1, output: 1 },
+        },
+      ])
+    )
+
+    const { getChatModelRegistry } = await import(
+      '../src/lib/server/chatModelRegistry'
+    )
+    const byId = new Map(
+      getChatModelRegistry().map((model) => [model.id, model])
+    )
+
+    expect(byId.get('auto')).toMatchObject({
+      supportsReasoning: false,
+      usesResponsesApi: true,
+      supportedReasoningEfforts: [],
+    })
+    expect(byId.get('reasoning')).toMatchObject({
+      supportsReasoning: true,
+      usesResponsesApi: true,
+      supportedReasoningEfforts: ['medium'],
+    })
+    expect(byId.get('fallback')).toMatchObject({
+      supportsReasoning: false,
+      usesResponsesApi: false,
+      supportedReasoningEfforts: [],
+    })
+  })
+})

--- a/apps/chat/test/modelRegistryParity.test.ts
+++ b/apps/chat/test/modelRegistryParity.test.ts
@@ -12,6 +12,8 @@ type ParityModel = {
   id: string
   deploymentId: string
   fallback: boolean
+  supportsReasoning: boolean
+  usesResponsesApi?: boolean
   supportedReasoningEfforts: string[]
 }
 
@@ -48,6 +50,18 @@ describe('default chat model registry parity', () => {
           .sort()
           .join(',')
       ).toBe([...model.supportedReasoningEfforts].sort().join(','))
+    }
+  })
+
+  test('every model uses the same OpenAI API adapter', () => {
+    const backendById = byId(backendModels)
+    for (const model of chatModels) {
+      expect(backendById.get(model.id)?.supportsReasoning).toBe(
+        model.supportsReasoning
+      )
+      expect(backendById.get(model.id)?.usesResponsesApi).toBe(
+        model.usesResponsesApi
+      )
     }
   })
 

--- a/apps/chat/test/modelRegistryParity.test.ts
+++ b/apps/chat/test/modelRegistryParity.test.ts
@@ -13,7 +13,7 @@ type ParityModel = {
   deploymentId: string
   fallback: boolean
   supportsReasoning: boolean
-  usesResponsesApi?: boolean
+  usesResponsesApi: boolean
   supportedReasoningEfforts: string[]
 }
 

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -223,6 +223,7 @@ chat:
       name: Auto
       description: Automatic model selection (routes to the best model per request)
       supportsImageAttachments: true
+      usesResponsesApi: true
       fallback: false
       cost:
         input: 1.25

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -187,6 +187,7 @@ chat:
       name: Auto
       description: Automatic model selection (routes to the best model per request)
       supportsImageAttachments: true
+      usesResponsesApi: true
       fallback: false
       cost:
         input: 1.25

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -84,6 +84,13 @@ direct GPT-5.6 picker option; the router's tier targets are internal.
 Both staging and production now use `auto` as the global automatic-model
 primary, so chatbots using automatic model selection use Auto by default.
 Chatbots with an explicit model selection can continue using that selection.
+Model registry capabilities separate the student-facing reasoning-effort
+selector from the provider protocol: `supportsReasoning` controls whether the
+effort picker is offered, while `usesResponsesApi` selects OpenAI Responses so
+reasoning summary parts can stream. When `usesResponsesApi` is omitted it
+inherits `supportsReasoning`, preserving older registry JSON and existing
+reasoning models. Auto sets only `usesResponsesApi: true`, so its routed tier
+keeps ownership of effort instead of accepting a participant override.
 
 The local devcontainer simulation in `util/litellm/config.yaml` mirrors the
 deployed Klicker Auto V2 policy and semantic corpus with local, unprefixed model
@@ -110,6 +117,13 @@ usage cost. A model call still requires the operator's local
 `UPSTREAM_OPENAI_API_KEY`; without it, verify service health, model exposure,
 picker state, and request error handling, but do not claim an end-to-end answer
 stream.
+
+Local LiteLLM enables `LITELLM_REASONING_AUTO_SUMMARY` for the Responses path.
+That maps each routed alias's fixed `reasoning_effort` to a visible summary
+without adding a request-level effort that would flatten Auto's Luna/Sol tier
+policy. The deployed LiteLLM configuration is external; a local summary proves
+the development path only, and staging still needs a Responses + tool-loop
+smoke test before a production compatibility claim.
 
 - Omitted `supportsImageAttachments` defaults to **false** — every image-capable model must set it explicitly in deployment values or the attach button disappears.
 - Zero-credit course chatbots need a usable fallback model (`CHAT_FALLBACK_MODEL_ID`, default `gpt-4.1-mini`) AND explicit chatbot `allowedModelIds` must include it. Audit/fix with `packages/prisma-data/src/scripts/2026-06-15_ensure_chatbot_fallback_model.ts`.
@@ -169,6 +183,11 @@ composition lives in `src/components/message-parts.tsx:AssistantMessageParts`: a
 reasoning parts share one disclosure, adjacent tool calls share one group when there is more
 than one, and a single tool call keeps its direct result disclosure. Reasoning auto-opens only
 while active until the participant manually chooses an open state; that manual choice then wins.
+The source-card section is derived from completed `doc_query` tool results but
+stays hidden until the same assistant message contains non-whitespace answer
+text. This keeps tool activity in stream order while preventing a result card
+from appearing as if it were the answer during the gap between tool completion
+and the model's next text step.
 The runtime render boundary is deliberately narrow: `RuntimeProvider` selects only the active
 thread's messages/running state and the actions it calls, while `Thread` keeps a memoized
 `ThreadPrimitive.Messages` component map and passes the chatbot avatar through context. Runtime

--- a/docs/log/2026-08-12-chat-stream-transparency.md
+++ b/docs/log/2026-08-12-chat-stream-transparency.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+- **Update**: [Chat Platform](../chat-platform.md) now documents answer-first
+  source cards and the separate Responses API capability used to surface Auto
+  Mode reasoning summaries without exposing a manual effort override.

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -11,6 +11,7 @@ const chatModelSchema = z
     description: z.string().default(''),
     fallback: z.boolean().default(false),
     supportsReasoning: z.boolean().default(false),
+    usesResponsesApi: z.boolean().optional(),
     supportedReasoningEfforts: z.array(z.string().min(1)).optional(),
     maxOutputTokens: z.number().positive().optional(),
     apiVersion: z.string().min(1).optional(),
@@ -37,8 +38,9 @@ const chatModelRegistrySchema = z.array(chatModelSchema).min(1)
 type RawChatModelConfig = z.infer<typeof chatModelSchema>
 type ChatModelCapability = Omit<
   RawChatModelConfig,
-  'supportedReasoningEfforts'
+  'supportedReasoningEfforts' | 'usesResponsesApi'
 > & {
+  usesResponsesApi: boolean
   supportedReasoningEfforts: string[]
 }
 type ChatbotReasoningConfigEntry = {
@@ -54,6 +56,7 @@ export const DEFAULT_CHAT_MODEL_REGISTRY: ChatModelCapability[] = [
     description: 'Automatic model selection through the LiteLLM auto router',
     fallback: false,
     supportsReasoning: false,
+    usesResponsesApi: true,
     supportedReasoningEfforts: [],
     apiVersion: 'preview',
     cost: { input: 1.25, output: 10.0 },
@@ -65,6 +68,7 @@ export const DEFAULT_CHAT_MODEL_REGISTRY: ChatModelCapability[] = [
     description: 'OpenAI reasoning model',
     fallback: false,
     supportsReasoning: true,
+    usesResponsesApi: true,
     supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
     apiVersion: 'preview',
     cost: { input: 1.25, output: 10.0 },
@@ -76,6 +80,7 @@ export const DEFAULT_CHAT_MODEL_REGISTRY: ChatModelCapability[] = [
     description: 'OpenAI model',
     fallback: false,
     supportsReasoning: false,
+    usesResponsesApi: false,
     supportedReasoningEfforts: [],
     apiVersion: 'preview',
     cost: { input: 2.0, output: 8.0 },
@@ -87,6 +92,7 @@ export const DEFAULT_CHAT_MODEL_REGISTRY: ChatModelCapability[] = [
     description: 'Small OpenAI model',
     fallback: true,
     supportsReasoning: false,
+    usesResponsesApi: false,
     supportedReasoningEfforts: [],
     apiVersion: 'preview',
     cost: { input: 0.4, output: 1.6 },
@@ -98,11 +104,14 @@ let cachedChatModelRegistry: ChatModelCapability[] | null = null
 const dedupeStrings = (values: readonly string[]) => Array.from(new Set(values))
 
 function normalizeChatModel(model: RawChatModelConfig): ChatModelCapability {
+  const usesResponsesApi = model.usesResponsesApi ?? model.supportsReasoning
+
   if (!model.supportsReasoning) {
-    return { ...model, supportedReasoningEfforts: [] }
+    return { ...model, usesResponsesApi, supportedReasoningEfforts: [] }
   }
   return {
     ...model,
+    usesResponsesApi,
     supportedReasoningEfforts: dedupeStrings(
       model.supportedReasoningEfforts ?? []
     ),

--- a/playwright/tests/U-catalog.spec.ts
+++ b/playwright/tests/U-catalog.spec.ts
@@ -185,7 +185,7 @@ test.describe
       page.getByTestId('transfer-ownership'),
       ownership ? 'exist' : 'not.exist'
     )
-    await page.getByTestId('close-share-object').click({ force: true })
+    await page.getByTestId('close-share-object').click()
     await expect(page.getByTestId('close-share-object')).toBeHidden()
     await clickCatalogCollectionAction(
       data.CCPublic,
@@ -197,10 +197,9 @@ test.describe
       .click()
     await page.getByTestId('insert-catalog-collection-name').click()
     await page.getByTestId('insert-catalog-collection-name').clear()
-    await typeInto(
-      page.getByTestId('insert-catalog-collection-name'),
-      `${data.CCPublic} NEW`
-    )
+    await page
+      .getByTestId('insert-catalog-collection-name')
+      .fill(`${data.CCPublic} NEW`)
     await page.getByTestId('catalog-collection-name-change-confirm').click()
     await expectByAssertion(
       page.getByTestId(`catalog-object-${data.CCPublic} NEW`),
@@ -211,10 +210,7 @@ test.describe
       .click()
     await page.getByTestId('insert-catalog-collection-name').click()
     await page.getByTestId('insert-catalog-collection-name').clear()
-    await typeInto(
-      page.getByTestId('insert-catalog-collection-name'),
-      `${data.CCPublic}`
-    )
+    await page.getByTestId('insert-catalog-collection-name').fill(data.CCPublic)
     await page.getByTestId('catalog-collection-name-change-confirm').click()
     await expectByAssertion(
       page.getByTestId(`catalog-object-${data.CCPublic}`),
@@ -544,11 +540,7 @@ test.describe
     await loginLecturer(page)
     await openCatalogPage()
     await page.getByTestId('create-catalog-collection-button').click()
-    await page.getByTestId('catalog-collection-name-input').click()
-    await typeInto(
-      page.getByTestId('catalog-collection-name-input'),
-      data.CCPublic
-    )
+    await page.getByTestId('catalog-collection-name-input').fill(data.CCPublic)
     await expect(page.getByTestId('modal-object-access')).toContainText(
       messages.manage.catalog.accessPUBLIC
     )
@@ -561,11 +553,9 @@ test.describe
       page.getByTestId(`catalog-object-${data.CCPublic}`)
     ).toContainText(messages.manage.catalog.accessPUBLIC)
     await page.getByTestId('create-catalog-collection-button').click()
-    await page.getByTestId('catalog-collection-name-input').click()
-    await typeInto(
-      page.getByTestId('catalog-collection-name-input'),
-      data.CCRestricted
-    )
+    await page
+      .getByTestId('catalog-collection-name-input')
+      .fill(data.CCRestricted)
     await page.getByTestId('modal-object-access').click()
     await page.getByTestId('object-access-restricted').click()
     await expect(page.getByTestId('modal-object-access')).toContainText(
@@ -1140,7 +1130,7 @@ test.describe
       page.getByTestId('new-permission-username-or-email'),
       'exist'
     )
-    await page.getByTestId('close-share-object').click({ force: true })
+    await page.getByTestId('close-share-object').click()
     await expect(page.getByTestId('close-share-object')).toBeHidden()
     await clickCatalogCollectionAction(
       data.CCRestricted,

--- a/playwright/tests/Y-chat.spec.ts
+++ b/playwright/tests/Y-chat.spec.ts
@@ -1984,6 +1984,8 @@ test.describe('Chatbot Source Citations', () => {
   }) => {
     await mockChatStream(page, {
       text: 'Live answer citing [1] and also [2].',
+      chunkDelayMs: 20,
+      pauseAfterToolOutput: true,
       toolCalls: [
         {
           toolCallId: 'live-call-1',
@@ -2011,6 +2013,20 @@ test.describe('Chatbot Source Citations', () => {
     await sendMessage(page, 'Search the course materials')
 
     const section = page.getByTestId('chat-sources-section')
+    await expect(page.getByTestId('chat-tool-call-toggle')).toHaveText(
+      'Searched course materials',
+      { timeout: 15_000 }
+    )
+    await expect(section).toHaveCount(0)
+    await expect(page.getByText('Live answer citing')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      const state = window as typeof window & {
+        __releaseMockChatStream?: () => void
+      }
+      state.__releaseMockChatStream?.()
+    })
+
     await expect(section).toBeVisible({ timeout: 15_000 })
     await expect(section).toContainText('Sources · 2')
     await expect(page.getByTestId('chat-source-card')).toHaveCount(2)

--- a/playwright/util/chat.ts
+++ b/playwright/util/chat.ts
@@ -367,6 +367,8 @@ export type StreamOptions = {
   chunkDelayMs?: number
   /** Pauses after this many text deltas until the test releases the stream. */
   pauseAfterTextChunk?: number
+  /** Pauses after the first tool output, before answer text starts. */
+  pauseAfterToolOutput?: boolean
   /** Payload of the `finish` part; omitted entirely when not given. */
   metadata?: StreamFinishMetadata
   /** Tool calls emitted before the answer text. */
@@ -447,7 +449,13 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
     const lines = makeStreamLines(options.text ?? 'assistant reply #1', options)
 
     await page.addInitScript(
-      ({ chatbotPath, lines: streamLines, delayMs, pauseAfterTextChunk }) => {
+      ({
+        chatbotPath,
+        lines: streamLines,
+        delayMs,
+        pauseAfterTextChunk,
+        pauseAfterToolOutput,
+      }) => {
         const originalFetch = window.fetch.bind(window)
         let releasePausedStream: (() => void) | undefined
         ;(
@@ -507,6 +515,14 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
                   })
                 }
               }
+              if (
+                pauseAfterToolOutput &&
+                eventType === 'tool-output-available'
+              ) {
+                await new Promise<void>((resolve) => {
+                  releasePausedStream = resolve
+                })
+              }
             },
           })
 
@@ -521,6 +537,7 @@ export async function mockChatStream(page: Page, options: StreamOptions = {}) {
         lines,
         delayMs: options.chunkDelayMs,
         pauseAfterTextChunk: options.pauseAfterTextChunk,
+        pauseAfterToolOutput: options.pauseAfterToolOutput,
       }
     )
     return

--- a/playwright/util/fixtures.ts
+++ b/playwright/util/fixtures.ts
@@ -44,6 +44,7 @@ async function setSessionCookie(
   cookieName: string = 'next-auth.session-token',
   redirectUrl?: string
 ) {
+  await page.goto('about:blank')
   await context.clearCookies()
 
   const target = redirectUrl ?? process.env.URL_MANAGE ?? URL_MANAGE

--- a/project/2026-08-12-chat-stream-transparency-plan.md
+++ b/project/2026-08-12-chat-stream-transparency-plan.md
@@ -1,0 +1,51 @@
+# Chat Stream Transparency Follow-up
+
+## Goal and package
+
+- Problem: source cards derived from a completed `doc_query` result render before the model begins its answer, and Auto Mode uses Chat Completions so assistant-ui receives no reasoning parts.
+- Evidence: the real Browser run showed the source section at 5.1 s while the stream was active and no answer text existed; direct Luna showed `Denkprozess`, Auto did not. The current model registry uses `supportsReasoning` both for the user effort selector and for choosing Responses versus Chat Completions.
+- Decision: add one separate `usesResponsesApi` capability to the model registry, keep Auto's manual reasoning-effort selector disabled, and configure local LiteLLM to turn each routed alias's fixed effort into a reasoning summary. An omitted capability inherits `supportsReasoning`, preserving the current adapter for every existing reasoning model and older registry JSON. Keep source cards derived from tool results, but reveal them only after answer text exists.
+- Package: full-path follow-up layer `rs/chat-stream-transparency` above `rs/chat-local-mcp-fixture-clean`. It is one coherent student-visible stream-transparency package; no push or PR update is authorized.
+- Risk: the model capability changes an OpenAI-compatible protocol seam and the LiteLLM summary behavior. It requires intermediate review and real local Auto/MCP proof.
+
+## Planning review
+
+- Initial attempt: blocked before repository inspection because the dispatch omitted the exact path allowlist and complete register preflight metadata.
+- Correction: `DONE_WITH_CONCERNS`; all five required safeguards below are incorporated.
+- Accepted: preserve omitted-capability behavior; subscribe to answer text independently from source normalization; add a deterministic post-tool/pre-text pause; prove routed Auto summaries rather than only direct aliases; use separate immutable slice commits and review ranges.
+
+## Slice 1: Preserve answer-first source presentation
+
+- Route: main.
+- Execution-tier skip reason: critical-path coupling with assistant-ui's ordered message parts, citation normalization, and the deterministic streaming browser seam.
+- Test obligation: extend existing Playwright coverage. The distinct regression is a valid source result becoming visible before any answer text; existing final-state assertions do not catch it.
+- Do: select non-whitespace answer presence independently from the memoized tool-result normalization and withhold the standalone source section until that text exists. The gate updates on the first non-empty text delta without reparsing source results on every token; inline citation normalization remains available to streamed markdown.
+- Check: focused chat tests, an extension to the existing stream fixture that pauses immediately after tool output and before text, and the existing live citation test proving sources remain absent during that pause and appear after the first non-whitespace text. Repeat the real Browser source/MCP journey.
+- Commit: `fix(chat): defer sources until answer text`.
+
+## Slice 2: Surface Auto reasoning without a manual effort override
+
+- Route: main.
+- Execution-tier skip reason: critical-path coupling across registry schema, API adapter choice, LiteLLM per-tier effort semantics, deployment values, and live OpenRouter proof.
+- Test obligation: extend registry parity/config checks and the real upstream Browser flow. The failure to catch is Auto still selecting Chat Completions or request-level effort flattening the router's tier-specific policy.
+- Do:
+  - Add `usesResponsesApi` to both registry schemas. Normalize an omitted value to `supportsReasoning`, so direct reasoning models and older deployment JSON retain their current adapter; set Auto explicitly true while leaving `supportsReasoning: false` and no configurable efforts.
+  - Enable it for Auto in built-in registries and staged/production values, and extend parity/config checks to compare `supportsReasoning`, `usesResponsesApi`, and rendered deployment values.
+  - Make `store` follow the Responses capability.
+  - Enable LiteLLM reasoning auto-summary locally so fixed Luna/Sol alias efforts become Responses reasoning parts; do not send a request-level effort for Auto.
+  - Update the Chat wiki, test runbook, plan progress, and one wiki change log.
+- Check: schema/parity tests and rendered staging/production registry compatibility. Locally, call `auto-router` through Responses with controlled semantic Luna and Sol routes; correlate the routed model and fixed effort in LiteLLM logs with a returned reasoning-summary part. Then run full Chat tests, root checks/build, and real Browser proof that Auto shows reasoning and still completes/reloads the MCP answer with sources. Deployed router configuration remains external: production compatibility is not claimed without an authorized staging Responses/tool-continuation/reasoning smoke test.
+- Commit: `fix(chat): expose Auto reasoning summaries`.
+
+## Completion gates
+
+- Slice 1 receives its own simplifier and records that intermediate review is not required because it changes presentation timing without a trust, protocol, or data-integrity boundary.
+- Slice 2 receives one simplifier and one intermediate reviewer in parallel on its separate immutable commit/range.
+- Integrated final reviewer covers correctness, plan compliance, maintainability, security, and the changed protocol/configuration seam.
+- Stop before push, PR creation/update, or merge.
+
+## Progress
+
+- Planning-stage review: done; all required corrections incorporated.
+- Active: Slice 1 implementation.
+- Remaining: Slice 1 verification/review, Slice 2 implementation/verification/review, integrated final review.

--- a/project/2026-08-12-chat-stream-transparency-plan.md
+++ b/project/2026-08-12-chat-stream-transparency-plan.md
@@ -51,5 +51,6 @@
 - Slice 1 simplifier: done — no justified net reduction. Intermediate review: not required — presentation timing and deterministic fixture only, with no trust, protocol, or data-integrity boundary change.
 - Slice 2 implementation: complete. Registry compatibility tests preserve the omitted-field behavior, rendered staging/production values keep Auto on Responses without a manual effort capability, and the recreated local LiteLLM v1.96.2 service reports the new summary flag as active.
 - Real Browser pass: complete. Auto remained selected; the live MCP turn showed no source section during the post-tool/pre-answer gap, then produced and persisted the marker, answer, tool result, and synthetic source. A controlled Auto reasoning turn rendered `Denkprozess`, and LiteLLM recorded the semantic REASONING route to `gpt-5.6-sol-medium`.
-- Active: Slice 2 verification and immutable commit.
-- Remaining: Slice 2 simplifier/intermediate review, final package checks, integrated final review.
+- Slice 2: committed as `9d0c3c200`; the simplifier's accepted test-type reduction is `c19b1ab0d`. The configured intermediate reviewer remained runtime-unavailable after bounded retries, so no substitute review is claimed.
+- Final package verification: root `check:all` and production build passed. The exact branch range has 239 substantive changed lines.
+- Blocked: the configured integrated-final reviewer is also runtime-unavailable (`agent type is currently not available`). The package is locally verified but cannot be presented as review-complete or published until that required gate can run.

--- a/project/2026-08-12-chat-stream-transparency-plan.md
+++ b/project/2026-08-12-chat-stream-transparency-plan.md
@@ -47,5 +47,9 @@
 ## Progress
 
 - Planning-stage review: done; all required corrections incorporated.
-- Active: Slice 1 implementation.
-- Remaining: Slice 1 verification/review, Slice 2 implementation/verification/review, integrated final review.
+- Slice 1: committed as `a03162584`; Chat check, 239 Chat tests, Playwright typecheck/list, and root `check:all` passed. The focused Playwright runtime was blocked before page launch because the DevPod lacks the pinned Chromium binary; a real Browser pass remains in the package completion gate.
+- Slice 1 simplifier: done — no justified net reduction. Intermediate review: not required — presentation timing and deterministic fixture only, with no trust, protocol, or data-integrity boundary change.
+- Slice 2 implementation: complete. Registry compatibility tests preserve the omitted-field behavior, rendered staging/production values keep Auto on Responses without a manual effort capability, and the recreated local LiteLLM v1.96.2 service reports the new summary flag as active.
+- Real Browser pass: complete. Auto remained selected; the live MCP turn showed no source section during the post-tool/pre-answer gap, then produced and persisted the marker, answer, tool result, and synthetic source. A controlled Auto reasoning turn rendered `Denkprozess`, and LiteLLM recorded the semantic REASONING route to `gpt-5.6-sol-medium`.
+- Active: Slice 2 verification and immutable commit.
+- Remaining: Slice 2 simplifier/intermediate review, final package checks, integrated final review.


### PR DESCRIPTION
## Summary

Make streamed chat output explain its intermediate state in the order a learner experiences it: answer text starts first, sources appear only once answer content exists, and reasoning summaries remain visible for Auto Mode.

## What changed

- Defer the sources section until assistant answer text has started streaming, avoiding a sources-first layout during tool calls.
- Preserve direct reasoning parts and expose LiteLLM/Responses API semantic reasoning summaries for Auto Mode.
- Add model-registry capability metadata and parity coverage so Responses API routing is explicit and stays aligned with supported models.
- Add a deterministic Playwright pause after the tool result and before answer text, asserting that sources are absent during the pause and visible after the answer begins.
- Keep the local devcontainer, deployment values, GraphQL service metadata, and chat documentation aligned with the new stream contract.

## Scope and size

This branch contains the complete stream-transparency follow-up on top of the local fixture package. The computed substantive diff against `rs/chat-local-mcp-fixture-clean` is 14 files, 177 additions, and 7 deletions (184 lines total), excluding project-artifact docs and lockfiles.

## Verification

- Local chat tests, chat checks, GraphQL checks, and the root check/build path passed in the self-contained container.
- Helm values rendered successfully and gitleaks passed.
- Real devrouter/browser verification observed no sources during the tool-result/pre-answer pause, then observed sources after answer text started; a reasoning prompt showed the expanded `Denkprozess` section.
- LiteLLM logs confirmed the semantic reasoning route to the configured Sol model.
- Current hosted required checks are green on head `b2cb2df` after rerunning the setup-only `pnpm/action-setup` failure.

## Review status and limits

This PR is intentionally still a draft. The configured integrated-final reviewer was unavailable at runtime; the local review record is `project/_local/reviews/2026-08-12-chat-stream-transparency-integrated-final-runtime-blocked.md` (ignored and not part of the PR). No production deployment or merge was performed.
