### PR TITLE
fix(chat): separate exact and prompt cache boundaries

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -29,15 +29,9 @@ replace a real-upstream staging smoke test.
 
 For OpenAI-compatible request-policy or prompt-cache changes, run
 `apps/chat/test/openai-cache-policy.test.ts` and
-`apps/chat/test/prompt-cache-identity.test.ts` after the streaming fixture.
-They capture synthetic Chat Completions and Responses requests, verify the
-default/custom exact-cache boundary and deterministic prompt identity, and
-assert public `usage.inputTokenDetails` buckets for uncached, cache-read, and
-cache-write input. The fixtures are no-network local proof only: they do not
-establish LiteLLM, provider, router, production, latency, or cost behavior.
-These changes are server-side and need no browser run; use the browser gate if
-the same change reaches UI, auth, redirect, cookie, or user-visible chat
-behavior.
+`apps/chat/test/prompt-cache-identity.test.ts` after the streaming fixture;
+see [docs/testing.md](../../../docs/testing.md#which-level-for-which-change)
+for contract details and evidence boundaries.
 
 For chat conversation-rendering changes, `playwright/util/chat.ts` supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -27,6 +27,18 @@ fixture uses injected OpenAI-compatible SSE with a sparse first tool-call index
 and proves public tool-call/finish conversion without a model key; it does not
 replace a real-upstream staging smoke test.
 
+For OpenAI-compatible request-policy or prompt-cache changes, run
+`apps/chat/test/openai-cache-policy.test.ts` and
+`apps/chat/test/prompt-cache-identity.test.ts` after the streaming fixture.
+They capture synthetic Chat Completions and Responses requests, verify the
+default/custom exact-cache boundary and deterministic prompt identity, and
+assert public `usage.inputTokenDetails` buckets for uncached, cache-read, and
+cache-write input. The fixtures are no-network local proof only: they do not
+establish LiteLLM, provider, router, production, latency, or cost behavior.
+These changes are server-side and need no browser run; use the browser gate if
+the same change reaches UI, auth, redirect, cookie, or user-visible chat
+behavior.
+
 For chat conversation-rendering changes, `playwright/util/chat.ts` supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
 `ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -882,7 +882,6 @@ export async function POST(
       : null
   const promptCacheOptions = promptCacheRequest
     ? getOpenAIPromptCacheOptions({
-        deploymentId: selectedModelConfig.deploymentId,
         promptCacheKey: promptCacheRequest.promptCacheKey,
         routingSource: routing.source,
       })

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -18,6 +18,10 @@ import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions
 import { createOpenAIFetch } from '@/src/lib/server/openaiCachePolicy'
 import { getOpenAIResponsesStore } from '@/src/lib/server/openaiResponsesOptions'
 import {
+  buildPromptCacheRequest,
+  getOpenAIPromptCacheOptions,
+} from '@/src/lib/server/promptCacheIdentity'
+import {
   mapAssistantStepContent,
   type PersistedAssistantContentPart,
 } from '@/src/lib/server/persistedAssistantContent'
@@ -865,6 +869,24 @@ export async function POST(
       : undefined
 
   const { model, routing } = getModel(chatbot, selectedModelConfig)
+  const promptCacheRequest =
+    routing.source === 'default'
+      ? await buildPromptCacheRequest({
+          deploymentId: selectedModelConfig.deploymentId,
+          transport: selectedModelConfig.supportsReasoning
+            ? 'responses'
+            : 'chat',
+          instructions: systemPrompt,
+          tools: mcpTools,
+        })
+      : null
+  const promptCacheOptions = promptCacheRequest
+    ? getOpenAIPromptCacheOptions({
+        deploymentId: selectedModelConfig.deploymentId,
+        promptCacheKey: promptCacheRequest.promptCacheKey,
+        routingSource: routing.source,
+      })
+    : {}
 
   // create image descriptions if images attached
   let imageDescriptionCost: number = 0
@@ -1181,6 +1203,7 @@ export async function POST(
       telemetry: { isEnabled: isAiTelemetryEnabled },
       providerOptions: {
         openai: {
+          ...promptCacheOptions,
           ...(selectedModelConfig.usesResponsesApi && {
             store: getOpenAIResponsesStore(),
           }),
@@ -1191,7 +1214,8 @@ export async function POST(
         },
       },
       messages: modelMessages as ModelMessage[],
-      tools: mcpTools,
+      tools: promptCacheRequest?.tools ?? mcpTools,
+      toolOrder: promptCacheRequest?.toolOrder,
       toolChoice: 'auto',
       stopWhen: isStepCount(5),
       instructions: systemPrompt,

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -15,6 +15,7 @@ import {
   isAiTelemetryEnabled,
 } from '@/src/lib/server/langfuseTracing'
 import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions'
+import { createOpenAIFetch } from '@/src/lib/server/openaiCachePolicy'
 import { getOpenAIResponsesStore } from '@/src/lib/server/openaiResponsesOptions'
 import {
   mapAssistantStepContent,
@@ -75,40 +76,6 @@ const isDevLogging = process.env.NODE_ENV === 'development'
 const MAX_LOG_STRING_LENGTH = 500
 const HASH_DIGEST_LENGTH = 12
 
-/**
- * Custom fetch that patches Responses API request body to add
- * `status: "completed"` and `type: "message"` on assistant messages.
- * AI SDK omits these fields but some strict Responses API providers require them.
- *
- * Workaround for: https://github.com/vercel/ai/issues/12754
- */
-const responsesApiFetch: typeof globalThis.fetch = async (input, init) => {
-  if (init?.body && typeof init.body === 'string') {
-    try {
-      const body = JSON.parse(init.body)
-      if (Array.isArray(body.input)) {
-        body.input = body.input.map((item: Record<string, unknown>) =>
-          item.role === 'assistant'
-            ? { ...item, type: 'message', status: 'completed' }
-            : item
-        )
-        init = { ...init, body: JSON.stringify(body) }
-      }
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        // not JSON, pass through
-      } else {
-        console.error(
-          '[responsesApiFetch] Unexpected error patching body:',
-          error
-        )
-        throw error
-      }
-    }
-  }
-  return globalThis.fetch(input, init)
-}
-
 type ModelRouting = {
   source: 'custom' | 'default'
   hasCustomKey: boolean
@@ -163,7 +130,7 @@ function getModel(chatbot: Chatbot, modelConfig: ChatModelConfig) {
         createOpenAI({
           baseURL: baseUrl,
           apiKey: apiKey || 'no-key',
-          fetch: responsesApiFetch,
+          fetch: createOpenAIFetch('custom'),
         }),
         modelConfig
       ),
@@ -183,7 +150,7 @@ function getModel(chatbot: Chatbot, modelConfig: ChatModelConfig) {
       createOpenAI({
         baseURL: process.env.OPENAI_BASE_URL,
         apiKey: process.env.OPENAI_API_KEY || 'no-key',
-        fetch: responsesApiFetch,
+        fetch: createOpenAIFetch('default'),
       }),
       modelConfig
     ),

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -870,7 +870,7 @@ export async function POST(
     routing.source === 'default'
       ? await buildPromptCacheRequest({
           deploymentId: selectedModelConfig.deploymentId,
-          transport: selectedModelConfig.supportsReasoning
+          transport: selectedModelConfig.usesResponsesApi
             ? 'responses'
             : 'chat',
           instructions: systemPrompt,

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -17,10 +17,7 @@ import {
 import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions'
 import { createOpenAIFetch } from '@/src/lib/server/openaiCachePolicy'
 import { getOpenAIResponsesStore } from '@/src/lib/server/openaiResponsesOptions'
-import {
-  buildPromptCacheRequest,
-  getOpenAIPromptCacheOptions,
-} from '@/src/lib/server/promptCacheIdentity'
+import { buildPromptCacheRequest } from '@/src/lib/server/promptCacheIdentity'
 import {
   mapAssistantStepContent,
   type PersistedAssistantContentPart,
@@ -880,12 +877,6 @@ export async function POST(
           tools: mcpTools,
         })
       : null
-  const promptCacheOptions = promptCacheRequest
-    ? getOpenAIPromptCacheOptions({
-        promptCacheKey: promptCacheRequest.promptCacheKey,
-        routingSource: routing.source,
-      })
-    : {}
 
   // create image descriptions if images attached
   let imageDescriptionCost: number = 0
@@ -1202,7 +1193,9 @@ export async function POST(
       telemetry: { isEnabled: isAiTelemetryEnabled },
       providerOptions: {
         openai: {
-          ...promptCacheOptions,
+          ...(promptCacheRequest
+            ? { promptCacheKey: promptCacheRequest.promptCacheKey }
+            : {}),
           ...(selectedModelConfig.usesResponsesApi && {
             store: getOpenAIResponsesStore(),
           }),

--- a/apps/chat/src/lib/server/openaiCachePolicy.ts
+++ b/apps/chat/src/lib/server/openaiCachePolicy.ts
@@ -11,6 +11,16 @@ function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function parseJsonObject(body: string): JsonObject | undefined {
+  try {
+    const value = JSON.parse(body)
+    return isJsonObject(value) ? value : undefined
+  } catch (error) {
+    if (error instanceof SyntaxError) return undefined
+    throw error
+  }
+}
+
 function patchResponsesInput(body: JsonObject) {
   if (!Array.isArray(body.input)) return
 
@@ -38,25 +48,21 @@ export function createOpenAIFetch(
       return fetchImpl(input, init)
     }
 
-    try {
-      const body = JSON.parse(init.body)
-      if (!isJsonObject(body)) return fetchImpl(input, init)
-
-      patchResponsesInput(body)
-
-      if (routingSource === 'default') {
-        body.cache = {
-          ...(isJsonObject(body.cache) ? body.cache : {}),
-          ...EXACT_RESPONSE_CACHE_BYPASS,
-        }
-      }
-
-      return fetchImpl(input, { ...init, body: JSON.stringify(body) })
-    } catch (error) {
-      if (!(error instanceof SyntaxError)) throw error
+    const body = parseJsonObject(init.body)
+    if (!body) {
       // Non-JSON request bodies pass through unchanged.
+      return fetchImpl(input, init)
     }
 
-    return fetchImpl(input, init)
+    patchResponsesInput(body)
+
+    if (routingSource === 'default') {
+      body.cache = {
+        ...(isJsonObject(body.cache) ? body.cache : {}),
+        ...EXACT_RESPONSE_CACHE_BYPASS,
+      }
+    }
+
+    return fetchImpl(input, { ...init, body: JSON.stringify(body) })
   }
 }

--- a/apps/chat/src/lib/server/openaiCachePolicy.ts
+++ b/apps/chat/src/lib/server/openaiCachePolicy.ts
@@ -1,0 +1,63 @@
+type RoutingSource = 'custom' | 'default'
+
+type JsonObject = Record<string, unknown>
+
+const EXACT_RESPONSE_CACHE_BYPASS = {
+  'no-cache': true,
+  'no-store': true,
+} as const
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function patchResponsesInput(body: JsonObject) {
+  if (!Array.isArray(body.input)) return
+
+  body.input = body.input.map((item: unknown) =>
+    isJsonObject(item) && item.role === 'assistant'
+      ? { ...item, type: 'message', status: 'completed' }
+      : item
+  )
+}
+
+/**
+ * Creates the fetch boundary for an OpenAI-compatible chatbot provider.
+ *
+ * The default provider must not reuse personalized requests from LiteLLM's
+ * exact-response cache. Custom chatbot endpoints keep their existing request
+ * shape, while Responses requests still receive the compatibility fields that
+ * strict providers require.
+ */
+export function createOpenAIFetch(
+  routingSource: RoutingSource,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        const body = JSON.parse(init.body)
+        if (isJsonObject(body)) {
+          patchResponsesInput(body)
+
+          if (routingSource === 'default') {
+            body.cache = {
+              ...(isJsonObject(body.cache) ? body.cache : {}),
+              ...EXACT_RESPONSE_CACHE_BYPASS,
+            }
+          }
+
+          init = { ...init, body: JSON.stringify(body) }
+        }
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          // Non-JSON request bodies pass through unchanged.
+        } else {
+          throw error
+        }
+      }
+    }
+
+    return fetchImpl(input, init)
+  }
+}

--- a/apps/chat/src/lib/server/openaiCachePolicy.ts
+++ b/apps/chat/src/lib/server/openaiCachePolicy.ts
@@ -34,28 +34,27 @@ export function createOpenAIFetch(
   fetchImpl: typeof globalThis.fetch = globalThis.fetch
 ): typeof globalThis.fetch {
   return async (input, init) => {
-    if (init?.body && typeof init.body === 'string') {
-      try {
-        const body = JSON.parse(init.body)
-        if (isJsonObject(body)) {
-          patchResponsesInput(body)
+    if (!init?.body || typeof init.body !== 'string') {
+      return fetchImpl(input, init)
+    }
 
-          if (routingSource === 'default') {
-            body.cache = {
-              ...(isJsonObject(body.cache) ? body.cache : {}),
-              ...EXACT_RESPONSE_CACHE_BYPASS,
-            }
-          }
+    try {
+      const body = JSON.parse(init.body)
+      if (!isJsonObject(body)) return fetchImpl(input, init)
 
-          init = { ...init, body: JSON.stringify(body) }
-        }
-      } catch (error) {
-        if (error instanceof SyntaxError) {
-          // Non-JSON request bodies pass through unchanged.
-        } else {
-          throw error
+      patchResponsesInput(body)
+
+      if (routingSource === 'default') {
+        body.cache = {
+          ...(isJsonObject(body.cache) ? body.cache : {}),
+          ...EXACT_RESPONSE_CACHE_BYPASS,
         }
       }
+
+      return fetchImpl(input, { ...init, body: JSON.stringify(body) })
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error
+      // Non-JSON request bodies pass through unchanged.
     }
 
     return fetchImpl(input, init)

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -25,6 +25,13 @@ type UnknownObject = Record<string, unknown>
 
 type PromptCacheTransport = 'chat' | 'responses'
 
+const OPENAI_RESPONSES_TOOL_OPTION_KEYS = [
+  'allowedCallers',
+  'deferLoading',
+  'namespace',
+  'outputSchema',
+] as const
+
 function compareStrings(left: string, right: string) {
   return left.localeCompare(right, 'en-US')
 }
@@ -67,7 +74,12 @@ function canonicalizeJson(value: unknown): JsonValue | undefined {
   for (const key of Object.keys(value).sort(compareStrings)) {
     const canonicalValue = canonicalizeJson(value[key])
     if (canonicalValue !== undefined) {
-      result[key] = canonicalValue
+      Object.defineProperty(result, key, {
+        value: canonicalValue,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
     }
   }
   return result
@@ -86,7 +98,8 @@ function getProviderFunctionTool(
   name: string,
   tool: UnknownObject,
   inputSchema: JsonValue | undefined,
-  description: string | undefined
+  description: string | undefined,
+  transport: PromptCacheTransport
 ): JsonObject {
   const providerTool: JsonObject = {
     type: 'function',
@@ -96,9 +109,23 @@ function getProviderFunctionTool(
 
   if (description !== undefined) providerTool.description = description
 
-  for (const key of ['inputExamples', 'providerOptions', 'strict'] as const) {
-    const value = canonicalizeJson(tool[key])
-    if (value !== undefined) providerTool[key] = value
+  const strict = canonicalizeJson(tool.strict)
+  if (strict !== undefined) providerTool.strict = strict
+
+  const providerOptions = tool.providerOptions
+  const openAIOptions =
+    isObject(providerOptions) && isObject(providerOptions.openai)
+      ? providerOptions.openai
+      : undefined
+  if (transport === 'responses' && openAIOptions) {
+    const responsesOptions: JsonObject = {}
+    for (const key of OPENAI_RESPONSES_TOOL_OPTION_KEYS) {
+      const value = canonicalizeJson(openAIOptions[key])
+      if (value !== undefined) responsesOptions[key] = value
+    }
+    if (Object.keys(responsesOptions).length > 0) {
+      providerTool.responsesOptions = responsesOptions
+    }
   }
 
   return providerTool
@@ -106,7 +133,8 @@ function getProviderFunctionTool(
 
 async function canonicalizeTool(
   name: string,
-  rawTool: unknown
+  rawTool: unknown,
+  transport: PromptCacheTransport
 ): Promise<{ providerTool: JsonObject; tool: unknown }> {
   if (!isObject(rawTool)) {
     throw new Error(`Invalid tool definition for ${name}`)
@@ -154,7 +182,8 @@ async function canonicalizeTool(
       name,
       rawTool,
       schemaJson,
-      description
+      description,
+      transport
     ),
     tool: canonicalTool,
   }
@@ -168,7 +197,7 @@ export async function buildPromptCacheRequest(
   )
   const canonicalEntries = await Promise.all(
     entries.map(async ([name, tool]) => {
-      const canonicalTool = await canonicalizeTool(name, tool)
+      const canonicalTool = await canonicalizeTool(name, tool, input.transport)
       return [name, canonicalTool] as const
     })
   )

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -37,7 +37,6 @@ export type PromptCacheProviderOptionsInput = {
 
 export type PromptCacheRequest = {
   promptCacheKey: string
-  providerTools: JsonObject[]
   toolOrder: string[]
   tools: ToolSet
 }
@@ -193,7 +192,6 @@ export async function buildPromptCacheRequest(
 
   return {
     promptCacheKey: `${PROMPT_CACHE_KEY_VERSION}:sha256:${digest}`,
-    providerTools,
     toolOrder,
     tools,
   }

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto'
 import { asSchema, type FlexibleSchema, jsonSchema, type ToolSet } from 'ai'
 
-const PROMPT_CACHE_KEY_VERSION = 'klicker:prompt-prefix:v1'
+const PROMPT_CACHE_KEY_VERSION = 'klicker:pc:v1'
+const PROMPT_CACHE_KEY_MAX_LENGTH = 64
+const PROMPT_CACHE_KEY_DIGEST_LENGTH =
+  PROMPT_CACHE_KEY_MAX_LENGTH - PROMPT_CACHE_KEY_VERSION.length - 1
 const IMPLICIT_PROMPT_CACHE_DEPLOYMENTS = new Set([
   'gpt-5.6',
   'gpt-5.6-luna',
@@ -191,7 +194,10 @@ export async function buildPromptCacheRequest(
     .digest('hex')
 
   return {
-    promptCacheKey: `${PROMPT_CACHE_KEY_VERSION}:sha256:${digest}`,
+    promptCacheKey: `${PROMPT_CACHE_KEY_VERSION}:${digest.slice(
+      0,
+      PROMPT_CACHE_KEY_DIGEST_LENGTH
+    )}`,
     toolOrder,
     tools,
   }

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -25,6 +25,10 @@ type UnknownObject = Record<string, unknown>
 
 type PromptCacheTransport = 'chat' | 'responses'
 
+function compareStrings(left: string, right: string) {
+  return left.localeCompare(right, 'en-US')
+}
+
 export type PromptCacheIdentityInput = {
   deploymentId: string
   transport: PromptCacheTransport
@@ -60,7 +64,7 @@ function canonicalizeJson(value: unknown): JsonValue | undefined {
   if (!isObject(value)) return undefined
 
   const result: JsonObject = {}
-  for (const key of Object.keys(value).sort()) {
+  for (const key of Object.keys(value).sort(compareStrings)) {
     const canonicalValue = canonicalizeJson(value[key])
     if (canonicalValue !== undefined) {
       result[key] = canonicalValue
@@ -160,7 +164,7 @@ export async function buildPromptCacheRequest(
   input: PromptCacheIdentityInput
 ): Promise<PromptCacheRequest> {
   const entries = Object.entries(input.tools).sort(([left], [right]) =>
-    left < right ? -1 : left > right ? 1 : 0
+    compareStrings(left, right)
   )
   const canonicalEntries = await Promise.all(
     entries.map(async ([name, tool]) => {

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -1,0 +1,219 @@
+import { createHash } from 'node:crypto'
+import { asSchema, type FlexibleSchema, jsonSchema, type ToolSet } from 'ai'
+
+const PROMPT_CACHE_KEY_VERSION = 'klicker:prompt-prefix:v1'
+const IMPLICIT_PROMPT_CACHE_DEPLOYMENTS = new Set([
+  'gpt-5.6',
+  'gpt-5.6-luna',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+])
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type JsonObject = { [key: string]: JsonValue }
+type UnknownObject = Record<string, unknown>
+
+type PromptCacheTransport = 'chat' | 'responses'
+
+export type PromptCacheIdentityInput = {
+  deploymentId: string
+  transport: PromptCacheTransport
+  instructions: string
+  tools: ToolSet
+}
+
+export type PromptCacheProviderOptionsInput = {
+  deploymentId: string
+  promptCacheKey: string
+  routingSource: 'custom' | 'default'
+}
+
+export type PromptCacheRequest = {
+  promptCacheKey: string
+  providerTools: JsonObject[]
+  toolOrder: string[]
+  tools: ToolSet
+}
+
+function isObject(value: unknown): value is UnknownObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function canonicalizeJson(value: unknown): JsonValue | undefined {
+  if (value === undefined || typeof value === 'function') return undefined
+  if (value === null) return null
+  if (
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string'
+  ) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeJson(item) ?? null)
+  }
+
+  if (!isObject(value)) return undefined
+
+  const result: JsonObject = {}
+  for (const key of Object.keys(value).sort()) {
+    const canonicalValue = canonicalizeJson(value[key])
+    if (canonicalValue !== undefined) {
+      result[key] = canonicalValue
+    }
+  }
+  return result
+}
+
+function getDescription(tool: UnknownObject): string | undefined {
+  const description = tool.description
+  if (typeof description === 'string') return description
+  if (typeof description !== 'function') return undefined
+
+  const resolved = description({ context: undefined })
+  return typeof resolved === 'string' ? resolved : undefined
+}
+
+function getProviderFunctionTool(
+  name: string,
+  tool: UnknownObject,
+  inputSchema: JsonValue | undefined,
+  description: string | undefined
+): JsonObject {
+  const providerTool: JsonObject = {
+    type: 'function',
+    name,
+    inputSchema: inputSchema ?? {},
+  }
+
+  if (description !== undefined) providerTool.description = description
+
+  for (const key of ['inputExamples', 'providerOptions', 'strict'] as const) {
+    const value = canonicalizeJson(tool[key])
+    if (value !== undefined) providerTool[key] = value
+  }
+
+  return providerTool
+}
+
+async function canonicalizeTool(
+  name: string,
+  rawTool: unknown
+): Promise<{ providerTool: JsonObject; tool: unknown }> {
+  if (!isObject(rawTool)) {
+    throw new Error(`Invalid tool definition for ${name}`)
+  }
+
+  if (rawTool.type === 'provider') {
+    const providerTool: JsonObject = {
+      type: 'provider',
+      name,
+      id: canonicalizeJson(rawTool.id) ?? null,
+      args: canonicalizeJson(rawTool.args) ?? null,
+    }
+    return {
+      providerTool,
+      tool: rawTool,
+    }
+  }
+
+  const inputSchema = rawTool.inputSchema
+  if (inputSchema === undefined) {
+    throw new Error(`Tool ${name} has no input schema`)
+  }
+
+  const schema = asSchema(inputSchema as FlexibleSchema<unknown>)
+  const schemaJson = canonicalizeJson(await schema.jsonSchema)
+  const canonicalSchema = jsonSchema(
+    schemaJson ?? {},
+    schema.validate ? { validate: schema.validate } : undefined
+  )
+  const description = getDescription(rawTool)
+  const canonicalTool = {
+    ...rawTool,
+    inputSchema: canonicalSchema,
+    ...(description === undefined ? {} : { description }),
+    ...(rawTool.inputExamples === undefined
+      ? {}
+      : { inputExamples: canonicalizeJson(rawTool.inputExamples) }),
+    ...(rawTool.providerOptions === undefined
+      ? {}
+      : { providerOptions: canonicalizeJson(rawTool.providerOptions) }),
+  }
+
+  return {
+    providerTool: getProviderFunctionTool(
+      name,
+      rawTool,
+      schemaJson,
+      description
+    ),
+    tool: canonicalTool,
+  }
+}
+
+export async function buildPromptCacheRequest(
+  input: PromptCacheIdentityInput
+): Promise<PromptCacheRequest> {
+  const entries = Object.entries(input.tools).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0
+  )
+  const canonicalEntries = await Promise.all(
+    entries.map(async ([name, tool]) => {
+      const canonicalTool = await canonicalizeTool(name, tool)
+      return [name, canonicalTool] as const
+    })
+  )
+
+  const tools = Object.fromEntries(
+    canonicalEntries.map(([name, canonicalTool]) => [name, canonicalTool.tool])
+  ) as ToolSet
+  const providerTools = canonicalEntries.map(
+    ([, canonicalTool]) => canonicalTool.providerTool
+  )
+  const toolOrder = canonicalEntries.map(([name]) => name)
+  const fingerprint = canonicalizeJson({
+    version: PROMPT_CACHE_KEY_VERSION,
+    deploymentId: input.deploymentId,
+    transport: input.transport,
+    instructions: input.instructions,
+    tools: providerTools,
+  })
+  const digest = createHash('sha256')
+    .update(JSON.stringify(fingerprint))
+    .digest('hex')
+
+  return {
+    promptCacheKey: `${PROMPT_CACHE_KEY_VERSION}:sha256:${digest}`,
+    providerTools,
+    toolOrder,
+    tools,
+  }
+}
+
+export function supportsImplicitPromptCaching(deploymentId: string): boolean {
+  return IMPLICIT_PROMPT_CACHE_DEPLOYMENTS.has(deploymentId)
+}
+
+export function getOpenAIPromptCacheOptions({
+  deploymentId,
+  promptCacheKey,
+  routingSource,
+}: PromptCacheProviderOptionsInput): Record<string, unknown> {
+  if (routingSource !== 'default') return {}
+
+  return {
+    promptCacheKey,
+    ...(supportsImplicitPromptCaching(deploymentId)
+      ? { promptCacheOptions: { mode: 'implicit' } }
+      : {}),
+  }
+}

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -1,16 +1,16 @@
 import { createHash } from 'node:crypto'
-import { asSchema, type FlexibleSchema, jsonSchema, type ToolSet } from 'ai'
+import {
+  asSchema,
+  type FlexibleSchema,
+  type JSONSchema7,
+  jsonSchema,
+  type ToolSet,
+} from 'ai'
 
 const PROMPT_CACHE_KEY_VERSION = 'klicker:pc:v1'
 const PROMPT_CACHE_KEY_MAX_LENGTH = 64
 const PROMPT_CACHE_KEY_DIGEST_LENGTH =
   PROMPT_CACHE_KEY_MAX_LENGTH - PROMPT_CACHE_KEY_VERSION.length - 1
-const IMPLICIT_PROMPT_CACHE_DEPLOYMENTS = new Set([
-  'gpt-5.6',
-  'gpt-5.6-luna',
-  'gpt-5.6-sol',
-  'gpt-5.6-terra',
-])
 
 export type JsonValue =
   | null
@@ -33,7 +33,6 @@ export type PromptCacheIdentityInput = {
 }
 
 export type PromptCacheProviderOptionsInput = {
-  deploymentId: string
   promptCacheKey: string
   routingSource: 'custom' | 'default'
 }
@@ -135,7 +134,7 @@ async function canonicalizeTool(
   const schema = asSchema(inputSchema as FlexibleSchema<unknown>)
   const schemaJson = canonicalizeJson(await schema.jsonSchema)
   const canonicalSchema = jsonSchema(
-    schemaJson ?? {},
+    (schemaJson ?? {}) as JSONSchema7,
     schema.validate ? { validate: schema.validate } : undefined
   )
   const description = getDescription(rawTool)
@@ -203,21 +202,11 @@ export async function buildPromptCacheRequest(
   }
 }
 
-export function supportsImplicitPromptCaching(deploymentId: string): boolean {
-  return IMPLICIT_PROMPT_CACHE_DEPLOYMENTS.has(deploymentId)
-}
-
 export function getOpenAIPromptCacheOptions({
-  deploymentId,
   promptCacheKey,
   routingSource,
-}: PromptCacheProviderOptionsInput): Record<string, unknown> {
+}: PromptCacheProviderOptionsInput): { promptCacheKey?: string } {
   if (routingSource !== 'default') return {}
 
-  return {
-    promptCacheKey,
-    ...(supportsImplicitPromptCaching(deploymentId)
-      ? { promptCacheOptions: { mode: 'implicit' } }
-      : {}),
-  }
+  return { promptCacheKey }
 }

--- a/apps/chat/src/lib/server/promptCacheIdentity.ts
+++ b/apps/chat/src/lib/server/promptCacheIdentity.ts
@@ -32,11 +32,6 @@ export type PromptCacheIdentityInput = {
   tools: ToolSet
 }
 
-export type PromptCacheProviderOptionsInput = {
-  promptCacheKey: string
-  routingSource: 'custom' | 'default'
-}
-
 export type PromptCacheRequest = {
   promptCacheKey: string
   toolOrder: string[]
@@ -200,13 +195,4 @@ export async function buildPromptCacheRequest(
     toolOrder,
     tools,
   }
-}
-
-export function getOpenAIPromptCacheOptions({
-  promptCacheKey,
-  routingSource,
-}: PromptCacheProviderOptionsInput): { promptCacheKey?: string } {
-  if (routingSource !== 'default') return {}
-
-  return { promptCacheKey }
 }

--- a/apps/chat/test/openai-cache-policy.test.ts
+++ b/apps/chat/test/openai-cache-policy.test.ts
@@ -1,0 +1,201 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateText } from 'ai'
+import { describe, expect, test } from 'vitest'
+import { createOpenAIFetch } from '../src/lib/server/openaiCachePolicy'
+
+type JsonObject = Record<string, unknown>
+
+function chatResponse() {
+  return {
+    id: 'chatcmpl-cache-policy',
+    object: 'chat.completion',
+    created: 1,
+    model: 'test-model',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'Synthetic answer.' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    },
+  }
+}
+
+function responsesResponse() {
+  return {
+    id: 'response-cache-policy',
+    object: 'response',
+    created_at: 1,
+    status: 'completed',
+    model: 'test-model',
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        id: 'message-cache-policy',
+        status: 'completed',
+        content: [
+          { type: 'output_text', text: 'Synthetic answer.', annotations: [] },
+        ],
+      },
+    ],
+    usage: {
+      input_tokens: 1,
+      output_tokens: 2,
+      total_tokens: 3,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    },
+  }
+}
+
+function captureFetch(responseBody: unknown, captures: JsonObject[]) {
+  return async (_input: RequestInfo | URL, init?: RequestInit) => {
+    captures.push(JSON.parse(String(init?.body)) as JsonObject)
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+}
+
+describe('OpenAI exact-response cache policy', () => {
+  test('adds the bypass to default Chat Completions requests', async () => {
+    const captures: JsonObject[] = []
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: createOpenAIFetch(
+        'default',
+        captureFetch(chatResponse(), captures)
+      ),
+    })
+
+    const result = await generateText({
+      model: provider.chat('test-model'),
+      prompt: 'Synthetic prompt.',
+      maxRetries: 0,
+    })
+
+    expect(result.text).toBe('Synthetic answer.')
+    expect(captures).toHaveLength(1)
+    expect(captures[0]?.cache).toEqual({
+      'no-cache': true,
+      'no-store': true,
+    })
+  })
+
+  test('adds the bypass and preserves Responses assistant normalization', async () => {
+    const captures: JsonObject[] = []
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: createOpenAIFetch(
+        'default',
+        captureFetch(responsesResponse(), captures)
+      ),
+    })
+
+    const result = await generateText({
+      model: provider.responses('test-model'),
+      messages: [{ role: 'assistant', content: 'Previous answer.' }],
+      maxRetries: 0,
+    })
+
+    expect(result.text).toBe('Synthetic answer.')
+    expect(captures).toHaveLength(1)
+    expect(captures[0]?.cache).toEqual({
+      'no-cache': true,
+      'no-store': true,
+    })
+    expect(captures[0]?.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'assistant',
+          type: 'message',
+          status: 'completed',
+        }),
+      ])
+    )
+  })
+
+  test('preserves custom Responses fields without adding gateway cache policy', async () => {
+    const captures: JsonObject[] = []
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://custom.example/v1',
+      fetch: createOpenAIFetch(
+        'custom',
+        captureFetch(responsesResponse(), captures)
+      ),
+    })
+
+    await generateText({
+      model: provider.responses('gpt-5.6-luna'),
+      prompt: 'Synthetic prompt.',
+      providerOptions: {
+        openai: {
+          store: true,
+          reasoningEffort: 'high',
+        },
+      },
+      maxRetries: 0,
+    })
+
+    expect(captures).toHaveLength(1)
+    expect(captures[0]).not.toHaveProperty('cache')
+    expect(captures[0]?.store).toBe(true)
+    expect(captures[0]?.reasoning).toMatchObject({ effort: 'high' })
+  })
+
+  test('adds the bypass to image-shaped default requests without a prompt cache key', async () => {
+    const captures: JsonObject[] = []
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: createOpenAIFetch(
+        'default',
+        captureFetch(chatResponse(), captures)
+      ),
+    })
+
+    await generateText({
+      model: provider.chat('test-model'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', image: 'data:image/png;base64,c3ludGhldGlj' },
+            { type: 'text', text: 'Describe this synthetic image.' },
+          ],
+        },
+      ],
+      maxRetries: 0,
+    })
+
+    expect(captures).toHaveLength(1)
+    expect(captures[0]?.cache).toEqual({
+      'no-cache': true,
+      'no-store': true,
+    })
+    expect(captures[0]).not.toHaveProperty('prompt_cache_key')
+  })
+
+  test('passes non-JSON bodies through without changing custom requests', async () => {
+    const body = 'synthetic-body'
+    let receivedInit: RequestInit | undefined
+    const fetch = createOpenAIFetch('custom', async (_input, init) => {
+      receivedInit = init
+      return new Response('ok')
+    })
+
+    await fetch('https://custom.example/v1', { method: 'POST', body })
+
+    expect(receivedInit).toEqual({ method: 'POST', body })
+  })
+})

--- a/apps/chat/test/openai-cache-policy.test.ts
+++ b/apps/chat/test/openai-cache-policy.test.ts
@@ -19,9 +19,14 @@ function chatResponse() {
       },
     ],
     usage: {
-      prompt_tokens: 1,
+      prompt_tokens: 1536,
       completion_tokens: 2,
-      total_tokens: 3,
+      total_tokens: 1538,
+      prompt_tokens_details: {
+        cached_tokens: 1024,
+        cache_write_tokens: 256,
+      },
+      completion_tokens_details: { reasoning_tokens: 0 },
     },
   }
 }
@@ -45,10 +50,13 @@ function responsesResponse() {
       },
     ],
     usage: {
-      input_tokens: 1,
+      input_tokens: 1536,
       output_tokens: 2,
-      total_tokens: 3,
-      input_tokens_details: { cached_tokens: 0 },
+      total_tokens: 1538,
+      input_tokens_details: {
+        cached_tokens: 1024,
+        cache_write_tokens: 256,
+      },
       output_tokens_details: { reasoning_tokens: 0 },
     },
   }
@@ -88,6 +96,11 @@ describe('OpenAI exact-response cache policy', () => {
       'no-cache': true,
       'no-store': true,
     })
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: 256,
+      cacheReadTokens: 1024,
+      cacheWriteTokens: 256,
+    })
   })
 
   test('adds the bypass and preserves Responses assistant normalization', async () => {
@@ -122,6 +135,11 @@ describe('OpenAI exact-response cache policy', () => {
         }),
       ])
     )
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: 256,
+      cacheReadTokens: 1024,
+      cacheWriteTokens: 256,
+    })
   })
 
   test('preserves custom Responses fields without adding gateway cache policy', async () => {

--- a/apps/chat/test/openai-cache-policy.test.ts
+++ b/apps/chat/test/openai-cache-policy.test.ts
@@ -1,6 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai'
 import { generateText } from 'ai'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createOpenAIFetch } from '../src/lib/server/openaiCachePolicy'
 
 type JsonObject = Record<string, unknown>
@@ -215,5 +215,22 @@ describe('OpenAI exact-response cache policy', () => {
     await fetch('https://custom.example/v1', { method: 'POST', body })
 
     expect(receivedInit).toEqual({ method: 'POST', body })
+  })
+
+  test('propagates a synchronous fetch SyntaxError without retrying', async () => {
+    const fetchError = new SyntaxError('synthetic fetch failure')
+    const fetchImpl = vi.fn(() => {
+      throw fetchError
+    }) as unknown as typeof globalThis.fetch
+    const fetch = createOpenAIFetch('default', fetchImpl)
+
+    await expect(
+      fetch('https://example.test/v1', {
+        method: 'POST',
+        body: JSON.stringify({ messages: [] }),
+      })
+    ).rejects.toBe(fetchError)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -2,10 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { generateText, type ToolSet, tool } from 'ai'
 import { describe, expect, test } from 'vitest'
 import { z } from 'zod'
-import {
-  buildPromptCacheRequest,
-  getOpenAIPromptCacheOptions,
-} from '../src/lib/server/promptCacheIdentity'
+import { buildPromptCacheRequest } from '../src/lib/server/promptCacheIdentity'
 
 type StablePrefixChange = {
   deploymentId?: string
@@ -283,10 +280,7 @@ describe('prompt cache identity', () => {
       tools: chatRequest.tools,
       toolOrder: chatRequest.toolOrder,
       providerOptions: {
-        openai: getOpenAIPromptCacheOptions({
-          promptCacheKey: chatRequest.promptCacheKey,
-          routingSource: 'default',
-        }),
+        openai: { promptCacheKey: chatRequest.promptCacheKey },
       },
       maxRetries: 0,
     })
@@ -298,9 +292,12 @@ describe('prompt cache identity', () => {
     expect(
       chatTools.map((entry) => (entry.function as Record<string, unknown>).name)
     ).toEqual(['read', 'search'])
+    const searchChatTool = chatTools.find(
+      (entry) => (entry.function as Record<string, unknown>)?.name === 'search'
+    )
     expect(
       Object.keys(
-        ((chatTools[1]?.function as Record<string, unknown>)?.parameters ??
+        ((searchChatTool?.function as Record<string, unknown>)?.parameters ??
           {}) as Record<string, unknown>
       )
     ).toEqual([
@@ -336,10 +333,7 @@ describe('prompt cache identity', () => {
       tools: responsesRequest.tools,
       toolOrder: responsesRequest.toolOrder,
       providerOptions: {
-        openai: getOpenAIPromptCacheOptions({
-          promptCacheKey: responsesRequest.promptCacheKey,
-          routingSource: 'default',
-        }),
+        openai: { promptCacheKey: responsesRequest.promptCacheKey },
       },
       maxRetries: 0,
     })
@@ -351,9 +345,12 @@ describe('prompt cache identity', () => {
     )
     expect(responsesBody?.prompt_cache_options).toBeUndefined()
     expect(responseTools.map((entry) => entry.name)).toEqual(['read', 'search'])
+    const searchResponseTool = responseTools.find(
+      (entry) => entry.name === 'search'
+    )
     expect(
       Object.keys(
-        (responseTools[1]?.parameters ?? {}) as Record<string, unknown>
+        (searchResponseTool?.parameters ?? {}) as Record<string, unknown>
       )
     ).toEqual([
       '$schema',
@@ -368,20 +365,5 @@ describe('prompt cache identity', () => {
       cacheReadTokens: 1024,
       cacheWriteTokens: 256,
     })
-  })
-
-  test('emits the prompt cache key only for the default route', () => {
-    expect(
-      getOpenAIPromptCacheOptions({
-        promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test',
-        routingSource: 'default',
-      })
-    ).toEqual({ promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test' })
-    expect(
-      getOpenAIPromptCacheOptions({
-        promptCacheKey: 'synthetic-key',
-        routingSource: 'custom',
-      })
-    ).toEqual({})
   })
 })

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -197,11 +197,18 @@ describe('prompt cache identity', () => {
 
   test('hashes only transport-visible OpenAI tool options', async () => {
     const baseTools = createTools()
-    baseTools.search.inputExamples = [{ input: { query: 'base' } }]
-    baseTools.search.providerOptions = { openai: { deferLoading: false } }
-    const changedTools = createTools()
-    changedTools.search.inputExamples = [{ input: { query: 'changed' } }]
-    changedTools.search.providerOptions = { openai: { deferLoading: true } }
+    const inputExampleTools = createTools()
+    inputExampleTools.search.inputExamples = [{ input: { query: 'changed' } }]
+    const unrelatedProviderTools = createTools()
+    unrelatedProviderTools.search.providerOptions = {
+      synthetic: { marker: 'changed' },
+    }
+    const wireChangedTools = createTools()
+    wireChangedTools.search.inputExamples = [{ input: { query: 'changed' } }]
+    wireChangedTools.search.providerOptions = {
+      synthetic: { marker: 'changed' },
+      openai: { deferLoading: true },
+    }
 
     const baseChat = await buildPromptCacheRequest({
       deploymentId: 'gpt-4.1',
@@ -209,11 +216,17 @@ describe('prompt cache identity', () => {
       instructions: 'Synthetic instructions.',
       tools: baseTools,
     })
-    const changedChat = await buildPromptCacheRequest({
+    const inputExampleChat = await buildPromptCacheRequest({
       deploymentId: 'gpt-4.1',
       transport: 'chat',
       instructions: 'Synthetic instructions.',
-      tools: changedTools,
+      tools: inputExampleTools,
+    })
+    const unrelatedProviderChat = await buildPromptCacheRequest({
+      deploymentId: 'gpt-4.1',
+      transport: 'chat',
+      instructions: 'Synthetic instructions.',
+      tools: unrelatedProviderTools,
     })
     const baseResponses = await buildPromptCacheRequest({
       deploymentId: 'gpt-5.6-luna',
@@ -221,15 +234,34 @@ describe('prompt cache identity', () => {
       instructions: 'Synthetic instructions.',
       tools: baseTools,
     })
-    const changedResponses = await buildPromptCacheRequest({
+    const inputExampleResponses = await buildPromptCacheRequest({
       deploymentId: 'gpt-5.6-luna',
       transport: 'responses',
       instructions: 'Synthetic instructions.',
-      tools: changedTools,
+      tools: inputExampleTools,
+    })
+    const unrelatedProviderResponses = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: unrelatedProviderTools,
+    })
+    const wireChangedResponses = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: wireChangedTools,
     })
 
-    expect(changedChat.promptCacheKey).toBe(baseChat.promptCacheKey)
-    expect(changedResponses.promptCacheKey).not.toBe(
+    expect(inputExampleChat.promptCacheKey).toBe(baseChat.promptCacheKey)
+    expect(unrelatedProviderChat.promptCacheKey).toBe(baseChat.promptCacheKey)
+    expect(inputExampleResponses.promptCacheKey).toBe(
+      baseResponses.promptCacheKey
+    )
+    expect(unrelatedProviderResponses.promptCacheKey).toBe(
+      baseResponses.promptCacheKey
+    )
+    expect(wireChangedResponses.promptCacheKey).not.toBe(
       baseResponses.promptCacheKey
     )
 
@@ -242,8 +274,8 @@ describe('prompt cache identity', () => {
     await generateText({
       model: provider.responses('gpt-5.6-luna'),
       prompt: 'Synthetic prompt.',
-      tools: changedResponses.tools,
-      toolOrder: changedResponses.toolOrder,
+      tools: wireChangedResponses.tools,
+      toolOrder: wireChangedResponses.toolOrder,
       maxRetries: 0,
     })
 

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -295,18 +295,19 @@ describe('prompt cache identity', () => {
     const searchChatTool = chatTools.find(
       (entry) => (entry.function as Record<string, unknown>)?.name === 'search'
     )
-    expect(
-      Object.keys(
-        ((searchChatTool?.function as Record<string, unknown>)?.parameters ??
-          {}) as Record<string, unknown>
+    const chatParameters = ((
+      searchChatTool?.function as Record<string, unknown>
+    )?.parameters ?? {}) as Record<string, unknown>
+    const chatParameterKeys = Object.keys(chatParameters)
+    expect(chatParameterKeys).toEqual(
+      [...chatParameterKeys].sort((left, right) =>
+        left.localeCompare(right, 'en-US')
       )
-    ).toEqual([
-      '$schema',
-      'additionalProperties',
-      'properties',
-      'required',
-      'type',
-    ])
+    )
+    expect(chatParameters).toMatchObject({
+      type: 'object',
+      properties: expect.any(Object),
+    })
     expect(chatResult.usage.inputTokenDetails).toEqual({
       noCacheTokens: 256,
       cacheReadTokens: 1024,
@@ -348,17 +349,17 @@ describe('prompt cache identity', () => {
     const searchResponseTool = responseTools.find(
       (entry) => entry.name === 'search'
     )
-    expect(
-      Object.keys(
-        (searchResponseTool?.parameters ?? {}) as Record<string, unknown>
+    const responseParameters = (searchResponseTool?.parameters ?? {}) as Record<
+      string,
+      unknown
+    >
+    const responseParameterKeys = Object.keys(responseParameters)
+    expect(responseParameterKeys).toEqual(
+      [...responseParameterKeys].sort((left, right) =>
+        left.localeCompare(right, 'en-US')
       )
-    ).toEqual([
-      '$schema',
-      'additionalProperties',
-      'properties',
-      'required',
-      'type',
-    ])
+    )
+    expect(responseParameters).toEqual(chatParameters)
 
     expect(responseResult.usage.inputTokenDetails).toEqual({
       noCacheTokens: 256,

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -105,7 +105,6 @@ describe('prompt cache identity', () => {
     expect(first.promptCacheKey).toBe(second.promptCacheKey)
     expect(first.toolOrder).toEqual(['read', 'search'])
     expect(second.toolOrder).toEqual(first.toolOrder)
-    expect(first.providerTools).toEqual(second.providerTools)
   })
 
   test.each([

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -115,6 +115,7 @@ describe('prompt cache identity', () => {
     })
 
     expect(first.promptCacheKey).toBe(second.promptCacheKey)
+    expect(first.promptCacheKey).toHaveLength(64)
     expect(first.toolOrder).toEqual(['read', 'search'])
     expect(second.toolOrder).toEqual(first.toolOrder)
   })

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -1,14 +1,19 @@
 import { createOpenAI } from '@ai-sdk/openai'
-import { generateText, tool } from 'ai'
+import { generateText, type ToolSet, tool } from 'ai'
 import { describe, expect, test } from 'vitest'
 import { z } from 'zod'
 import {
   buildPromptCacheRequest,
   getOpenAIPromptCacheOptions,
-  supportsImplicitPromptCaching,
 } from '../src/lib/server/promptCacheIdentity'
 
-function createTools(order: 'first' | 'second' = 'first') {
+type StablePrefixChange = {
+  deploymentId?: string
+  instructions?: string
+  transport?: 'chat' | 'responses'
+}
+
+function createTools(order: 'first' | 'second' = 'first'): ToolSet {
   const first = tool({
     description: 'Search the synthetic corpus.',
     inputSchema: z.object({
@@ -120,7 +125,7 @@ describe('prompt cache identity', () => {
     expect(second.toolOrder).toEqual(first.toolOrder)
   })
 
-  test.each([
+  test.each<[string, StablePrefixChange]>([
     ['instructions', { instructions: 'Changed instructions.' }],
     ['deployment', { deploymentId: 'auto-router' }],
     ['transport', { transport: 'chat' as const }],
@@ -155,10 +160,10 @@ describe('prompt cache identity', () => {
       instructions: 'Synthetic instructions.',
       tools: {
         ...createTools(),
-        search: tool({
+        search: tool<{ query: string }, { ok: boolean }, Record<never, never>>({
           description: 'Changed search description.',
           inputSchema: z.object({ query: z.string() }),
-          execute: async () => ({ differentRuntime: true }),
+          execute: async (_input) => ({ ok: true }),
         }),
       },
     })
@@ -174,11 +179,11 @@ describe('prompt cache identity', () => {
       transport: 'responses',
       instructions: 'Synthetic instructions.',
       tools: {
-        search: tool({
+        search: tool<{ query: string }, { ok: boolean }, Record<never, never>>({
           description: 'Search the synthetic corpus.',
           inputSchema: z.object({ query: z.string() }),
           strict: true,
-          inputExamples: [{ query: 'base' }],
+          inputExamples: [{ input: { query: 'base' } }],
           providerOptions: { openai: { strictJsonSchema: true } },
           execute: async () => ({ ok: true }),
         }),
@@ -189,11 +194,11 @@ describe('prompt cache identity', () => {
       transport: 'responses',
       instructions: 'Synthetic instructions.',
       tools: {
-        search: tool({
+        search: tool<{ query: string }, { ok: boolean }, Record<never, never>>({
           description: 'Search the synthetic corpus.',
           inputSchema: z.object({ query: z.string() }),
           strict: false,
-          inputExamples: [{ query: 'changed' }],
+          inputExamples: [{ input: { query: 'changed' } }],
           providerOptions: { openai: { strictJsonSchema: false } },
           execute: async () => ({ ok: true }),
         }),
@@ -206,7 +211,7 @@ describe('prompt cache identity', () => {
   test('ignores runtime-only changes while retaining the executable tool', async () => {
     const firstTools = createTools()
     const secondTools = createTools()
-    secondTools.search.execute = async () => ({ runtime: 'changed' })
+    secondTools.search.execute = async () => ({ ok: true })
 
     const first = await buildPromptCacheRequest({
       deploymentId: 'gpt-5.6-luna',
@@ -279,7 +284,6 @@ describe('prompt cache identity', () => {
       toolOrder: chatRequest.toolOrder,
       providerOptions: {
         openai: getOpenAIPromptCacheOptions({
-          deploymentId: 'gpt-4.1',
           promptCacheKey: chatRequest.promptCacheKey,
           routingSource: 'default',
         }),
@@ -333,7 +337,6 @@ describe('prompt cache identity', () => {
       toolOrder: responsesRequest.toolOrder,
       providerOptions: {
         openai: getOpenAIPromptCacheOptions({
-          deploymentId: 'gpt-5.6-luna',
           promptCacheKey: responsesRequest.promptCacheKey,
           routingSource: 'default',
         }),
@@ -346,7 +349,7 @@ describe('prompt cache identity', () => {
     expect(responsesBody?.prompt_cache_key).toBe(
       responsesRequest.promptCacheKey
     )
-    expect(responsesBody?.prompt_cache_options).toEqual({ mode: 'implicit' })
+    expect(responsesBody?.prompt_cache_options).toBeUndefined()
     expect(responseTools.map((entry) => entry.name)).toEqual(['read', 'search'])
     expect(
       Object.keys(
@@ -367,31 +370,15 @@ describe('prompt cache identity', () => {
     })
   })
 
-  test('emits prompt options only for the default route and supported deployment', () => {
-    expect(supportsImplicitPromptCaching('gpt-5.6-luna')).toBe(true)
-    expect(supportsImplicitPromptCaching('gpt-5.6')).toBe(true)
-    expect(supportsImplicitPromptCaching('gpt-4.1')).toBe(false)
-    expect(supportsImplicitPromptCaching('auto-router')).toBe(false)
+  test('emits the prompt cache key only for the default route', () => {
     expect(
       getOpenAIPromptCacheOptions({
-        deploymentId: 'gpt-5.6-luna',
         promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test',
         routingSource: 'default',
       })
-    ).toEqual({
-      promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test',
-      promptCacheOptions: { mode: 'implicit' },
-    })
+    ).toEqual({ promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test' })
     expect(
       getOpenAIPromptCacheOptions({
-        deploymentId: 'auto-router',
-        promptCacheKey: 'synthetic-key',
-        routingSource: 'default',
-      })
-    ).toEqual({ promptCacheKey: 'synthetic-key' })
-    expect(
-      getOpenAIPromptCacheOptions({
-        deploymentId: 'gpt-5.6-luna',
         promptCacheKey: 'synthetic-key',
         routingSource: 'custom',
       })

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -42,7 +42,16 @@ function chatResponse() {
         finish_reason: 'stop',
       },
     ],
-    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    usage: {
+      prompt_tokens: 1536,
+      completion_tokens: 1,
+      total_tokens: 1537,
+      prompt_tokens_details: {
+        cached_tokens: 1024,
+        cache_write_tokens: 256,
+      },
+      completion_tokens_details: { reasoning_tokens: 0 },
+    },
   }
 }
 
@@ -65,10 +74,13 @@ function responsesResponse() {
       },
     ],
     usage: {
-      input_tokens: 1,
+      input_tokens: 1536,
       output_tokens: 1,
-      total_tokens: 2,
-      input_tokens_details: { cached_tokens: 0 },
+      total_tokens: 1537,
+      input_tokens_details: {
+        cached_tokens: 1024,
+        cache_write_tokens: 256,
+      },
       output_tokens_details: { reasoning_tokens: 0 },
     },
   }
@@ -258,7 +270,7 @@ describe('prompt cache identity', () => {
       fetch: captureFetch(chatResponse(), chatCaptures),
     })
 
-    await generateText({
+    const chatResult = await generateText({
       model: chatProvider.chat('gpt-4.1'),
       prompt: 'Synthetic prompt.',
       instructions: 'Synthetic instructions.',
@@ -293,6 +305,11 @@ describe('prompt cache identity', () => {
       'required',
       'type',
     ])
+    expect(chatResult.usage.inputTokenDetails).toEqual({
+      noCacheTokens: 256,
+      cacheReadTokens: 1024,
+      cacheWriteTokens: 256,
+    })
 
     const responsesCaptures: Record<string, unknown>[] = []
     const responsesRequest = await buildPromptCacheRequest({
@@ -307,7 +324,7 @@ describe('prompt cache identity', () => {
       fetch: captureFetch(responsesResponse(), responsesCaptures),
     })
 
-    await generateText({
+    const responseResult = await generateText({
       model: responsesProvider.responses('gpt-5.6-luna'),
       prompt: 'Synthetic prompt.',
       instructions: 'Synthetic instructions.',
@@ -341,6 +358,12 @@ describe('prompt cache identity', () => {
       'required',
       'type',
     ])
+
+    expect(responseResult.usage.inputTokenDetails).toEqual({
+      noCacheTokens: 256,
+      cacheReadTokens: 1024,
+      cacheWriteTokens: 256,
+    })
   })
 
   test('emits prompt options only for the default route and supported deployment', () => {

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai'
-import { generateText, type ToolSet, tool } from 'ai'
+import { asSchema, generateText, jsonSchema, type ToolSet, tool } from 'ai'
 import { describe, expect, test } from 'vitest'
 import { z } from 'zod'
 import { buildPromptCacheRequest } from '../src/lib/server/promptCacheIdentity'
@@ -48,11 +48,6 @@ function chatResponse() {
       prompt_tokens: 1536,
       completion_tokens: 1,
       total_tokens: 1537,
-      prompt_tokens_details: {
-        cached_tokens: 1024,
-        cache_write_tokens: 256,
-      },
-      completion_tokens_details: { reasoning_tokens: 0 },
     },
   }
 }
@@ -80,8 +75,7 @@ function responsesResponse() {
       output_tokens: 1,
       total_tokens: 1537,
       input_tokens_details: {
-        cached_tokens: 1024,
-        cache_write_tokens: 256,
+        cached_tokens: 0,
       },
       output_tokens_details: { reasoning_tokens: 0 },
     },
@@ -170,7 +164,7 @@ describe('prompt cache identity', () => {
     expect(base.tools.search.execute).toBe(baseTools.search.execute)
   })
 
-  test('changes the key for provider-visible tool options', async () => {
+  test('changes the key for serialized tool strictness', async () => {
     const base = await buildPromptCacheRequest({
       deploymentId: 'gpt-5.6-luna',
       transport: 'responses',
@@ -180,8 +174,6 @@ describe('prompt cache identity', () => {
           description: 'Search the synthetic corpus.',
           inputSchema: z.object({ query: z.string() }),
           strict: true,
-          inputExamples: [{ input: { query: 'base' } }],
-          providerOptions: { openai: { strictJsonSchema: true } },
           execute: async () => ({ ok: true }),
         }),
       },
@@ -195,14 +187,95 @@ describe('prompt cache identity', () => {
           description: 'Search the synthetic corpus.',
           inputSchema: z.object({ query: z.string() }),
           strict: false,
-          inputExamples: [{ input: { query: 'changed' } }],
-          providerOptions: { openai: { strictJsonSchema: false } },
           execute: async () => ({ ok: true }),
         }),
       },
     })
 
     expect(changed.promptCacheKey).not.toBe(base.promptCacheKey)
+  })
+
+  test('hashes only transport-visible OpenAI tool options', async () => {
+    const baseTools = createTools()
+    baseTools.search.inputExamples = [{ input: { query: 'base' } }]
+    baseTools.search.providerOptions = { openai: { deferLoading: false } }
+    const changedTools = createTools()
+    changedTools.search.inputExamples = [{ input: { query: 'changed' } }]
+    changedTools.search.providerOptions = { openai: { deferLoading: true } }
+
+    const baseChat = await buildPromptCacheRequest({
+      deploymentId: 'gpt-4.1',
+      transport: 'chat',
+      instructions: 'Synthetic instructions.',
+      tools: baseTools,
+    })
+    const changedChat = await buildPromptCacheRequest({
+      deploymentId: 'gpt-4.1',
+      transport: 'chat',
+      instructions: 'Synthetic instructions.',
+      tools: changedTools,
+    })
+    const baseResponses = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: baseTools,
+    })
+    const changedResponses = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: changedTools,
+    })
+
+    expect(changedChat.promptCacheKey).toBe(baseChat.promptCacheKey)
+    expect(changedResponses.promptCacheKey).not.toBe(
+      baseResponses.promptCacheKey
+    )
+
+    const captures: Record<string, unknown>[] = []
+    const provider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: captureFetch(responsesResponse(), captures),
+    })
+    await generateText({
+      model: provider.responses('gpt-5.6-luna'),
+      prompt: 'Synthetic prompt.',
+      tools: changedResponses.tools,
+      toolOrder: changedResponses.toolOrder,
+      maxRetries: 0,
+    })
+
+    const responseTools = captures[0]?.tools as Record<string, unknown>[]
+    expect(
+      responseTools.find((entry) => entry.name === 'search')
+    ).toMatchObject({ defer_loading: true })
+  })
+
+  test('retains a __proto__ property in canonical tool schemas', async () => {
+    const request = await buildPromptCacheRequest({
+      deploymentId: 'gpt-4.1',
+      transport: 'chat',
+      instructions: 'Synthetic instructions.',
+      tools: {
+        inspect: tool({
+          inputSchema: jsonSchema(
+            JSON.parse(
+              '{"type":"object","properties":{"__proto__":{"type":"string"}}}'
+            )
+          ),
+          execute: async () => ({ ok: true }),
+        }),
+      },
+    })
+
+    const schema = await asSchema(request.tools.inspect.inputSchema).jsonSchema
+    const properties = schema.properties as Record<string, unknown>
+    expect(Object.hasOwn(properties, '__proto__')).toBe(true)
+    expect(
+      Object.getOwnPropertyDescriptor(properties, '__proto__')?.value
+    ).toEqual({ type: 'string' })
   })
 
   test('ignores runtime-only changes while retaining the executable tool', async () => {
@@ -273,7 +346,7 @@ describe('prompt cache identity', () => {
       fetch: captureFetch(chatResponse(), chatCaptures),
     })
 
-    const chatResult = await generateText({
+    await generateText({
       model: chatProvider.chat('gpt-4.1'),
       prompt: 'Synthetic prompt.',
       instructions: 'Synthetic instructions.',
@@ -308,12 +381,6 @@ describe('prompt cache identity', () => {
       type: 'object',
       properties: expect.any(Object),
     })
-    expect(chatResult.usage.inputTokenDetails).toEqual({
-      noCacheTokens: 256,
-      cacheReadTokens: 1024,
-      cacheWriteTokens: 256,
-    })
-
     const responsesCaptures: Record<string, unknown>[] = []
     const responsesRequest = await buildPromptCacheRequest({
       deploymentId: 'gpt-5.6-luna',
@@ -327,7 +394,7 @@ describe('prompt cache identity', () => {
       fetch: captureFetch(responsesResponse(), responsesCaptures),
     })
 
-    const responseResult = await generateText({
+    await generateText({
       model: responsesProvider.responses('gpt-5.6-luna'),
       prompt: 'Synthetic prompt.',
       instructions: 'Synthetic instructions.',
@@ -360,11 +427,5 @@ describe('prompt cache identity', () => {
       )
     )
     expect(responseParameters).toEqual(chatParameters)
-
-    expect(responseResult.usage.inputTokenDetails).toEqual({
-      noCacheTokens: 256,
-      cacheReadTokens: 1024,
-      cacheWriteTokens: 256,
-    })
   })
 })

--- a/apps/chat/test/prompt-cache-identity.test.ts
+++ b/apps/chat/test/prompt-cache-identity.test.ts
@@ -1,0 +1,377 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateText, tool } from 'ai'
+import { describe, expect, test } from 'vitest'
+import { z } from 'zod'
+import {
+  buildPromptCacheRequest,
+  getOpenAIPromptCacheOptions,
+  supportsImplicitPromptCaching,
+} from '../src/lib/server/promptCacheIdentity'
+
+function createTools(order: 'first' | 'second' = 'first') {
+  const first = tool({
+    description: 'Search the synthetic corpus.',
+    inputSchema: z.object({
+      query: z.string().describe('Search query'),
+      limit: z.number().int().optional(),
+    }),
+    strict: true,
+    execute: async () => ({ ok: true }),
+  })
+  const second = tool({
+    description: 'Read one synthetic result.',
+    inputSchema: z.object({ resultId: z.string() }),
+    execute: async () => ({ ok: true }),
+  })
+
+  return order === 'first'
+    ? { search: first, read: second }
+    : { read: second, search: first }
+}
+
+function chatResponse() {
+  return {
+    id: 'chatcmpl-prompt-cache-identity',
+    object: 'chat.completion',
+    created: 1,
+    model: 'gpt-4.1',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'Synthetic answer.' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  }
+}
+
+function responsesResponse() {
+  return {
+    id: 'response-prompt-cache-identity',
+    object: 'response',
+    created_at: 1,
+    status: 'completed',
+    model: 'gpt-5.6-luna',
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        id: 'message-prompt-cache-identity',
+        status: 'completed',
+        content: [
+          { type: 'output_text', text: 'Synthetic answer.', annotations: [] },
+        ],
+      },
+    ],
+    usage: {
+      input_tokens: 1,
+      output_tokens: 1,
+      total_tokens: 2,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    },
+  }
+}
+
+function captureFetch(
+  responseBody: unknown,
+  captures: Record<string, unknown>[]
+) {
+  return async (_input: RequestInfo | URL, init?: RequestInit) => {
+    captures.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+}
+
+describe('prompt cache identity', () => {
+  test('is stable across tool insertion order and returns one provider order', async () => {
+    const first = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: createTools('first'),
+    })
+    const second = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: createTools('second'),
+    })
+
+    expect(first.promptCacheKey).toBe(second.promptCacheKey)
+    expect(first.toolOrder).toEqual(['read', 'search'])
+    expect(second.toolOrder).toEqual(first.toolOrder)
+    expect(first.providerTools).toEqual(second.providerTools)
+  })
+
+  test.each([
+    ['instructions', { instructions: 'Changed instructions.' }],
+    ['deployment', { deploymentId: 'auto-router' }],
+    ['transport', { transport: 'chat' as const }],
+  ])('changes the key when the stable prefix %s changes', async (_, change) => {
+    const base = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: createTools(),
+    })
+    const changed = await buildPromptCacheRequest({
+      deploymentId: change.deploymentId ?? 'gpt-5.6-luna',
+      transport: change.transport ?? 'responses',
+      instructions: change.instructions ?? 'Synthetic instructions.',
+      tools: createTools(),
+    })
+
+    expect(changed.promptCacheKey).not.toBe(base.promptCacheKey)
+  })
+
+  test('changes the key for provider-visible tool changes but not runtime functions', async () => {
+    const baseTools = createTools()
+    const base = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: baseTools,
+    })
+    const changed = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: {
+        ...createTools(),
+        search: tool({
+          description: 'Changed search description.',
+          inputSchema: z.object({ query: z.string() }),
+          execute: async () => ({ differentRuntime: true }),
+        }),
+      },
+    })
+
+    expect(changed.promptCacheKey).not.toBe(base.promptCacheKey)
+    expect(changed.tools.search.execute).not.toBeUndefined()
+    expect(base.tools.search.execute).toBe(baseTools.search.execute)
+  })
+
+  test('changes the key for provider-visible tool options', async () => {
+    const base = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: {
+        search: tool({
+          description: 'Search the synthetic corpus.',
+          inputSchema: z.object({ query: z.string() }),
+          strict: true,
+          inputExamples: [{ query: 'base' }],
+          providerOptions: { openai: { strictJsonSchema: true } },
+          execute: async () => ({ ok: true }),
+        }),
+      },
+    })
+    const changed = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: {
+        search: tool({
+          description: 'Search the synthetic corpus.',
+          inputSchema: z.object({ query: z.string() }),
+          strict: false,
+          inputExamples: [{ query: 'changed' }],
+          providerOptions: { openai: { strictJsonSchema: false } },
+          execute: async () => ({ ok: true }),
+        }),
+      },
+    })
+
+    expect(changed.promptCacheKey).not.toBe(base.promptCacheKey)
+  })
+
+  test('ignores runtime-only changes while retaining the executable tool', async () => {
+    const firstTools = createTools()
+    const secondTools = createTools()
+    secondTools.search.execute = async () => ({ runtime: 'changed' })
+
+    const first = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: firstTools,
+    })
+    const second = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: secondTools,
+    })
+
+    expect(second.promptCacheKey).toBe(first.promptCacheKey)
+    expect(second.tools.search.execute).toBe(secondTools.search.execute)
+  })
+
+  test.each([
+    ['userId', 'synthetic-user'],
+    ['participantId', 'synthetic-participant'],
+    ['chatbotId', 'synthetic-chatbot'],
+    ['threadId', 'synthetic-thread'],
+    ['assistantMessageId', 'synthetic-assistant'],
+    ['messageId', 'synthetic-message'],
+    ['requestId', 'synthetic-request'],
+    ['toolCallId', 'synthetic-tool-call'],
+    ['mcpServerId', 'synthetic-mcp-server'],
+  ])('does not accept %s as a stable identity input', async (field, value) => {
+    const base = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: createTools(),
+    })
+    const inputWithRequestIdentifier = {
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses' as const,
+      instructions: 'Synthetic instructions.',
+      tools: createTools(),
+      [field]: value,
+    }
+
+    const withRequestIdentifiers = await buildPromptCacheRequest(
+      inputWithRequestIdentifier
+    )
+
+    expect(withRequestIdentifiers.promptCacheKey).toBe(base.promptCacheKey)
+  })
+
+  test('serializes the same canonical tool projection on Chat and Responses', async () => {
+    const chatCaptures: Record<string, unknown>[] = []
+    const chatRequest = await buildPromptCacheRequest({
+      deploymentId: 'gpt-4.1',
+      transport: 'chat',
+      instructions: 'Synthetic instructions.',
+      tools: createTools(),
+    })
+    const chatProvider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: captureFetch(chatResponse(), chatCaptures),
+    })
+
+    await generateText({
+      model: chatProvider.chat('gpt-4.1'),
+      prompt: 'Synthetic prompt.',
+      instructions: 'Synthetic instructions.',
+      tools: chatRequest.tools,
+      toolOrder: chatRequest.toolOrder,
+      providerOptions: {
+        openai: getOpenAIPromptCacheOptions({
+          deploymentId: 'gpt-4.1',
+          promptCacheKey: chatRequest.promptCacheKey,
+          routingSource: 'default',
+        }),
+      },
+      maxRetries: 0,
+    })
+
+    const chatBody = chatCaptures[0]
+    const chatTools = chatBody?.tools as Record<string, unknown>[]
+    expect(chatBody?.prompt_cache_key).toBe(chatRequest.promptCacheKey)
+    expect(chatBody?.prompt_cache_options).toBeUndefined()
+    expect(
+      chatTools.map((entry) => (entry.function as Record<string, unknown>).name)
+    ).toEqual(['read', 'search'])
+    expect(
+      Object.keys(
+        ((chatTools[1]?.function as Record<string, unknown>)?.parameters ??
+          {}) as Record<string, unknown>
+      )
+    ).toEqual([
+      '$schema',
+      'additionalProperties',
+      'properties',
+      'required',
+      'type',
+    ])
+
+    const responsesCaptures: Record<string, unknown>[] = []
+    const responsesRequest = await buildPromptCacheRequest({
+      deploymentId: 'gpt-5.6-luna',
+      transport: 'responses',
+      instructions: 'Synthetic instructions.',
+      tools: createTools(),
+    })
+    const responsesProvider = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      fetch: captureFetch(responsesResponse(), responsesCaptures),
+    })
+
+    await generateText({
+      model: responsesProvider.responses('gpt-5.6-luna'),
+      prompt: 'Synthetic prompt.',
+      instructions: 'Synthetic instructions.',
+      tools: responsesRequest.tools,
+      toolOrder: responsesRequest.toolOrder,
+      providerOptions: {
+        openai: getOpenAIPromptCacheOptions({
+          deploymentId: 'gpt-5.6-luna',
+          promptCacheKey: responsesRequest.promptCacheKey,
+          routingSource: 'default',
+        }),
+      },
+      maxRetries: 0,
+    })
+
+    const responsesBody = responsesCaptures[0]
+    const responseTools = responsesBody?.tools as Record<string, unknown>[]
+    expect(responsesBody?.prompt_cache_key).toBe(
+      responsesRequest.promptCacheKey
+    )
+    expect(responsesBody?.prompt_cache_options).toEqual({ mode: 'implicit' })
+    expect(responseTools.map((entry) => entry.name)).toEqual(['read', 'search'])
+    expect(
+      Object.keys(
+        (responseTools[1]?.parameters ?? {}) as Record<string, unknown>
+      )
+    ).toEqual([
+      '$schema',
+      'additionalProperties',
+      'properties',
+      'required',
+      'type',
+    ])
+  })
+
+  test('emits prompt options only for the default route and supported deployment', () => {
+    expect(supportsImplicitPromptCaching('gpt-5.6-luna')).toBe(true)
+    expect(supportsImplicitPromptCaching('gpt-5.6')).toBe(true)
+    expect(supportsImplicitPromptCaching('gpt-4.1')).toBe(false)
+    expect(supportsImplicitPromptCaching('auto-router')).toBe(false)
+    expect(
+      getOpenAIPromptCacheOptions({
+        deploymentId: 'gpt-5.6-luna',
+        promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test',
+        routingSource: 'default',
+      })
+    ).toEqual({
+      promptCacheKey: 'klicker:prompt-prefix:v1:sha256:test',
+      promptCacheOptions: { mode: 'implicit' },
+    })
+    expect(
+      getOpenAIPromptCacheOptions({
+        deploymentId: 'auto-router',
+        promptCacheKey: 'synthetic-key',
+        routingSource: 'default',
+      })
+    ).toEqual({ promptCacheKey: 'synthetic-key' })
+    expect(
+      getOpenAIPromptCacheOptions({
+        deploymentId: 'gpt-5.6-luna',
+        promptCacheKey: 'synthetic-key',
+        routingSource: 'custom',
+      })
+    ).toEqual({})
+  })
+})

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -72,6 +72,11 @@ provider request: `cache.no-cache` and `cache.no-store` are both `true`.
 Custom endpoints retain their existing request fields. The same fetch boundary
 continues to normalize assistant items for Responses requests.
 
+A chatbot with a custom API key is treated as custom routing even when it has
+no custom base URL and therefore still reaches the shared gateway. That
+key-only path intentionally receives neither the default exact-response bypass
+nor the default prompt-cache identity.
+
 For default requests, `POST` passes the final `systemPrompt`, requested
 deployment identity, transport family, and MCP tools to
 `buildPromptCacheRequest`. The helper hashes only a versioned canonical
@@ -82,6 +87,11 @@ participant/user/chatbot/thread/message/request identifiers, and raw tool-call
 identifiers are not identity inputs. The rebuilt tools retain runtime
 execution, and the route supplies their deterministic `toolOrder` to both
 transport families.
+
+Function-valued tool descriptions are resolved with an undefined tool context
+for both the fingerprint and the provider request because this route does not
+pass AI SDK `toolsContext`. Introducing context-dependent descriptions would
+require extending this identity contract before they can participate safely.
 
 The provider's implicit prompt-cache behavior remains the default; the route
 does not override it with a deployment allow-list or an explicit

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -84,9 +84,11 @@ provider-visible projection with SHA-256, then emits the provider-safe
 `klicker:pc:v1:<50-hex-character-digest>` key and
 passes it to the OpenAI provider. Tool execution functions, MCP clients,
 participant/user/chatbot/thread/message/request identifiers, and raw tool-call
-identifiers are not identity inputs. The rebuilt tools retain runtime
-execution, and the route supplies their deterministic `toolOrder` to both
-transport families.
+identifiers are not identity inputs. Tool input examples are excluded because
+neither OpenAI transport serializes them. Tool provider options are excluded
+for Chat Completions and limited to the OpenAI Responses options that reach the
+request. The rebuilt tools retain runtime execution, and the route supplies
+their deterministic `toolOrder` to both transport families.
 
 Function-valued tool descriptions are resolved with an undefined tool context
 for both the fingerprint and the provider request because this route does not

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -84,12 +84,11 @@ identifiers are not identity inputs. The rebuilt tools retain runtime
 execution, and the route supplies their deterministic `toolOrder` to both
 transport families.
 
-Implicit prompt-cache mode is emitted only for the explicit direct GPT-5.6
-deployment allow-list in `supportsImplicitPromptCaching`; older deployments
-and the unresolved `auto-router` identity receive the stable key without that
-mode. The route does not emit an explicit prompt-cache breakpoint. These
-choices preserve a stable-prefix contract without claiming resolved router
-behavior or a provider cache hit.
+The provider's implicit prompt-cache behavior remains the default; the route
+does not override it with a deployment allow-list or an explicit
+`promptCacheOptions.mode`. The route does not emit an explicit prompt-cache
+breakpoint. The stable key is an optimization for provider cache matching, not
+evidence of resolved router behavior or a provider cache hit.
 
 `apps/chat/test/openai-cache-policy.test.ts` and
 `apps/chat/test/prompt-cache-identity.test.ts` use synthetic, no-network Chat

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -77,8 +77,7 @@ deployment identity, transport family, and MCP tools to
 `buildPromptCacheRequest`. The helper hashes only a versioned canonical
 provider-visible projection with SHA-256, then emits the provider-safe
 `klicker:pc:v1:<50-hex-character-digest>` key and
-`getOpenAIPromptCacheOptions` passes it to the OpenAI provider. Tool execution
-functions, MCP clients,
+passes it to the OpenAI provider. Tool execution functions, MCP clients,
 participant/user/chatbot/thread/message/request identifiers, and raw tool-call
 identifiers are not identity inputs. The rebuilt tools retain runtime
 execution, and the route supplies their deterministic `toolOrder` to both

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -75,8 +75,10 @@ continues to normalize assistant items for Responses requests.
 For default requests, `POST` passes the final `systemPrompt`, requested
 deployment identity, transport family, and MCP tools to
 `buildPromptCacheRequest`. The helper hashes only a versioned canonical
-provider-visible projection with SHA-256, then `getOpenAIPromptCacheOptions`
-passes the key to the OpenAI provider. Tool execution functions, MCP clients,
+provider-visible projection with SHA-256, then emits the provider-safe
+`klicker:pc:v1:<50-hex-character-digest>` key and
+`getOpenAIPromptCacheOptions` passes it to the OpenAI provider. Tool execution
+functions, MCP clients,
 participant/user/chatbot/thread/message/request identifiers, and raw tool-call
 identifiers are not identity inputs. The rebuilt tools retain runtime
 execution, and the route supplies their deterministic `toolOrder` to both

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -63,6 +63,41 @@ fixture in `apps/chat/test/openai-chat-streaming.test.ts` covers this boundary
 with injected SSE. A green fixture proves the local provider conversion path;
 it does not replace a real-upstream first-turn staging smoke test.
 
+## Provider request cache boundaries
+
+The chat route keeps two cache mechanisms separate. `getModel` constructs a
+default OpenAI-compatible provider or a chatbot-specific custom provider, and
+`createOpenAIFetch` adds LiteLLM's exact-response bypass only to the default
+provider request: `cache.no-cache` and `cache.no-store` are both `true`.
+Custom endpoints retain their existing request fields. The same fetch boundary
+continues to normalize assistant items for Responses requests.
+
+For default requests, `POST` passes the final `systemPrompt`, requested
+deployment identity, transport family, and MCP tools to
+`buildPromptCacheRequest`. The helper hashes only a versioned canonical
+provider-visible projection with SHA-256, then `getOpenAIPromptCacheOptions`
+passes the key to the OpenAI provider. Tool execution functions, MCP clients,
+participant/user/chatbot/thread/message/request identifiers, and raw tool-call
+identifiers are not identity inputs. The rebuilt tools retain runtime
+execution, and the route supplies their deterministic `toolOrder` to both
+transport families.
+
+Implicit prompt-cache mode is emitted only for the explicit direct GPT-5.6
+deployment allow-list in `supportsImplicitPromptCaching`; older deployments
+and the unresolved `auto-router` identity receive the stable key without that
+mode. The route does not emit an explicit prompt-cache breakpoint. These
+choices preserve a stable-prefix contract without claiming resolved router
+behavior or a provider cache hit.
+
+`apps/chat/test/openai-cache-policy.test.ts` and
+`apps/chat/test/prompt-cache-identity.test.ts` use synthetic, no-network Chat
+Completions and Responses responses. They verify serialized cache fields,
+canonical tool order, privacy-negative identity inputs, and the public AI SDK
+`usage.inputTokenDetails` buckets for uncached, cache-read, and cache-write
+tokens. The tests prove local request shaping and SDK response conversion only;
+they do not prove LiteLLM, Redis, Azure OpenAI, router affinity, production
+cache hits, latency, or cost savings.
+
 ## Auth guard pattern (route handlers)
 
 Three steps: `getParticipantId` → `getChatbotOr404` → `requireParticipation`. The composed helper `withChatbotAuth(req, chatbotId)` (`src/lib/server/apiGuards.ts`) covers the standard `{ courseId: true }` case — use it for new routes; fall back to the individual guards only for a custom chatbot `select`. Participant identity comes from the same participant JWT cookies as the PWA ([Auth Model](./auth-model.md)); local chat dev therefore needs the backend's `APP_SECRET` and `DATABASE_URL` visible to the chat app, or cookies won't verify and Prisma can't load chatbots.

--- a/docs/log/2026-08-13-chat-cache-request-boundary.md
+++ b/docs/log/2026-08-13-chat-cache-request-boundary.md
@@ -1,0 +1,22 @@
+---
+type: Change Log
+title: Chat cache request boundary
+description: Documentation updates for the default/custom cache boundary and synthetic transport proof.
+timestamp: '2026-08-13'
+tags:
+  - chat
+  - testing
+---
+
+## 2026-08-13
+
+- **Update**: [chat-platform](../chat-platform.md) documents the separate
+  default/custom exact-response boundary, the stable prompt-prefix identity,
+  privacy exclusions, capability-gated implicit mode, and local synthetic
+  proof limits.
+- **Update**: [testing](../testing.md) names the focused cache-policy and
+  prompt-identity fixtures, their public usage-bucket assertions, and the
+  unchanged browser boundary.
+- **Update**: the
+  [Klicker testing-verification skill](../../.agents/skills/klicker-testing-verification/SKILL.md)
+  adds the focused request-policy checks and their evidence boundary.

--- a/docs/log/2026-08-13-chat-cache-request-boundary.md
+++ b/docs/log/2026-08-13-chat-cache-request-boundary.md
@@ -12,7 +12,7 @@ tags:
 
 - **Update**: [chat-platform](../chat-platform.md) documents the separate
   default/custom exact-response boundary, the stable prompt-prefix identity,
-  privacy exclusions, capability-gated implicit mode, and local synthetic
+  privacy exclusions, provider-managed implicit caching, and local synthetic
   proof limits.
 - **Update**: [testing](../testing.md) names the focused cache-policy and
   prompt-identity fixtures, their public usage-bucket assertions, and the
@@ -20,3 +20,7 @@ tags:
 - **Update**: the
   [Klicker testing-verification skill](../../.agents/skills/klicker-testing-verification/SKILL.md)
   adds the focused request-policy checks and their evidence boundary.
+- **Decision**: removed the redundant GPT-5.6 deployment allow-list and
+  `promptCacheOptions.mode: 'implicit'` override. Provider-managed implicit
+  caching remains enabled by default; the stable prompt-cache key and exact
+  response-cache bypass remain separate concerns.

--- a/docs/log/2026-08-13-chat-cache-request-boundary.md
+++ b/docs/log/2026-08-13-chat-cache-request-boundary.md
@@ -24,3 +24,11 @@ tags:
   `promptCacheOptions.mode: 'implicit'` override. Provider-managed implicit
   caching remains enabled by default; the stable prompt-cache key and exact
   response-cache bypass remain separate concerns.
+
+## 2026-08-14
+
+- **Correction**: prompt-cache transport identity now follows
+  `usesResponsesApi`, matching the actual provider transport for Auto routing.
+- **Clarification**: [chat-platform](../chat-platform.md) documents the
+  key-only custom-routing residual and the current undefined-context contract
+  for function-valued tool descriptions.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,19 @@ index, so it proves provider conversion without a database, MCP server, or
 model key. It is a local regression gate, not evidence that a real upstream
 first turn works in staging.
 
+For OpenAI-compatible request-policy or prompt-cache changes, also run
+`apps/chat/test/openai-cache-policy.test.ts` and
+`apps/chat/test/prompt-cache-identity.test.ts`. These fixtures capture the
+final synthetic Chat Completions and Responses JSON bodies, verify the default
+exact-response bypass and custom-provider boundary, and assert public
+`usage.inputTokenDetails` values for uncached input, cache reads, and cache
+writes. They use no database, credentials, gateway, Redis, or paid model.
+A passing fixture proves local AI SDK serialization and response conversion;
+it does not prove a LiteLLM/provider cache hit, router resolution, production
+behavior, latency, or cost impact. This is server-side request policy, so it
+does not require browser evidence; add the normal browser path if the change
+also affects UI, auth, redirect, cookie, or user-visible chat behavior.
+
 For chat conversation-rendering changes, `playwright/util/chat.ts` also supports
 `textChunks` and `chunkDelayMs` to deliver separate deltas through a browser
 `ReadableStream`; `pauseAfterTextChunk` holds the stream at a deterministic

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -557,8 +557,18 @@ the report preserves the exact identity that was reviewed.
   helper-only TypeScript and Biome checks pass. The full package check still
   requires the validated devcontainer, which is unavailable because of the
   devrouter process-identity lock.
-- [ ] Slice 3 review gate: commit the immutable slice, then run one
-  read-only `slice-reviewer` and one `simplifier` in parallel before Slice 4.
+- [x] Slice 3 review gate: the immutable commit was approved by the generic
+  `slice-reviewer` fallback at
+  `project/_local/reviews/2026-08-13-chat-cache-request-boundary-slice-3-slice-review.md`.
+  The native `simplifier` initially stopped on a malformed dispatch envelope;
+  its correction returned `DONE_WITH_CONCERNS` and identified an unused
+  `providerTools` result field. All repository callers were checked, the field
+  and its coupled test assertion were removed, and the focused identity,
+  TypeScript, Biome, and whitespace checks passed again. The correction report
+  is recorded at
+  `project/_local/reviews/2026-08-13-chat-cache-request-boundary-slice-3-simplification-correction.md`.
+- [ ] Slice 4: convert the transport/usage assertions into repository tests,
+  update the chat wiki and verification skill, and run the integrated checks.
 - [ ] Implement and verify the approved slices.
 
 ## Next action after user approval

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -543,8 +543,22 @@ the report preserves the exact identity that was reviewed.
   cache bypass while preserving Responses normalization, and the focused
   synthetic transport/image tests pass. The executor returned `NEEDS_CONTEXT`
   without edits, so the main session retained provider-boundary integration.
-- [ ] Slice 2 review gate: commit the immutable slice, then run one
-  `slice-reviewer` and one `simplifier` in parallel before Slice 3.
+- [x] Slice 2 review gate: the immutable commit was approved by the
+  slice-reviewer at
+  `project/_local/reviews/2026-08-12-chat-cache-request-boundary-slice-2-slice-review.md`.
+  The simplifier returned `KEEP` at
+  `project/_local/reviews/2026-08-12-chat-cache-request-boundary-slice-2-simplification-correction.md`;
+  its malformed initial dispatch and correction are retained in the register.
+- [x] Slice 3 implemented: the default route now derives a versioned SHA-256
+  prompt-prefix key from requested deployment/transport, final instructions,
+  and canonical provider-visible tools; it preserves executable tool behavior,
+  uses explicit stable tool order, and gates implicit mode to the explicit
+  GPT-5.6 deployment allow-list. Focused identity/transport tests pass 18/18;
+  helper-only TypeScript and Biome checks pass. The full package check still
+  requires the validated devcontainer, which is unavailable because of the
+  devrouter process-identity lock.
+- [ ] Slice 3 review gate: commit the immutable slice, then run one
+  read-only `slice-reviewer` and one `simplifier` in parallel before Slice 4.
 - [ ] Implement and verify the approved slices.
 
 ## Next action after user approval

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -1,0 +1,528 @@
+# Chat cache request boundary and stable prompt-prefix identity
+
+## Goal
+
+Protect personalized Klicker chat from unsafe or ineffective exact-response
+cache reuse while preserving provider-managed prompt-prefix caching for the
+default OpenAI-compatible gateway path. Make the provider request contract
+observable and deterministic for both AI SDK OpenAI transports without adding a
+Klicker-side cache, call ledger, or production measurement path.
+
+The package owns two separate request contracts:
+
+1. The default gateway request carries LiteLLM's per-request exact-cache bypass
+   flags, so personalized requests neither read from nor write to the gateway
+   exact-response cache.
+2. The default gateway request carries a privacy-safe, versioned fingerprint of
+   the stable prompt prefix as its provider prompt-cache identity. The
+   fingerprint is independent of the person, thread, assistant response, and
+   raw database identifiers.
+
+## Non-goals
+
+- Do not change LiteLLM, Redis, Azure OpenAI, router-affinity, or deployment
+  configuration.
+- Do not fork LiteLLM or introduce a permanent gateway cache policy.
+- Do not add a database table, per-call ledger, CronJob, cache accounting
+  reader, Langfuse mapping, cost measurement, or paid model call.
+- Do not change custom chatbot endpoint request behavior. Custom endpoints
+  retain their current provider request shape and receive neither the default
+  gateway cache-bypass field nor the default prompt-cache identity.
+- Do not add explicit provider prompt-cache breakpoints. The installed local
+  probe proves serialization of a system-message breakpoint but does not prove
+  that separately serialized tool definitions are before the breakpoint.
+- Do not claim that the fingerprint produces cross-route cache reuse. The first
+  version includes the requested deployment identity, including `auto-router`;
+  resolved-model cache partitioning remains a later runtime confirmation.
+- Do not change the public UI, chat semantics, credits model, authentication,
+  authorization, thread ownership, MCP authorization, or image attachment
+  behavior.
+- Do not resume the closed affinity/accounting branch or copy its
+  thread-derived prompt-cache key. Its code and tests are reference evidence
+  only.
+
+## Plan identity and authority
+
+- Status: draft pending user approval after planning-stage review.
+- Plan: `project/2026-08-12-chat-cache-request-boundary-plan.md`
+- Repository: `/Users/rschlae/Git/klicker/klicker-uzh`
+- Branch: `rs/chat-cache-request-boundary`
+- Worktree: `/Users/rschlae/Git/klicker/klicker-uzh/trees/chat-cache-request-boundary`
+- Target/base: `v3` / `origin/v3`
+- Base SHA validated on 2026-08-12: `5264353ff77afc598ea69f05f262b25f882ca38c`
+- Existing reference worktree:
+  `/Users/rschlae/Git/klicker/klicker-uzh/trees/chat-turn-affinity-cache`
+- Existing reference PR: #5365, closed, unmerged, draft; reference only.
+- Project artifact root: `project/`
+- Local review artifacts: `project/_local/reviews/` (ignored, never staged).
+- First post-approval commit: this plan only, before implementation.
+- No implementation, commit, push, PR, merge, deployment, cluster/tunnel
+  access, measurement, or production mutation is authorized by this plan.
+
+The primary checkout contains unrelated user changes. It is not an execution
+surface and must remain untouched. The reference worktree contains one
+uncommitted plan update and must remain read-only. The named worktree is clean
+and was created from the validated `origin/v3` ref. `trees/` is already
+gitignored.
+
+## Settled architecture
+
+### Request boundary
+
+The route currently constructs one OpenAI provider for either a custom
+chatbot endpoint or the default OpenAI-compatible gateway. Both paths already
+share `responsesApiFetch`, which patches assistant input items for strict
+Responses-compatible providers. The implementation will preserve that patch
+and make the exact-response policy an explicit property of the provider
+construction:
+
+- `routing.source === 'default'`: apply the existing Responses normalization
+  and add the top-level request field
+  `cache: { "no-cache": true, "no-store": true }` after AI SDK serialization.
+- `routing.source === 'custom'`: apply the existing Responses normalization
+  only; do not add the gateway cache field or default prompt-cache fields.
+
+The wrapper is attached to the provider, rather than only to `streamText`, so
+all personalized requests made through the default provider obey the same
+exact-cache boundary. This includes the route's image-description
+`generateText` request, whose user-supplied image and context must not become
+eligible for a gateway exact-response cache. The image-description request does
+not receive the stable chat prompt-prefix identity because it has a different
+prompt contract.
+
+The same wrapper covers Chat Completions and Responses because AI SDK selects
+the transport through `provider.chat(deploymentId)` or
+`provider.responses(deploymentId)` while both models use the provider's fetch
+option. The test contract must exercise both paths and verify that custom
+provider construction remains unchanged.
+
+### Stable prompt-prefix identity
+
+The route assembles the final `systemPrompt` after applying the language-style
+and citation contracts, loads the final MCP tool set, and resolves the selected
+model configuration before calling `streamText`. The identity helper will
+receive only provider-visible stable-prefix inputs:
+
+- a fixed identity version marker, such as `klicker:prompt-prefix:v1`;
+- the requested provider/deployment compatibility identity, including the
+  configured `deploymentId` and transport family (`chat` or `responses`);
+- the final effective `instructions` string;
+- canonical enabled tool names; and
+- canonical provider-visible tool descriptions and JSON schemas.
+
+The helper will serialize that structure deterministically and hash it with
+SHA-256. The emitted OpenAI prompt-cache key will contain the version and hash,
+for example `klicker:prompt-prefix:v1:sha256:<digest>`. The raw effective
+prompt and tool schemas remain local inputs to hashing and are never logged or
+sent as identity metadata.
+
+The canonical tool representation must use the provider-visible schema rather
+than executable functions or MCP client instances. It should resolve each
+tool's `inputSchema` through the installed AI SDK schema boundary, retain the
+tool name and description, include every provider-visible function-tool field
+that the installed SDK forwards (`strict`, `inputExamples`, and
+`providerOptions` where present), sort tools by canonical name, and recursively
+sort object keys. Array order remains meaningful unless the provider-visible
+schema contract proves that a particular array is set-like; the helper must not
+silently reorder semantic arrays.
+
+The canonical provider-tool projection must be used twice: first as the input
+to the fingerprint, and second as the provider-facing tool object passed to
+AI SDK. Re-wrap each canonical JSON schema through the SDK's JSON-schema
+boundary while retaining the executable `execute` function and other runtime
+behavior. Pass the same canonical tool order through AI SDK's `toolOrder`.
+Tests must compare normalized logical tool projections from both wire shapes
+(Chat Completions nests function fields while Responses does not) and must
+assert that schema key order in the captured request is canonical as well as
+that the tool order is stable.
+
+The helper must not accept or derive identity from participant IDs, user IDs,
+chatbot IDs, thread IDs, assistant message IDs, request IDs, message content,
+tool-call arguments/results, raw MCP server IDs, or telemetry trace IDs. Those
+values may continue to serve their existing authentication, persistence, and
+telemetry roles but cannot partition a reusable stable prefix.
+
+For the default route, `providerOptions.openai` will carry the stable
+`promptCacheKey`. The `promptCacheOptions: { mode: 'implicit' }` field is
+capability-gated: the first implementation may emit it only for an explicit
+allow-list of direct GPT-5.6-or-later deployment identities supported by the
+installed provider contract. Older direct deployments and unresolved
+`auto-router` requests must omit that mode until their compatibility is
+explicitly established. The fingerprint still includes the requested
+deployment identity, including `auto-router`, but serialization or a key is
+not evidence of a resolved model or a provider cache hit. Keep the key and
+mode as separate options so a supported stable key does not imply unsupported
+implicit-mode behavior. The route will not carry an explicit breakpoint.
+
+For custom endpoints, preserve the provider options already emitted by the
+route—Responses `store` and any applicable reasoning fields—and omit only the
+new default-gateway exact-cache and prompt-cache fields. The plan does not
+claim that custom provider options are currently empty.
+
+### Cache mechanism separation
+
+The package keeps these mechanisms independent:
+
+| Mechanism | This package changes | Identity/policy owner |
+| --- | --- | --- |
+| LiteLLM exact-response cache | Default personalized request bypass only | Request fetch boundary |
+| Provider prompt-prefix cache | Versioned stable-prefix key, implicit mode | OpenAI provider options |
+| Router classification affinity | No change | Gateway/deployment policy |
+| Retrieval, embedding, and rerank caches | No change | Their existing services |
+
+The exact-response bypass must not be implemented by reusing the prompt-prefix
+key, and the prompt-prefix key must not contain a person or conversation
+identity merely to make gateway behavior observable.
+
+## Verified repository and external-boundary evidence
+
+The following evidence was read during planning. It is local or synthetic
+evidence, not live provider or production proof.
+
+- `apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts`: the provider
+  construction seam, final prompt assembly, MCP tool loading, model registry
+  resolution, image-description request, and shared `streamText` call.
+- `apps/chat/src/lib/server/chatModelRegistry.ts`: `deploymentId`, transport
+  capability, and the `auto-router` registry identity.
+- `apps/chat/src/services/mcpClients.ts`: priority-based aggregation and
+  deterministic namespacing of MCP tools.
+- `apps/chat/package.json`: AI SDK `7.0.52` and OpenAI provider `4.0.30`.
+- `/tmp/klicker-cache-contract-prototype/README.md` and `probe.mjs`: a
+  no-network synthetic capture passed for both Chat Completions and Responses.
+  It showed `prompt_cache_key`, `prompt_cache_options`, the top-level LiteLLM
+  bypass field injected by an application fetch wrapper, and normalized
+  `usage.inputTokenDetails` buckets. It intentionally did not contact
+  LiteLLM, Redis, Azure OpenAI, Langfuse, or a paid model.
+- The installed AI SDK source documents `toolOrder` as the stable ordering
+  boundary and resolves tool schemas through `asSchema(...).jsonSchema`.
+- The installed OpenAI provider source serializes `promptCacheKey` and
+  `promptCacheOptions` for both transport families. Its usage conversion maps
+  provider cached and cache-write counts to the public AI SDK
+  `inputTokenDetails` shape.
+- `docs/chat-platform.md`, `docs/testing.md`, and
+  `.agents/skills/klicker-testing-verification/SKILL.md`: existing chat
+  architecture, local LiteLLM boundary, and verification conventions.
+- `docs/adr/0003-chat-framework-upgrade.md` and
+  `docs/adr/0004-chat-citations-from-tool-call-parts.md`: existing chat
+  framework and citation decisions that remain applicable; no new ADR is
+  needed for this bounded request-contract change unless implementation
+  uncovers a genuinely forward-looking architecture decision.
+
+Historical evidence from the closed affinity branch is explicitly not treated
+as current implementation or CI proof. Live remote ref verification used
+`git ls-remote` because the sandbox rejected writing `.git/FETCH_HEAD`; the
+read-only remote result matched the local `origin/v3` ref. A host fetch was
+attempted and rejected by the sandbox policy, so the plan records that
+limitation rather than claiming a successful fetch.
+
+## Test portfolio
+
+Each behavior is assigned one primary stable seam. Tests should be added only
+where the existing suite does not already protect the named failure.
+
+| Risk or behavior | Existing evidence | Planned protection | Primary seam |
+| --- | --- | --- | --- |
+| Default Chat Completions requests bypass exact-response reads and writes | Disposable synthetic wrapper capture only | Assert both flags are added after SDK serialization and reach the final JSON body | `apps/chat/test/openai-cache-policy.test.ts` |
+| Default Responses requests bypass exact-response reads and writes while the existing assistant-item patch remains | Disposable synthetic wrapper capture; current route wrapper | Assert both flags and the existing Responses normalization in one final request capture | `apps/chat/test/openai-cache-policy.test.ts` |
+| Custom chatbot endpoints retain their request shape | Current `routing.source` branch; no cache-policy test | Assert custom provider requests omit the gateway cache field and default prompt-cache fields | `apps/chat/test/openai-cache-policy.test.ts` and provider-options test |
+| Stable identity changes when effective instructions change | No current protection | Pure helper table cases for prompt version and instruction changes | `apps/chat/test/prompt-cache-identity.test.ts` |
+| Stable identity partitions requested deployment/transport compatibility | Registry exposes deployment and reasoning transport | Pure helper cases for deployment, `auto-router`, and Chat/Responses changes | `apps/chat/test/prompt-cache-identity.test.ts` |
+| Tool insertion order does not change identity or request order | MCP aggregation is priority/insertion based; AI SDK defaults to object order | Canonical tool-name/schema fixtures with reordered input objects and explicit `toolOrder` assertions | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-chat-streaming.test.ts` |
+| Tool schema, description, strictness, examples, or provider-visible options change the identity and wire contract | AI SDK schema conversion exists; no package contract | Pure synthetic tool definitions with changed provider-visible fields; compare canonical wire projections for both transports | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-chat-streaming.test.ts` |
+| User, participant, chatbot, thread, assistant-message, message/content, request, tool-call, and raw MCP identifiers do not affect identity | Existing route has all values in scope, but no negative test | Separate privacy-negative fixtures for each identifier class and an assertion that only the stable-prefix input is accepted | `apps/chat/test/prompt-cache-identity.test.ts` |
+| Both transports preserve prompt-cache fields and public usage buckets | Disposable no-network probe | Repository-owned synthetic Chat/Responses fixtures assert serialized fields and public `usage.inputTokenDetails` | `apps/chat/test/openai-chat-streaming.test.ts` and a focused Responses fixture |
+| Image-description requests bypass exact cache but do not receive chat-prefix identity | Route calls `generateText` through the selected provider at `route.ts:915-930`; no test currently protects the policy | Synthetic `generateText` capture through a default provider asserts the two bypass flags and absence of `prompt_cache_key` | `apps/chat/test/openai-cache-policy.test.ts` |
+| Direct older models and unresolved auto-router do not receive unsupported implicit mode | Installed provider docs scope `promptCacheOptions` to GPT-5.6+; registry contains older and auto-router deployments | Provider-options matrix asserts stable key separation and mode omission for unsupported/unknown capability identities | `apps/chat/test/prompt-cache-identity.test.ts` and provider-options test |
+| Existing chat behavior remains green | Current package test suite and typecheck | Run focused transport tests, full chat tests, chat typecheck, root checks, and build | Package/root verification |
+| Operators can understand the boundary and its proof limits | Existing docs describe the route but not this contract | Update chat platform, testing documentation, and chat testing skill with source-linked facts | Documentation review |
+
+No browser test is required because the package changes server-side request
+policy and provider metadata, not user-visible UI behavior. If implementation
+changes a visible chat response or auth/redirect/cookie behavior, the package
+must be promoted to include the repository's mandatory browser path before
+implementation continues.
+
+## Execution slices after approval
+
+### Slice 1 — Commit the approved plan
+
+**Scope:** Stage and commit only this plan from the named worktree. Do not
+include the ignored review register or any primary-checkout changes.
+
+**Acceptance:** The commit contains the plan as the first branch commit;
+`git diff --cached` has been reviewed for secrets and personal data; the
+worktree has no unrelated staged files.
+
+**Suggested commit:**
+`docs(project): plan chat cache request boundary`
+
+**Review:** Plan-stage review is completed before this slice is offered for
+approval. The normal implementation final-review gates remain for the
+integrated branch.
+
+### Slice 2 — Default-provider exact-response cache boundary
+
+**Scope:** Extract or extend the existing fetch wrapper in
+`apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts` and, if useful, add
+`apps/chat/src/lib/server/openaiCachePolicy.ts`. Keep the existing Responses
+assistant-item normalization. Select the exact-cache policy from
+`routing.source`, adding the top-level `cache` object only to default gateway
+requests. Keep custom requests unchanged. Preserve request headers, abort
+signals, response parsing, retries, and the provider choice.
+
+**Tests:** Add or extend
+`apps/chat/test/openai-cache-policy.test.ts` with synthetic no-network
+captures for Chat Completions, Responses, default routing, custom routing, and
+the image-description `generateText` path. The image fixture must assert the
+default exact-cache flags and the absence of `prompt_cache_key`, without
+requiring route/database setup. Add a separate transport-policy assertion for
+custom Responses that preserves the pre-existing `store` and reasoning fields.
+Keep the existing streamed tool-call fixture in
+`apps/chat/test/openai-chat-streaming.test.ts` as the focused regression seam
+for a provider request that can span multiple steps.
+
+**Acceptance:**
+
+- The final default Chat Completions and Responses JSON bodies contain exactly
+  `cache.no-cache === true` and `cache.no-store === true`.
+- The custom path contains neither gateway bypass flag.
+- The Responses body still has the existing assistant-message fields required
+  by the strict provider workaround.
+- No network, credential, gateway, Redis, or paid-provider call is needed for
+  the tests.
+- The image-description request continues to use the same default provider
+  wrapper and is therefore covered by the exact-cache boundary without
+  receiving the stable chat-prefix key.
+
+**Route and commit boundary:** The main session owns the provider-construction
+decision and integration because it crosses the custom/default trust boundary;
+the implementation commit owns only the fetch-policy helper, route wiring, and
+its focused synthetic tests. No prompt identity or documentation changes are
+included in this commit.
+
+**Verification and stop condition:** Run the focused cache-policy tests through
+the validated devcontainer, then the chat suite and chat typecheck. Stop and
+return to the main session if the wrapper cannot distinguish default from
+custom construction, changes request headers or abort behavior, or requires a
+gateway call to prove the contract. After the immutable commit, if the change
+still qualifies as a substantive provider-boundary slice, start exactly one
+read-only `slice-reviewer` and one `simplifier` in parallel before integrating;
+both must return before the next slice.
+
+**Suggested commit:** `enhance(chat): bypass exact cache for personalized chat`
+
+### Slice 3 — Stable prompt-prefix identity and deterministic request order
+
+**Scope:** Add
+`apps/chat/src/lib/server/promptCacheIdentity.ts` and integrate it at the
+route's final prompt/tool assembly. The helper should produce a versioned
+SHA-256 key from the requested deployment/transport identity, final effective
+instructions, and canonical provider-visible tool names/descriptions/schemas.
+Use the installed AI SDK schema conversion boundary; do not serialize tool
+execution functions, MCP clients, or request-specific values. Build one
+provider-facing canonical tool projection for both the fingerprint and the
+request, preserving runtime execution behavior and all provider-visible
+fields. Pass an explicit stable `toolOrder` to the model request and use the
+same canonical ordering for the fingerprint. Attach `promptCacheKey` for the
+default gateway path; attach implicit mode only for the explicit supported
+direct-model capability set. Omit explicit breakpoints.
+
+**Tests:** Add
+`apps/chat/test/prompt-cache-identity.test.ts` for determinism, meaningful
+changes, deployment/transport partitioning, capability-gated implicit mode,
+canonical tool order/schema/provider-visible-field changes, and separate
+privacy-negative inputs for user, participant, chatbot, thread,
+assistant-message, message/content, request, tool-call, and raw MCP identifiers.
+Extend
+`apps/chat/test/openai-chat-streaming.test.ts` or add a focused Responses
+fixture to assert that both transports serialize the key, canonical tools, and
+only the supported implicit options.
+
+**Acceptance:**
+
+- Equivalent stable prefixes with different object insertion order produce the
+  same key and the same provider tool order.
+- Any changed effective instruction, tool name, description, provider-visible
+  schema, version marker, requested deployment, or transport family produces a
+  different key.
+- Participant, user, chatbot, thread, assistant-response, request, tool-call,
+  and raw MCP database identifiers cannot affect the key.
+- The requested `auto-router` identity is included as-is; the implementation
+  does not claim that it represents the resolved model.
+- The custom endpoint path retains its existing provider-options shape.
+- Custom Responses requests retain existing `store` and reasoning options;
+  only the new default-gateway fields are absent.
+- No explicit `promptCacheBreakpoint` is emitted.
+
+**Route and commit boundary:** The main session owns the stable-prefix input
+contract and the provider-facing canonical-tool projection because it couples
+prompt identity, tool execution, and both transport serializers. The
+implementation commit owns the identity helper, canonical tool adapter,
+provider-option integration, explicit `toolOrder`, and focused identity/
+transport tests. Do not change exact-cache policy in this commit.
+
+**Verification and stop condition:** Run identity and both-transport capture
+tests through the validated devcontainer, then the chat suite and chat
+typecheck. Stop if the canonical projection cannot preserve tool execution or
+if the installed SDK exposes provider-visible fields that cannot be represented
+without expanding the stable-prefix contract. After the immutable commit,
+start exactly one read-only `slice-reviewer` and one `simplifier` in parallel
+when the substantive-slice gate applies; await and disposition both before
+integration.
+
+**Suggested commit:** `enhance(chat): add stable prompt cache identity`
+
+### Slice 4 — Transport contract, documentation, and closure
+
+**Scope:** Convert the useful assertions from the disposable probe into
+repository-owned tests, including public AI SDK `usage.inputTokenDetails` for
+both transports. Update `docs/chat-platform.md`, `docs/testing.md`, and
+`.agents/skills/klicker-testing-verification/SKILL.md` with the request-boundary
+contract, deterministic identity inputs, privacy exclusions, synthetic proof
+boundary, and deferred live verification. Add dated wiki maintenance logs as
+required by the repository skill. Do not add an ADR unless a new durable
+architecture decision is actually discovered.
+
+**Acceptance:**
+
+- Focused Chat/Responses transport tests pass with synthetic responses.
+- The public usage assertion distinguishes uncached input, cache reads, and
+  cache writes without changing credits or cost calculation semantics.
+- Documentation names local serialization proof as local evidence only and
+  does not imply LiteLLM, provider, router, production, or cost proof.
+- The relevant chat testing skill describes the new focused tests and the
+  unchanged browser rule.
+- The integrated final review covers correctness, plan compliance,
+  maintainability, security, and architecture/data-flow concerns applicable to
+  the changed server boundary.
+
+**Route and commit boundary:** The main session owns integration, documentation
+fact-checking, and final readiness. This slice may contain focused test and
+documentation edits only; it must not add a new runtime behavior that bypasses
+slice review. If documentation changes exceed the package's settled contract,
+stop for a plan correction.
+
+**Verification and stop condition:** Run the focused and full chat checks,
+root checks, and the production build through the validated devcontainer. Stop
+before final review if any check is unavailable, if public usage buckets are
+not exposed as planned, or if docs would need live-provider claims. This slice
+is documentation/test-heavy and normally does not need simplification; if it
+contains substantive executable changes, apply the same parallel
+`simplifier`/`slice-reviewer` gate.
+
+**Suggested commit:** `docs(chat): document cache request contracts`
+
+## Verification contract
+
+Run checks in this order after each applicable implementation slice. All
+package-manager, test, typecheck, lint, and build commands run inside the
+validated self-contained devcontainer; only `devrouter ensure` and the host
+worktree/Git commands run on the host.
+
+1. Focused transport and identity tests, using the package's Vitest runner and
+   the exact new/changed test files, through `devrouter exec`.
+2. Full chat tests:
+   `devrouter exec <validated-devpod> -- pnpm --filter @klicker-uzh/chat test:run`.
+3. Chat typecheck:
+   `devrouter exec <validated-devpod> -- pnpm --filter @klicker-uzh/chat check`.
+4. Relevant formatting/lint checks, then repository checks:
+   `devrouter exec <validated-devpod> -- pnpm run check:all`.
+5. Production build through the self-contained devcontainer, not the host:
+   validate the checkout with `devrouter ensure . --json`, then run the exact
+   validated DevPod command for `devrouter exec <validated-devpod> -- pnpm run build`.
+
+The exact focused Vitest invocation may use the repository's package script
+with the changed file paths after confirming its argument forwarding. Do not
+install dependencies or start a dev server merely to run the planning task.
+Do not use the cluster tunnel, staging, production, Langfuse, LiteLLM, Redis,
+Azure, or a paid model for this package. A green local test, typecheck, or
+build proves only that local contract; it does not prove gateway cache
+behavior, provider cache hits, resolved auto-router partitioning, latency, or
+cost.
+
+## Documentation changes planned for the implementation package
+
+| File | Planned fact to add or update | Evidence to cite in the file |
+| --- | --- | --- |
+| `docs/chat-platform.md` | Default versus custom provider request boundary; stable prompt-prefix identity inputs/exclusions; implicit caching and no-breakpoint decision | Route symbols, model registry, AI SDK/OpenAI provider source, synthetic test path |
+| `docs/testing.md` | Focused synthetic transport contract, public usage-bucket assertion, and proof boundary | Test files, disposable-probe result, package commands |
+| `.agents/skills/klicker-testing-verification/SKILL.md` | Required focused checks for OpenAI-compatible request-policy changes and the unchanged browser condition | Repository test scripts and chat test files |
+| `docs/solutions/` | Only if implementation uncovers a non-obvious durable incident lesson | `$rs-compound` after the lesson is verified; not created speculatively |
+
+The plan itself does not edit those documentation surfaces. Any behavior
+change implementation must update them in the same package, following
+`$klicker-wiki-maintenance`; the edits must remain fact-linked and must not
+copy session provenance or private evidence into the wiki.
+
+## Review and approval gates
+
+### Planning-stage review
+
+Before presenting this plan for approval, run one separate read-only configured
+`planner` review against the frozen draft identity. Reserve the tuple in
+`project/_local/reviews/chat-cache-request-boundary-gate-register.md` before
+dispatch. The planner must inspect the plan, the named worktree, the relevant
+route/provider/test seams, the disposable probe, and the repository's review
+rubric. It must return a verdict with quoted path/symbol evidence and address:
+
+- whether the cache boundaries are technically distinct and correctly scoped;
+- whether custom endpoints, Responses, Chat Completions, image descriptions,
+  tool schemas, and `auto-router` identity are handled without accidental
+  leakage or unsupported claims;
+- whether the test portfolio catches the named failure modes at stable seams;
+- whether the plan stays within the planning authority and avoids live/paid
+  operations; and
+- whether the documentation and verification closure is complete.
+
+Record the full report at
+`project/_local/reviews/2026-08-12-chat-cache-request-boundary-planning-stage.md`
+and update the plan with the verdict and any verified accepted findings. If a
+finding materially changes the architecture, scope, or acceptance contract,
+stop and reassess rather than silently expanding the plan.
+
+Planning-stage result: `DONE_WITH_CONCERNS`, with the report recorded at the
+path above. The parent verified and accepted all five required corrections:
+capability-gated implicit mode, one canonical provider-tool projection for
+hashing and wire submission, the real custom-provider option invariant, direct
+image/privacy-negative test seams, and per-slice route/commit/verification
+contracts including the parallel simplifier/reviewer gate. The corrected plan
+remains within the settled architecture and planning authority. Its final
+working-tree hash is intentionally different from the frozen pre-review hash;
+the report preserves the exact identity that was reviewed.
+
+### Post-approval implementation reviews
+
+- The approved plan is committed first.
+- The exact-cache boundary and stable identity slices are substantive server
+  changes crossing a provider/data-flow boundary, so each requires one
+  risk-selected read-only slice review after its exact commit and before
+  integration.
+- The integrated branch requires one configured read-only final reviewer after
+  verification and before it is presented as complete or added to a PR.
+- Review register identity, package key, scope key, report paths, and any
+  correction attempt remain under the new package's ignored review directory.
+- No review authorizes edits, commits, pushes, publication, deployment, or
+  production access.
+
+## Progress at planning handoff
+
+- [x] Read the takeover handoff and required workflow skills.
+- [x] Validate the live `v3` ref through read-only remote lookup.
+- [x] Verify the existing worktrees and closed reference PR.
+- [x] Create the named clean worktree from current `origin/v3`.
+- [x] Inspect the route, model registry, MCP aggregation, AI SDK seam, tests,
+  docs, and synthetic contract evidence.
+- [x] Draft this full execution plan.
+- [x] Reserve and complete the independent planning-stage review.
+- [x] Incorporate verified review corrections and independently recheck them.
+- [x] Present the reviewed plan for user approval; approval received on
+  2026-08-12.
+- [ ] Commit the approved plan as the branch's first commit.
+- [ ] Implement and verify the approved slices.
+
+## Next action after user approval
+
+Approval has now been received. Commit this plan as the first branch commit,
+then execute the slices in order. A generic approval here does not
+authorize push, PR creation, merge, deployment, measurement, tunnel use, paid
+calls, or production mutation; those remain separate named gates.

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -578,9 +578,19 @@ the report preserves the exact identity that was reviewed.
   package check, root checks, and production build remain unavailable because
   `devrouter ensure . --json` cannot determine process identity for its
   workspace lock.
-- [ ] Integrated verification and final review (initial review found and
-  corrected a provider key-length defect; the correction review remains).
-- [ ] Implement and verify the approved slices.
+- [x] Integrated final review: the initial review found a 96-character
+  provider key, which was corrected to the derived 64-character
+  `klicker:pc:v1:<50-hex-character-digest>` form with a focused length
+  assertion. The allowed correction review approved the exact final commit at
+  `project/_local/reviews/2026-08-13-chat-cache-request-boundary-integrated-final-correction.md`.
+  Full package/root/build verification remains unavailable because the
+  devrouter process-identity lock prevents the authoritative devcontainer and
+  the named worktree has no dependency mount; the package is not presented as
+  fully verified or ready for publication.
+- [x] Implemented and locally verified the approved slices through committed
+  code, focused tests, documentation, and integrated review. Authority ends at
+  these local commits; no push, PR, merge, deployment, live call, measurement,
+  tunnel, cluster access, or cleanup was performed.
 
 ## Next action after user approval
 

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -111,10 +111,12 @@ receive only provider-visible stable-prefix inputs:
 - canonical provider-visible tool descriptions and JSON schemas.
 
 The helper will serialize that structure deterministically and hash it with
-SHA-256. The emitted OpenAI prompt-cache key will contain the version and hash,
-for example `klicker:prompt-prefix:v1:sha256:<digest>`. The raw effective
-prompt and tool schemas remain local inputs to hashing and are never logged or
-sent as identity metadata.
+SHA-256. The emitted OpenAI prompt-cache key will use the provider-safe
+64-character form `klicker:pc:v1:<50-hex-character-digest>`; the full versioned
+fingerprint remains the hash input, while the wire key stays within the
+provider's key-length contract. The raw effective prompt and tool schemas
+remain local inputs to hashing and are never logged or sent as identity
+metadata.
 
 The canonical tool representation must use the provider-visible schema rather
 than executable functions or MCP client instances. It should resolve each
@@ -576,7 +578,8 @@ the report preserves the exact identity that was reviewed.
   package check, root checks, and production build remain unavailable because
   `devrouter ensure . --json` cannot determine process identity for its
   workspace lock.
-- [ ] Integrated verification and final review.
+- [ ] Integrated verification and final review (initial review found and
+  corrected a provider key-length defect; the correction review remains).
 - [ ] Implement and verify the approved slices.
 
 ## Next action after user approval

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -567,8 +567,16 @@ the report preserves the exact identity that was reviewed.
   TypeScript, Biome, and whitespace checks passed again. The correction report
   is recorded at
   `project/_local/reviews/2026-08-13-chat-cache-request-boundary-slice-3-simplification-correction.md`.
-- [ ] Slice 4: convert the transport/usage assertions into repository tests,
-  update the chat wiki and verification skill, and run the integrated checks.
+- [x] Slice 4: repository-owned transport fixtures now assert Chat and
+  Responses prompt-cache fields plus public `usage.inputTokenDetails`; the
+  chat wiki, testing guide, verification skill, and dated maintenance log were
+  updated. Focused transport/identity/streaming tests pass 24/24; full chat
+  Vitest reaches 176 passing tests but cannot load 14 suites because the named
+  worktree has no dependency mount. The authoritative devcontainer route,
+  package check, root checks, and production build remain unavailable because
+  `devrouter ensure . --json` cannot determine process identity for its
+  workspace lock.
+- [ ] Integrated verification and final review.
 - [ ] Implement and verify the approved slices.
 
 ## Next action after user approval

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -145,16 +145,12 @@ values may continue to serve their existing authentication, persistence, and
 telemetry roles but cannot partition a reusable stable prefix.
 
 For the default route, `providerOptions.openai` will carry the stable
-`promptCacheKey`. The `promptCacheOptions: { mode: 'implicit' }` field is
-capability-gated: the first implementation may emit it only for an explicit
-allow-list of direct GPT-5.6-or-later deployment identities supported by the
-installed provider contract. Older direct deployments and unresolved
-`auto-router` requests must omit that mode until their compatibility is
-explicitly established. The fingerprint still includes the requested
-deployment identity, including `auto-router`, but serialization or a key is
-not evidence of a resolved model or a provider cache hit. Keep the key and
-mode as separate options so a supported stable key does not imply unsupported
-implicit-mode behavior. The route will not carry an explicit breakpoint.
+`promptCacheKey`. The provider's implicit prompt-cache behavior remains the
+default; the route does not override it with a deployment allow-list or an
+explicit `promptCacheOptions.mode`. The fingerprint still includes the
+requested deployment identity, including `auto-router`, but serialization or a
+key is not evidence of a resolved model or a provider cache hit. The route will
+not carry an explicit breakpoint.
 
 For custom endpoints, preserve the provider options already emitted by the
 route—Responses `store` and any applicable reasoning fields—and omit only the
@@ -168,7 +164,7 @@ The package keeps these mechanisms independent:
 | Mechanism | This package changes | Identity/policy owner |
 | --- | --- | --- |
 | LiteLLM exact-response cache | Default personalized request bypass only | Request fetch boundary |
-| Provider prompt-prefix cache | Versioned stable-prefix key, implicit mode | OpenAI provider options |
+| Provider prompt-prefix cache | Versioned stable-prefix key; provider-managed implicit mode | OpenAI provider options |
 | Router classification affinity | No change | Gateway/deployment policy |
 | Retrieval, embedding, and rerank caches | No change | Their existing services |
 
@@ -197,8 +193,8 @@ evidence, not live provider or production proof.
   LiteLLM, Redis, Azure OpenAI, Langfuse, or a paid model.
 - The installed AI SDK source documents `toolOrder` as the stable ordering
   boundary and resolves tool schemas through `asSchema(...).jsonSchema`.
-- The installed OpenAI provider source serializes `promptCacheKey` and
-  `promptCacheOptions` for both transport families. Its usage conversion maps
+- The installed OpenAI provider source serializes `promptCacheKey` for both
+  transport families. Its usage conversion maps
   provider cached and cache-write counts to the public AI SDK
   `inputTokenDetails` shape.
 - `docs/chat-platform.md`, `docs/testing.md`, and
@@ -234,7 +230,7 @@ where the existing suite does not already protect the named failure.
 | User, participant, chatbot, thread, assistant-message, message/content, request, tool-call, and raw MCP identifiers do not affect identity | Existing route has all values in scope, but no negative test | Separate privacy-negative fixtures for each identifier class and an assertion that only the stable-prefix input is accepted | `apps/chat/test/prompt-cache-identity.test.ts` |
 | Both transports preserve prompt-cache fields and public usage buckets | Disposable no-network probe | Repository-owned synthetic Chat/Responses fixtures assert serialized fields and public `usage.inputTokenDetails` | `apps/chat/test/openai-chat-streaming.test.ts` and a focused Responses fixture |
 | Image-description requests bypass exact cache but do not receive chat-prefix identity | Route calls `generateText` through the selected provider at `route.ts:915-930`; no test currently protects the policy | Synthetic `generateText` capture through a default provider asserts the two bypass flags and absence of `prompt_cache_key` | `apps/chat/test/openai-cache-policy.test.ts` |
-| Direct older models and unresolved auto-router do not receive unsupported implicit mode | Installed provider docs scope `promptCacheOptions` to GPT-5.6+; registry contains older and auto-router deployments | Provider-options matrix asserts stable key separation and mode omission for unsupported/unknown capability identities | `apps/chat/test/prompt-cache-identity.test.ts` and provider-options test |
+| Provider-managed implicit caching remains the default while the stable key stays default-route-only | The provider supports implicit caching and stable `promptCacheKey` matching; this package does not need a deployment allow-list | Both transports assert the stable key is serialized and no explicit `prompt_cache_options` override is emitted | `apps/chat/test/prompt-cache-identity.test.ts` |
 | Existing chat behavior remains green | Current package test suite and typecheck | Run focused transport tests, full chat tests, chat typecheck, root checks, and build | Package/root verification |
 | Operators can understand the boundary and its proof limits | Existing docs describe the route but not this contract | Update chat platform, testing documentation, and chat testing skill with source-linked facts | Documentation review |
 
@@ -341,19 +337,19 @@ provider-facing canonical tool projection for both the fingerprint and the
 request, preserving runtime execution behavior and all provider-visible
 fields. Pass an explicit stable `toolOrder` to the model request and use the
 same canonical ordering for the fingerprint. Attach `promptCacheKey` for the
-default gateway path; attach implicit mode only for the explicit supported
-direct-model capability set. Omit explicit breakpoints.
+default gateway path and rely on the provider's implicit mode by default. Omit
+explicit breakpoints.
 
 **Tests:** Add
 `apps/chat/test/prompt-cache-identity.test.ts` for determinism, meaningful
-changes, deployment/transport partitioning, capability-gated implicit mode,
+changes, deployment/transport partitioning, provider-managed implicit mode,
 canonical tool order/schema/provider-visible-field changes, and separate
 privacy-negative inputs for user, participant, chatbot, thread,
 assistant-message, message/content, request, tool-call, and raw MCP identifiers.
 Extend
 `apps/chat/test/openai-chat-streaming.test.ts` or add a focused Responses
 fixture to assert that both transports serialize the key, canonical tools, and
-only the supported implicit options.
+leave implicit-mode selection to the provider default.
 
 **Acceptance:**
 
@@ -504,14 +500,15 @@ finding materially changes the architecture, scope, or acceptance contract,
 stop and reassess rather than silently expanding the plan.
 
 Planning-stage result: `DONE_WITH_CONCERNS`, with the report recorded at the
-path above. The parent verified and accepted all five required corrections:
-capability-gated implicit mode, one canonical provider-tool projection for
-hashing and wire submission, the real custom-provider option invariant, direct
-image/privacy-negative test seams, and per-slice route/commit/verification
-contracts including the parallel simplifier/reviewer gate. The corrected plan
-remains within the settled architecture and planning authority. Its final
-working-tree hash is intentionally different from the frozen pre-review hash;
-the report preserves the exact identity that was reviewed.
+path above. The parent verified and accepted the five original corrections,
+including the then-proposed capability gate, canonical provider-tool
+projection, custom-provider invariant, direct image/privacy-negative seams,
+and per-slice route/commit/verification contracts. The later user-approved
+simplification removed the redundant implicit-mode deployment allow-list and
+relies on provider-managed implicit caching while retaining the stable key.
+The plan remains within the settled architecture and planning authority. Its
+final working-tree hash is intentionally different from the frozen pre-review
+hash; the report preserves the exact identity that was reviewed.
 
 ### Post-approval implementation reviews
 
@@ -554,8 +551,8 @@ the report preserves the exact identity that was reviewed.
 - [x] Slice 3 implemented: the default route now derives a versioned SHA-256
   prompt-prefix key from requested deployment/transport, final instructions,
   and canonical provider-visible tools; it preserves executable tool behavior,
-  uses explicit stable tool order, and gates implicit mode to the explicit
-  GPT-5.6 deployment allow-list. Focused identity/transport tests pass 18/18;
+  uses explicit stable tool order, and leaves implicit mode to the provider
+  default. Focused identity/transport tests pass 18/18;
   helper-only TypeScript and Biome checks pass. The full package check still
   requires the validated devcontainer, which is unavailable because of the
   devrouter process-identity lock.
@@ -588,9 +585,18 @@ the report preserves the exact identity that was reviewed.
   the named worktree has no dependency mount; the package is not presented as
   fully verified or ready for publication.
 - [x] Implemented and locally verified the approved slices through committed
-  code, focused tests, documentation, and integrated review. Authority ends at
-  these local commits; no push, PR, merge, deployment, live call, measurement,
+  code, focused tests, documentation, and integrated review. A later
+  simplification removed the redundant implicit-mode deployment allow-list and
+  retained provider-managed implicit caching plus the stable key. The draft PR
+  is the delivery boundary; no merge, deployment, live call, measurement,
   tunnel, cluster access, or cleanup was performed.
+- [x] User-approved final simplification: removed the explicit implicit-mode
+  override and deployment allow-list from the provider options. Focused
+  request-shape verification passes 23/23 focused tests, plus Biome, Prettier,
+  and whitespace checks. The existing integrated-final and Claude Opus reports
+  remain the review record; full package/root/build checks still remain
+  unavailable because generated workspace outputs are missing and the host is
+  running Node 26 instead of the repository's pinned Node 24.
 
 ## Next action after user approval
 

--- a/project/2026-08-12-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-chat-cache-request-boundary-plan.md
@@ -43,7 +43,7 @@ The package owns two separate request contracts:
 
 ## Plan identity and authority
 
-- Status: draft pending user approval after planning-stage review.
+- Status: approved; implementation in progress on the named branch.
 - Plan: `project/2026-08-12-chat-cache-request-boundary-plan.md`
 - Repository: `/Users/rschlae/Git/klicker/klicker-uzh`
 - Branch: `rs/chat-cache-request-boundary`
@@ -262,6 +262,15 @@ integrated branch.
 
 ### Slice 2 — Default-provider exact-response cache boundary
 
+**Route:** `executor` for the bounded fetch-policy implementation and focused
+synthetic tests; the main session owns provider-boundary integration and
+acceptance verification.
+
+**Acceptance:** Default Chat Completions, Responses, and image-description
+requests carry both exact-cache bypass flags; custom requests preserve their
+existing fields and omit only the new gateway fields; focused tests pass in the
+validated devcontainer.
+
 **Scope:** Extract or extend the existing fetch wrapper in
 `apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts` and, if useful, add
 `apps/chat/src/lib/server/openaiCachePolicy.ts`. Keep the existing Responses
@@ -312,6 +321,12 @@ both must return before the next slice.
 **Suggested commit:** `enhance(chat): bypass exact cache for personalized chat`
 
 ### Slice 3 — Stable prompt-prefix identity and deterministic request order
+
+**Route:** `main`.
+
+**Execution-tier skip reason:** critical-path coupling — the identity helper,
+canonical provider-facing tool projection, executable tool behavior, and both
+transport serializers must be designed and integrated together.
 
 **Scope:** Add
 `apps/chat/src/lib/server/promptCacheIdentity.ts` and integrate it at the
@@ -373,6 +388,12 @@ integration.
 **Suggested commit:** `enhance(chat): add stable prompt cache identity`
 
 ### Slice 4 — Transport contract, documentation, and closure
+
+**Route:** `main`.
+
+**Execution-tier skip reason:** critical-path coupling — documentation,
+public-usage assertions, and final verification must be fact-checked against
+the integrated runtime contract.
 
 **Scope:** Convert the useful assertions from the disposable probe into
 repository-owned tests, including public AI SDK `usage.inputTokenDetails` for
@@ -504,7 +525,7 @@ the report preserves the exact identity that was reviewed.
 - No review authorizes edits, commits, pushes, publication, deployment, or
   production access.
 
-## Progress at planning handoff
+## Progress
 
 - [x] Read the takeover handoff and required workflow skills.
 - [x] Validate the live `v3` ref through read-only remote lookup.
@@ -517,7 +538,13 @@ the report preserves the exact identity that was reviewed.
 - [x] Incorporate verified review corrections and independently recheck them.
 - [x] Present the reviewed plan for user approval; approval received on
   2026-08-12.
-- [ ] Commit the approved plan as the branch's first commit.
+- [x] Commit the approved plan as the branch's first commit (`1c8ff5bf0`).
+- [x] Slice 2 implemented: the default-provider fetch boundary adds the exact
+  cache bypass while preserving Responses normalization, and the focused
+  synthetic transport/image tests pass. The executor returned `NEEDS_CONTEXT`
+  without edits, so the main session retained provider-boundary integration.
+- [ ] Slice 2 review gate: commit the immutable slice, then run one
+  `slice-reviewer` and one `simplifier` in parallel before Slice 3.
 - [ ] Implement and verify the approved slices.
 
 ## Next action after user approval

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -640,7 +640,10 @@ hash; the report preserves the exact identity that was reviewed.
   the regression test. Per policy, these non-behavioral edits close through
   main-session verification without a third final review. The report is
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-integrated-final-correction.md`.
-- [ ] PR closeout: commit the closeout corrections, push, and update
+- [x] Local PR closeout: committed the closeout corrections and reran the full
+  chat suite at 291/291 on the exact head.
+- [ ] PR delivery: force-with-lease push the rebased branch, update the PR, and
+  confirm current-head Node 24 checks
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -611,10 +611,10 @@ hash; the report preserves the exact identity that was reviewed.
   lists with ordering and cross-transport semantic assertions; documented the
   key-only custom route and function-description context contract. Focused
   tests pass 24/24 after the review correction, the full chat suite passes
-  288/288 before that correction after generating local
-  workspace outputs, the chat package check passes, root `check:all` passes,
-  and the production build passes 22/22 tasks. The host uses Node 26 instead
-  of the required Node 24, so current-head CI remains the Node 24 release gate.
+  289/289 after generating local workspace outputs, the chat package check
+  passes, root `check:all` passes, and the production build passes 22/22 tasks.
+  The host uses Node 26 instead of the required Node 24, so current-head CI
+  remains the Node 24 release gate.
 - [x] Corrective-slice review: the simplifier approved the committed correction
   without another reduction. The slice reviewer found that the fetch wrapper
   could retry a request if the fetch implementation threw a synchronous
@@ -623,8 +623,8 @@ hash; the report preserves the exact identity that was reviewed.
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-simplification.md`
   and
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-slice-review.md`.
-- [ ] PR closeout: commit and verify the review correction, run fresh integrated
-  final review, push, and update
+- [ ] PR closeout: run fresh integrated final review on the exact verified head,
+  push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -610,8 +610,8 @@ hash; the report preserves the exact identity that was reviewed.
   removed machine-local plan references; replaced SDK-internal schema key
   lists with ordering and cross-transport semantic assertions; documented the
   key-only custom route and function-description context contract. Focused
-  tests pass 24/24 after the review correction, the full chat suite passes
-  289/289 after generating local workspace outputs, the chat package check
+  tests pass 26/26 after the final-review correction, the full chat suite passes
+  291/291 after generating local workspace outputs, the chat package check
   passes, root `check:all` passes, and the production build passes 22/22 tasks.
   The host uses Node 26 instead of the required Node 24, so current-head CI
   remains the Node 24 release gate.
@@ -631,8 +631,8 @@ hash; the report preserves the exact identity that was reviewed.
   and schema regressions, and removes the duplicate usage assertions. Focused
   tests pass 26/26. The initial report is
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-integrated-final.md`.
-- [ ] PR closeout: commit and verify the final-review correction, run the one
-  allowed correction review, push, and update
+- [ ] PR closeout: run the one allowed correction review on the exact verified
+  head, push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -623,15 +623,23 @@ hash; the report preserves the exact identity that was reviewed.
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-simplification.md`
   and
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-slice-review.md`.
-- [ ] PR closeout: run fresh integrated final review on the exact verified head,
-  push, and update
+- [x] Integrated final review: the initial final review found that fingerprint
+  projection included non-wire tool fields, canonicalization lost an own
+  `__proto__` schema key, and the identity suite duplicated usage-conversion
+  assertions. The correction makes tool options transport-aware, preserves
+  reserved property names with own-property definitions, adds paired key/wire
+  and schema regressions, and removes the duplicate usage assertions. Focused
+  tests pass 26/26. The initial report is
+  `project/_local/reviews/2026-08-14-chat-cache-request-boundary-integrated-final.md`.
+- [ ] PR closeout: commit and verify the final-review correction, run the one
+  allowed correction review, push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action
 
 The user authorized this correction package, its commits, a force-with-lease
 push after the approved rebase, and finalization of the existing PR. The next
-action is fresh focused and package verification followed by the required
-simplification, risk-selected slice review, and integrated final review on the
-exact committed range. Merge, deployment, measurement, tunnel use, paid calls,
-and production mutation remain separate gates.
+action is fresh verification and the one allowed integrated-final correction
+review on the exact committed range, followed by the push and PR update. Merge,
+deployment, measurement, tunnel use, paid calls, and production mutation remain
+separate gates.

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -604,10 +604,19 @@ hash; the report preserves the exact identity that was reviewed.
   remain the review record; full package/root/build checks still remain
   unavailable because generated workspace outputs are missing and the host is
   running Node 26 instead of the repository's pinned Node 24.
-- [ ] PR review correction and closeout: rebased onto current `v3`; align the
-  prompt-cache transport with `usesResponsesApi`, clear the Sonar findings,
-  remove machine-local plan references, avoid SDK-internal schema key lists,
-  run fresh verification and integrated final review, then push and update
+- [x] PR review correction implementation: rebased onto current `v3`; aligned
+  prompt-cache transport with `usesResponsesApi`; reduced the two Sonar
+  maintainability findings and supplied an explicit locale-aware comparator;
+  removed machine-local plan references; replaced SDK-internal schema key
+  lists with ordering and cross-transport semantic assertions; documented the
+  key-only custom route and function-description context contract. Focused
+  tests pass 23/23, the full chat suite passes 288/288 after generating local
+  workspace outputs, the chat package check passes, root `check:all` passes,
+  and the production build passes 22/22 tasks. The host uses Node 26 instead
+  of the required Node 24, so current-head CI remains the Node 24 release gate.
+- [ ] PR closeout: complete the corrective slice simplification and
+  risk-selected review, record their dispositions, run fresh integrated final
+  review, push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -1,4 +1,4 @@
-# Chat cache request boundary and stable prompt-prefix identity
+# PR #5387: Chat cache request boundary and stable prompt-prefix identity
 
 ## Goal
 
@@ -43,21 +43,27 @@ The package owns two separate request contracts:
 
 ## Plan identity and authority
 
-- Status: approved; implementation in progress on the named branch.
-- Plan: `project/2026-08-12-chat-cache-request-boundary-plan.md`
-- Repository: `/Users/rschlae/Git/klicker/klicker-uzh`
+- Status: approved; PR review correction and closeout in progress.
+- Plan: `project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md`
+- Repository: `klicker-uzh`
 - Branch: `rs/chat-cache-request-boundary`
-- Worktree: `/Users/rschlae/Git/klicker/klicker-uzh/trees/chat-cache-request-boundary`
+- Worktree: `trees/chat-cache-request-boundary`
 - Target/base: `v3` / `origin/v3`
-- Base SHA validated on 2026-08-12: `5264353ff77afc598ea69f05f262b25f882ca38c`
-- Existing reference worktree:
-  `/Users/rschlae/Git/klicker/klicker-uzh/trees/chat-turn-affinity-cache`
-- Existing reference PR: #5365, closed, unmerged, draft; reference only.
+- Current base after the 2026-08-14 rebase:
+  `6ff729ad0f01429108537f47f4cf4d1d437cc29a`.
+- Initial base validated on 2026-08-12:
+  `5264353ff77afc598ea69f05f262b25f882ca38c`.
+- Existing reference worktree: `trees/chat-turn-affinity-cache`.
+- Delivery PR: [#5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
+- Existing reference PR:
+  [#5365](https://github.com/uzh-bf/klicker-uzh/pull/5365), closed,
+  unmerged, draft; reference only.
 - Project artifact root: `project/`
 - Local review artifacts: `project/_local/reviews/` (ignored, never staged).
 - First post-approval commit: this plan only, before implementation.
-- No implementation, commit, push, PR, merge, deployment, cluster/tunnel
-  access, measurement, or production mutation is authorized by this plan.
+- The 2026-08-14 closeout authorizes edits, commits, branch push, and PR
+  finalization. Merge, deployment, cluster/tunnel access, measurement, paid
+  calls, and production mutation remain outside this package.
 
 The primary checkout contains unrelated user changes. It is not an execution
 surface and must remain untouched. The reference worktree contains one
@@ -185,8 +191,8 @@ evidence, not live provider or production proof.
 - `apps/chat/src/services/mcpClients.ts`: priority-based aggregation and
   deterministic namespacing of MCP tools.
 - `apps/chat/package.json`: AI SDK `7.0.52` and OpenAI provider `4.0.30`.
-- `/tmp/klicker-cache-contract-prototype/README.md` and `probe.mjs`: a
-  no-network synthetic capture passed for both Chat Completions and Responses.
+- A discarded no-network synthetic prototype captured both Chat Completions
+  and Responses request shapes.
   It showed `prompt_cache_key`, `prompt_cache_options`, the top-level LiteLLM
   bypass field injected by an application fetch wrapper, and normalized
   `usage.inputTokenDetails` buckets. It intentionally did not contact
@@ -537,7 +543,8 @@ hash; the report preserves the exact identity that was reviewed.
 - [x] Incorporate verified review corrections and independently recheck them.
 - [x] Present the reviewed plan for user approval; approval received on
   2026-08-12.
-- [x] Commit the approved plan as the branch's first commit (`1c8ff5bf0`).
+- [x] Commit the approved plan as the branch's first commit (`5064ff88c`
+  after the 2026-08-14 rebase).
 - [x] Slice 2 implemented: the default-provider fetch boundary adds the exact
   cache bypass while preserving Responses normalization, and the focused
   synthetic transport/image tests pass. The executor returned `NEEDS_CONTEXT`
@@ -592,15 +599,22 @@ hash; the report preserves the exact identity that was reviewed.
   tunnel, cluster access, or cleanup was performed.
 - [x] User-approved final simplification: removed the explicit implicit-mode
   override and deployment allow-list from the provider options. Focused
-  request-shape verification passes 23/23 focused tests, plus Biome, Prettier,
+  request-shape verification passed 22/22 focused tests, plus Biome, Prettier,
   and whitespace checks. The existing integrated-final and Claude Opus reports
   remain the review record; full package/root/build checks still remain
   unavailable because generated workspace outputs are missing and the host is
   running Node 26 instead of the repository's pinned Node 24.
+- [ ] PR review correction and closeout: rebased onto current `v3`; align the
+  prompt-cache transport with `usesResponsesApi`, clear the Sonar findings,
+  remove machine-local plan references, avoid SDK-internal schema key lists,
+  run fresh verification and integrated final review, then push and update
+  [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
-## Next action after user approval
+## Current closeout authority and next action
 
-Approval has now been received. Commit this plan as the first branch commit,
-then execute the slices in order. A generic approval here does not
-authorize push, PR creation, merge, deployment, measurement, tunnel use, paid
-calls, or production mutation; those remain separate named gates.
+The user authorized this correction package, its commits, a force-with-lease
+push after the approved rebase, and finalization of the existing PR. The next
+action is fresh focused and package verification followed by the required
+simplification, risk-selected slice review, and integrated final review on the
+exact committed range. Merge, deployment, measurement, tunnel use, paid calls,
+and production mutation remain separate gates.

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -610,13 +610,21 @@ hash; the report preserves the exact identity that was reviewed.
   removed machine-local plan references; replaced SDK-internal schema key
   lists with ordering and cross-transport semantic assertions; documented the
   key-only custom route and function-description context contract. Focused
-  tests pass 23/23, the full chat suite passes 288/288 after generating local
+  tests pass 24/24 after the review correction, the full chat suite passes
+  288/288 before that correction after generating local
   workspace outputs, the chat package check passes, root `check:all` passes,
   and the production build passes 22/22 tasks. The host uses Node 26 instead
   of the required Node 24, so current-head CI remains the Node 24 release gate.
-- [ ] PR closeout: complete the corrective slice simplification and
-  risk-selected review, record their dispositions, run fresh integrated final
-  review, push, and update
+- [x] Corrective-slice review: the simplifier approved the committed correction
+  without another reduction. The slice reviewer found that the fetch wrapper
+  could retry a request if the fetch implementation threw a synchronous
+  `SyntaxError`; the parse-only error boundary and a one-call regression test
+  correct that issue. Reports are in
+  `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-simplification.md`
+  and
+  `project/_local/reviews/2026-08-14-chat-cache-request-boundary-closeout-slice-review.md`.
+- [ ] PR closeout: commit and verify the review correction, run fresh integrated
+  final review, push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action

--- a/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
+++ b/project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md
@@ -127,12 +127,14 @@ metadata.
 The canonical tool representation must use the provider-visible schema rather
 than executable functions or MCP client instances. It should resolve each
 tool's `inputSchema` through the installed AI SDK schema boundary, retain the
-tool name and description, include every provider-visible function-tool field
-that the installed SDK forwards (`strict`, `inputExamples`, and
-`providerOptions` where present), sort tools by canonical name, and recursively
-sort object keys. Array order remains meaningful unless the provider-visible
-schema contract proves that a particular array is set-like; the helper must not
-silently reorder semantic arrays.
+tool name, description, and `strict` field, and exclude `inputExamples` because
+neither OpenAI transport serializes them. Chat tool provider options are
+excluded. Responses identity includes only the forwarded OpenAI tool options:
+`allowedCallers`, `deferLoading`, `namespace`, and `outputSchema`. Tools are
+sorted by canonical name and object keys are sorted recursively. Array order
+remains meaningful unless the provider-visible schema contract proves that a
+particular array is set-like; the helper must not silently reorder semantic
+arrays.
 
 The canonical provider-tool projection must be used twice: first as the input
 to the fingerprint, and second as the provider-facing tool object passed to
@@ -232,9 +234,9 @@ where the existing suite does not already protect the named failure.
 | Stable identity changes when effective instructions change | No current protection | Pure helper table cases for prompt version and instruction changes | `apps/chat/test/prompt-cache-identity.test.ts` |
 | Stable identity partitions requested deployment/transport compatibility | Registry exposes deployment and reasoning transport | Pure helper cases for deployment, `auto-router`, and Chat/Responses changes | `apps/chat/test/prompt-cache-identity.test.ts` |
 | Tool insertion order does not change identity or request order | MCP aggregation is priority/insertion based; AI SDK defaults to object order | Canonical tool-name/schema fixtures with reordered input objects and explicit `toolOrder` assertions | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-chat-streaming.test.ts` |
-| Tool schema, description, strictness, examples, or provider-visible options change the identity and wire contract | AI SDK schema conversion exists; no package contract | Pure synthetic tool definitions with changed provider-visible fields; compare canonical wire projections for both transports | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-chat-streaming.test.ts` |
+| Tool schema, description, strictness, or transport-visible options change the identity; examples and non-OpenAI options do not | AI SDK schema conversion exists; no package contract | Vary wire and non-wire fields separately; compare canonical wire projections for both transports | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-chat-streaming.test.ts` |
 | User, participant, chatbot, thread, assistant-message, message/content, request, tool-call, and raw MCP identifiers do not affect identity | Existing route has all values in scope, but no negative test | Separate privacy-negative fixtures for each identifier class and an assertion that only the stable-prefix input is accepted | `apps/chat/test/prompt-cache-identity.test.ts` |
-| Both transports preserve prompt-cache fields and public usage buckets | Disposable no-network probe | Repository-owned synthetic Chat/Responses fixtures assert serialized fields and public `usage.inputTokenDetails` | `apps/chat/test/openai-chat-streaming.test.ts` and a focused Responses fixture |
+| Both transports preserve prompt-cache fields and public usage buckets | Disposable no-network probe | Identity fixtures assert serialized prompt-cache fields; exact-cache transport fixtures assert public `usage.inputTokenDetails` once | `apps/chat/test/prompt-cache-identity.test.ts` and `apps/chat/test/openai-cache-policy.test.ts` |
 | Image-description requests bypass exact cache but do not receive chat-prefix identity | Route calls `generateText` through the selected provider at `route.ts:915-930`; no test currently protects the policy | Synthetic `generateText` capture through a default provider asserts the two bypass flags and absence of `prompt_cache_key` | `apps/chat/test/openai-cache-policy.test.ts` |
 | Provider-managed implicit caching remains the default while the stable key stays default-route-only | The provider supports implicit caching and stable `promptCacheKey` matching; this package does not need a deployment allow-list | Both transports assert the stable key is serialized and no explicit `prompt_cache_options` override is emitted | `apps/chat/test/prompt-cache-identity.test.ts` |
 | Existing chat behavior remains green | Current package test suite and typecheck | Run focused transport tests, full chat tests, chat typecheck, root checks, and build | Package/root verification |
@@ -631,15 +633,20 @@ hash; the report preserves the exact identity that was reviewed.
   and schema regressions, and removes the duplicate usage assertions. Focused
   tests pass 26/26. The initial report is
   `project/_local/reviews/2026-08-14-chat-cache-request-boundary-integrated-final.md`.
-- [ ] PR closeout: run the one allowed correction review on the exact verified
-  head, push, and update
+- [x] Integrated-final correction review: confirmed all executable findings
+  were closed without a correctness, security, privacy, architecture, or
+  data-flow regression. Its two closeout findings are addressed by correcting
+  the stale plan contract and isolating non-wire from wire-visible changes in
+  the regression test. Per policy, these non-behavioral edits close through
+  main-session verification without a third final review. The report is
+  `project/_local/reviews/2026-08-14-chat-cache-request-boundary-integrated-final-correction.md`.
+- [ ] PR closeout: commit the closeout corrections, push, and update
   [PR #5387](https://github.com/uzh-bf/klicker-uzh/pull/5387).
 
 ## Current closeout authority and next action
 
 The user authorized this correction package, its commits, a force-with-lease
 push after the approved rebase, and finalization of the existing PR. The next
-action is fresh verification and the one allowed integrated-final correction
-review on the exact committed range, followed by the push and PR update. Merge,
-deployment, measurement, tunnel use, paid calls, and production mutation remain
-separate gates.
+action is the authorized force-with-lease push and PR update after committing
+the verified closeout corrections. Merge, deployment, measurement, tunnel use,
+paid calls, and production mutation remain separate gates.


### PR DESCRIPTION
## Summary

This PR separates the two cache contracts used by the personalized chat route:

- Default OpenAI-compatible requests add LiteLLM's exact-response cache bypass;
  custom chatbot routing keeps its existing request shape.
- Default Chat Completions and Responses requests receive a versioned,
  provider-safe prompt-cache identity derived from deployment, actual transport,
  final instructions, and canonical provider-visible tools.
- Tool execution and deterministic order are preserved. Provider-managed
  implicit prompt caching remains the default; there is no deployment allow-list
  or explicit prompt-cache mode.

## How It Works

- `openaiCachePolicy.ts` adds `cache.no-cache` and `cache.no-store` only for the
  default route and keeps Responses assistant-item normalization intact.
- `promptCacheIdentity.ts` emits
  `klicker:pc:v1:<50-hex-character-digest>` (64 characters total). It excludes
  user, participant, chatbot, thread, message, request, tool-call, MCP-runtime,
  and non-wire tool fields.
- Transport identity follows `usesResponsesApi`, including Auto routing.
- Tool strictness is fingerprinted on both transports. Input examples and Chat
  tool provider options are excluded; Responses includes only the OpenAI tool
  options serialized by the installed provider.
- Custom-key-only requests remain custom routing even when they still reach the
  shared gateway, so they receive neither default cache behavior.

## Scope and Package Checks

- Base commit used for the branch: `v3` at
  `6ff729ad0f01429108537f47f4cf4d1d437cc29a`.
- Head: `2de45764c5d90fb674d13a5c5c3246cdb053899b`.
- Reviewed: 17 commits, 10 changed paths, +1,773/-37 overall.
- Substantive size: 1,121 changed lines, excluding the committed project plan
  and project change log.
- Execution record:
  [`project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md`](project/2026-08-12-pr-5387-chat-cache-request-boundary-plan.md).

## Review Focus

- Confirm default and custom routing preserve their separate trust boundaries.
- Confirm the fingerprint contains only stable provider-visible inputs and the
  provider receives the same canonical tools and order.
- Confirm the fetch wrapper never retries a request after a synchronous fetch
  error and Responses normalization still happens exactly once.
- Confirm provider-managed implicit caching remains an intentional non-change.

## Verification

Current executable head:

- Focused cache/model tests: 26/26 passed.
- `pnpm --filter @klicker-uzh/chat test:run`: 35 files, 291/291 passed.
- `pnpm --filter @klicker-uzh/chat check`: passed.
- `pnpm run check:all`: passed.
- `pnpm run build`: 22/22 tasks passed.
- Biome, Prettier, staged data-hygiene, and diff checks: passed.

The local host used Node 26 while the repository pins Node 24. Current-head
GitHub checks are therefore the release-parity gate. No browser run is needed
for this server-only request-boundary change.

Not run: provider, gateway, Redis, router, cache-hit, staging, production,
latency, or cost measurements. Those remain separately authorized operational
work and are not required to establish this code contract.

## Review Outcome

- The corrective simplifier approved the implementation without another
  reduction.
- The risk-selected review found and closed a possible duplicate send after a
  synchronous fetch `SyntaxError`.
- Integrated final review found and closed non-wire fingerprint inputs,
  `__proto__` schema-key preservation, and duplicate usage assertions.
- The allowed correction review confirmed the executable findings were closed
  without a correctness, security, privacy, architecture, or data-flow
  regression. Its plan/test closeout comments were also applied and verified.

## Security / Privacy

- Prompt and schema contents are hashed locally and are not logged as raw
  identity metadata.
- Person, conversation, request, tool-call, and MCP-runtime identifiers are not
  fingerprint inputs.
- No secrets, credentials, production data, or provider payloads are included.
- This branch does not change authentication, authorization, credits,
  deployment, or production configuration.

## Blocking Before Merge

- [ ] GitHub reports the branch as mergeable but behind the latest `v3`. The
  current head passes all checks; updating the branch and rerunning CI requires
  a separately approved rebase and force-push.

## Follow-Up After Merge

- Run the previously deferred on-demand affinity spend comparison when
  measurement resumes; do not add a recurring CronJob unless reconciliation is
  repeatedly useful.
- Research cache-token field mapping separately only if total-spend evidence is
  insufficient to explain cached versus uncached components.

## Local Session Artifacts

- Worktree: `trees/chat-cache-request-boundary` in `klicker-uzh`.
- Review reports: `project/_local/reviews/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved chat request caching for default and custom providers.
  - Added more consistent prompt-prefix caching across Chat Completions and Responses requests.
  - Preserved tool ordering and configuration to improve cache stability.
  - Improved handling of streamed responses and image requests.
  - Maintained provider-specific behavior while preventing inappropriate response caching.

- **Documentation**
  - Added guidance describing caching behavior, supported scenarios, and verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
