### PR TITLE
enhance(prisma-data): add aggregate chatbot analytics reports

### DIFF
--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -365,7 +365,7 @@ purpose, time window, and output directory and writes disclosure-controlled JSON
 and XLSX from the same report model. Its Prisma provider loads only the selected
 window and direct assistant replies needed for lineage. The provider returns no
 eligibility decisions until an authoritative effective-dated source exists, so
-database-backed runs exclude every record and remain fully suppressed. The
+database-backed runs exclude every record and suppress the aggregate. The
 synthetic provider test proves the executable path without database or
 production access. LiteLLM and Langfuse remain authoritative for actual model,
 spend, cache, trace, and latency facts and are not copied into the PostgreSQL

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -347,6 +347,25 @@ product ruling (`project/2026-07-27-student-chat-v3-follow-up-roadmap.md`, W7 it
 switcher is hidden entirely when a chatbot exposes a single mode — `mode-switcher.tsx` returns
 `null` for one or fewer mode keys, so there is no disabled one-pill state to style.
 
+## Learning analytics boundary
+
+Chat usage is retained in PostgreSQL for product-quality and learning-analytics
+work, but the legacy usage exporter is an operational baseline rather than a
+safe personal-data download. Its historical `--includeMessageContent` option
+is rejected; content-bearing analysis must use the governed restricted-export
+contract with purpose-specific effective eligibility, an authoritative
+operator, a verified encrypted destination, an append-only audit record, an
+expiry, and withdrawal/rebuild metadata. Default reporting is aggregate-only
+with small-cell and complementary-disclosure suppression. Research eligibility
+is a separate purpose and is never inferred from learning-analytics eligibility.
+
+The reusable analysis model lives in
+`packages/prisma-data/src/chatbot-analysis/`. It is currently synthetic-only:
+the production eligibility, operator, audit, destination, expiry, and deletion
+providers remain explicit integration dependencies. LiteLLM and Langfuse remain
+authoritative for actual model, spend, cache, trace, and latency facts and are
+not copied into the PostgreSQL analytics model.
+
 ## Sources and citations
 
 An answer's sources are **derived from the message's own tool-call parts**, not carried in a

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -352,19 +352,24 @@ switcher is hidden entirely when a chatbot exposes a single mode — `mode-switc
 Chat usage is retained in PostgreSQL for product-quality and learning-analytics
 work, but the legacy usage exporter is an operational baseline rather than a
 safe personal-data download. Its historical `--includeMessageContent` option
-is rejected; content-bearing analysis must use the governed restricted-export
-contract with purpose-specific effective eligibility, an authoritative
-operator, a verified encrypted destination, an append-only audit record, an
-expiry, and withdrawal/rebuild metadata. Default reporting is aggregate-only
-with small-cell and complementary-disclosure suppression. Research eligibility
-is a separate purpose and is never inferred from learning-analytics eligibility.
+is rejected, and no content-bearing export path exists. A future restricted
+export must satisfy the governance boundary in ADR-0005; that implementation is
+not part of the current package. Default reporting is aggregate-only with
+small-cell and complementary-disclosure suppression. Research eligibility is a
+separate purpose and is never inferred from learning-analytics eligibility.
 
 The reusable analysis model lives in
-`packages/prisma-data/src/chatbot-analysis/`. It is currently synthetic-only:
-the production eligibility, operator, audit, destination, expiry, and deletion
-providers remain explicit integration dependencies. LiteLLM and Langfuse remain
-authoritative for actual model, spend, cache, trace, and latency facts and are
-not copied into the PostgreSQL analytics model.
+`packages/prisma-data/src/chatbot-analysis/`. The bounded aggregate command is
+`src/scripts/2026-08-13_chatbot_aggregate_report.ts`; it accepts one course,
+purpose, time window, and output directory and writes disclosure-controlled JSON
+and XLSX from the same report model. Its Prisma provider loads only the selected
+window and direct assistant replies needed for lineage. The provider returns no
+eligibility decisions until an authoritative effective-dated source exists, so
+database-backed runs exclude every record and remain fully suppressed. The
+synthetic provider test proves the executable path without database or
+production access. LiteLLM and Langfuse remain authoritative for actual model,
+spend, cache, trace, and latency facts and are not copied into the PostgreSQL
+analytics model.
 
 ## Sources and citations
 

--- a/packages/prisma-data/src/chatbot-analysis/core.ts
+++ b/packages/prisma-data/src/chatbot-analysis/core.ts
@@ -22,6 +22,8 @@ export type AnalysisMessage = {
   text: string
   attachmentCount: number
   creditsUsed: number | null
+  chatMode?: string | null
+  modelId?: string | null
 }
 
 export type AnalysisRecordProvider = {

--- a/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
@@ -1,10 +1,20 @@
 import { prisma } from '@klicker-uzh/prisma'
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createPrismaAnalysisRecordProvider } from './prismaProvider.js'
 
+const COURSE_ID = '00000000-0000-4000-8000-000000000001'
+const OTHER_COURSE_ID = '00000000-0000-4000-8000-000000000002'
+const CHATBOT_ID = '00000000-0000-4000-8000-000000000003'
+const THREAD_ID = '00000000-0000-4000-8000-000000000004'
+const USER_ID = '00000000-0000-4000-8000-000000000005'
+
 afterAll(async () => {
   await prisma.$disconnect()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Prisma chatbot analysis provider', () => {
@@ -20,5 +30,57 @@ describe('Prisma chatbot analysis provider', () => {
         to: new Date('2026-08-02T00:00:00.000Z'),
       })
     ).resolves.toEqual([])
+  })
+
+  it('loads only the selected course window and its direct assistant replies', async () => {
+    const from = new Date('2026-08-01T00:00:00.000Z')
+    const to = new Date('2026-08-02T00:00:00.000Z')
+    const selected = [
+      {
+        id: USER_ID,
+        parentId: null,
+        role: 'user',
+        chatMode: 'tutor',
+        modelId: null,
+        rating: null,
+        creditsUsed: null,
+        createdAt: from,
+        attachments: [],
+        thread: {
+          id: THREAD_ID,
+          participantId: '00000000-0000-4000-8000-000000000006',
+          chatbot: { id: CHATBOT_ID, courseId: COURSE_ID },
+        },
+      },
+    ]
+    const findMany = vi
+      .spyOn(prisma.chatMessage, 'findMany')
+      .mockResolvedValueOnce(selected as never)
+      .mockResolvedValueOnce([] as never)
+
+    const provider = createPrismaAnalysisRecordProvider(COURSE_ID)
+    await provider.loadMessages({ from, to })
+
+    expect(findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          createdAt: { gte: from, lte: to },
+          thread: { chatbot: { courseId: COURSE_ID } },
+        },
+      })
+    )
+    expect(findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          parentId: { in: [USER_ID] },
+          role: 'assistant',
+          createdAt: { gt: to },
+          thread: { chatbot: { courseId: COURSE_ID } },
+        },
+      })
+    )
+    expect(findMany.mock.calls.flat().join(' ')).not.toContain(OTHER_COURSE_ID)
   })
 })

--- a/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
@@ -81,6 +81,6 @@ describe('Prisma chatbot analysis provider', () => {
         },
       })
     )
-    expect(findMany.mock.calls.flat().join(' ')).not.toContain(OTHER_COURSE_ID)
+    expect(JSON.stringify(findMany.mock.calls)).not.toContain(OTHER_COURSE_ID)
   })
 })

--- a/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/prismaProvider.test.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@klicker-uzh/prisma'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { createPrismaAnalysisRecordProvider } from './prismaProvider.js'
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+describe('Prisma chatbot analysis provider', () => {
+  it('fails closed while authoritative eligibility is unavailable', async () => {
+    const provider = createPrismaAnalysisRecordProvider('course-1')
+
+    await expect(
+      provider.loadEligibility({
+        participantIds: ['participant-1'],
+        purpose: 'learning-analytics',
+        courseIds: ['course-1'],
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-02T00:00:00.000Z'),
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/packages/prisma-data/src/chatbot-analysis/prismaProvider.ts
+++ b/packages/prisma-data/src/chatbot-analysis/prismaProvider.ts
@@ -1,0 +1,98 @@
+import { prisma } from '@klicker-uzh/prisma'
+import type { Prisma } from '@klicker-uzh/prisma/client'
+
+import type { AnalysisMessage, AnalysisRecordProvider } from './core.js'
+
+const messageSelect = {
+  id: true,
+  parentId: true,
+  role: true,
+  chatMode: true,
+  modelId: true,
+  rating: true,
+  creditsUsed: true,
+  createdAt: true,
+  attachments: { select: { id: true } },
+  thread: {
+    select: {
+      id: true,
+      participantId: true,
+      chatbot: { select: { id: true, courseId: true } },
+    },
+  },
+} as const satisfies Prisma.ChatMessageSelect
+
+type MessageRow = Prisma.ChatMessageGetPayload<{ select: typeof messageSelect }>
+
+function decimalToNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number') return value
+  const decimal = value as { toNumber?: () => number }
+  if (typeof decimal.toNumber === 'function') return decimal.toNumber()
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function toAnalysisMessage(message: MessageRow): AnalysisMessage {
+  return {
+    id: message.id,
+    threadId: message.thread.id,
+    participantId: message.thread.participantId,
+    chatbotId: message.thread.chatbot.id,
+    courseId: message.thread.chatbot.courseId,
+    parentId: message.parentId,
+    role: message.role,
+    createdAt: message.createdAt,
+    rating: message.rating,
+    // Aggregate reporting does not inspect or emit message content.
+    text: '',
+    attachmentCount: message.attachments.length,
+    creditsUsed: decimalToNumber(message.creditsUsed),
+    chatMode: message.chatMode,
+    modelId: message.modelId,
+  }
+}
+
+export function createPrismaAnalysisRecordProvider(
+  courseId: string
+): AnalysisRecordProvider {
+  return {
+    loadMessages: async ({ from, to }) => {
+      const selected = await prisma.chatMessage.findMany({
+        where: {
+          createdAt: { gte: from, lte: to },
+          thread: { chatbot: { courseId } },
+        },
+        select: messageSelect,
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      })
+      const userIds = selected
+        .filter((message) => message.role === 'user')
+        .map((message) => message.id)
+      const replies =
+        userIds.length === 0
+          ? []
+          : await prisma.chatMessage.findMany({
+              where: {
+                parentId: { in: userIds },
+                role: 'assistant',
+                createdAt: { gt: to },
+                thread: { chatbot: { courseId } },
+              },
+              select: messageSelect,
+              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+            })
+
+      return [...selected, ...replies]
+        .sort(
+          (left, right) =>
+            left.createdAt.getTime() - right.createdAt.getTime() ||
+            left.id.localeCompare(right.id)
+        )
+        .map(toAnalysisMessage)
+    },
+    // An authoritative effective-dated eligibility source does not exist yet.
+    // Empty decisions make every database-backed aggregate run fail closed.
+    loadEligibility: async () => [],
+  }
+}

--- a/packages/prisma-data/src/chatbot-analysis/reports.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.test.ts
@@ -139,6 +139,30 @@ describe('governed chatbot reports', () => {
     expect(JSON.stringify(report)).not.toContain('participant-1')
   })
 
+  it('suppresses the fail-closed database population', () => {
+    const excluded = message('excluded')
+    const report = buildAggregateReport({
+      core: {
+        eligible: { messages: [], excludedMessageIds: [excluded.id] },
+        exchanges: [],
+        ratingCoverage: {
+          ratedResponses: 0,
+          unratedResponses: 0,
+          up: 0,
+          down: 0,
+          coverage: 0,
+        },
+      },
+      messages: [],
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.summary.eligibleMessages).toBeNull()
+    expect(report.provenance[0]?.unknownCount).toBeNull()
+    expect(report.privacy.suppressedTables).toContain('summary.userPopulation')
+  })
+
   it('suppresses a scalar total when a same-population dimension has a hidden cell', () => {
     const users = Array.from({ length: 6 }, (_, index) =>
       message(`user-${index}`, {

--- a/packages/prisma-data/src/chatbot-analysis/reports.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.test.ts
@@ -1,17 +1,17 @@
-import { mkdtemp, readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
-import type { AnalysisCoreResult } from './core.js'
+import type {
+  AnalysisCoreResult,
+  AnalysisRecordProvider,
+  EligibilityDecision,
+} from './core.js'
 import {
   assertLegacyMessageContentExportDisabled,
-  authorizeRestrictedExport,
   buildAggregateReport,
   buildDisclosureTable,
   type ReportMessage,
-  type RestrictedExportAuditEvent,
-  type RestrictedExportDependencies,
-  type RestrictedExportMessage,
-  writeAggregateReportFiles,
+  runAggregateReport,
 } from './reports.js'
 
 const window = {
@@ -21,8 +21,8 @@ const window = {
 
 function message(
   id: string,
-  overrides: Partial<RestrictedExportMessage> = {}
-): RestrictedExportMessage {
+  overrides: Partial<ReportMessage> = {}
+): ReportMessage {
   return {
     id,
     threadId: `thread-${id}`,
@@ -37,6 +37,20 @@ function message(
     attachmentCount: 0,
     creditsUsed: 1,
     ...overrides,
+  }
+}
+
+function eligible(
+  participantId: string,
+  courseId = 'course-1'
+): EligibilityDecision {
+  return {
+    participantId,
+    purpose: 'learning-analytics',
+    courseId,
+    effectiveFrom: window.from,
+    effectiveTo: window.to,
+    eligible: true,
   }
 }
 
@@ -62,7 +76,6 @@ function core(messages: ReportMessage[]): AnalysisCoreResult {
       down: assistant?.rating === 'DOWN' ? 1 : 0,
       coverage: assistant?.rating ? 1 : 0,
     },
-    provenance: {},
   }
 }
 
@@ -450,147 +463,43 @@ describe('governed chatbot reports', () => {
     )
   })
 
-  it('writes JSON and workbook artifacts from the same aggregate model', async () => {
-    const report = buildAggregateReport({
-      core: core([message('user')]),
-      messages: [message('user')],
+  it('runs the aggregate path from a synthetic provider to JSON and XLSX', async () => {
+    const messages = Array.from({ length: 5 }, (_, index) =>
+      message(`synthetic-user-${index}`, {
+        participantId: `synthetic-participant-${index}`,
+        threadId: `synthetic-thread-${index}`,
+        chatMode: 'tutor',
+      })
+    )
+    const provider: AnalysisRecordProvider = {
+      loadMessages: async () => messages,
+      loadEligibility: async () =>
+        messages.map((value) => eligible(value.participantId)),
+    }
+    const output = await mkdtemp(`${tmpdir()}/chatbot-learning-analytics-`)
+    const result = await runAggregateReport({
+      provider,
       purpose: 'learning-analytics',
       window,
-    })
-    const output = await mkdtemp(`${tmpdir()}/chatbot-learning-analytics-`)
-    const files = await writeAggregateReportFiles({
       outDir: output,
       filePrefix: 'synthetic-aggregate',
-      report,
     })
 
-    expect(files.jsonPath).toMatch(/synthetic-aggregate\.json$/)
-    expect(files.workbookPath).toMatch(/synthetic-aggregate\.xlsx$/)
-    expect(await readFile(files.jsonPath, 'utf8')).toContain(
-      '"reportKind": "aggregate"'
-    )
-  })
-
-  it('denies restricted exports unless every gate is satisfied', async () => {
-    const events: RestrictedExportAuditEvent[] = []
-    const request = {
-      purpose: 'learning-analytics' as const,
-      courseId: 'course-1',
-      operatorId: 'operator-1',
-      from: window.from,
-      to: window.to,
-      expiresAt: new Date('2026-08-03T00:00:00.000Z'),
+    expect(result.files.jsonPath).toMatch(/synthetic-aggregate\.json$/)
+    expect(result.files.workbookPath).toMatch(/synthetic-aggregate\.xlsx$/)
+    expect(result.report.summary.eligibleMessages).toBe(5)
+    const jsonText = await readFile(result.files.jsonPath, 'utf8')
+    expect(JSON.parse(jsonText)).toEqual(result.report)
+    expect((await stat(result.files.workbookPath)).size).toBeGreaterThan(0)
+    const workbookText = await readFile(result.files.workbookPath, 'latin1')
+    for (const sensitiveValue of [
+      messages[0]!.text,
+      messages[0]!.id,
+      messages[0]!.threadId,
+      messages[0]!.participantId,
+    ]) {
+      expect(jsonText).not.toContain(sensitiveValue)
+      expect(workbookText).not.toContain(sensitiveValue)
     }
-    const dependencies = {
-      eligibility: {
-        available: false,
-        filterApplied: false,
-        purpose: 'learning-analytics' as const,
-        courseId: 'course-1',
-        from: window.from,
-        to: window.to,
-        populationDescription: 'synthetic eligible cohort',
-        authority: 'synthetic eligibility provider',
-        eligibleMessageIds: new Set<string>(),
-      },
-      operator: { authoritative: false },
-      destination: { encrypted: false, verified: false, descriptor: '' },
-      deletion: { owner: '', rebuildKey: '' },
-      audit: {
-        append: async (event: RestrictedExportAuditEvent): Promise<void> => {
-          events.push(event)
-        },
-      },
-    }
-
-    await expect(
-      authorizeRestrictedExport({
-        messages: [message('user')],
-        request,
-        dependencies,
-        pseudonymSecret: 'synthetic-secret',
-        now: new Date('2026-08-01T00:00:00.000Z'),
-      })
-    ).rejects.toThrow('Restricted export denied')
-    expect(events).toEqual([])
-  })
-
-  it('pseudonymizes restricted rows and audits only metadata', async () => {
-    const events: RestrictedExportAuditEvent[] = []
-    const user = message('user', {
-      participantId: 'participant-1',
-      threadId: 'thread-1',
-      text: 'student content',
-      attachmentDescriptions: ['graph image'],
-    })
-    const assistant = message('assistant', {
-      participantId: 'participant-1',
-      threadId: 'thread-1',
-      role: 'assistant',
-      parentId: 'user',
-      text: 'tutor content',
-    })
-    const dependencies: RestrictedExportDependencies = {
-      eligibility: {
-        available: true,
-        filterApplied: true,
-        purpose: 'learning-analytics',
-        courseId: 'course-1',
-        from: window.from,
-        to: window.to,
-        populationDescription: 'synthetic eligible cohort',
-        authority: 'synthetic eligibility provider',
-        eligibleMessageIds: new Set(['user', 'assistant']),
-      },
-      operator: { authoritative: true },
-      destination: {
-        encrypted: true,
-        verified: true,
-        descriptor: 'synthetic-encrypted-destination',
-      },
-      deletion: { owner: 'owner-1', rebuildKey: 'rebuild-1' },
-      audit: {
-        append: async (event) => {
-          events.push(event)
-        },
-      },
-    }
-    const artifact = await authorizeRestrictedExport({
-      messages: [user, assistant],
-      request: {
-        purpose: 'learning-analytics',
-        courseId: 'course-1',
-        operatorId: 'operator-1',
-        from: window.from,
-        to: window.to,
-        expiresAt: new Date('2026-08-03T00:00:00.000Z'),
-      },
-      dependencies,
-      pseudonymSecret: 'synthetic-secret',
-      now: new Date('2026-08-01T00:00:00.000Z'),
-    })
-
-    expect(artifact.rows).toHaveLength(2)
-    expect(artifact.rows[0]?.participantPseudonym).toMatch(/^[0-9a-f]{24}$/)
-    expect(artifact.rows[0]?.participantPseudonym).not.toBe('participant-1')
-    expect(artifact.rows.find((row) => row.role === 'user')?.text).toBe(
-      'student content'
-    )
-    expect(artifact.rows[0]).not.toHaveProperty('reasoningContent')
-    expect(artifact.manifest.excludedFields).toContain('rawImageBytes')
-    expect(artifact.manifest).toMatchObject({
-      eligibilityFrom: window.from.toISOString(),
-      eligibilityTo: window.to.toISOString(),
-      populationDescription: 'synthetic eligible cohort',
-      eligibilityAuthority: 'synthetic eligibility provider',
-      outputTier: 'restricted',
-    })
-    expect(events).toHaveLength(1)
-    expect(events[0]).not.toHaveProperty('text')
-    expect(events[0]?.destinationDescriptor).toBe(
-      'synthetic-encrypted-destination'
-    )
-    expect(events[0]?.artifactSha256).toBe(artifact.manifest.artifactSha256)
-    expect(events[0]?.eligibilityFrom).toBe(window.from.toISOString())
   })
 })

--- a/packages/prisma-data/src/chatbot-analysis/reports.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.test.ts
@@ -1,0 +1,596 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import type { AnalysisCoreResult } from './core.js'
+import {
+  assertLegacyMessageContentExportDisabled,
+  authorizeRestrictedExport,
+  buildAggregateReport,
+  buildDisclosureTable,
+  type ReportMessage,
+  type RestrictedExportAuditEvent,
+  type RestrictedExportDependencies,
+  type RestrictedExportMessage,
+  writeAggregateReportFiles,
+} from './reports.js'
+
+const window = {
+  from: new Date('2026-08-01T00:00:00.000Z'),
+  to: new Date('2026-08-01T23:59:59.999Z'),
+}
+
+function message(
+  id: string,
+  overrides: Partial<RestrictedExportMessage> = {}
+): RestrictedExportMessage {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    participantId: `participant-${id}`,
+    chatbotId: 'chatbot-1',
+    courseId: 'course-1',
+    parentId: null,
+    role: 'user',
+    createdAt: new Date('2026-08-01T10:00:00.000Z'),
+    rating: null,
+    text: `synthetic ${id}`,
+    attachmentCount: 0,
+    creditsUsed: 1,
+    ...overrides,
+  }
+}
+
+function core(messages: ReportMessage[]): AnalysisCoreResult {
+  const assistant = messages.find((message) => message.role === 'assistant')
+  const user = messages.find((message) => message.role === 'user')
+  return {
+    eligible: { messages, excludedMessageIds: [] },
+    exchanges: user
+      ? [
+          {
+            userMessage: user,
+            assistantMessage: assistant ?? null,
+            status: assistant ? 'linked' : 'absent',
+            candidateAssistantIds: assistant ? [assistant.id] : [],
+          },
+        ]
+      : [],
+    ratingCoverage: {
+      ratedResponses: assistant?.rating ? 1 : 0,
+      unratedResponses: assistant?.rating ? 0 : assistant ? 1 : 0,
+      up: assistant?.rating === 'UP' ? 1 : 0,
+      down: assistant?.rating === 'DOWN' ? 1 : 0,
+      coverage: assistant?.rating ? 1 : 0,
+    },
+    provenance: {},
+  }
+}
+
+describe('governed chatbot reports', () => {
+  it('suppresses small one-dimensional cells and omits the total', () => {
+    const table = buildDisclosureTable(
+      'mode',
+      new Map([
+        ['auto', 5],
+        ['manual', 2],
+      ])
+    )
+
+    expect(table).toEqual({
+      dimension: 'mode',
+      minimumCellSize: 5,
+      suppressed: true,
+      rows: [
+        { label: 'auto', value: 5 },
+        { label: 'manual', value: null },
+      ],
+      total: null,
+    })
+  })
+
+  it('builds an aggregate report without content or stable identifiers', () => {
+    const user = message('user', {
+      participantId: 'participant-1',
+      threadId: 'thread-1',
+      chatMode: 'tutor',
+      attachmentCount: 1,
+    })
+    const assistant = message('assistant', {
+      participantId: 'participant-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      parentId: 'user',
+      modelId: 'auto',
+      rating: 'UP',
+    })
+    const report = buildAggregateReport({
+      core: core([user, assistant]),
+      messages: [user, assistant],
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.reportKind).toBe('aggregate')
+    expect(report.privacy.containsMessageContent).toBe(false)
+    expect(report.privacy.containsStableIdentifiers).toBe(false)
+    expect(report.summary).toMatchObject({
+      eligibleMessages: null,
+      userMessages: null,
+      assistantMessages: null,
+      participants: null,
+      conversations: null,
+      attachments: null,
+      creditsInternalUnits: null,
+    })
+    expect(JSON.stringify(report)).not.toContain('synthetic user')
+    expect(JSON.stringify(report)).not.toContain('participant-1')
+  })
+
+  it('suppresses a scalar total when a same-population dimension has a hidden cell', () => {
+    const users = Array.from({ length: 6 }, (_, index) =>
+      message(`user-${index}`, {
+        threadId: 'thread-1',
+        participantId: `participant-${index}`,
+        chatMode: index === 0 ? 'hard' : 'tutor',
+      })
+    )
+    const report = buildAggregateReport({
+      core: core(users),
+      messages: users,
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.dimensions.chatModes.suppressed).toBe(true)
+    expect(report.summary.userMessages).toBeNull()
+    expect(report.summary.eligibleMessages).toBeNull()
+    expect(report.summary.creditsInternalUnits).toBeNull()
+  })
+
+  it('suppresses every user-population dimension when any user cell is hidden', () => {
+    const users = Array.from({ length: 10 }, (_, index) =>
+      message(`user-${index}`, {
+        participantId: `participant-${index}`,
+        chatMode: 'tutor',
+        attachmentCount: index === 0 ? 1 : 0,
+      })
+    )
+    const report = buildAggregateReport({
+      core: core(users),
+      messages: users,
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.dimensions.attachmentModality.suppressed).toBe(true)
+    expect(
+      report.dimensions.chatModes.rows.every((row) => row.value === null)
+    ).toBe(true)
+    expect(report.dimensions.selectedModels.rows).toEqual([])
+    expect(report.summary.userMessages).toBeNull()
+    expect(report.summary.exchanges).toEqual({
+      linked: null,
+      ambiguous: null,
+      absent: null,
+      outside_window: null,
+    })
+  })
+
+  it('suppresses additive rating and exchange partitions independently', () => {
+    const users = Array.from({ length: 25 }, (_, index) =>
+      message(`user-${index}`, {
+        participantId: `participant-${index}`,
+        chatMode: 'tutor',
+      })
+    )
+    const report = buildAggregateReport({
+      core: {
+        ...core(users),
+        exchanges: users.map((user, index) => ({
+          userMessage: user,
+          assistantMessage: null,
+          status:
+            index < 12
+              ? ('linked' as const)
+              : index < 14
+                ? ('ambiguous' as const)
+                : ('absent' as const),
+          candidateAssistantIds: [],
+        })),
+        ratingCoverage: {
+          ratedResponses: 12,
+          unratedResponses: 0,
+          up: 10,
+          down: 2,
+          coverage: 1,
+        },
+      },
+      messages: users,
+      purpose: 'learning-analytics',
+      window,
+      minimumCellSize: 5,
+    })
+
+    expect(report.summary.exchanges).toEqual({
+      linked: null,
+      ambiguous: null,
+      absent: null,
+      outside_window: null,
+    })
+    expect(report.summary.ratingCoverage).toEqual({
+      ratedResponses: null,
+      unratedResponses: null,
+      up: null,
+      down: null,
+      coverage: null,
+    })
+    expect(report.privacy.suppressedTables).toEqual(
+      expect.arrayContaining(['summary.exchanges', 'summary.ratingCoverage'])
+    )
+  })
+
+  it('suppresses the message-role partition when one role is small', () => {
+    const users = Array.from({ length: 6 }, (_, index) =>
+      message(`user-${index}`, {
+        participantId: `participant-${index}`,
+        chatMode: 'tutor',
+      })
+    )
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user-0',
+      modelId: 'model-a',
+      participantId: 'participant-0',
+    })
+    const report = buildAggregateReport({
+      core: {
+        ...core([...users, assistant]),
+        exchanges: users.map((user, index) => ({
+          userMessage: user,
+          assistantMessage: index === 0 ? assistant : null,
+          status: index === 0 ? ('linked' as const) : ('absent' as const),
+          candidateAssistantIds: index === 0 ? ['assistant'] : [],
+        })),
+      },
+      messages: [...users, assistant],
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.summary.eligibleMessages).toBeNull()
+    expect(report.summary.userMessages).toBeNull()
+    expect(report.summary.assistantMessages).toBeNull()
+  })
+
+  it('suppresses exploratory signal counts in the default aggregate', () => {
+    const report = buildAggregateReport({
+      core: core([message('user')]),
+      messages: [message('user')],
+      purpose: 'learning-analytics',
+      window,
+      exploratorySignals: [
+        {
+          name: 'asks-for-explanation',
+          assignedMessages: 2,
+          eligibleMessages: 6,
+          coverage: 1 / 3,
+          stability: 0.9,
+          validated: false,
+        },
+      ],
+    })
+
+    expect(report.exploratorySignals[0]).toMatchObject({
+      assignedMessages: null,
+      eligibleMessages: null,
+      coverage: null,
+      validated: false,
+    })
+  })
+
+  it('cascades suppression when selected-model cells are small', () => {
+    const users = Array.from({ length: 6 }, (_, index) =>
+      message(`user-${index}`, {
+        threadId: 'thread-1',
+        participantId: `participant-${index}`,
+        chatMode: 'tutor',
+      })
+    )
+    const assistants = users.map((user, index) =>
+      message(`assistant-${index}`, {
+        threadId: 'thread-1',
+        participantId: user.participantId,
+        role: 'assistant',
+        parentId: user.id,
+        modelId: index < 4 ? 'model-a' : 'model-b',
+        rating: 'UP',
+      })
+    )
+    const allMessages = [...users, ...assistants]
+    const report = buildAggregateReport({
+      core: {
+        ...core(allMessages),
+        exchanges: users.map((user, index) => ({
+          userMessage: user,
+          assistantMessage: assistants[index]!,
+          status: 'linked' as const,
+          candidateAssistantIds: [assistants[index]!.id],
+        })),
+        ratingCoverage: {
+          ratedResponses: 6,
+          unratedResponses: 0,
+          up: 6,
+          down: 0,
+          coverage: 1,
+        },
+      },
+      messages: allMessages,
+      purpose: 'learning-analytics',
+      window,
+    })
+
+    expect(report.dimensions.selectedModels.suppressed).toBe(true)
+    expect(report.dimensions.chatModes.suppressed).toBe(true)
+    expect(report.summary.userMessages).toBeNull()
+    expect(report.summary.assistantMessages).toBeNull()
+    expect(report.summary.eligibleMessages).toBeNull()
+    expect(report.summary.exchanges.linked).toBeNull()
+    expect(report.summary.ratingCoverage).toEqual({
+      ratedResponses: null,
+      unratedResponses: null,
+      up: null,
+      down: null,
+      coverage: null,
+    })
+    expect(report.summary.creditsInternalUnits).toBeNull()
+    expect(report.summary.attachments).toBeNull()
+    expect(report.summary.participants).toBeNull()
+    expect(report.summary.conversations).toBeNull()
+    expect(report.summary.exchanges).toEqual({
+      linked: null,
+      ambiguous: null,
+      absent: null,
+      outside_window: null,
+    })
+    expect(
+      report.provenance.find(
+        (entry) => entry.field === 'summary.eligibleMessages'
+      )?.unknownCount
+    ).toBeNull()
+    expect(
+      report.provenance.find((entry) => entry.field === 'dimensions.chatModes')
+        ?.unknownCount
+    ).toBeNull()
+    expect(
+      report.provenance.find(
+        (entry) => entry.field === 'dimensions.selectedModels'
+      )?.unknownCount
+    ).toBeNull()
+    expect(
+      report.provenance.find(
+        (entry) => entry.field === 'summary.ratingCoverage'
+      )?.unknownCount
+    ).toBeNull()
+  })
+
+  it('resolves linked model fields from the report records by id', () => {
+    const user = message('user', { chatMode: 'tutor' })
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user',
+      modelId: 'model-a',
+    })
+    const secondUser = message('user-2', {
+      chatMode: 'tutor',
+      participantId: 'participant-2',
+    })
+    const secondAssistant = message('assistant-2', {
+      role: 'assistant',
+      parentId: 'user-2',
+      modelId: 'model-a',
+      participantId: 'participant-2',
+    })
+    const extraUsers = Array.from({ length: 6 }, (_, index) =>
+      message(`extra-user-${index}`, {
+        chatMode: 'tutor',
+        participantId: `extra-participant-${index}`,
+      })
+    )
+    const report = buildAggregateReport({
+      core: {
+        ...core([user, assistant, secondUser, secondAssistant, ...extraUsers]),
+        exchanges: [
+          {
+            userMessage: { ...user },
+            assistantMessage: { ...assistant },
+            status: 'linked',
+            candidateAssistantIds: ['assistant'],
+          },
+          {
+            userMessage: { ...secondUser },
+            assistantMessage: { ...secondAssistant },
+            status: 'linked',
+            candidateAssistantIds: ['assistant-2'],
+          },
+          ...extraUsers.slice(0, 2).map((extraUser) => ({
+            userMessage: extraUser,
+            assistantMessage: null,
+            status: 'absent' as const,
+            candidateAssistantIds: [],
+          })),
+          ...extraUsers.slice(2, 4).map((extraUser) => ({
+            userMessage: extraUser,
+            assistantMessage: null,
+            status: 'ambiguous' as const,
+            candidateAssistantIds: [],
+          })),
+          ...extraUsers.slice(4).map((extraUser) => ({
+            userMessage: extraUser,
+            assistantMessage: null,
+            status: 'outside_window' as const,
+            candidateAssistantIds: [],
+          })),
+        ],
+      },
+      messages: [user, assistant, secondUser, secondAssistant, ...extraUsers],
+      purpose: 'learning-analytics',
+      window,
+      minimumCellSize: 2,
+    })
+
+    expect(report.dimensions.selectedModels.rows).toEqual([
+      { label: 'model-a', value: 2 },
+    ])
+  })
+
+  it('rejects the historical raw-content export flag', () => {
+    expect(() => assertLegacyMessageContentExportDisabled(false)).not.toThrow()
+    expect(() => assertLegacyMessageContentExportDisabled(true)).toThrow(
+      '--includeMessageContent is disabled'
+    )
+  })
+
+  it('writes JSON and workbook artifacts from the same aggregate model', async () => {
+    const report = buildAggregateReport({
+      core: core([message('user')]),
+      messages: [message('user')],
+      purpose: 'learning-analytics',
+      window,
+    })
+    const output = await mkdtemp(`${tmpdir()}/chatbot-learning-analytics-`)
+    const files = await writeAggregateReportFiles({
+      outDir: output,
+      filePrefix: 'synthetic-aggregate',
+      report,
+    })
+
+    expect(files.jsonPath).toMatch(/synthetic-aggregate\.json$/)
+    expect(files.workbookPath).toMatch(/synthetic-aggregate\.xlsx$/)
+    expect(await readFile(files.jsonPath, 'utf8')).toContain(
+      '"reportKind": "aggregate"'
+    )
+  })
+
+  it('denies restricted exports unless every gate is satisfied', async () => {
+    const events: RestrictedExportAuditEvent[] = []
+    const request = {
+      purpose: 'learning-analytics' as const,
+      courseId: 'course-1',
+      operatorId: 'operator-1',
+      from: window.from,
+      to: window.to,
+      expiresAt: new Date('2026-08-03T00:00:00.000Z'),
+    }
+    const dependencies = {
+      eligibility: {
+        available: false,
+        filterApplied: false,
+        purpose: 'learning-analytics' as const,
+        courseId: 'course-1',
+        from: window.from,
+        to: window.to,
+        populationDescription: 'synthetic eligible cohort',
+        authority: 'synthetic eligibility provider',
+        eligibleMessageIds: new Set<string>(),
+      },
+      operator: { authoritative: false },
+      destination: { encrypted: false, verified: false, descriptor: '' },
+      deletion: { owner: '', rebuildKey: '' },
+      audit: {
+        append: async (event: RestrictedExportAuditEvent): Promise<void> => {
+          events.push(event)
+        },
+      },
+    }
+
+    await expect(
+      authorizeRestrictedExport({
+        messages: [message('user')],
+        request,
+        dependencies,
+        pseudonymSecret: 'synthetic-secret',
+        now: new Date('2026-08-01T00:00:00.000Z'),
+      })
+    ).rejects.toThrow('Restricted export denied')
+    expect(events).toEqual([])
+  })
+
+  it('pseudonymizes restricted rows and audits only metadata', async () => {
+    const events: RestrictedExportAuditEvent[] = []
+    const user = message('user', {
+      participantId: 'participant-1',
+      threadId: 'thread-1',
+      text: 'student content',
+      attachmentDescriptions: ['graph image'],
+    })
+    const assistant = message('assistant', {
+      participantId: 'participant-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      parentId: 'user',
+      text: 'tutor content',
+    })
+    const dependencies: RestrictedExportDependencies = {
+      eligibility: {
+        available: true,
+        filterApplied: true,
+        purpose: 'learning-analytics',
+        courseId: 'course-1',
+        from: window.from,
+        to: window.to,
+        populationDescription: 'synthetic eligible cohort',
+        authority: 'synthetic eligibility provider',
+        eligibleMessageIds: new Set(['user', 'assistant']),
+      },
+      operator: { authoritative: true },
+      destination: {
+        encrypted: true,
+        verified: true,
+        descriptor: 'synthetic-encrypted-destination',
+      },
+      deletion: { owner: 'owner-1', rebuildKey: 'rebuild-1' },
+      audit: {
+        append: async (event) => {
+          events.push(event)
+        },
+      },
+    }
+    const artifact = await authorizeRestrictedExport({
+      messages: [user, assistant],
+      request: {
+        purpose: 'learning-analytics',
+        courseId: 'course-1',
+        operatorId: 'operator-1',
+        from: window.from,
+        to: window.to,
+        expiresAt: new Date('2026-08-03T00:00:00.000Z'),
+      },
+      dependencies,
+      pseudonymSecret: 'synthetic-secret',
+      now: new Date('2026-08-01T00:00:00.000Z'),
+    })
+
+    expect(artifact.rows).toHaveLength(2)
+    expect(artifact.rows[0]?.participantPseudonym).toMatch(/^[0-9a-f]{24}$/)
+    expect(artifact.rows[0]?.participantPseudonym).not.toBe('participant-1')
+    expect(artifact.rows.find((row) => row.role === 'user')?.text).toBe(
+      'student content'
+    )
+    expect(artifact.rows[0]).not.toHaveProperty('reasoningContent')
+    expect(artifact.manifest.excludedFields).toContain('rawImageBytes')
+    expect(artifact.manifest).toMatchObject({
+      eligibilityFrom: window.from.toISOString(),
+      eligibilityTo: window.to.toISOString(),
+      populationDescription: 'synthetic eligible cohort',
+      eligibilityAuthority: 'synthetic eligibility provider',
+      outputTier: 'restricted',
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0]).not.toHaveProperty('text')
+    expect(events[0]?.destinationDescriptor).toBe(
+      'synthetic-encrypted-destination'
+    )
+    expect(events[0]?.artifactSha256).toBe(artifact.manifest.artifactSha256)
+    expect(events[0]?.eligibilityFrom).toBe(window.from.toISOString())
+  })
+})

--- a/packages/prisma-data/src/chatbot-analysis/reports.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.ts
@@ -257,6 +257,8 @@ export function buildAggregateReport(input: {
   const messages = input.messages.filter((message) =>
     eligibleIds.has(message.id)
   )
+  const eligibilityUnavailable =
+    messages.length === 0 && input.core.eligible.excludedMessageIds.length > 0
   const messageById = new Map(messages.map((message) => [message.id, message]))
   const users = messages.filter((message) => message.role === 'user')
   const assistants = messages.filter((message) => message.role === 'assistant')
@@ -314,6 +316,7 @@ export function buildAggregateReport(input: {
     (table) => table.suppressed
   )
   const messagePopulationSuppressed =
+    eligibilityUnavailable ||
     rawDimensionSuppressed ||
     exchangePartitionSuppressed ||
     messageRolePartitionSuppressed

--- a/packages/prisma-data/src/chatbot-analysis/reports.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.ts
@@ -1,4 +1,3 @@
-import { createHash, createHmac } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -13,17 +12,15 @@ import type {
   AnalysisExchange,
   AnalysisMessage,
   AnalysisPurpose,
+  AnalysisRecordProvider,
   AnalysisWindow,
 } from './core.js'
+import { runAnalysisCore } from './core.js'
 
 export const AGGREGATE_REPORT_SCHEMA_VERSION = 1
-export const RESTRICTED_EXPORT_SCHEMA_VERSION = 1
 export const DEFAULT_MINIMUM_CELL_SIZE = 5
 
-export type ReportMessage = AnalysisMessage & {
-  chatMode?: string | null
-  modelId?: string | null
-}
+export type ReportMessage = AnalysisMessage
 
 export type DisclosureCell = {
   label: string
@@ -40,13 +37,22 @@ export type DisclosureTable = {
   total: number | null
 }
 
-export type ExploratorySignalSummary = {
+export type ExploratorySignalInput = {
   name: string
+  assignedMessages: number
+  eligibleMessages: number
+  coverage: number
+  stability: number | null
+  validated: false
+}
+
+export type ExploratorySignalSummary = Omit<
+  ExploratorySignalInput,
+  'assignedMessages' | 'eligibleMessages' | 'coverage'
+> & {
   assignedMessages: DisclosureNumber
   eligibleMessages: DisclosureNumber
   coverage: DisclosureNumber
-  stability: number | null
-  validated: false
 }
 
 export type AggregateReport = {
@@ -91,18 +97,6 @@ export type AggregateReport = {
     denominator: string
     unknownCount: DisclosureNumber
   }>
-}
-
-export type RestrictedExportEligibility = {
-  available: boolean
-  filterApplied: boolean
-  purpose: AnalysisPurpose
-  courseId: string
-  from: Date
-  to: Date
-  populationDescription: string
-  authority: string
-  eligibleMessageIds: ReadonlySet<string>
 }
 
 type DimensionValue = string | null | undefined
@@ -254,7 +248,7 @@ export function buildAggregateReport(input: {
   purpose: AnalysisPurpose
   window: AnalysisWindow
   minimumCellSize?: number
-  exploratorySignals?: ExploratorySignalSummary[]
+  exploratorySignals?: ExploratorySignalInput[]
 }): AggregateReport {
   const minimumCellSize = input.minimumCellSize ?? DEFAULT_MINIMUM_CELL_SIZE
   const eligibleIds = new Set(
@@ -266,12 +260,11 @@ export function buildAggregateReport(input: {
   const messageById = new Map(messages.map((message) => [message.id, message]))
   const users = messages.filter((message) => message.role === 'user')
   const assistants = messages.filter((message) => message.role === 'assistant')
-  const linked = input.core.exchanges
+  const selectedModels = input.core.exchanges
     .map((exchange) => messageById.get(exchange.assistantMessage?.id ?? ''))
     .filter(
       (message): message is ReportMessage => message?.role === 'assistant'
     )
-  const selectedModels = linked
   const exchangeCountsByStatus = exchangeCounts(input.core.exchanges)
   const participants = new Set(messages.map((message) => message.participantId))
   const conversations = new Set(messages.map((message) => message.threadId))
@@ -350,17 +343,17 @@ export function buildAggregateReport(input: {
     ...signal,
     assignedMessages: messagePopulationSuppressed
       ? null
-      : discloseCount(signal.assignedMessages ?? 0, minimumCellSize),
+      : discloseCount(signal.assignedMessages, minimumCellSize),
     eligibleMessages: messagePopulationSuppressed
       ? null
-      : discloseCount(signal.eligibleMessages ?? 0, minimumCellSize),
+      : discloseCount(signal.eligibleMessages, minimumCellSize),
     coverage: messagePopulationSuppressed
       ? null
-      : (signal.assignedMessages ?? 0) < minimumCellSize
+      : signal.assignedMessages < minimumCellSize
         ? null
         : discloseRatio(
-            signal.assignedMessages ?? 0,
-            signal.eligibleMessages ?? 0,
+            signal.assignedMessages,
+            signal.eligibleMessages,
             minimumCellSize
           ),
   }))
@@ -443,16 +436,15 @@ export function buildAggregateReport(input: {
 }
 
 /**
- * The historical exporter can still calculate content-sensitive sheets
- * internally, but its old content flag must not be an output authorization.
- * Callers must use the governed restricted-export contract instead.
+ * The historical exporter's content flag must not become an output
+ * authorization. ADR-0005 defines the boundary for any future governed path.
  */
 export function assertLegacyMessageContentExportDisabled(
   includeMessageContent: boolean
 ) {
   if (includeMessageContent) {
     throw new Error(
-      '--includeMessageContent is disabled; use the governed restricted-export action with eligibility, operator, destination, audit, expiry, and deletion gates.'
+      '--includeMessageContent is disabled; no content-bearing export exists. A governed restricted export remains future work under ADR-0005.'
     )
   }
 }
@@ -554,323 +546,31 @@ export async function writeAggregateReportFiles(input: {
   return { jsonPath, workbookPath }
 }
 
-export type RestrictedExportMessage = ReportMessage & {
-  attachmentDescriptions?: string[]
-}
-
-export type RestrictedExportRequest = {
+export async function runAggregateReport(input: {
+  provider: AnalysisRecordProvider
   purpose: AnalysisPurpose
-  courseId: string
-  operatorId: string
-  from: Date
-  to: Date
-  expiresAt: Date
-}
-
-export type RestrictedExportDependencies = {
-  eligibility: RestrictedExportEligibility
-  operator: { authoritative: boolean }
-  destination: { encrypted: boolean; verified: boolean; descriptor: string }
-  deletion: { owner: string; rebuildKey: string }
-  audit: {
-    append: (event: RestrictedExportAuditEvent) => Promise<void>
-  }
-}
-
-export type RestrictedExportAuditEvent = {
-  schemaVersion: typeof RESTRICTED_EXPORT_SCHEMA_VERSION
-  eventType: 'chatbot-restricted-export-authorized'
-  purpose: AnalysisPurpose
-  courseId: string
-  operatorId: string
-  expiresAt: string
-  destinationDescriptor: string
-  rowCount: number
-  artifactSha256: string
-  fields: string[]
-  eligibilityFrom: string
-  eligibilityTo: string
-  populationDescription: string
-  eligibilityAuthority: string
-  outputTier: 'restricted'
-  limitations: string[]
-}
-
-export type RestrictedExportRow = {
-  coursePseudonym: string
-  participantPseudonym: string
-  threadPseudonym: string
-  messagePseudonym: string
-  parentMessagePseudonym: string | null
-  role: string
-  messageCreatedAt: string
-  chatMode: string | null
-  selectedModel: string | null
-  rating: 'UP' | 'DOWN' | null
-  creditsInternalUnits: number | null
-  attachmentDescriptions: string[]
-  text: string
-}
-
-export type RestrictedExportArtifact = {
-  schemaVersion: typeof RESTRICTED_EXPORT_SCHEMA_VERSION
-  rows: RestrictedExportRow[]
-  manifest: {
-    purpose: AnalysisPurpose
-    coursePseudonym: string
-    expiresAt: string
-    deletionOwner: string
-    rebuildKey: string
-    artifactSha256: string
-    fields: string[]
-    excludedFields: string[]
-    eligibilityFrom: string
-    eligibilityTo: string
-    populationDescription: string
-    eligibilityAuthority: string
-    outputTier: 'restricted'
-    limitations: string[]
-  }
-}
-
-function scopedPseudonym(
-  value: string,
-  purpose: AnalysisPurpose,
-  courseId: string,
-  secret: string,
-  domain: string
-) {
-  return createHmac('sha256', secret)
-    .update(`${domain}\0${purpose}\0${courseId}\0${value}`)
-    .digest('hex')
-    .slice(0, 24)
-}
-
-function restrictedRows(
-  messages: RestrictedExportMessage[],
-  request: RestrictedExportRequest,
-  secret: string
-): RestrictedExportRow[] {
-  const sorted = [...messages].sort(
-    (left, right) =>
-      left.createdAt.getTime() - right.createdAt.getTime() ||
-      left.id.localeCompare(right.id)
-  )
-  const messagePseudonyms = new Map(
-    sorted.map((message) => [
-      message.id,
-      scopedPseudonym(
-        message.id,
-        request.purpose,
-        request.courseId,
-        secret,
-        'message'
-      ),
-    ])
-  )
-  const coursePseudonym = scopedPseudonym(
-    request.courseId,
-    request.purpose,
-    request.courseId,
-    secret,
-    'course'
-  )
-
-  return sorted.map((message) => ({
-    coursePseudonym,
-    participantPseudonym: scopedPseudonym(
-      message.participantId,
-      request.purpose,
-      request.courseId,
-      secret,
-      'participant'
-    ),
-    threadPseudonym: scopedPseudonym(
-      message.threadId,
-      request.purpose,
-      request.courseId,
-      secret,
-      'thread'
-    ),
-    messagePseudonym: messagePseudonyms.get(message.id)!,
-    parentMessagePseudonym: message.parentId
-      ? (messagePseudonyms.get(message.parentId) ?? null)
-      : null,
-    role: message.role,
-    messageCreatedAt: message.createdAt.toISOString(),
-    chatMode: message.chatMode ?? null,
-    selectedModel: message.modelId ?? null,
-    rating: message.rating,
-    creditsInternalUnits: message.creditsUsed,
-    attachmentDescriptions: (message.attachmentDescriptions ?? []).filter(
-      (description) => description.trim().length > 0
-    ),
-    text: message.text,
-  }))
-}
-
-function digestRows(rows: RestrictedExportRow[]) {
-  return createHash('sha256').update(JSON.stringify(rows)).digest('hex')
-}
-
-function assertRestrictedRequest(
-  request: RestrictedExportRequest,
-  dependencies: RestrictedExportDependencies,
-  secret: string,
-  now: Date,
-  messages: RestrictedExportMessage[]
-) {
-  const failures: string[] = []
-  if (!request.operatorId.trim()) failures.push('operator identity is missing')
-  if (!dependencies.operator.authoritative) {
-    failures.push('operator identity is not authoritative')
-  }
-  if (!dependencies.eligibility.available) {
-    failures.push('authoritative eligibility is unavailable')
-  }
-  if (!dependencies.eligibility.filterApplied) {
-    failures.push('eligibility filter was not applied')
-  }
-  if (dependencies.eligibility.purpose !== request.purpose) {
-    failures.push('eligibility purpose does not match the export purpose')
-  }
-  if (dependencies.eligibility.courseId !== request.courseId) {
-    failures.push('eligibility course does not match the export course')
-  }
-  if (
-    dependencies.eligibility.from.getTime() !== request.from.getTime() ||
-    dependencies.eligibility.to.getTime() !== request.to.getTime()
-  ) {
-    failures.push('eligibility period does not match the export period')
-  }
-  if (!dependencies.eligibility.populationDescription.trim()) {
-    failures.push('eligibility population description is missing')
-  }
-  if (!dependencies.eligibility.authority.trim()) {
-    failures.push('eligibility authority is missing')
-  }
-  if (
-    messages.some(
-      (message) =>
-        message.courseId !== request.courseId ||
-        !dependencies.eligibility.eligibleMessageIds.has(message.id)
-    )
-  ) {
-    failures.push('one or more rows are outside the authoritative eligible set')
-  }
-  if (request.expiresAt.getTime() <= now.getTime()) {
-    failures.push('export expiry must be in the future')
-  }
-  if (!dependencies.destination.encrypted) {
-    failures.push('destination is not encrypted')
-  }
-  if (
-    !dependencies.destination.verified ||
-    !dependencies.destination.descriptor.trim()
-  ) {
-    failures.push('destination verification is missing')
-  }
-  if (!dependencies.deletion.owner.trim())
-    failures.push('deletion owner is missing')
-  if (!dependencies.deletion.rebuildKey.trim()) {
-    failures.push('withdrawal rebuild key is missing')
-  }
-  if (!secret.trim()) failures.push('pseudonym secret is missing')
-  if (failures.length > 0) {
-    throw new Error(`Restricted export denied: ${failures.join('; ')}.`)
-  }
-}
-
-export async function authorizeRestrictedExport(input: {
-  messages: RestrictedExportMessage[]
-  request: RestrictedExportRequest
-  dependencies: RestrictedExportDependencies
-  pseudonymSecret: string
-  now?: Date
-}): Promise<RestrictedExportArtifact> {
-  assertRestrictedRequest(
-    input.request,
-    input.dependencies,
-    input.pseudonymSecret,
-    input.now ?? new Date(),
-    input.messages
-  )
-  const rows = restrictedRows(
-    input.messages,
-    input.request,
-    input.pseudonymSecret
-  )
-  const fields = [
-    'coursePseudonym',
-    'participantPseudonym',
-    'threadPseudonym',
-    'messagePseudonym',
-    'parentMessagePseudonym',
-    'role',
-    'messageCreatedAt',
-    'chatMode',
-    'selectedModel',
-    'rating',
-    'creditsInternalUnits',
-    'attachmentDescriptions',
-    'text',
-  ]
-  const excludedFields = [
-    'participantId',
-    'threadId',
-    'messageId',
-    'reasoningContent',
-    'rawImageBytes',
-    'rawToolResults',
-  ]
-  const artifactSha256 = digestRows(rows)
-  const manifest = {
-    purpose: input.request.purpose,
-    coursePseudonym: scopedPseudonym(
-      input.request.courseId,
-      input.request.purpose,
-      input.request.courseId,
-      input.pseudonymSecret,
-      'course'
-    ),
-    expiresAt: input.request.expiresAt.toISOString(),
-    eligibilityFrom: input.request.from.toISOString(),
-    eligibilityTo: input.request.to.toISOString(),
-    populationDescription: input.dependencies.eligibility.populationDescription,
-    eligibilityAuthority: input.dependencies.eligibility.authority,
-    outputTier: 'restricted' as const,
-    limitations: [
-      'Purpose-scoped pseudonyms are not a substitute for access control.',
-      'Raw reasoning, image bytes, and tool results are excluded.',
-    ],
-    deletionOwner: input.dependencies.deletion.owner,
-    rebuildKey: input.dependencies.deletion.rebuildKey,
-    artifactSha256,
-    fields,
-    excludedFields,
-  }
-  await input.dependencies.audit.append({
-    schemaVersion: RESTRICTED_EXPORT_SCHEMA_VERSION,
-    eventType: 'chatbot-restricted-export-authorized',
-    purpose: input.request.purpose,
-    courseId: input.request.courseId,
-    operatorId: input.request.operatorId,
-    expiresAt: manifest.expiresAt,
-    eligibilityFrom: manifest.eligibilityFrom,
-    eligibilityTo: manifest.eligibilityTo,
-    populationDescription: manifest.populationDescription,
-    eligibilityAuthority: manifest.eligibilityAuthority,
-    outputTier: manifest.outputTier,
-    limitations: manifest.limitations,
-    destinationDescriptor: input.dependencies.destination.descriptor,
-    rowCount: rows.length,
-    artifactSha256,
-    fields,
+  window: AnalysisWindow
+  outDir: string
+  filePrefix: string
+  minimumCellSize?: number
+  exploratorySignals?: ExploratorySignalInput[]
+}) {
+  const core = await runAnalysisCore(input.provider, {
+    purpose: input.purpose,
+    window: input.window,
   })
-
-  return {
-    schemaVersion: RESTRICTED_EXPORT_SCHEMA_VERSION,
-    rows,
-    manifest,
-  }
+  const report = buildAggregateReport({
+    core,
+    messages: core.eligible.messages,
+    purpose: input.purpose,
+    window: input.window,
+    minimumCellSize: input.minimumCellSize,
+    exploratorySignals: input.exploratorySignals,
+  })
+  const files = await writeAggregateReportFiles({
+    outDir: input.outDir,
+    filePrefix: input.filePrefix,
+    report,
+  })
+  return { core, report, files }
 }

--- a/packages/prisma-data/src/chatbot-analysis/reports.ts
+++ b/packages/prisma-data/src/chatbot-analysis/reports.ts
@@ -1,0 +1,876 @@
+import { createHash, createHmac } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import type { WorkbookSheet } from '../scripts/lib/simpleWorkbook.js'
+import {
+  sanitizeFilename,
+  writeWorkbookFile,
+} from '../scripts/lib/simpleWorkbook.js'
+
+import type {
+  AnalysisCoreResult,
+  AnalysisExchange,
+  AnalysisMessage,
+  AnalysisPurpose,
+  AnalysisWindow,
+} from './core.js'
+
+export const AGGREGATE_REPORT_SCHEMA_VERSION = 1
+export const RESTRICTED_EXPORT_SCHEMA_VERSION = 1
+export const DEFAULT_MINIMUM_CELL_SIZE = 5
+
+export type ReportMessage = AnalysisMessage & {
+  chatMode?: string | null
+  modelId?: string | null
+}
+
+export type DisclosureCell = {
+  label: string
+  value: number | null
+}
+
+export type DisclosureNumber = number | null
+
+export type DisclosureTable = {
+  dimension: string
+  minimumCellSize: number
+  suppressed: boolean
+  rows: DisclosureCell[]
+  total: number | null
+}
+
+export type ExploratorySignalSummary = {
+  name: string
+  assignedMessages: DisclosureNumber
+  eligibleMessages: DisclosureNumber
+  coverage: DisclosureNumber
+  stability: number | null
+  validated: false
+}
+
+export type AggregateReport = {
+  schemaVersion: typeof AGGREGATE_REPORT_SCHEMA_VERSION
+  reportKind: 'aggregate'
+  purpose: AnalysisPurpose
+  window: { from: string; to: string }
+  privacy: {
+    containsMessageContent: false
+    containsStableIdentifiers: false
+    containsParticipantPseudonyms: false
+    minimumCellSize: number
+    suppressedTables: string[]
+  }
+  summary: {
+    eligibleMessages: DisclosureNumber
+    userMessages: DisclosureNumber
+    assistantMessages: DisclosureNumber
+    participants: DisclosureNumber
+    conversations: DisclosureNumber
+    attachments: DisclosureNumber
+    creditsInternalUnits: DisclosureNumber
+    exchanges: Record<AnalysisExchange['status'], DisclosureNumber>
+    ratingCoverage: {
+      ratedResponses: DisclosureNumber
+      unratedResponses: DisclosureNumber
+      up: DisclosureNumber
+      down: DisclosureNumber
+      coverage: DisclosureNumber
+    }
+  }
+  dimensions: {
+    chatModes: DisclosureTable
+    selectedModels: DisclosureTable
+    attachmentModality: DisclosureTable
+  }
+  exploratorySignals: ExploratorySignalSummary[]
+  provenance: Array<{
+    field: string
+    source: 'postgresql'
+    definition: string
+    denominator: string
+    unknownCount: DisclosureNumber
+  }>
+}
+
+export type RestrictedExportEligibility = {
+  available: boolean
+  filterApplied: boolean
+  purpose: AnalysisPurpose
+  courseId: string
+  from: Date
+  to: Date
+  populationDescription: string
+  authority: string
+  eligibleMessageIds: ReadonlySet<string>
+}
+
+type DimensionValue = string | null | undefined
+
+function normalizeDimension(value: DimensionValue) {
+  return value && value.trim().length > 0 ? value : 'unknown'
+}
+
+function round(value: number) {
+  const factor = 10 ** 6
+  return Math.round(value * factor) / factor
+}
+
+function discloseCount(value: number, minimumCellSize: number) {
+  return value === 0 || value >= minimumCellSize ? value : null
+}
+
+function discloseRatio(
+  numerator: number,
+  denominator: number,
+  minimumCellSize: number
+) {
+  if (denominator === 0) return 0
+  return denominator >= minimumCellSize ? round(numerator / denominator) : null
+}
+
+function countBy<T>(values: T[], getValue: (value: T) => DimensionValue) {
+  const counts = new Map<string, number>()
+  for (const value of values) {
+    const label = normalizeDimension(getValue(value))
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+  }
+  return counts
+}
+
+export function buildDisclosureTable(
+  dimension: string,
+  counts: Map<string, number>,
+  minimumCellSize = DEFAULT_MINIMUM_CELL_SIZE
+): DisclosureTable {
+  if (!Number.isInteger(minimumCellSize) || minimumCellSize < 2) {
+    throw new Error('minimumCellSize must be an integer greater than one.')
+  }
+
+  const rows = Array.from(counts.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([label, count]) => ({
+      label,
+      value: count < minimumCellSize ? null : count,
+    }))
+  const suppressed = rows.some((row) => row.value === null)
+
+  return {
+    dimension,
+    minimumCellSize,
+    suppressed,
+    rows,
+    // Omitting the margin whenever a cell is suppressed prevents a displayed
+    // total from reconstructing the hidden cell in this one-dimensional table.
+    total: suppressed
+      ? null
+      : rows.reduce((total, row) => total + (row.value ?? 0), 0),
+  }
+}
+
+function suppressDisclosureTable(table: DisclosureTable): DisclosureTable {
+  return {
+    ...table,
+    suppressed: true,
+    rows: table.rows.map((row) => ({ ...row, value: null })),
+    total: null,
+  }
+}
+
+function exchangeCounts(exchanges: AnalysisExchange[]) {
+  const counts: Record<AnalysisExchange['status'], number> = {
+    linked: 0,
+    ambiguous: 0,
+    absent: 0,
+    outside_window: 0,
+  }
+  for (const exchange of exchanges) counts[exchange.status] += 1
+  return counts
+}
+
+function provenance(
+  core: AnalysisCoreResult,
+  users: ReportMessage[],
+  selectedModels: ReportMessage[],
+  minimumCellSize: number,
+  messagePopulationSuppressed: boolean,
+  ratingCoverageSuppressed: boolean
+): AggregateReport['provenance'] {
+  const unknownModes = users.filter(
+    (message) => !message.chatMode || message.chatMode.trim().length === 0
+  ).length
+  const unknownModels = selectedModels.filter(
+    (message) => !message.modelId || message.modelId.trim().length === 0
+  ).length
+
+  return [
+    {
+      field: 'summary.eligibleMessages',
+      source: 'postgresql',
+      definition:
+        'Messages with exactly one matching effective purpose decision',
+      denominator: 'selected message records',
+      unknownCount: messagePopulationSuppressed
+        ? null
+        : discloseCount(
+            core.eligible.excludedMessageIds.length,
+            minimumCellSize
+          ),
+    },
+    {
+      field: 'summary.ratingCoverage',
+      source: 'postgresql',
+      definition: 'Explicit UP or DOWN ratings on linked tutor responses',
+      denominator: 'linked tutor responses',
+      unknownCount: ratingCoverageSuppressed
+        ? null
+        : discloseCount(core.ratingCoverage.unratedResponses, minimumCellSize),
+    },
+    {
+      field: 'dimensions.chatModes',
+      source: 'postgresql',
+      definition: 'Stored chat mode on eligible user messages',
+      denominator: 'eligible user messages',
+      unknownCount: messagePopulationSuppressed
+        ? null
+        : discloseCount(unknownModes, minimumCellSize),
+    },
+    {
+      field: 'dimensions.selectedModels',
+      source: 'postgresql',
+      definition:
+        'Stored selected model identifier, not actual provider routing',
+      denominator: 'linked tutor responses',
+      unknownCount: messagePopulationSuppressed
+        ? null
+        : discloseCount(unknownModels, minimumCellSize),
+    },
+  ]
+}
+
+export function buildAggregateReport(input: {
+  core: AnalysisCoreResult
+  messages: ReportMessage[]
+  purpose: AnalysisPurpose
+  window: AnalysisWindow
+  minimumCellSize?: number
+  exploratorySignals?: ExploratorySignalSummary[]
+}): AggregateReport {
+  const minimumCellSize = input.minimumCellSize ?? DEFAULT_MINIMUM_CELL_SIZE
+  const eligibleIds = new Set(
+    input.core.eligible.messages.map((message) => message.id)
+  )
+  const messages = input.messages.filter((message) =>
+    eligibleIds.has(message.id)
+  )
+  const messageById = new Map(messages.map((message) => [message.id, message]))
+  const users = messages.filter((message) => message.role === 'user')
+  const assistants = messages.filter((message) => message.role === 'assistant')
+  const linked = input.core.exchanges
+    .map((exchange) => messageById.get(exchange.assistantMessage?.id ?? ''))
+    .filter(
+      (message): message is ReportMessage => message?.role === 'assistant'
+    )
+  const selectedModels = linked
+  const exchangeCountsByStatus = exchangeCounts(input.core.exchanges)
+  const participants = new Set(messages.map((message) => message.participantId))
+  const conversations = new Set(messages.map((message) => message.threadId))
+  const attachments = messages.reduce(
+    (total, message) => total + message.attachmentCount,
+    0
+  )
+  const credits = messages.reduce(
+    (total, message) => total + (message.creditsUsed ?? 0),
+    0
+  )
+  const ratedResponses = input.core.ratingCoverage.ratedResponses
+  const unratedResponses = input.core.ratingCoverage.unratedResponses
+  const linkedResponses = ratedResponses + unratedResponses
+  const exchangePartitionSuppressed = Object.values(
+    exchangeCountsByStatus
+  ).some((count) => count > 0 && count < minimumCellSize)
+  const ratingPartitionSuppressed = [
+    ratedResponses,
+    unratedResponses,
+    input.core.ratingCoverage.up,
+    input.core.ratingCoverage.down,
+  ].some((count) => count > 0 && count < minimumCellSize)
+  const messageRolePartitionSuppressed = [users.length, assistants.length].some(
+    (count) => count > 0 && count < minimumCellSize
+  )
+  const rawDimensions = {
+    chatModes: buildDisclosureTable(
+      'chatMode',
+      countBy(users, (message) => message.chatMode),
+      minimumCellSize
+    ),
+    selectedModels: buildDisclosureTable(
+      'selectedModel',
+      countBy(selectedModels, (message) => message.modelId),
+      minimumCellSize
+    ),
+    attachmentModality: buildDisclosureTable(
+      'attachmentModality',
+      countBy(users, (message) =>
+        message.attachmentCount > 0 ? 'with_attachment' : 'without_attachment'
+      ),
+      minimumCellSize
+    ),
+  }
+  const rawDimensionSuppressed = Object.values(rawDimensions).some(
+    (table) => table.suppressed
+  )
+  const messagePopulationSuppressed =
+    rawDimensionSuppressed ||
+    exchangePartitionSuppressed ||
+    messageRolePartitionSuppressed
+  const dimensions = {
+    chatModes: messagePopulationSuppressed
+      ? suppressDisclosureTable(rawDimensions.chatModes)
+      : rawDimensions.chatModes,
+    selectedModels: messagePopulationSuppressed
+      ? suppressDisclosureTable(rawDimensions.selectedModels)
+      : rawDimensions.selectedModels,
+    attachmentModality: messagePopulationSuppressed
+      ? suppressDisclosureTable(rawDimensions.attachmentModality)
+      : rawDimensions.attachmentModality,
+  }
+  const ratingCoverageSuppressed =
+    messagePopulationSuppressed || ratingPartitionSuppressed
+  const suppressedTables = [
+    ...Object.values(dimensions)
+      .filter((table) => table.suppressed)
+      .map((table) => table.dimension),
+    ...(messagePopulationSuppressed
+      ? ['summary.userPopulation', 'summary.exchanges', 'exploratorySignals']
+      : []),
+    ...(ratingCoverageSuppressed ? ['summary.ratingCoverage'] : []),
+  ]
+  const exploratorySignals = (input.exploratorySignals ?? []).map((signal) => ({
+    ...signal,
+    assignedMessages: messagePopulationSuppressed
+      ? null
+      : discloseCount(signal.assignedMessages ?? 0, minimumCellSize),
+    eligibleMessages: messagePopulationSuppressed
+      ? null
+      : discloseCount(signal.eligibleMessages ?? 0, minimumCellSize),
+    coverage: messagePopulationSuppressed
+      ? null
+      : (signal.assignedMessages ?? 0) < minimumCellSize
+        ? null
+        : discloseRatio(
+            signal.assignedMessages ?? 0,
+            signal.eligibleMessages ?? 0,
+            minimumCellSize
+          ),
+  }))
+
+  return {
+    schemaVersion: AGGREGATE_REPORT_SCHEMA_VERSION,
+    reportKind: 'aggregate',
+    purpose: input.purpose,
+    window: {
+      from: input.window.from.toISOString(),
+      to: input.window.to.toISOString(),
+    },
+    privacy: {
+      containsMessageContent: false,
+      containsStableIdentifiers: false,
+      containsParticipantPseudonyms: false,
+      minimumCellSize,
+      suppressedTables,
+    },
+    summary: {
+      eligibleMessages: messagePopulationSuppressed
+        ? null
+        : discloseCount(messages.length, minimumCellSize),
+      userMessages: messagePopulationSuppressed
+        ? null
+        : discloseCount(users.length, minimumCellSize),
+      assistantMessages: messagePopulationSuppressed
+        ? null
+        : discloseCount(assistants.length, minimumCellSize),
+      participants: messagePopulationSuppressed
+        ? null
+        : discloseCount(participants.size, minimumCellSize),
+      conversations: messagePopulationSuppressed
+        ? null
+        : discloseCount(conversations.size, minimumCellSize),
+      attachments: messagePopulationSuppressed
+        ? null
+        : discloseCount(attachments, minimumCellSize),
+      creditsInternalUnits:
+        participants.size < minimumCellSize || messagePopulationSuppressed
+          ? null
+          : round(credits),
+      exchanges: Object.fromEntries(
+        Object.entries(exchangeCountsByStatus).map(([status, count]) => [
+          status,
+          messagePopulationSuppressed || exchangePartitionSuppressed
+            ? null
+            : discloseCount(count, minimumCellSize),
+        ])
+      ) as Record<AnalysisExchange['status'], DisclosureNumber>,
+      ratingCoverage: {
+        ratedResponses: ratingCoverageSuppressed
+          ? null
+          : discloseCount(ratedResponses, minimumCellSize),
+        unratedResponses: ratingCoverageSuppressed
+          ? null
+          : discloseCount(unratedResponses, minimumCellSize),
+        up: ratingCoverageSuppressed
+          ? null
+          : discloseCount(input.core.ratingCoverage.up, minimumCellSize),
+        down: ratingCoverageSuppressed
+          ? null
+          : discloseCount(input.core.ratingCoverage.down, minimumCellSize),
+        coverage: ratingCoverageSuppressed
+          ? null
+          : discloseRatio(ratedResponses, linkedResponses, minimumCellSize),
+      },
+    },
+    dimensions,
+    exploratorySignals,
+    provenance: provenance(
+      input.core,
+      users,
+      selectedModels,
+      minimumCellSize,
+      messagePopulationSuppressed,
+      ratingCoverageSuppressed
+    ),
+  }
+}
+
+/**
+ * The historical exporter can still calculate content-sensitive sheets
+ * internally, but its old content flag must not be an output authorization.
+ * Callers must use the governed restricted-export contract instead.
+ */
+export function assertLegacyMessageContentExportDisabled(
+  includeMessageContent: boolean
+) {
+  if (includeMessageContent) {
+    throw new Error(
+      '--includeMessageContent is disabled; use the governed restricted-export action with eligibility, operator, destination, audit, expiry, and deletion gates.'
+    )
+  }
+}
+
+function aggregateReportSheets(report: AggregateReport): WorkbookSheet[] {
+  const summary: Array<[string, string, string | number]> = Object.entries(
+    report.summary
+  ).flatMap(([field, value]) => {
+    if (field === 'exchanges' || field === 'ratingCoverage') {
+      return Object.entries(value as Record<string, number>).map(
+        ([subfield, subvalue]) =>
+          [field, subfield, subvalue] as [string, string, string | number]
+      )
+    }
+    return [
+      ['summary', field, value as string | number] as [
+        string,
+        string,
+        string | number,
+      ],
+    ]
+  })
+  const dimensions: Array<[string, string, number | null, boolean, number]> =
+    Object.values(report.dimensions).flatMap((table) =>
+      table.rows.map(
+        (row) =>
+          [
+            table.dimension,
+            row.label,
+            row.value,
+            table.suppressed,
+            table.minimumCellSize,
+          ] as [string, string, number | null, boolean, number]
+      )
+    )
+
+  return [
+    {
+      name: 'Summary',
+      headers: ['section', 'field', 'value'],
+      rows: summary,
+    },
+    {
+      name: 'Dimensions',
+      headers: ['dimension', 'label', 'value', 'suppressed', 'minimumCellSize'],
+      rows: dimensions,
+    },
+    {
+      name: 'Exploratory Signals',
+      headers: [
+        'name',
+        'assignedMessages',
+        'eligibleMessages',
+        'coverage',
+        'stability',
+        'validated',
+      ],
+      rows: report.exploratorySignals.map((signal) => [
+        signal.name,
+        signal.assignedMessages,
+        signal.eligibleMessages,
+        signal.coverage,
+        signal.stability,
+        signal.validated,
+      ]),
+    },
+    {
+      name: 'Provenance',
+      headers: ['field', 'source', 'definition', 'denominator', 'unknownCount'],
+      rows: report.provenance.map((entry) => [
+        entry.field,
+        entry.source,
+        entry.definition,
+        entry.denominator,
+        entry.unknownCount,
+      ]),
+    },
+  ]
+}
+
+export async function writeAggregateReportFiles(input: {
+  outDir: string
+  filePrefix: string
+  report: AggregateReport
+}) {
+  await mkdir(input.outDir, { recursive: true })
+  const prefix = sanitizeFilename(input.filePrefix)
+  const jsonPath = resolve(input.outDir, `${prefix}.json`)
+  await writeFile(
+    jsonPath,
+    `${JSON.stringify(input.report, null, 2)}\n`,
+    'utf8'
+  )
+  const workbookPath = await writeWorkbookFile(
+    input.outDir,
+    `${prefix}.xlsx`,
+    aggregateReportSheets(input.report)
+  )
+  return { jsonPath, workbookPath }
+}
+
+export type RestrictedExportMessage = ReportMessage & {
+  attachmentDescriptions?: string[]
+}
+
+export type RestrictedExportRequest = {
+  purpose: AnalysisPurpose
+  courseId: string
+  operatorId: string
+  from: Date
+  to: Date
+  expiresAt: Date
+}
+
+export type RestrictedExportDependencies = {
+  eligibility: RestrictedExportEligibility
+  operator: { authoritative: boolean }
+  destination: { encrypted: boolean; verified: boolean; descriptor: string }
+  deletion: { owner: string; rebuildKey: string }
+  audit: {
+    append: (event: RestrictedExportAuditEvent) => Promise<void>
+  }
+}
+
+export type RestrictedExportAuditEvent = {
+  schemaVersion: typeof RESTRICTED_EXPORT_SCHEMA_VERSION
+  eventType: 'chatbot-restricted-export-authorized'
+  purpose: AnalysisPurpose
+  courseId: string
+  operatorId: string
+  expiresAt: string
+  destinationDescriptor: string
+  rowCount: number
+  artifactSha256: string
+  fields: string[]
+  eligibilityFrom: string
+  eligibilityTo: string
+  populationDescription: string
+  eligibilityAuthority: string
+  outputTier: 'restricted'
+  limitations: string[]
+}
+
+export type RestrictedExportRow = {
+  coursePseudonym: string
+  participantPseudonym: string
+  threadPseudonym: string
+  messagePseudonym: string
+  parentMessagePseudonym: string | null
+  role: string
+  messageCreatedAt: string
+  chatMode: string | null
+  selectedModel: string | null
+  rating: 'UP' | 'DOWN' | null
+  creditsInternalUnits: number | null
+  attachmentDescriptions: string[]
+  text: string
+}
+
+export type RestrictedExportArtifact = {
+  schemaVersion: typeof RESTRICTED_EXPORT_SCHEMA_VERSION
+  rows: RestrictedExportRow[]
+  manifest: {
+    purpose: AnalysisPurpose
+    coursePseudonym: string
+    expiresAt: string
+    deletionOwner: string
+    rebuildKey: string
+    artifactSha256: string
+    fields: string[]
+    excludedFields: string[]
+    eligibilityFrom: string
+    eligibilityTo: string
+    populationDescription: string
+    eligibilityAuthority: string
+    outputTier: 'restricted'
+    limitations: string[]
+  }
+}
+
+function scopedPseudonym(
+  value: string,
+  purpose: AnalysisPurpose,
+  courseId: string,
+  secret: string,
+  domain: string
+) {
+  return createHmac('sha256', secret)
+    .update(`${domain}\0${purpose}\0${courseId}\0${value}`)
+    .digest('hex')
+    .slice(0, 24)
+}
+
+function restrictedRows(
+  messages: RestrictedExportMessage[],
+  request: RestrictedExportRequest,
+  secret: string
+): RestrictedExportRow[] {
+  const sorted = [...messages].sort(
+    (left, right) =>
+      left.createdAt.getTime() - right.createdAt.getTime() ||
+      left.id.localeCompare(right.id)
+  )
+  const messagePseudonyms = new Map(
+    sorted.map((message) => [
+      message.id,
+      scopedPseudonym(
+        message.id,
+        request.purpose,
+        request.courseId,
+        secret,
+        'message'
+      ),
+    ])
+  )
+  const coursePseudonym = scopedPseudonym(
+    request.courseId,
+    request.purpose,
+    request.courseId,
+    secret,
+    'course'
+  )
+
+  return sorted.map((message) => ({
+    coursePseudonym,
+    participantPseudonym: scopedPseudonym(
+      message.participantId,
+      request.purpose,
+      request.courseId,
+      secret,
+      'participant'
+    ),
+    threadPseudonym: scopedPseudonym(
+      message.threadId,
+      request.purpose,
+      request.courseId,
+      secret,
+      'thread'
+    ),
+    messagePseudonym: messagePseudonyms.get(message.id)!,
+    parentMessagePseudonym: message.parentId
+      ? (messagePseudonyms.get(message.parentId) ?? null)
+      : null,
+    role: message.role,
+    messageCreatedAt: message.createdAt.toISOString(),
+    chatMode: message.chatMode ?? null,
+    selectedModel: message.modelId ?? null,
+    rating: message.rating,
+    creditsInternalUnits: message.creditsUsed,
+    attachmentDescriptions: (message.attachmentDescriptions ?? []).filter(
+      (description) => description.trim().length > 0
+    ),
+    text: message.text,
+  }))
+}
+
+function digestRows(rows: RestrictedExportRow[]) {
+  return createHash('sha256').update(JSON.stringify(rows)).digest('hex')
+}
+
+function assertRestrictedRequest(
+  request: RestrictedExportRequest,
+  dependencies: RestrictedExportDependencies,
+  secret: string,
+  now: Date,
+  messages: RestrictedExportMessage[]
+) {
+  const failures: string[] = []
+  if (!request.operatorId.trim()) failures.push('operator identity is missing')
+  if (!dependencies.operator.authoritative) {
+    failures.push('operator identity is not authoritative')
+  }
+  if (!dependencies.eligibility.available) {
+    failures.push('authoritative eligibility is unavailable')
+  }
+  if (!dependencies.eligibility.filterApplied) {
+    failures.push('eligibility filter was not applied')
+  }
+  if (dependencies.eligibility.purpose !== request.purpose) {
+    failures.push('eligibility purpose does not match the export purpose')
+  }
+  if (dependencies.eligibility.courseId !== request.courseId) {
+    failures.push('eligibility course does not match the export course')
+  }
+  if (
+    dependencies.eligibility.from.getTime() !== request.from.getTime() ||
+    dependencies.eligibility.to.getTime() !== request.to.getTime()
+  ) {
+    failures.push('eligibility period does not match the export period')
+  }
+  if (!dependencies.eligibility.populationDescription.trim()) {
+    failures.push('eligibility population description is missing')
+  }
+  if (!dependencies.eligibility.authority.trim()) {
+    failures.push('eligibility authority is missing')
+  }
+  if (
+    messages.some(
+      (message) =>
+        message.courseId !== request.courseId ||
+        !dependencies.eligibility.eligibleMessageIds.has(message.id)
+    )
+  ) {
+    failures.push('one or more rows are outside the authoritative eligible set')
+  }
+  if (request.expiresAt.getTime() <= now.getTime()) {
+    failures.push('export expiry must be in the future')
+  }
+  if (!dependencies.destination.encrypted) {
+    failures.push('destination is not encrypted')
+  }
+  if (
+    !dependencies.destination.verified ||
+    !dependencies.destination.descriptor.trim()
+  ) {
+    failures.push('destination verification is missing')
+  }
+  if (!dependencies.deletion.owner.trim())
+    failures.push('deletion owner is missing')
+  if (!dependencies.deletion.rebuildKey.trim()) {
+    failures.push('withdrawal rebuild key is missing')
+  }
+  if (!secret.trim()) failures.push('pseudonym secret is missing')
+  if (failures.length > 0) {
+    throw new Error(`Restricted export denied: ${failures.join('; ')}.`)
+  }
+}
+
+export async function authorizeRestrictedExport(input: {
+  messages: RestrictedExportMessage[]
+  request: RestrictedExportRequest
+  dependencies: RestrictedExportDependencies
+  pseudonymSecret: string
+  now?: Date
+}): Promise<RestrictedExportArtifact> {
+  assertRestrictedRequest(
+    input.request,
+    input.dependencies,
+    input.pseudonymSecret,
+    input.now ?? new Date(),
+    input.messages
+  )
+  const rows = restrictedRows(
+    input.messages,
+    input.request,
+    input.pseudonymSecret
+  )
+  const fields = [
+    'coursePseudonym',
+    'participantPseudonym',
+    'threadPseudonym',
+    'messagePseudonym',
+    'parentMessagePseudonym',
+    'role',
+    'messageCreatedAt',
+    'chatMode',
+    'selectedModel',
+    'rating',
+    'creditsInternalUnits',
+    'attachmentDescriptions',
+    'text',
+  ]
+  const excludedFields = [
+    'participantId',
+    'threadId',
+    'messageId',
+    'reasoningContent',
+    'rawImageBytes',
+    'rawToolResults',
+  ]
+  const artifactSha256 = digestRows(rows)
+  const manifest = {
+    purpose: input.request.purpose,
+    coursePseudonym: scopedPseudonym(
+      input.request.courseId,
+      input.request.purpose,
+      input.request.courseId,
+      input.pseudonymSecret,
+      'course'
+    ),
+    expiresAt: input.request.expiresAt.toISOString(),
+    eligibilityFrom: input.request.from.toISOString(),
+    eligibilityTo: input.request.to.toISOString(),
+    populationDescription: input.dependencies.eligibility.populationDescription,
+    eligibilityAuthority: input.dependencies.eligibility.authority,
+    outputTier: 'restricted' as const,
+    limitations: [
+      'Purpose-scoped pseudonyms are not a substitute for access control.',
+      'Raw reasoning, image bytes, and tool results are excluded.',
+    ],
+    deletionOwner: input.dependencies.deletion.owner,
+    rebuildKey: input.dependencies.deletion.rebuildKey,
+    artifactSha256,
+    fields,
+    excludedFields,
+  }
+  await input.dependencies.audit.append({
+    schemaVersion: RESTRICTED_EXPORT_SCHEMA_VERSION,
+    eventType: 'chatbot-restricted-export-authorized',
+    purpose: input.request.purpose,
+    courseId: input.request.courseId,
+    operatorId: input.request.operatorId,
+    expiresAt: manifest.expiresAt,
+    eligibilityFrom: manifest.eligibilityFrom,
+    eligibilityTo: manifest.eligibilityTo,
+    populationDescription: manifest.populationDescription,
+    eligibilityAuthority: manifest.eligibilityAuthority,
+    outputTier: manifest.outputTier,
+    limitations: manifest.limitations,
+    destinationDescriptor: input.dependencies.destination.descriptor,
+    rowCount: rows.length,
+    artifactSha256,
+    fields,
+  })
+
+  return {
+    schemaVersion: RESTRICTED_EXPORT_SCHEMA_VERSION,
+    rows,
+    manifest,
+  }
+}

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -595,7 +595,7 @@ function usage() {
     '  --filePrefix <prefix>       Output filename prefix. Default: date + scope.',
     '  --minTopicMessages <n>      Minimum user messages for topic labels. Default: 5.',
     '  --minTopicParticipants <n>  Minimum participants for topic labels. Default: 3.',
-    '  --includeMessageContent     Rejected with a migration error; use the governed restricted-export action for content.',
+    '  --includeMessageContent     Rejected; no content-bearing export exists. See ADR-0005 for future governance.',
   ].join('\n')
 }
 

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -1,8 +1,8 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { prisma } from '@klicker-uzh/prisma'
-import { Prisma } from '@klicker-uzh/prisma/client'
-import { open } from 'fs/promises'
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import type { Prisma } from '@klicker-uzh/prisma/client'
+import { assertLegacyMessageContentExportDisabled } from '../chatbot-analysis/reports.js'
 import type { SheetValue, WorkbookSheet } from './lib/simpleWorkbook.js'
 import {
   formatDate,
@@ -23,7 +23,6 @@ type CliOptions = {
   filePrefix: string
   minTopicMessages: number
   minTopicParticipants: number
-  includeMessageContent: boolean
 }
 
 type ChatContentItem = {
@@ -161,8 +160,6 @@ type ClusterTerm = {
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '../../../..')
 const todayPrefix = new Date().toISOString().slice(0, 10)
-const XLSX_CELL_TEXT_LIMIT = 32767
-const WORKBOOK_MESSAGE_CONTENT_PREVIEW_LIMIT = 2000
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -598,7 +595,7 @@ function usage() {
     '  --filePrefix <prefix>       Output filename prefix. Default: date + scope.',
     '  --minTopicMessages <n>      Minimum user messages for topic labels. Default: 5.',
     '  --minTopicParticipants <n>  Minimum participants for topic labels. Default: 3.',
-    '  --includeMessageContent     Write full raw message content JSONL and include workbook previews.',
+    '  --includeMessageContent     Rejected with a migration error; use the governed restricted-export action for content.',
   ].join('\n')
 }
 
@@ -741,6 +738,10 @@ function parseArgs(): CliOptions {
 
   validateArgs(args)
 
+  if (hasFlag(args, '--includeMessageContent')) {
+    assertLegacyMessageContentExportDisabled(true)
+  }
+
   const all = hasFlag(args, '--all')
   const query = getArgValue(args, '--query') ?? getArgValue(args, '--course')
   const chatbotId = getArgValue(args, '--chatbotId')
@@ -810,7 +811,6 @@ function parseArgs(): CliOptions {
       getArgValue(args, '--minTopicParticipants'),
       3
     ),
-    includeMessageContent: hasFlag(args, '--includeMessageContent'),
   }
 }
 
@@ -909,14 +909,6 @@ function createKeyMap(values: string[], prefix: string) {
 function round(value: number, digits = 6) {
   const factor = 10 ** digits
   return Math.round(value * factor) / factor
-}
-
-function truncateForWorkbookCell(value: string, limit = XLSX_CELL_TEXT_LIMIT) {
-  const safeLimit = Math.min(limit, XLSX_CELL_TEXT_LIMIT)
-  if (value.length <= safeLimit) return value
-
-  const suffix = '\n...[truncated; full value is in message content JSONL]'
-  return `${value.slice(0, safeLimit - suffix.length)}${suffix}`
 }
 
 function sum(values: number[]) {
@@ -2228,15 +2220,7 @@ function buildSheets(
         ['chatbots', chatbots.length],
         [
           'privacy',
-          options.includeMessageContent
-            ? 'Raw message text/content is included because --includeMessageContent was passed. Participant names, emails, LMS identifiers, and database ids are still excluded.'
-            : 'No raw message text, participant names, emails, LMS identifiers, or database ids are included.',
-        ],
-        [
-          'messageContent',
-          options.includeMessageContent
-            ? `Full raw message content is written to ${sanitizeFilename(options.filePrefix)}_message_content.jsonl. Workbook content columns are previews capped to ${WORKBOOK_MESSAGE_CONTENT_PREVIEW_LIMIT} characters.`
-            : 'Full raw message content is not exported.',
+          'Legacy operational workbook is not a governed aggregate or restricted export. It must not be shared as a personal-data download.',
         ],
         [
           'participants',
@@ -3099,14 +3083,6 @@ function buildSheets(
     'attachmentCount',
     'topicClusterId',
   ]
-  if (options.includeMessageContent) {
-    messageMetadataHeaders.push(
-      'messageTextPreview',
-      'messageContentJsonPreview',
-      'reasoningContentPreview'
-    )
-  }
-
   sheets.push({
     name: 'Message Metadata',
     headers: messageMetadataHeaders,
@@ -3140,75 +3116,11 @@ function buildSheets(
         assignment?.clusterId ?? null,
       ]
 
-      if (options.includeMessageContent) {
-        row.push(
-          truncateForWorkbookCell(
-            message.text,
-            WORKBOOK_MESSAGE_CONTENT_PREVIEW_LIMIT
-          ),
-          truncateForWorkbookCell(
-            JSON.stringify(message.content) ?? '',
-            WORKBOOK_MESSAGE_CONTENT_PREVIEW_LIMIT
-          ),
-          truncateForWorkbookCell(
-            message.reasoningContent ?? '',
-            WORKBOOK_MESSAGE_CONTENT_PREVIEW_LIMIT
-          )
-        )
-      }
-
       return row
     }),
   })
 
   return sheets
-}
-
-async function writeMessageContentJsonl(
-  outDir: string,
-  filePrefix: string,
-  messages: MessageRecord[]
-) {
-  const filename = `${sanitizeFilename(filePrefix)}_message_content.jsonl`
-  const path = resolve(outDir, filename)
-  const file = await open(path, 'w')
-
-  try {
-    for (const message of messages) {
-      await file.write(
-        `${JSON.stringify({
-          courseName: message.courseName,
-          courseDisplayName: message.courseDisplayName,
-          chatbotKey: message.chatbotKey,
-          chatbotName: message.chatbotName,
-          threadKey: message.threadKey,
-          participantKey: message.participantKey,
-          messageKey: message.messageKey,
-          role: message.role,
-          messageCreatedAt: message.messageCreatedAt.toISOString(),
-          chatMode: message.chatMode,
-          modelId: message.modelId,
-          reasoningEffort: message.reasoningEffort,
-          parentMessageKey: message.parentId
-            ? (messageKeyById.get(message.parentId) ?? null)
-            : null,
-          rating: message.rating,
-          creditsUsed: message.creditsUsed,
-          toolCallCount: toolCallCount(message.content),
-          attachmentCount: message.attachmentCount,
-          text: message.text,
-          content: message.content,
-          reasoningContent: message.reasoningContent,
-        })}\n`,
-        undefined,
-        'utf8'
-      )
-    }
-  } finally {
-    await file.close()
-  }
-
-  return path
 }
 
 async function main() {
@@ -3272,14 +3184,6 @@ async function main() {
   )
   const filename = `${sanitizeFilename(options.filePrefix)}.xlsx`
   const path = await writeWorkbookFile(options.outDir, filename, sheets)
-  const messageContentPath = options.includeMessageContent
-    ? await writeMessageContentJsonl(
-        options.outDir,
-        options.filePrefix,
-        messages
-      )
-    : null
-
   console.log(
     `Window: ${formatDate(options.from)} to ${formatDate(options.to)}`
   )
@@ -3305,9 +3209,6 @@ async function main() {
     )
   }
   console.log(`Output: ${path}`)
-  if (messageContentPath) {
-    console.log(`Message content output: ${messageContentPath}`)
-  }
 }
 
 try {

--- a/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
+++ b/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
@@ -31,7 +31,7 @@ function usage() {
     '  --filePrefix <name>            Default: chatbot-aggregate.',
     '  --minimumCellSize <n>          Default: 5.',
     '',
-    'Database-backed runs currently produce a fully suppressed aggregate because authoritative effective-dated eligibility is not yet configured.',
+    'Database-backed runs currently produce a suppressed aggregate because authoritative effective-dated eligibility is not yet configured.',
   ].join('\n')
 }
 
@@ -133,7 +133,7 @@ try {
   console.log(`JSON: ${result.files.jsonPath}`)
   console.log(`XLSX: ${result.files.workbookPath}`)
   console.log(
-    `Eligibility: authoritative decisions are unavailable; ${result.core.eligible.excludedMessageIds.length} selected records were excluded fail closed.`
+    'Eligibility: authoritative decisions are unavailable; fail closed.'
   )
 } catch (error) {
   console.error(

--- a/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
+++ b/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
@@ -1,0 +1,146 @@
+import { prisma } from '@klicker-uzh/prisma'
+
+import type { AnalysisPurpose } from '../chatbot-analysis/core.js'
+import { createPrismaAnalysisRecordProvider } from '../chatbot-analysis/prismaProvider.js'
+import { runAggregateReport } from '../chatbot-analysis/reports.js'
+
+type CliOptions = {
+  courseId: string
+  purpose: AnalysisPurpose
+  from: Date
+  to: Date
+  outDir: string
+  filePrefix: string
+  minimumCellSize: number | undefined
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function usage() {
+  return [
+    'Usage:',
+    '  pnpm --filter @klicker-uzh/prisma-data script:prod src/scripts/2026-08-13_chatbot_aggregate_report.ts --courseId <uuid> --from <date> --to <date> --outDir <path>',
+    '',
+    'Options:',
+    '  --courseId <uuid>              Analyze chatbots for one course.',
+    '  --purpose <learning-analytics> Purpose. Research is not enabled.',
+    '  --from <date>                  Inclusive ISO date or timestamp.',
+    '  --to <date>                    Inclusive ISO date or timestamp.',
+    '  --outDir <path>                Destination for JSON and XLSX.',
+    '  --filePrefix <name>            Default: chatbot-aggregate.',
+    '  --minimumCellSize <n>          Default: 5.',
+    '',
+    'Database-backed runs currently produce a fully suppressed aggregate because authoritative effective-dated eligibility is not yet configured.',
+  ].join('\n')
+}
+
+function getRequiredArg(args: string[], name: string) {
+  const index = args.indexOf(name)
+  const value = index >= 0 ? args[index + 1] : undefined
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}.`)
+  }
+  return value
+}
+
+function getOptionalArg(args: string[], name: string) {
+  const index = args.indexOf(name)
+  if (index < 0) return undefined
+  const value = args[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}.`)
+  }
+  return value
+}
+
+function parseDate(value: string, name: string, endOfDay = false) {
+  const date = new Date(
+    /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? `${value}T${endOfDay ? '23:59:59.999' : '00:00:00.000'}Z`
+      : value
+  )
+  if (Number.isNaN(date.getTime()))
+    throw new Error(`Invalid ${name}: ${value}.`)
+  return date
+}
+
+function parseArgs(args: string[]): CliOptions {
+  if (args.includes('--help')) {
+    console.log(usage())
+    process.exit(0)
+  }
+  const known = new Set([
+    '--courseId',
+    '--purpose',
+    '--from',
+    '--to',
+    '--outDir',
+    '--filePrefix',
+    '--minimumCellSize',
+  ])
+  for (const arg of args) {
+    if (arg.startsWith('--') && !known.has(arg)) {
+      throw new Error(`Unknown option: ${arg}.`)
+    }
+  }
+
+  const courseId = getRequiredArg(args, '--courseId')
+  if (!UUID_PATTERN.test(courseId)) throw new Error('Invalid --courseId UUID.')
+  const purpose = getOptionalArg(args, '--purpose') ?? 'learning-analytics'
+  if (purpose !== 'learning-analytics' && purpose !== 'research') {
+    throw new Error('Invalid --purpose.')
+  }
+  if (purpose === 'research') {
+    throw new Error('Only --purpose learning-analytics is currently enabled.')
+  }
+  const from = parseDate(getRequiredArg(args, '--from'), '--from')
+  const to = parseDate(getRequiredArg(args, '--to'), '--to', true)
+  if (from > to) throw new Error('--from must be before or equal to --to.')
+  const minimumCellSizeValue = args.includes('--minimumCellSize')
+    ? Number(getRequiredArg(args, '--minimumCellSize'))
+    : undefined
+  if (
+    minimumCellSizeValue !== undefined &&
+    (!Number.isInteger(minimumCellSizeValue) || minimumCellSizeValue < 2)
+  ) {
+    throw new Error('--minimumCellSize must be an integer greater than one.')
+  }
+
+  return {
+    courseId,
+    purpose,
+    from,
+    to,
+    outDir: getRequiredArg(args, '--outDir'),
+    filePrefix: args.includes('--filePrefix')
+      ? getRequiredArg(args, '--filePrefix')
+      : 'chatbot-aggregate',
+    minimumCellSize: minimumCellSizeValue,
+  }
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2))
+  const result = await runAggregateReport({
+    provider: createPrismaAnalysisRecordProvider(options.courseId),
+    purpose: options.purpose,
+    window: { from: options.from, to: options.to },
+    outDir: options.outDir,
+    filePrefix: options.filePrefix,
+    minimumCellSize: options.minimumCellSize,
+  })
+  console.log(`JSON: ${result.files.jsonPath}`)
+  console.log(`XLSX: ${result.files.workbookPath}`)
+  console.log(
+    'Eligibility: unavailable; all database records were excluded fail closed.'
+  )
+} catch (error) {
+  console.error(
+    `ERROR: ${error instanceof Error ? error.message : String(error)}`
+  )
+  console.error('Run with --help for usage.')
+  process.exitCode = 1
+} finally {
+  await prisma.$disconnect()
+}

--- a/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
+++ b/packages/prisma-data/src/scripts/2026-08-13_chatbot_aggregate_report.ts
@@ -133,7 +133,7 @@ try {
   console.log(`JSON: ${result.files.jsonPath}`)
   console.log(`XLSX: ${result.files.workbookPath}`)
   console.log(
-    'Eligibility: unavailable; all database records were excluded fail closed.'
+    `Eligibility: authoritative decisions are unavailable; ${result.core.eligible.excludedMessageIds.length} selected records were excluded fail closed.`
   )
 } catch (error) {
   console.error(

--- a/packages/prisma-data/tsconfig.analysis-check.json
+++ b/packages/prisma-data/tsconfig.analysis-check.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/chatbot-analysis/**/*.ts"]
+  "include": [
+    "src/chatbot-analysis/**/*.ts",
+    "src/scripts/2026-08-13_chatbot_aggregate_report.ts"
+  ]
 }

--- a/project/2026-08-12-chatbot-learning-analytics-plan.md
+++ b/project/2026-08-12-chatbot-learning-analytics-plan.md
@@ -380,8 +380,8 @@ aggregate-artifact contracts and makes the aggregate path executable.
   source exists. The standalone command therefore writes only a fully
   suppressed database-backed report. An injected synthetic provider proves the
   JSON/XLSX path and scans both artifacts for content and stable identifiers.
-- W2 verification before review: 20 focused synthetic tests pass (8 core, 11
-  report, 1 fail-closed provider), strict `check:analysis` passes, changed-path
+- W2 verification before review: 21 focused synthetic tests passed (8 core, 11
+  report, 2 provider), strict `check:analysis` passed, changed-path
   Biome and Prettier pass, `git diff --check` passes, and no `RestrictedExport`
   implementation symbol remains. Both implementation commits also passed the
   repository pre-commit `check:all` hook under host Node 26. Repository-pinned
@@ -389,8 +389,20 @@ aggregate-artifact contracts and makes the aggregate path executable.
   `devrouter exec` fail with `could not determine process identity for workspace
   lifecycle lock` in this session.
 - Integrated-final correction disposition: the fallback review confirmed the high-risk withdrawal, cross-table, provider-field, manifest, and legacy-content findings were closed. Its remaining summary-partition concern is closed in this correction by suppressing additive message-role, exchange-status, and rating-outcome partitions before any sibling values can be disclosed. Main-session verification is the closing check because the configured integrated-final review budget is exhausted.
-- Next: run the W2 simplifier and privacy/data-integrity slice review on the
-  immutable local range, apply any accepted correction once, then run the
-  integrated-final review across both corrected layers. No push, pull-request
-  update, production query, or real-data artifact is authorized in this
-  session.
+- W2 reviews: the configured simplifier returned `DONE` with no justified
+  reduction. The privacy/data-integrity review returned `PASS-WITH-FIXES`; its
+  course/query test and CLI accuracy findings were closed in `5f25c394b`.
+  Reports are at
+  `project/_local/reviews/2026-08-13-chatbot-governed-reports-w2-simplifier.md`
+  and
+  `project/_local/reviews/2026-08-13-chatbot-governed-reports-w2-slice-review.md`.
+- Integrated-final review: `PASS-WITH-FIXES`. The correction suppresses the
+  zero-eligible fail-closed population rather than exposing its selected-record
+  count in artifact provenance or console output, fixes the vacuous
+  cross-course assertion, and updates this progress record. A fresh correction
+  review is the remaining gate. No push, pull-request update, production query,
+  or real-data artifact is authorized in this session.
+- Post-final correction verification: 22 focused tests pass (8 core, 12 report,
+  2 provider), strict `check:analysis`, changed-path Biome/Prettier, and
+  `git diff --check` pass under host Node 26. The correction review remains the
+  final local gate.

--- a/project/2026-08-12-chatbot-learning-analytics-plan.md
+++ b/project/2026-08-12-chatbot-learning-analytics-plan.md
@@ -346,8 +346,8 @@ aggregate-artifact contracts and makes the aggregate path executable.
 
 ## Progress
 
-- Status: pragmatic correction W1 accepted locally; W2 is planned and has not
-  started.
+- Status: W2 implementation is complete locally and awaits the required
+  simplification, privacy/data-integrity, and integrated-final reviews.
 - W1 result: visible delegated task
   `019ffcc6-c396-7b23-882e-1836e7cff349` completed range
   `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b..550a266d2f497cfb8cf1c15b22b9a998d9b24bea`
@@ -367,12 +367,30 @@ aggregate-artifact contracts and makes the aggregate path executable.
 - Review gate: the user-requested Claude fallback ran the Layer 1 slice review and returned `DONE_WITH_CONCERNS`; its report identifies an eligibility parent-closure leak, a missing no-decision fixture, and an unresolved Layer 1 pseudonymization commitment. The fallback simplifier reached terminal `NEEDS_CONTEXT` because its tool-minimized contract requires exact hunks and call-site evidence, while the first fallback prompt supplied only a prose manifest. Reports and register entries are recorded at `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-slice-review-fallback.md`, `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-simplifier-fallback-needs-context.md`, and `project/_local/reviews/chatbot-learning-analytics-gate-register.md`.
 - Layer 1 correction complete: the parent-closure filter now admits only out-of-window assistant records for lineage classification; in-window assistants excluded by purpose, course, withdrawal, or effective interval remain excluded. The synthetic suite covers a participant with no eligibility decision and an in-window reply excluded by an expired eligibility interval. The Layer 1 pseudonymization finding is resolved as a scope boundary: the core may hold raw IDs internally, while Layer 2 owns the purpose-and-course pseudonym before any artifact path.
 - Layer 1 review: Claude fallback slice review returned `DONE_WITH_CONCERNS`; the eligibility finding was fixed in `0093c85b0`, and the follow-up invariant comment/progress wording are applied below. Claude fallback simplifier returned `DONE` with no net simplification. Reports: `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-slice-review-fallback-correction.md` and `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-simplifier-fallback-correction.md`.
-- Layer 2 active slice: governed aggregate JSON/XLSX model plus explicit restricted-export authorization contract. Aggregate summaries disclose only cells at or above the configured minimum, suppress same-population scalar totals whenever a dimension is suppressed, and omit exact low-count totals; exploratory signal counts are suppressed and marked unvalidated. Restricted rows require authoritative eligibility membership, operator identity, encrypted verified destination, append-only audit, expiry, and deletion/rebuild metadata. All adapters are synthetic/inert; no CLI or production provider is wired yet.
+- Layer 2 outcome: the aggregate JSON/XLSX model remains, while the unused
+  restricted-export object graph and its two tests are removed. No
+  content-bearing export path exists; ADR-0005 remains the policy boundary for
+  future work. Exploratory signal inputs now require numeric counts and become
+  nullable only inside disclosure processing.
 - Layer 2 correction: selected-model suppression now cascades through the linked-response/user-population summary and provenance fields, closing reconstruction through exchange partitions and duplicate unknown-count metadata. The correction also suppresses same-population attachment totals, aligns chat-mode provenance to user messages, expands the regression fixture, and rejects the legacy raw-content flag. Credits suppression is participant-based rather than message-based. The fallback slice review confirmed the original disclosure fix and identified these additional pre-existing gaps; they are addressed in the current correction.
-- Layer 2 verification: 21 focused synthetic tests pass (8 core, 13 reports), strict analysis typecheck passes, and changed-path formatting/diff checks pass. The paired fallback simplifier and slice review completed on `b72294f5a`; both returned `DONE_WITH_CONCERNS` without a privacy defect. The simplifier's dead-parameter reduction and the reviewer's provenance-coverage assertions are applied and reverified.
+- W2 execution path: `runAggregateReport` composes the existing core, aggregate
+  model, and artifact writer. The bounded Prisma provider selects one course and
+  window plus direct out-of-window assistant replies, omits message content,
+  and returns no eligibility decisions until an authoritative effective-dated
+  source exists. The standalone command therefore writes only a fully
+  suppressed database-backed report. An injected synthetic provider proves the
+  JSON/XLSX path and scans both artifacts for content and stable identifiers.
+- W2 verification before review: 20 focused synthetic tests pass (8 core, 11
+  report, 1 fail-closed provider), strict `check:analysis` passes, changed-path
+  Biome and Prettier pass, `git diff --check` passes, and no `RestrictedExport`
+  implementation symbol remains. Both implementation commits also passed the
+  repository pre-commit `check:all` hook under host Node 26. Repository-pinned
+  Node 24 verification remains pending because `devrouter ensure` and
+  `devrouter exec` fail with `could not determine process identity for workspace
+  lifecycle lock` in this session.
 - Integrated-final correction disposition: the fallback review confirmed the high-risk withdrawal, cross-table, provider-field, manifest, and legacy-content findings were closed. Its remaining summary-partition concern is closed in this correction by suppressing additive message-role, exchange-status, and rating-outcome partitions before any sibling values can be disclosed. Main-session verification is the closing check because the configured integrated-final review budget is exhausted.
-- Next: W2 begins only through its own approved execution/delegation boundary.
-  First propagate W1 through the existing stack locally, then remove the inert
-  restricted-export subsystem, deliver the aggregate command/provider seam,
-  and run the named synthetic/privacy checks. No push, pull-request update,
-  production query, or real-data artifact is authorized in this session.
+- Next: run the W2 simplifier and privacy/data-integrity slice review on the
+  immutable local range, apply any accepted correction once, then run the
+  integrated-final review across both corrected layers. No push, pull-request
+  update, production query, or real-data artifact is authorized in this
+  session.

--- a/project/2026-08-12-chatbot-learning-analytics-plan.md
+++ b/project/2026-08-12-chatbot-learning-analytics-plan.md
@@ -404,5 +404,9 @@ aggregate-artifact contracts and makes the aggregate path executable.
   or real-data artifact is authorized in this session.
 - Post-final correction verification: 22 focused tests pass (8 core, 12 report,
   2 provider), strict `check:analysis`, changed-path Biome/Prettier, and
-  `git diff --check` pass under host Node 26. The correction review remains the
-  final local gate.
+  `git diff --check` pass under host Node 26. The correction review returned
+  `PASS` with no findings; its report is
+  `project/_local/reviews/2026-08-13-chatbot-learning-analytics-integrated-final-correction.md`.
+- W2 delivery: verified local commits only. The remote stacked pull requests
+  remain unchanged. No push/force-push, pull-request update, production query,
+  real-data run, publication, merge, or cleanup occurred.


### PR DESCRIPTION
## What This Adds

Layer 2 adds aggregate chatbot analytics reports on top of the eligibility-aware core.

- Generates versioned JSON and XLSX reports with small-cell, complementary, cross-table, and additive-summary suppression.
- Reports descriptive exchange, rating, attachment, selected-mode/model, credits, and exploratory question/response signals without row-level text or stable identifiers.
- Adds a course- and time-bounded Prisma provider that selects metadata only and includes direct assistant replies to in-window user messages.
- Adds an executable `learning-analytics` command with explicit course, inclusive date window, output directory, and minimum-cell-size inputs.
- Removes the speculative restricted-export object graph and keeps the legacy `--includeMessageContent` path disabled.

## Stack Context

Layer 2 of 2. Depends on #5390 and should be reviewed after it. Both PRs were already open for review before this update; the stack push did not change their readiness state.

## How It Works

The command composes the bounded Prisma provider with the aggregate report builder and writes one JSON and one XLSX artifact. The database projection omits message content, reasoning, image bytes and descriptions, and tool results. Research purpose is explicitly rejected.

The provider currently returns no eligibility decisions because the authoritative effective-dated source does not exist yet. Database-backed runs therefore succeed only with a fully suppressed aggregate; they do not expose the excluded population count.

## Branch Coverage

- Base: `rs/chatbot-analysis-core` at `5639f013b`.
- Head: `c6975f8fe`.
- Reviewed: 7 commits; substantive delta +1478/-110 after excluding the project-plan update. This includes 615 lines of focused report/provider tests.
- Covered: disclosure-safe report model and artifact writers, bounded Prisma provider, aggregate CLI, legacy raw-content quarantine, wiki documentation, removal of unused restricted-export machinery, review corrections, and plan/progress closure.

## Review Focus

- Confirm suppressed dimensions and additive summaries cannot be reconstructed from displayed sibling totals or provenance.
- Check that the provider projection and CLI cannot emit message content, stable identifiers, reasoning, raw images, descriptions, or tool results.
- Confirm the course/window query and bounded reply closure cannot pull cross-course messages or unrelated later conversation data.
- Review whether descriptive and exploratory terminology avoids claims about mastery, misconception, learning gain, or actual provider model/cost.

## Verification

Current head:

- `pnpm --filter @klicker-uzh/prisma-data test` -> 22 tests passed: 8 core, 12 report, and 2 Prisma-provider tests.
- `pnpm --filter @klicker-uzh/prisma-data check:analysis` -> passed.
- Changed-path Biome/Prettier and `git diff --check` -> passed.
- Final integrated correction review -> pass with no findings.
- [GitHub checks](https://github.com/uzh-bf/klicker-uzh/pull/5389/checks) -> running on `c6975f8fe`.

Failed/Warning:

- Fresh local checks ran under host Node 26. Node 24 DevPod verification was unavailable because `devrouter ensure` could not acquire the workspace lifecycle lock; GitHub CI is the current Node 24 publication gate.
- No production database, real course data, or generated stakeholder artifact was exercised.
- Layer 1 is behind the current `v3` head; the stack needs a stack-aware base refresh before merge.

## Security / Privacy

- No real course data, participant identifiers, raw exports, credentials, or stakeholder workbook are committed.
- Default artifacts are aggregate-only and disclosure-controlled; zero eligible messages suppress the complete aggregate population and provenance.
- The database projection omits content-bearing fields, and the legacy content-bearing export flag fails closed.
- Independent slice and final reviews covered correctness, maintainability, security/privacy, architecture, and data integrity.

## Activation and Compatibility

The aggregate command is executable, but database-backed output remains fully suppressed until an authoritative effective-dated eligibility source is configured. Existing operational analyzer selectors remain available; `--includeMessageContent` remains rejected.

## Blocking Before Merge

- [ ] Required GitHub CI is green at the current head.
- [ ] Refresh Layer 1 onto the current `v3` head and propagate this layer.
- [ ] Review and accept Layer 1 first.

## Follow-Up After Merge

- [ ] Integrate the authoritative effective-dated learning-analytics eligibility source through a separately reviewed change.
- [ ] Validate a bounded real-data aggregate run and stakeholder usefulness under the approved operational process; keep artifacts outside Git.
- [ ] Plan LiteLLM/Langfuse actual-model, spend, cache, and latency enrichment separately.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch, not review evidence.

- Machine: `MacBook-Pro`.
- Worktree: `trees/chatbot-learning-analytics` in repository `klicker-uzh`.
- Review reports: `project/_local/reviews/`.
