### PR TITLE
enhance(prisma-data): make chatbot analysis eligibility-aware

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,150 @@
+# Domain context
+
+## Chatbot analysis capability
+
+A reusable learning-analytics capability for examining educational chatbot use.
+Its initial purposes are internal product-quality improvement and learning
+analytics. Research is an additional purpose with separate eligibility and
+governance requirements.
+
+## Vorkurs pilot
+
+The first application of the chatbot analysis capability to the mathematics
+Vorkurs. It validates the generic concepts and reports without making the
+capability specific to one course.
+
+## Operational analysis
+
+The first delivery stage. It produces trustworthy, privacy-aware usage and
+conversation measures from the application's authoritative records.
+
+## Telemetry enrichment
+
+A later delivery stage that augments operational analysis with provider model,
+cost, cache, latency, and tracing observations from their authoritative
+telemetry systems.
+
+## Analysis join
+
+A purpose-bound association of facts read from their authoritative systems for
+one analysis run. It records unmatched or ambiguous records and does not create
+a new authoritative copy of provider calls.
+
+## Source authority
+
+The system responsible for a fact: PostgreSQL for chatbot conversations,
+ratings, and analysis eligibility; LiteLLM for actual routed model, spend, and
+cache usage; and Langfuse for trace and observation facts.
+
+## Educational coding
+
+A later delivery stage in which human-validated categories describe student
+questions and tutoring responses. Automated classification or clustering may
+support this stage only after the categories have been validated. This stage is
+capacity-gated and is not part of the first implementation.
+
+## Descriptive learning analytics
+
+Measures that report observable interaction structure and recorded signals
+without claiming to identify misconceptions, mastery, tutor quality, or learning
+gain. These measures form the first learning-analytics delivery.
+
+## Exchange
+
+A student message linked to its tutor response. It is the primary unit for the
+first descriptive analysis; the surrounding conversation supplies context.
+
+## Exploratory semantic signal
+
+An auditable rule-based indicator or unsupervised grouping derived from message
+content. It can support discovery and sampling, but is not a validated measure
+of tutoring quality, misconception, mastery, or learning.
+
+## Learning episode
+
+A sequence of exchanges concerning a coherent learning goal or difficulty.
+Automatic episode boundaries are deferred until a suitable method has been
+validated.
+
+## Restricted content analysis
+
+Analysis that may examine message text and stored image descriptions within a
+controlled environment. It excludes model reasoning payloads, raw image bytes,
+and raw tool results.
+
+## Analysis artifact
+
+An output derived from chatbot records for product-quality, learning-analytics,
+or approved research purposes. Its permitted audience and lifetime depend on
+whether it contains row-level or aggregate information.
+
+## Analysis eligibility
+
+The purpose-specific permission for a person's chatbot records to enter an
+analysis dataset. Learning-analytics eligibility and research eligibility are
+separate and may change over time. The analysis capability consumes these
+eligibility decisions from the system that owns them; it does not define how
+they are collected.
+
+## Durable analysis dataset
+
+A purpose-bound collection of eligible chatbot records and derived labels kept
+for longitudinal learning analytics or approved research. It remains personal
+data while a person can be identified, including through pseudonymous keys.
+
+## Purpose-and-course pseudonym
+
+A stable pseudonymous identity usable only within one analysis purpose and one
+course instance. It supports longitudinal analysis inside that boundary without
+enabling cross-purpose or cross-course linkage by default.
+
+## Personal-data export
+
+An artifact containing row-level records, free text, stable pseudonyms, or other
+information relating to an identifiable person. It is created only through an
+explicit restricted-export action for named operators, never as a general
+download, and requires purpose eligibility plus restricted access.
+
+## Eligibility withdrawal
+
+A person's removal of learning-analytics or research eligibility. Future
+processing for that purpose stops, and rebuildable row-level records and derived
+data for that person are removed. Only outputs shown to be genuinely anonymous
+may remain.
+
+## Prospective eligibility
+
+Records enter a purpose-bound analysis dataset only while the corresponding
+eligibility is active. A later opt-in does not make earlier records eligible
+unless the separate consent design explicitly authorizes retrospective use.
+
+## Aggregate report
+
+The default human-readable and machine-readable analysis output. It contains no
+row-level conversation content. Values for groups smaller than five are hidden,
+with complementary suppression across dimension tables and additive summary
+partitions where totals or sibling fields would otherwise reveal them.
+
+## Restricted export
+
+An explicit, audited export of eligible row-level records for a named operator
+and declared purpose. Content-bearing XLSX or JSONL files are never produced by
+the default report path.
+
+## Eligibility-ready analysis
+
+Analysis that fails closed when authoritative, effective-dated eligibility is
+unavailable. Before that integration exists, the capability may be developed
+and verified only with synthetic fixtures.
+
+## Rating coverage
+
+The share of eligible tutor responses that have an explicit UP or DOWN rating.
+Rating distributions are interpreted together with this coverage; unrated
+responses are not treated as neutral or representative feedback.
+
+## Exploratory cluster
+
+An unsupervised grouping used to discover patterns and guide sampling. Default
+reports may show disclosure-controlled size, coverage, and stability measures,
+but example text and exchange assignments belong only in restricted exports.

--- a/docs/adr/0005-purpose-bound-chatbot-learning-analytics.md
+++ b/docs/adr/0005-purpose-bound-chatbot-learning-analytics.md
@@ -1,0 +1,54 @@
+# ADR-0005: Keep chatbot learning analytics purpose-bound
+
+## Status
+
+Accepted
+
+## Context
+
+Chatbot conversations can support durable learning analytics, product-quality
+work, and later research. The same persistence and linkage that make
+longitudinal analysis useful also increase the possibility of identifying a
+student or reusing their records for another purpose. Pseudonymised conversation
+data therefore remains personal data.
+
+The consent and eligibility model is being designed separately. The analysis
+capability needs a stable boundary that can consume those decisions without
+turning a broad analytics role or an exported workbook into general access to
+personal information.
+
+## Decision
+
+Learning analytics and research are separate purposes with separate,
+fail-closed eligibility flags. The analysis capability consumes those flags and
+does not own their collection.
+
+Eligible records use stable pseudonyms only within one purpose and one course
+instance. Cross-purpose and cross-course linkage is unavailable by default.
+Eligibility is prospective unless the consent design explicitly authorizes and
+explains retrospective inclusion.
+
+Row-level content may leave the governed analysis environment only through an
+explicit restricted export. Each export records its purpose, named operator,
+eligibility filter, expiry date, and encrypted destination in an immutable audit
+record. Withdrawal stops future inclusion and removes the person from
+rebuildable row-level and derived datasets; only outputs demonstrated to be
+anonymous may remain.
+
+## Considered options
+
+- Global pseudonyms would make cross-course longitudinal analysis easier, but
+  would create a broader linkage boundary than the initial purposes require.
+- Per-export pseudonyms would minimize linkage, but would prevent longitudinal
+  analysis even within an eligible course cohort.
+- Role-only exports would be simpler, but would not bind portable copies to a
+  declared purpose or lifecycle.
+
+## Consequences
+
+- The first capability supports longitudinal analysis within a course instance,
+  not a person-level history across courses.
+- Restricted exports need technical access, audit, expiry, and deletion controls;
+  pseudonymisation alone is insufficient.
+- A later cross-course or retrospective-analysis feature requires a new
+  governance and architecture decision rather than a wider query.

--- a/docs/adr/0006-federate-chatbot-analysis-sources.md
+++ b/docs/adr/0006-federate-chatbot-analysis-sources.md
@@ -1,0 +1,49 @@
+# ADR-0006: Federate chatbot analysis sources
+
+## Status
+
+Accepted
+
+## Context
+
+Chatbot learning analytics needs application facts and, later, model-routing and
+observability facts. PostgreSQL already records conversations and feedback,
+LiteLLM records provider routing and spend, and Langfuse records traces and
+observations. Copying every provider call into Klicker would create a third
+ledger whose synchronization, correction, access, retention, and withdrawal
+behaviour would need to be maintained.
+
+The sources do not necessarily have complete one-to-one coverage. Auxiliary
+model calls and missing traces must not be silently attributed to a student
+exchange.
+
+## Decision
+
+The learning-analytics capability keeps each fact in its authoritative system
+and joins facts for a purpose-bound analysis run.
+
+PostgreSQL is authoritative for conversations, ratings, and analysis
+eligibility. LiteLLM is authoritative for actual routed model, spend, and cache
+usage. Langfuse is authoritative for traces and observations. Analysis outputs
+record source provenance, join coverage, ambiguity, and unmatched records.
+
+Klicker does not persist a duplicate provider-call ledger. Telemetry enrichment
+is a later package and cannot become a prerequisite for the initial
+database-backed descriptive report.
+
+## Considered options
+
+- Persisting each call in Klicker would simplify individual queries, but would
+  duplicate LiteLLM and Langfuse and create another personal-data lifecycle.
+- A dedicated analytics warehouse could support larger workloads later, but is
+  unnecessary before the source contracts and analysis value are validated.
+- Treating Langfuse as the sole source would omit authoritative application
+  ratings and would make basic reporting depend on trace completeness.
+
+## Consequences
+
+- Cross-system reports must expose join quality instead of assuming complete
+  attribution.
+- Source-specific access and retention controls continue to apply.
+- A future warehouse or materialized dataset requires a new decision covering
+  synchronization, purpose isolation, withdrawal, and deletion.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,5 @@ The durable record of **why** — the significant, hard-to-reverse choices behin
 
 - [0001](./0001-automate-db-migrations-via-argocd-presync-hook.md) — Automate database migrations via an ArgoCD PreSync hook
 - [0003](./0003-promote-stg-via-release-annotation-write-back.md) — Promote to staging by writing the built commit into a release annotation
+- [0005](./0005-purpose-bound-chatbot-learning-analytics.md) — Keep chatbot learning analytics purpose-bound
+- [0006](./0006-federate-chatbot-analysis-sources.md) — Federate chatbot analysis sources

--- a/packages/prisma-data/package.json
+++ b/packages/prisma-data/package.json
@@ -33,10 +33,12 @@
     "turndown": "~7.2.4",
     "typescript": "~6.0.3",
     "uuid": "~10.0.0",
+    "vitest": "~3.2.4",
     "xml2js": "~0.6.2"
   },
   "scripts": {
-    "check": "run-s --npm-path pnpm check:data check:scripts",
+    "check": "run-s --npm-path pnpm check:data check:scripts check:analysis",
+    "check:analysis": "tsc --noEmit -p tsconfig.analysis-check.json",
     "check:data": "tsc --noEmit -p tsconfig.check.json",
     "check:scripts": "tsc --noEmit --noCheck -p tsconfig.json",
     "script": "ENV=development ../../util/_run_with_infisical.sh --env dev tsx",
@@ -55,7 +57,8 @@
     "seed:qa": "ENV=development ../../util/_run_with_infisical.sh --env stg tsx src/data/seedTEST.ts",
     "seed:raw": "ENV=development run-s --npm-path pnpm seed:test seed:assessment-course",
     "seed:raw:course-awards": "tsx src/data/seedCourseAwards.ts",
-    "seed:test": "ENV=development tsx src/data/seedTEST.ts"
+    "seed:test": "ENV=development tsx src/data/seedTEST.ts",
+    "test": "vitest run"
   },
   "engines": {
     "node": "=24"

--- a/packages/prisma-data/src/chatbot-analysis/core.test.ts
+++ b/packages/prisma-data/src/chatbot-analysis/core.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type AnalysisMessage,
+  buildExchanges,
+  calculateRatingCoverage,
+  type EligibilityDecision,
+  runAnalysisCore,
+  selectEligibleMessages,
+} from './core.js'
+
+const window = {
+  from: new Date('2026-08-01T00:00:00.000Z'),
+  to: new Date('2026-08-01T23:59:59.999Z'),
+}
+
+function message(
+  id: string,
+  overrides: Partial<AnalysisMessage> = {}
+): AnalysisMessage {
+  return {
+    id,
+    threadId: 'thread-1',
+    participantId: 'participant-1',
+    chatbotId: 'chatbot-1',
+    courseId: 'course-1',
+    parentId: null,
+    role: 'user',
+    createdAt: new Date('2026-08-01T10:00:00.000Z'),
+    rating: null,
+    text: id,
+    attachmentCount: 0,
+    creditsUsed: null,
+    ...overrides,
+  }
+}
+
+function eligible(
+  overrides: Partial<EligibilityDecision> = {}
+): EligibilityDecision {
+  return {
+    participantId: 'participant-1',
+    purpose: 'learning-analytics',
+    courseId: 'course-1',
+    effectiveFrom: new Date('2026-08-01T00:00:00.000Z'),
+    effectiveTo: null,
+    eligible: true,
+    ...overrides,
+  }
+}
+
+describe('chatbot analysis core', () => {
+  it('fails closed for missing, withdrawn, and mismatched eligibility', () => {
+    const records = [
+      message('eligible'),
+      message('withdrawn', { participantId: 'participant-2' }),
+      message('research-only', { participantId: 'participant-3' }),
+      message('before-opt-in', {
+        participantId: 'participant-4',
+        createdAt: new Date('2026-07-31T23:59:59.999Z'),
+      }),
+      message('no-decision', { participantId: 'participant-5' }),
+    ]
+    const decisions = [
+      eligible(),
+      eligible({ participantId: 'participant-2', eligible: false }),
+      eligible({ participantId: 'participant-3', purpose: 'research' }),
+      eligible({
+        participantId: 'participant-4',
+        effectiveFrom: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    ]
+
+    const result = selectEligibleMessages(
+      records,
+      decisions,
+      'learning-analytics',
+      window
+    )
+
+    expect(result.messages.map((record) => record.id)).toEqual(['eligible'])
+    expect(result.excludedMessageIds).toEqual([
+      'withdrawn',
+      'research-only',
+      'before-opt-in',
+      'no-decision',
+    ])
+  })
+
+  it('lets a covering withdrawal veto an otherwise valid grant', () => {
+    const record = message('withdrawn-after-grant')
+    const result = selectEligibleMessages(
+      [record],
+      [
+        eligible(),
+        eligible({
+          eligible: false,
+          effectiveFrom: new Date('2026-08-01T09:00:00.000Z'),
+        }),
+      ],
+      'learning-analytics',
+      window
+    )
+
+    expect(result.messages).toEqual([])
+    expect(result.excludedMessageIds).toEqual(['withdrawn-after-grant'])
+  })
+
+  it('links a unique assistant child and preserves an outside-window child', () => {
+    const user = message('user')
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-01T10:01:00.000Z'),
+      rating: 'UP',
+    })
+    const outsideWindow = message('outside', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-02T10:01:00.000Z'),
+    })
+
+    const [linked] = buildExchanges([user, assistant], window)
+    const [outsideExchange] = buildExchanges([user, outsideWindow], window)
+
+    expect(linked?.status).toBe('linked')
+    expect(linked?.assistantMessage?.id).toBe('assistant')
+    expect(outsideExchange?.status).toBe('outside_window')
+    expect(outsideExchange?.assistantMessage).toBeNull()
+    expect(outsideExchange?.candidateAssistantIds).toEqual(['outside'])
+  })
+
+  it('marks regenerated answers ambiguous instead of choosing by timestamp', () => {
+    const user = message('user')
+    const first = message('assistant-a', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-01T10:01:00.000Z'),
+    })
+    const second = message('assistant-b', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-01T10:02:00.000Z'),
+    })
+
+    const [exchange] = buildExchanges([user, first, second], window)
+
+    expect(exchange?.status).toBe('ambiguous')
+    expect(exchange?.assistantMessage).toBeNull()
+    expect(exchange?.candidateAssistantIds).toEqual([
+      'assistant-a',
+      'assistant-b',
+    ])
+  })
+
+  it('reports rating coverage without treating unrated responses as neutral', () => {
+    const user = message('user')
+    const secondUser = message('user-2', {
+      createdAt: new Date('2026-08-01T10:01:30.000Z'),
+    })
+    const up = message('up', {
+      role: 'assistant',
+      parentId: 'user',
+      rating: 'UP',
+      createdAt: new Date('2026-08-01T10:01:00.000Z'),
+    })
+    const down = message('down', {
+      role: 'assistant',
+      parentId: 'user-2',
+      rating: 'DOWN',
+      createdAt: new Date('2026-08-01T10:02:00.000Z'),
+    })
+
+    const coverage = calculateRatingCoverage(
+      buildExchanges([user, secondUser, up, down], window)
+    )
+
+    expect(coverage).toEqual({
+      ratedResponses: 2,
+      unratedResponses: 0,
+      up: 1,
+      down: 1,
+      coverage: 1,
+    })
+  })
+
+  it('passes the purpose and window to the provider before producing a result', async () => {
+    const user = message('user')
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-01T10:01:00.000Z'),
+    })
+    const calls: Array<{
+      purpose: string
+      from: Date
+      to: Date
+    }> = []
+
+    const result = await runAnalysisCore(
+      {
+        loadMessages: async (input) => {
+          expect(input).toEqual(window)
+          return [user, assistant]
+        },
+        loadEligibility: async (input) => {
+          calls.push({ purpose: input.purpose, from: input.from, to: input.to })
+          return [eligible()]
+        },
+      },
+      { purpose: 'learning-analytics', window }
+    )
+
+    expect(calls).toEqual([
+      { purpose: 'learning-analytics', from: window.from, to: window.to },
+    ])
+    expect(result.exchanges[0]?.status).toBe('linked')
+  })
+
+  it('uses a bounded parent closure to classify an outside-window response', async () => {
+    const user = message('user')
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-02T10:01:00.000Z'),
+    })
+
+    const result = await runAnalysisCore(
+      {
+        loadMessages: async () => [user, assistant],
+        loadEligibility: async () => [eligible()],
+      },
+      { purpose: 'learning-analytics', window }
+    )
+
+    expect(result.exchanges[0]?.status).toBe('outside_window')
+    expect(result.exchanges[0]?.assistantMessage).toBeNull()
+  })
+
+  it('does not rescue an in-window assistant excluded by eligibility', async () => {
+    const user = message('user')
+    const assistant = message('assistant', {
+      role: 'assistant',
+      parentId: 'user',
+      createdAt: new Date('2026-08-01T10:01:00.000Z'),
+      rating: 'DOWN',
+    })
+
+    const result = await runAnalysisCore(
+      {
+        loadMessages: async () => [user, assistant],
+        loadEligibility: async () => [
+          eligible({ effectiveTo: new Date('2026-08-01T10:00:00.000Z') }),
+        ],
+      },
+      { purpose: 'learning-analytics', window }
+    )
+
+    expect(result.exchanges[0]?.status).toBe('absent')
+    expect(result.exchanges[0]?.assistantMessage).toBeNull()
+    expect(result.ratingCoverage).toEqual({
+      ratedResponses: 0,
+      unratedResponses: 0,
+      up: 0,
+      down: 0,
+      coverage: 0,
+    })
+  })
+})

--- a/packages/prisma-data/src/chatbot-analysis/core.ts
+++ b/packages/prisma-data/src/chatbot-analysis/core.ts
@@ -71,18 +71,10 @@ export type RatingCoverage = {
   coverage: number
 }
 
-export type MetricProvenance = {
-  source: 'postgresql'
-  definition: string
-  denominator: string
-  unknownCount: number
-}
-
 export type AnalysisCoreResult = {
   eligible: EligibleAnalysis
   exchanges: AnalysisExchange[]
   ratingCoverage: RatingCoverage
-  provenance: Record<string, MetricProvenance>
 }
 
 function isWithinWindow(date: Date, window: AnalysisWindow) {
@@ -226,28 +218,6 @@ export function calculateRatingCoverage(
   }
 }
 
-export function createMetricProvenance(
-  ratingCoverage: RatingCoverage,
-  excludedMessageIds: string[]
-): Record<string, MetricProvenance> {
-  return {
-    ratingCoverage: {
-      source: 'postgresql',
-      definition:
-        'Rated linked tutor responses divided by linked tutor responses',
-      denominator: 'linked tutor responses',
-      unknownCount: ratingCoverage.unratedResponses,
-    },
-    eligibilityExclusions: {
-      source: 'postgresql',
-      definition:
-        'Messages excluded because purpose eligibility did not match exactly once',
-      denominator: 'selected message records',
-      unknownCount: excludedMessageIds.length,
-    },
-  }
-}
-
 export async function runAnalysisCore(
   provider: AnalysisRecordProvider,
   input: {
@@ -293,9 +263,5 @@ export async function runAnalysisCore(
     eligible,
     exchanges,
     ratingCoverage,
-    provenance: createMetricProvenance(
-      ratingCoverage,
-      eligible.excludedMessageIds
-    ),
   }
 }

--- a/packages/prisma-data/src/chatbot-analysis/core.ts
+++ b/packages/prisma-data/src/chatbot-analysis/core.ts
@@ -1,0 +1,301 @@
+export type AnalysisPurpose = 'learning-analytics' | 'research'
+
+export type EligibilityDecision = {
+  participantId: string
+  purpose: AnalysisPurpose
+  courseId: string
+  effectiveFrom: Date
+  effectiveTo: Date | null
+  eligible: boolean
+}
+
+export type AnalysisMessage = {
+  id: string
+  threadId: string
+  participantId: string
+  chatbotId: string
+  courseId: string
+  parentId: string | null
+  role: 'user' | 'assistant' | string
+  createdAt: Date
+  rating: 'UP' | 'DOWN' | null
+  text: string
+  attachmentCount: number
+  creditsUsed: number | null
+}
+
+export type AnalysisRecordProvider = {
+  /**
+   * Returns records in the requested window plus the minimal parent closure
+   * needed to classify exchange lineage. Providers must not load an unbounded
+   * thread or course history.
+   */
+  loadMessages: (input: { from: Date; to: Date }) => Promise<AnalysisMessage[]>
+  loadEligibility: (input: {
+    participantIds: string[]
+    purpose: AnalysisPurpose
+    courseIds: string[]
+    from: Date
+    to: Date
+  }) => Promise<EligibilityDecision[]>
+}
+
+export type AnalysisWindow = {
+  from: Date
+  to: Date
+}
+
+export type EligibleAnalysis = {
+  messages: AnalysisMessage[]
+  excludedMessageIds: string[]
+}
+
+export type ExchangeStatus =
+  | 'linked'
+  | 'ambiguous'
+  | 'absent'
+  | 'outside_window'
+
+export type AnalysisExchange = {
+  userMessage: AnalysisMessage
+  assistantMessage: AnalysisMessage | null
+  status: ExchangeStatus
+  candidateAssistantIds: string[]
+}
+
+export type RatingCoverage = {
+  ratedResponses: number
+  unratedResponses: number
+  up: number
+  down: number
+  coverage: number
+}
+
+export type MetricProvenance = {
+  source: 'postgresql'
+  definition: string
+  denominator: string
+  unknownCount: number
+}
+
+export type AnalysisCoreResult = {
+  eligible: EligibleAnalysis
+  exchanges: AnalysisExchange[]
+  ratingCoverage: RatingCoverage
+  provenance: Record<string, MetricProvenance>
+}
+
+function isWithinWindow(date: Date, window: AnalysisWindow) {
+  return date >= window.from && date <= window.to
+}
+
+function intervalIncludes(decision: EligibilityDecision, date: Date) {
+  return (
+    decision.effectiveFrom <= date &&
+    (decision.effectiveTo === null || decision.effectiveTo >= date)
+  )
+}
+
+/**
+ * Selects records only when an explicit purpose decision covers their message
+ * timestamp. Missing, inactive, mismatched, and withdrawn decisions exclude the
+ * record; an analytics run never treats an absent flag as consent.
+ */
+export function selectEligibleMessages(
+  messages: AnalysisMessage[],
+  decisions: EligibilityDecision[],
+  purpose: AnalysisPurpose,
+  window: AnalysisWindow
+): EligibleAnalysis {
+  const byParticipant = new Map<string, EligibilityDecision[]>()
+  for (const decision of decisions) {
+    const values = byParticipant.get(decision.participantId) ?? []
+    values.push(decision)
+    byParticipant.set(decision.participantId, values)
+  }
+
+  const eligible: AnalysisMessage[] = []
+  const excludedMessageIds: string[] = []
+  for (const message of messages) {
+    const covering = (byParticipant.get(message.participantId) ?? []).filter(
+      (decision) =>
+        decision.purpose === purpose &&
+        decision.courseId === message.courseId &&
+        intervalIncludes(decision, message.createdAt)
+    )
+    const withdrawn = covering.some((decision) => !decision.eligible)
+    const grants = covering.filter((decision) => decision.eligible)
+    if (
+      isWithinWindow(message.createdAt, window) &&
+      !withdrawn &&
+      grants.length === 1
+    ) {
+      eligible.push(message)
+    } else {
+      excludedMessageIds.push(message.id)
+    }
+  }
+
+  return { messages: eligible, excludedMessageIds }
+}
+
+function compareMessages(a: AnalysisMessage, b: AnalysisMessage) {
+  const createdAt = a.createdAt.getTime() - b.createdAt.getTime()
+  return createdAt !== 0 ? createdAt : a.id.localeCompare(b.id)
+}
+
+/**
+ * Pairs only a unique assistant child of a user message. Multiple children are
+ * preserved as ambiguous; no timestamp heuristic chooses a regenerated answer.
+ */
+export function buildExchanges(
+  messages: AnalysisMessage[],
+  window: AnalysisWindow
+): AnalysisExchange[] {
+  const byParent = new Map<string, AnalysisMessage[]>()
+  const inWindowIds = new Set(
+    messages
+      .filter((message) => isWithinWindow(message.createdAt, window))
+      .map((message) => message.id)
+  )
+
+  for (const message of messages) {
+    if (message.parentId) {
+      const values = byParent.get(message.parentId) ?? []
+      values.push(message)
+      byParent.set(message.parentId, values)
+    }
+  }
+
+  return messages
+    .filter(
+      (message) =>
+        message.role === 'user' && isWithinWindow(message.createdAt, window)
+    )
+    .sort(compareMessages)
+    .map((userMessage) => {
+      const candidates = (byParent.get(userMessage.id) ?? [])
+        .filter((message) => message.role === 'assistant')
+        .sort(compareMessages)
+      if (candidates.length > 1) {
+        return {
+          userMessage,
+          assistantMessage: null,
+          status: 'ambiguous',
+          candidateAssistantIds: candidates.map((message) => message.id),
+        }
+      }
+      if (candidates.length === 1) {
+        const assistant = candidates[0]!
+        return {
+          userMessage,
+          assistantMessage: inWindowIds.has(assistant.id) ? assistant : null,
+          status: inWindowIds.has(assistant.id) ? 'linked' : 'outside_window',
+          candidateAssistantIds: [assistant.id],
+        }
+      }
+
+      const hasOutsideWindowChild = messages.some(
+        (message) =>
+          message.parentId === userMessage.id && message.role === 'assistant'
+      )
+      return {
+        userMessage,
+        assistantMessage: null,
+        status: hasOutsideWindowChild ? 'outside_window' : 'absent',
+        candidateAssistantIds: [],
+      }
+    })
+}
+
+export function calculateRatingCoverage(
+  exchanges: AnalysisExchange[]
+): RatingCoverage {
+  const responses = exchanges
+    .map((exchange) => exchange.assistantMessage)
+    .filter((message): message is AnalysisMessage => message !== null)
+  const up = responses.filter((message) => message.rating === 'UP').length
+  const down = responses.filter((message) => message.rating === 'DOWN').length
+  const ratedResponses = up + down
+  return {
+    ratedResponses,
+    unratedResponses: responses.length - ratedResponses,
+    up,
+    down,
+    coverage: responses.length > 0 ? ratedResponses / responses.length : 0,
+  }
+}
+
+export function createMetricProvenance(
+  ratingCoverage: RatingCoverage,
+  excludedMessageIds: string[]
+): Record<string, MetricProvenance> {
+  return {
+    ratingCoverage: {
+      source: 'postgresql',
+      definition:
+        'Rated linked tutor responses divided by linked tutor responses',
+      denominator: 'linked tutor responses',
+      unknownCount: ratingCoverage.unratedResponses,
+    },
+    eligibilityExclusions: {
+      source: 'postgresql',
+      definition:
+        'Messages excluded because purpose eligibility did not match exactly once',
+      denominator: 'selected message records',
+      unknownCount: excludedMessageIds.length,
+    },
+  }
+}
+
+export async function runAnalysisCore(
+  provider: AnalysisRecordProvider,
+  input: {
+    purpose: AnalysisPurpose
+    window: AnalysisWindow
+  }
+): Promise<AnalysisCoreResult> {
+  const messages = await provider.loadMessages(input.window)
+  const participantIds = [
+    ...new Set(messages.map((message) => message.participantId)),
+  ]
+  const courseIds = [...new Set(messages.map((message) => message.courseId))]
+  const decisions = await provider.loadEligibility({
+    participantIds,
+    purpose: input.purpose,
+    courseIds,
+    from: input.window.from,
+    to: input.window.to,
+  })
+  const eligible = selectEligibleMessages(
+    messages,
+    decisions,
+    input.purpose,
+    input.window
+  )
+  const eligibleIds = new Set(eligible.messages.map((message) => message.id))
+  // Only out-of-window replies may enter lineage classification; admitting an
+  // in-window ineligible reply would expose its content through assistantMessage.
+  const lineageMessages = messages.filter(
+    (message) =>
+      message.role === 'assistant' &&
+      message.parentId !== null &&
+      !eligibleIds.has(message.id) &&
+      eligibleIds.has(message.parentId) &&
+      !isWithinWindow(message.createdAt, input.window)
+  )
+  const exchanges = buildExchanges(
+    [...eligible.messages, ...lineageMessages],
+    input.window
+  )
+  const ratingCoverage = calculateRatingCoverage(exchanges)
+  return {
+    eligible,
+    exchanges,
+    ratingCoverage,
+    provenance: createMetricProvenance(
+      ratingCoverage,
+      eligible.excludedMessageIds
+    ),
+  }
+}

--- a/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
+++ b/packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts
@@ -58,6 +58,7 @@ type MessageRecord = {
   participantKey: string
   messageId: string
   messageKey: string
+  parentId: string | null
   role: string
   content: Prisma.JsonValue
   text: string
@@ -73,6 +74,7 @@ type MessageRecord = {
   modelId: string | null
   reasoningEffort: string | null
   reasoningContent: string | null
+  rating: 'UP' | 'DOWN' | null
   creditsUsed: number | null
   attachmentCount: number
 }
@@ -518,12 +520,14 @@ const chatbotSelect = {
 
 const threadMessageSelect = {
   id: true,
+  parentId: true,
   role: true,
   content: true,
   chatMode: true,
   modelId: true,
   reasoningEffort: true,
   reasoningContent: true,
+  rating: true,
   creditsUsed: true,
   createdAt: true,
   attachments: {
@@ -559,12 +563,14 @@ type ThreadRecord = {
   updatedAt: Date
   messages: Array<{
     id: string
+    parentId: string | null
     role: string
     content: Prisma.JsonValue
     chatMode: string | null
     modelId: string | null
     reasoningEffort: string | null
     reasoningContent: string | null
+    rating: 'UP' | 'DOWN' | null
     creditsUsed: unknown
     createdAt: Date
     attachments: Array<{ id: string }>
@@ -2122,6 +2128,7 @@ function flattenMessages(
         participantKey: participantKeyById.get(thread.participantId)!,
         messageId: message.id,
         messageKey: messageKeyById.get(message.id)!,
+        parentId: message.parentId,
         role: message.role,
         content: message.content as Prisma.JsonValue,
         text,
@@ -2139,6 +2146,7 @@ function flattenMessages(
         modelId: message.modelId,
         reasoningEffort: message.reasoningEffort,
         reasoningContent: message.reasoningContent,
+        rating: message.rating,
         creditsUsed: decimalToNumber(message.creditsUsed),
         attachmentCount: message.attachments.length,
       }
@@ -2186,6 +2194,9 @@ function buildSheets(
       assignment.messageKey,
       assignment,
     ])
+  )
+  const messageKeyById = new Map(
+    messages.map((message) => [message.messageId, message.messageKey])
   )
 
   const activeParticipantKeys = new Set(
@@ -3070,11 +3081,13 @@ function buildSheets(
     'threadKey',
     'participantKey',
     'messageKey',
+    'parentMessageKey',
     'role',
     'messageCreatedAt',
     'chatMode',
     'modelId',
     'reasoningEffort',
+    'rating',
     'creditsUsed',
     'contentTypes',
     'textCharCount',
@@ -3106,11 +3119,15 @@ function buildSheets(
         message.threadKey,
         message.participantKey,
         message.messageKey,
+        message.parentId
+          ? (messageKeyById.get(message.parentId) ?? null)
+          : null,
         message.role,
         message.messageCreatedAt,
         message.chatMode,
         message.modelId,
         message.reasoningEffort,
+        message.rating,
         message.creditsUsed,
         contentTypes(message.content),
         message.textCharCount,
@@ -3172,6 +3189,10 @@ async function writeMessageContentJsonl(
           chatMode: message.chatMode,
           modelId: message.modelId,
           reasoningEffort: message.reasoningEffort,
+          parentMessageKey: message.parentId
+            ? (messageKeyById.get(message.parentId) ?? null)
+            : null,
+          rating: message.rating,
           creditsUsed: message.creditsUsed,
           toolCallCount: toolCallCount(message.content),
           attachmentCount: message.attachmentCount,

--- a/packages/prisma-data/tsconfig.analysis-check.json
+++ b/packages/prisma-data/tsconfig.analysis-check.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/chatbot-analysis/**/*.ts"]
+}

--- a/packages/prisma-data/vitest.config.ts
+++ b/packages/prisma-data/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+  resolve: {
+    conditions: ['node', 'import', 'default'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2172,6 +2172,9 @@ importers:
       uuid:
         specifier: ~10.0.0
         version: 10.0.0
+      vitest:
+        specifier: ~3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.49.0)(tsx@4.19.4)(yaml@2.9.0)
       xml2js:
         specifier: ~0.6.2
         version: 0.6.2

--- a/project/2026-08-12-chatbot-learning-analytics-plan.md
+++ b/project/2026-08-12-chatbot-learning-analytics-plan.md
@@ -1,0 +1,239 @@
+# Chatbot learning analytics implementation plan
+
+## Goal and boundary
+
+- Problem: Chatbot usage has been investigated through one large committed exporter and several useful temporary Vorkurs scripts. The committed report omits ratings and parent lineage, its default row-level workbook is still personal data, its lexical clusters leave substantial content unclassified, and temporary scripts are not a governed or tested capability.
+- Goal: Build a generic, reusable, privacy-by-design learning-analytics capability around the existing TypeScript exporter. Deliver trustworthy descriptive exchange analytics, disclosure-controlled aggregate outputs, and an explicit restricted export path. Prove value with a governed real-data Vorkurs run once authoritative eligibility is available.
+- Non-goals for this package: collect consent; create research eligibility; schedule reports; build a dashboard or long-running analytics service; copy LiteLLM or Langfuse provider calls into PostgreSQL; automate misconception, mastery, tutoring-quality, or learning-gain claims; segment learning episodes; publish or commit real course data.
+- Ceremony: full path. The package changes personal-data flow, privacy defaults, and restricted-export behavior.
+- Authority: Plan approval authorizes local branch/worktree creation, implementation, synthetic verification, and read-only development-database checks. It does not authorize a production data query, restricted real-data export, push, draft PR creation, deployment, publication, merge, or deletion. Each requires its normal later gate; the real-data pilot additionally requires operational eligibility and a named operator authorization.
+
+## Identity and continuity
+
+- Planned artifact: `project/2026-08-12-chatbot-learning-analytics-plan.md`.
+- Target: `v3` at `5264353ff77afc598ea69f05f262b25f882ca38c` when drafted.
+- Branch/worktree after approval: create the first stack branch with the `rs/` prefix in a repo-local worktree under `trees/chatbot-learning-analytics/`; audit existing worktrees and fetch again before creation. Never implement from the dirty primary checkout.
+- Related history: `project/2026-08-07-vorkurs-chatbot-production-adjustments.md`, `project/2026-08-08-vorkurs-chatbot-finalization-plan.md`, and `project/2026-08-09-vorkurs-chatbot-sdk-fix-plan.md` cover production readiness, not this learning-analytics capability.
+- Durable decisions: ADR-0005, purpose-bound chatbot learning analytics; ADR-0006, federated chatbot analysis sources.
+- Grill outcome: generic learning analytics and product quality now, research later as a separate purpose; prospective purpose-and-course eligibility; exchange-first descriptive measures; exploratory heuristics/clusters only; aggregate by default; audited restricted exports; educational coding capacity-gated; database package first and telemetry later.
+
+## Primitive impact
+
+| Product primitive | Disposition | Contract delta | Consumers | Evidence |
+| --- | --- | --- | --- | --- |
+| Chat message and feedback | Reuse | Read `parentId`, `rating`, mode, attachment metadata, credits, and permitted content without changing message ownership | Exporter, exchange builder | Prisma chat schema; ADR-0002 |
+| Analysis eligibility | Compose | Consume effective-dated, purpose-specific eligibility fail closed; do not own consent collection | Dataset selector, aggregate report, restricted export | ADR-0005; separate consent work is a dependency |
+| Aggregate report | Create | No row-level text or stable IDs; suppress cells below five and complementary cells; disclose provenance and unknowns | Product/teaching evaluators | `CONTEXT.md` |
+| Restricted export | Create | Authoritative operator adapter, declared purpose, prospective eligibility filter, expiry, verified encrypted destination, immutable audit record, withdrawal-rebuild manifest | Authorized analysts only | ADR-0005 |
+| Provider telemetry | Compose later | Join source-owned model/cost/cache/trace facts without a duplicate ledger | Later telemetry package | ADR-0006 |
+
+## Research and existing capability
+
+- Evidence: `packages/prisma-data/src/scripts/2026-06-16_analyze_chatbot_usage.ts` already supplies selection/window CLI flags, pseudonymized XLSX/optional JSONL, usage/credits/model/tool sheets, and deterministic multilingual n-gram clustering. It remains the baseline rather than being replaced.
+- Evidence: the exporter currently does not select or emit `ChatMessage.rating` or `parentId`. It always loads message content for internal clustering even when content is omitted from outputs; its privacy modes therefore describe artifacts, not whether content was processed.
+- Evidence: temporary local scripts cover bounded usage, question heuristics, image modality, LaTeX auditing, model selection, and LiteLLM/Langfuse aggregation. Only generic, privacy-reviewed logic moves into the package. No temporary output, real message text, raw image, identifier, or credential enters Git.
+- Evidence: educational dialogue research supports separate student intent, tutor move, and next-turn dimensions, and treats unsupervised clusters as discovery aids requiring human interpretation. Human coding is deferred because two qualified coders are unavailable.
+- Gareth routing: use `learning-analytics-interpretation-guide` to keep reports decision-led and explicit about what data cannot show. Preserve future rubric inputs from `intelligent-tutoring-dialogue-designer`, `adaptive-hint-sequence-designer`, `feedback-quality-analyser`, `ai-feedback-design-principles`, `checking-for-understanding-protocol-designer`, `error-analysis-protocol`, and `gap-analysis-from-student-work`; none produces automated production labels in this package.
+- Limitation: the exact eligibility schema/API is not yet implemented. All production-content selection and durable real-data outputs fail closed until that separate owner supplies an effective-dated contract compatible with ADR-0005.
+
+### Script disposition
+
+| Existing capability | Disposition in this package | Reason and proof |
+| --- | --- | --- |
+| Committed `2026-06-16_analyze_chatbot_usage.ts` | Retain as CLI/report baseline; extract typed pure seams incrementally | Preserve its selectors, operational sheets, deterministic clustering, and backwards compatibility through synthetic golden summaries |
+| `vorkurs_usage_report.mjs` and `vorkurs_period_report.mjs` | Generalize response latency, unanswered/linkage, depth, mode, attachment, tool, and credit measures | Port formulas into tested modules; discard course IDs, direct production access, and ad hoc output shapes |
+| `vorkurs_question_signals.mjs` and period variant | Generalize only auditable intent/modality heuristic rules as explicitly exploratory | Version every rule; synthetic rule fixtures; no claim that regex labels are validated educational codes |
+| `vorkurs_image_stats.mjs` | Fold image-only versus text-plus-image counts into attachment modality | Use attachment metadata and eligible text presence; never serialize image bytes |
+| `vorkurs_quality_aggregate.mjs` | Replace with rating coverage, lineage, unanswered, and data-quality measures | Remove its hardcoded “ratings absent” assumption and reconcile against selected eligible records |
+| `read_vorkurs_analytics.py` | Use as requirements evidence, then retire | Reimplement useful workbook-derived measures in TypeScript so the report is reproducible from one typed model and adds no Python dependency |
+| `vorkurs_latex_audit.mjs` and focus variant | Defer to a separate prompt/rendering quality tool | Content-sensitive regex audit is not a core learning-analytics measure and would widen the first package |
+| `vorkurs_model_selection_report.mjs` | Keep selected-model counts only; actual routing is Roadmap B | Selected `auto` is not actual provider model |
+| Langfuse/LiteLLM aggregate and route scripts | Roadmap B evidence only | Cross-system fields and costs require a separately reviewed telemetry join |
+
+All temporary scripts remain local evidence. Implementation reads them only to
+port generic logic; it never copies real outputs, identifiers, URLs, credentials,
+or message examples into source, tests, review prompts, or documentation.
+
+## Source and field contract
+
+| Fact | Authority | Current package behavior |
+| --- | --- | --- |
+| Message content, lineage, rating, mode, attachments, stored credits | PostgreSQL | Read eligible records; label credits as internal units, never actual cost |
+| LA/research eligibility and effective period | Separate consent/eligibility owner in PostgreSQL | Required adapter; unavailable means synthetic-only and no real-data artifact |
+| Actual model, spend, cache tokens | LiteLLM | Roadmap only; never infer from selected `auto` or credits |
+| Trace, observation, latency, TTFT | Langfuse | Roadmap only; never make baseline reporting depend on trace coverage |
+| Educational labels | Human-validated codebook | Capacity-gated roadmap; unavailable in this package |
+
+## Output contract
+
+- Default aggregate run: XLSX plus versioned JSON summary. It contains cohort totals, time distributions at approved granularity, mode/attachment/tool/credit measures, exchange linkage coverage, rating coverage and suppressed UP/DOWN distribution, and exploratory heuristic/cluster size, coverage, and stability. It contains no message text, image description, reasoning, tool result, exchange assignment, stable pseudonym, exact low-frequency slice, or hidden-cell reconstruction path.
+- Restricted export: content-bearing XLSX and/or JSONL only after a separate explicit CLI action validates purpose, named operator, eligibility window, expiry, encrypted destination assertion, and audit destination. It may include eligible message text and stored image descriptions; it excludes reasoning, raw image bytes, and raw tool results. It carries field provenance, export manifest, withdrawal/rebuild key, and a machine-readable expiry.
+- Existing operational sheets and selection filters stay available where compatible. Breaking sheet/header changes are versioned and documented. Layer 2 removes `--includeMessageContent` or hard-aliases it to the fully gated restricted action with an explicit migration error; no merged command may write content-bearing output outside that gate.
+- The export audit records metadata and cryptographic artifact digest, never message content. Layer 2 defines and tests an audit interface with a synthetic append-only sink, but the production restricted-export command remains fail closed until a durable audit owner, authorized operator identity source, encrypted destination verification, and deletion executor are configured and proven.
+
+## Privacy-by-design defaults
+
+| Principle/default | Measure | Evidence required |
+| --- | --- | --- |
+| Transparency and purpose | Versioned manifest states purpose, population, fields, authority, eligibility period, output tier, exclusions, and limitations | Snapshot/contract test and workbook/JSON inspection |
+| Data minimization | Default aggregation never serializes row-level text; restricted selection excludes reasoning, raw images, and raw tool results | Artifact scanner plus explicit allowlist tests |
+| Purpose limitation | Purpose-and-course pseudonyms; separate LA/research eligibility; fail closed on missing or stale eligibility | Selector tests including retrospective and cross-purpose rejection |
+| Storage limitation | Restricted manifest contains expiry and rebuild/deletion key; real run requires an owned expiry/deletion procedure | Synthetic lifecycle test; operational evidence before pilot |
+| Access/confidentiality | Restricted action requires an authoritative operator adapter, verified encrypted destination, and audit record | CLI boundary and synthetic adapter integration test; production providers are an operational dependency |
+| Accuracy/accountability | Every metric names source, definition, denominator, unknown count, and report version | Reconciliation tests and provenance sheet |
+| Withdrawal | Rebuild excludes withdrawn subjects and regenerates derived outputs; only demonstrably anonymous aggregates survive | Synthetic before/after rebuild test |
+
+## Feature-wide test portfolio
+
+| Risk or behavior | Existing evidence | Obligation | Primary seam | Distinct failure caught | Owner |
+| --- | --- | --- | --- | --- | --- |
+| Eligibility and withdrawal | No analyzer integration | Add new | Pure effective-dated selector fixtures | Ineligible, withdrawn, pre-opt-in, wrong-purpose, or wrong-course records enter an artifact | Layer 1 |
+| Message lineage and ratings | Schema only; exporter omits fields | Add new | Pure exchange-builder fixtures | Timestamp pairing, regeneration ambiguity, outside-window parent errors, or missing rating coverage | Layer 1 |
+| Metric terminology/provenance | Workbook notes only | Extend | Report-model and header assertions | Credits become currency, `auto` becomes actual model, or denominators/unknowns disappear | Layer 1 |
+| Default disclosure safety | Current pseudonyms and content opt-in, no release tier | Add new | Aggregate table builder plus artifact scanner | Text/stable IDs leak, rare cells reveal people, or complementary totals reconstruct a suppressed value | Layer 2 |
+| Restricted export gate/audit | No comparable gate | Add new | CLI contract and audit-sink integration | Portable personal data is written without all purpose/access/expiry/destination fields or digest | Layer 2 |
+| Exploratory signal honesty | Deterministic clustering without stability contract | Extend | Synthetic corpus fixtures and report metadata | Cluster examples leak or exploratory results are presented as validated educational measures | Layer 2 |
+| Legacy analyzer regression | Manual exports only | Extend | Golden synthetic report summary | Existing course/chatbot/window counts and operational sheets silently drift | Both |
+| Real-data usefulness | Temporary ad hoc reports | No code test | Governed Vorkurs reconciliation checklist | The capability passes fixtures but cannot answer real review questions or reconcile with SQL | Milestone gate |
+
+## Stack topology
+
+```yaml
+feature: chatbot-learning-analytics
+provider: github
+base: v3
+mode: progressive
+layers:
+  - id: 01
+    name: analysis-core
+    work_package: eligibility-gated descriptive analysis model with auditable exchange lineage and metric provenance
+    responsibility: pure analysis core and legacy exporter compatibility
+    depends_on: v3
+    reviewer: data and privacy reviewers
+    attention: judgment-heavy
+    reviewer_focus:
+      - eligibility and withdrawal fail closed
+      - exchange/rating semantics and credits versus cost
+      - smallest extraction from the legacy script that creates stable test seams
+    validation:
+      - focused Vitest suite on synthetic fixtures through a record-provider seam
+      - package typecheck without `--noCheck` for the extracted analysis modules
+      - format and lint on changed paths
+      - legacy synthetic golden summary
+    activation: inert for real data until an authoritative eligibility adapter is configured
+    risk: high
+    size_signal: 350-500 human-authored lines across 5-8 files; threshold ruling: one work package because selector, exchange model, and provenance form one independently testable fail-closed core
+  - id: 02
+    name: governed-reports
+    work_package: aggregate-by-default reports and explicit audited restricted export
+    responsibility: disclosure controls, artifact contracts, exploratory signals, and operator workflow
+    depends_on: 01
+    reviewer: learning-analytics and operations reviewers
+    attention: judgment-heavy
+    reviewer_focus:
+      - n<5 and complementary suppression correctness
+      - no default personal-data download
+      - useful outputs and honest exploratory interpretation
+      - restricted export gate, audit metadata, expiry, and deletion/rebuild contract
+    validation:
+      - focused Vitest suite and workbook/JSON artifact scan
+      - package typecheck
+      - format and lint on changed paths
+      - synthetic end-to-end CLI runs for both output tiers
+    activation: aggregate complete on eligible inputs; restricted export inert for real data until eligibility, audit, operator identity, destination verification, and deletion owners are configured
+    risk: high
+    size_signal: 350-550 human-authored lines across 5-8 files; threshold ruling: one work package because aggregate and restricted paths must be reviewed together to establish the no-general-download invariant
+follow_up_stacks:
+  - telemetry enrichment joining LiteLLM model/spend/cache facts and Langfuse observations after trace and field reconciliation
+  - human-validated educational coding and later classifiers after two qualified coders and governance capacity exist
+```
+
+## Layer 1 — trustworthy analysis core
+
+- Route: executor for bounded pure-module/test extraction if the hosted-inference privacy boundary is acceptable; main session owns eligibility seam, privacy architecture, integration, and final verification. No real data enters worker prompts.
+- Problem: the monolithic exporter mixes database selection, transformations, clustering, and workbook construction, preventing focused proof of lineage, eligibility, ratings, and metric meaning.
+- Do: introduce the smallest adjacent `chatbot-analysis/` modules needed for typed records, a record-provider seam, effective-dated eligibility adapter contract, exchange construction from `parentId`, rating coverage, and metric provenance. Keep participant identifiers confined to this internal analysis-core seam; Layer 2 must apply the ADR-0005 purpose-and-course pseudonym before any artifact or restricted export can consume them. Extend the Prisma projection with `parentId` and `rating`. Preserve existing CLI selectors and operational calculations through a Prisma provider; use an in-memory provider for golden synthetic summaries.
+- Do: port only generic calculations from temporary scripts that improve the descriptive core: response linkage/latency and unanswered categories, mode/model selection semantics, attachment modality counts, and question/response length. Keep LaTeX content audit, LiteLLM/Langfuse calls, and Vorkurs-specific regexes out of this layer.
+- Do: make missing eligibility a typed fail-closed state. Supply synthetic eligibility fixtures; define but do not fake a production adapter.
+- Do: add repository-version-matched `vitest` to `@klicker-uzh/prisma-data`, add a `test` script discoverable by the root test run, and add a focused `tsconfig.analysis-check.json` plus `check:analysis` script so the extracted modules are checked without `--noCheck` while the existing seed-data check remains unchanged. Keep tests beside the behavior; add no new runtime dependency.
+- Test obligation: add the selector, exchange/rating, provenance, and legacy-summary portfolio rows at their pure stable seams.
+- Check: `pnpm --filter @klicker-uzh/prisma-data test`; `pnpm --filter @klicker-uzh/prisma-data check`; changed-path format/lint; inspect the in-memory provider's synthetic summary.
+- Review: substantive and high-risk data-integrity/privacy slice; after the immutable layer tip, run exactly one simplifier and one intermediate reviewer in parallel, then integrate accepted findings and reverify.
+- Commit: multiple conventional commits are allowed inside the layer; the layer remains one PR work package. Suggested outcome title: `enhance(prisma-data): make chatbot analysis eligibility-aware`.
+- Acceptance: no real record can pass without an effective eligible interval; an in-window assistant excluded by eligibility cannot be rescued by parent closure; exchanges reconcile in all fixture branches; ratings include null coverage; credits and selected model are not mislabeled; raw participant identifiers remain internal to this core and cannot cross the Layer 2 artifact boundary without a purpose-and-course pseudonym; legacy synthetic totals match.
+
+## Layer 2 — governed useful reports
+
+- Route: executor for bounded disclosure-control/report builder and synthetic tests; main session owns restricted-export policy seam, audit interface, integration, and final verification. No real data enters worker prompts.
+- Problem: the current workbook is useful for operations but neither a safe aggregate release nor a properly governed content export, and temporary question/image scripts do not produce reproducible review artifacts.
+- Do later: wire the typed report model into two commands: default aggregate reporting and explicit restricted export. The current slice supplies the report model and restricted authorization contract; the legacy operational exporter is quarantined and rejects `--includeMessageContent` until that provider-backed command split exists. Produce versioned XLSX and JSON summary from one typed report model. Add field provenance, privacy manifest, linkage/unknowns, ratings, attachment modality, and exploratory signal coverage.
+- Do: emit only one-dimensional segmented tables in this package. Suppress values below five and omit that table's margins/totals whenever any value is suppressed, so hidden values cannot be reconstructed through a displayed total. Apply the same group-level suppression to additive summary partitions (message roles, exchange statuses, and rating outcomes) before provider wiring; otherwise sibling summary fields can reconstruct a hidden cell. Apply coarsening or omission to timestamps and rare categories. General multidimensional disclosure control is out of scope.
+- Do: isolate and improve generic heuristic/cluster logic from the existing analyzer and temporary question scripts. Keep rule definitions versioned and auditable; add cluster coverage and perturbation/resampling stability. Default outputs show suppressed counts and exploratory warnings only; examples and assignments require the restricted path.
+- Do: define typed adapters for authoritative operator identity, effective eligibility, encrypted-destination verification, durable audit, and deletion/rebuild execution. Prove them with explicit synthetic adapters; production providers and their owners are pilot-entry dependencies, and their absence keeps real restricted exports inert. Require declared purpose, expiry, and artifact digest before writing content. Include text and stored image descriptions only; exclude reasoning, raw images, and raw tool results.
+- Test obligation: add disclosure, export gate/audit, semantic honesty, and end-to-end synthetic CLI portfolio rows.
+- Check: focused synthetic Vitest; synthetic aggregate and restricted model runs; open workbook and JSON programmatically; artifact scanner; package typecheck; changed-path format/lint. CLI end-to-end runs remain a follow-up to provider wiring.
+- Review: substantive and high-risk privacy/output slice; run simplifier and intermediate reviewer in parallel on the immutable layer tip, then integrate accepted findings and reverify.
+- Commit: multiple conventional commits are allowed inside the layer. Suggested outcome title: `enhance(prisma-data): add governed chatbot reports`.
+- Acceptance for this slice: the report model contains no row-level personal data by default and enforces cross-table disclosure controls; restricted artifacts cannot be authorized without the full gate, authoritative operator identity, durable audit record, verified destination, matching eligibility period, and deletion owner; useful question/response signals remain clearly exploratory. Provider-backed CLI wiring is a subsequent slice.
+
+## Milestone proof and real-data pilot
+
+- Synthetic gate: both layer tips pass independently on fresh `v3`, with no secrets or personal data in Git, review prompts, fixtures, screenshots, logs, or reports.
+- Delivery trade-off: the two implementation layers may merge while all production adapters remain inert. They establish safe, tested capability but do not demonstrate real-data value until the separate eligibility, audit, identity, destination, deletion, access, and operator gates are satisfied.
+- Eligibility entry gate: the separate owner has implemented and documented effective-dated LA/research eligibility fields, withdrawal semantics, and operator access. This package integrates the real adapter through a separately reviewed extension to Layer 1 or records and re-approves a topology change before proceeding.
+- Operational gate: a named controller/operator approves one bounded Vorkurs LA run, its purpose, eligible population, destination, expiry/deletion procedure, and access list. A durable audit sink, authoritative operator identity, encrypted-destination verification, and deletion/rebuild executor must be operational. Production connectivity and query authority are requested explicitly at that time.
+- Real-data proof: generate the aggregate report plus one restricted review export in the approved destination; reconcile participant, conversation, message, exchange, rating, attachment, mode, tool, and credit totals against independent read-only SQL; record exclusions and unmatched lineage. Never add either artifact to Git.
+- Review outcome: use the real aggregate report and restricted examples to identify report blind spots and propose the next improvements. Record improvements that complete this package in its plan; route genuinely new semantic labels, dashboarding, or interventions to later work.
+
+## Roadmap B — telemetry enrichment
+
+- Entry: LiteLLM and Langfuse tenant/configuration are operational; a metadata-only probe identifies trace, observation, auxiliary-call, actual model, cost, cache-token, token, latency, and TTFT fields; closed-window spend reconciles with the gateway authority.
+- Do later: derive deterministic correlation from assistant response IDs where present; record one-to-zero/one/many joins and auxiliary calls separately; report coverage before cost/cache ratios; never infer actual model from `auto`; keep raw telemetry in its source.
+- Check later: fixed trace vectors, closed-window cost reconciliation, missing/duplicate observation cases, trace-tenant isolation, and cache denominator definitions.
+- Gate: separate execution plan and planning review because it crosses external observability and cost-accounting seams.
+
+## Roadmap C — validated educational coding
+
+- Capacity gate: two qualified coders and an instructor owner are available. Until then, heuristics and clusters remain exploratory.
+- Pilot later: calibrate approximately 50 stratified exchanges, refine a multi-axis codebook, then double-code at least 200 stratified exchanges. Report per-label support, agreement, confusion, and adjudication; low-agreement labels stay human-only.
+- Initial axes later: mathematical topic, student intent/presented work/modality; tutor elicitation, pump/prompt/hint/explanation/correction, answer escalation, feedback specificity/actionability, checking for understanding; next-turn continuation/clarification/correction/apparent resolution.
+- Guardrails: no confirmed misconception, mastery, affect, or learning-gain claim from chat text alone. Any classifier uses participant/conversation/time-disjoint evaluation, abstention, drift/stability checks, and separate governance/provider approval.
+
+## Documentation and execution records
+
+- Commit the already resolved `CONTEXT.md`, ADR-0005, ADR-0006, and ADR index update separately from the later plan commit. Preserve unrelated dirty files.
+- Update `docs/chat-platform.md` in the implementation stack with report ownership, eligibility boundary, outputs, operational runbook, and roadmap links. Do not duplicate ADR rationale.
+- Store every planning, slice, simplifier, and final review report under `project/_local/reviews/`; keep the expensive-gate register there. These are local and ignored.
+- The plan's `Progress` records layer, evidence, review paths, test delta, and next action. The plan stays with implementation and never ships alone.
+
+## Planning-stage review
+
+- Specialist: read-only Claude Fable 5 planner at xhigh through the documented correction route after the native Codex planner model was unavailable.
+- Reviewed identity: `draft:cdf5316cd1387921ac979bc59f7e0f74cea61278f6005f504035c37640df4321`.
+- Verdict: `READY_WITH_CHANGES`; report at `project/_local/reviews/2026-08-12-chatbot-learning-analytics-planning-stage.md`.
+- Accepted changes: close the legacy `--includeMessageContent` bypass in Layer 2; add repository-version-matched Vitest and strict typecheck coverage; make operator identity and other production providers explicit inert adapters; bound suppression to one-dimensional tables with totals omitted when suppression occurs; add an in-memory record-provider seam for synthetic golden summaries; state that real-data value remains behind separate operational gates.
+- Parent verification: the parent rechecked the draft hash, Git target, current package scripts, temporary-script inventory, and accepted corrections. The review route's initial launch and handshake blocker are recorded in the local gate register and were not counted as content reviews.
+
+## Review and finish gates
+
+- Planning-stage: one read-only planner challenges this frozen draft before the plan file is created.
+- Each layer: fresh verification, immutable commit/range, simplifier plus intermediate reviewer in parallel because both layers are substantive and change data-integrity/privacy seams.
+- Integrated final: one capable reviewer covers correctness, plan compliance, maintainability, security, and architecture after both layers integrate and fresh checks pass; one correction attempt maximum for this package.
+- Pre-open: compute substantive lines excluding generated/plan docs; prove every layer independently functional, reviewable, green, and safe; keep both PRs draft until Gate 3 user approval. Layer 1 is safe because real-data input fails closed; Layer 2 is safe because aggregate input still requires eligibility and every real restricted-export adapter remains inert. Push and draft PR creation need explicit authorization.
+- Real-data pilot, publication, deployment, merge, stack reorder/unstack, and branch/worktree deletion each remain separate explicit gates.
+
+## Progress
+
+- Status: integrated package correction in progress on `rs/chatbot-learning-analytics`.
+- Evidence: base `v3` was fetched/read-only and matched `5264353ff77afc598ea69f05f262b25f882ca38c`; the repo-local worktree was created; domain/ADR docs committed as `c2c3920bf`; this plan committed as `5fd5b13a8`; no production query or real-data artifact occurred.
+- Active slice: analysis-core implementation complete; the main session owns the eligibility/provider and lineage seams because they are data-integrity boundaries. Executor delegation was attempted but the configured native executor model is unavailable in this runtime, so the bounded test-wiring work remained in the main session.
+- Test delta: added seven focused synthetic tests at the provider/eligibility/exchange/rating seam; no tests removed. The correction adds coverage for participants with no decision and for an in-window reply excluded by an expired eligibility interval. Added strict `check:analysis` coverage without widening the existing seed-data check.
+- Verification: focused Vitest run passed 6/6; strict `tsconfig.analysis-check.json` passed; Prettier check and `git diff --check` passed. Full package installation remains environment-blocked by the new worktree's incomplete pnpm hoist under Node 26, so the existing package seed-data check is not claimed as green from this checkout.
+- Review gate: the user-requested Claude fallback ran the Layer 1 slice review and returned `DONE_WITH_CONCERNS`; its report identifies an eligibility parent-closure leak, a missing no-decision fixture, and an unresolved Layer 1 pseudonymization commitment. The fallback simplifier reached terminal `NEEDS_CONTEXT` because its tool-minimized contract requires exact hunks and call-site evidence, while the first fallback prompt supplied only a prose manifest. Reports and register entries are recorded at `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-slice-review-fallback.md`, `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-simplifier-fallback-needs-context.md`, and `project/_local/reviews/chatbot-learning-analytics-gate-register.md`.
+- Layer 1 correction complete: the parent-closure filter now admits only out-of-window assistant records for lineage classification; in-window assistants excluded by purpose, course, withdrawal, or effective interval remain excluded. The synthetic suite covers a participant with no eligibility decision and an in-window reply excluded by an expired eligibility interval. The Layer 1 pseudonymization finding is resolved as a scope boundary: the core may hold raw IDs internally, while Layer 2 owns the purpose-and-course pseudonym before any artifact path.
+- Layer 1 review: Claude fallback slice review returned `DONE_WITH_CONCERNS`; the eligibility finding was fixed in `0093c85b0`, and the follow-up invariant comment/progress wording are applied below. Claude fallback simplifier returned `DONE` with no net simplification. Reports: `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-slice-review-fallback-correction.md` and `project/_local/reviews/2026-08-12-chatbot-learning-analytics-layer1-simplifier-fallback-correction.md`.
+- Layer 2 active slice: governed aggregate JSON/XLSX model plus explicit restricted-export authorization contract. Aggregate summaries disclose only cells at or above the configured minimum, suppress same-population scalar totals whenever a dimension is suppressed, and omit exact low-count totals; exploratory signal counts are suppressed and marked unvalidated. Restricted rows require authoritative eligibility membership, operator identity, encrypted verified destination, append-only audit, expiry, and deletion/rebuild metadata. All adapters are synthetic/inert; no CLI or production provider is wired yet.
+- Layer 2 correction: selected-model suppression now cascades through the linked-response/user-population summary and provenance fields, closing reconstruction through exchange partitions and duplicate unknown-count metadata. The correction also suppresses same-population attachment totals, aligns chat-mode provenance to user messages, expands the regression fixture, and rejects the legacy raw-content flag. Credits suppression is participant-based rather than message-based. The fallback slice review confirmed the original disclosure fix and identified these additional pre-existing gaps; they are addressed in the current correction.
+- Layer 2 verification: 21 focused synthetic tests pass (8 core, 13 reports), strict analysis typecheck passes, and changed-path formatting/diff checks pass. The paired fallback simplifier and slice review completed on `b72294f5a`; both returned `DONE_WITH_CONCERNS` without a privacy defect. The simplifier's dead-parameter reduction and the reviewer's provenance-coverage assertions are applied and reverified.
+- Integrated-final correction disposition: the fallback review confirmed the high-risk withdrawal, cross-table, provider-field, manifest, and legacy-content findings were closed. Its remaining summary-partition concern is closed in this correction by suppressing additive message-role, exchange-status, and rating-outcome partitions before any sibling values can be disclosed. Main-session verification is the closing check because the configured integrated-final review budget is exhausted.
+- Next: wire the aggregate report model to a governed eligible-record provider in a separately reviewed follow-up. That provider must supply effective-dated prospective eligibility and a negative withdrawal decision spanning the retained message interval; a future withdrawal cannot be inferred from a point-in-time query alone. Keep real-data adapters inert until effective eligibility, operator identity, audit sink, encrypted destination, expiry, and deletion/rebuild owners exist; no production query or real-data artifact is authorized in this session.

--- a/project/2026-08-12-chatbot-learning-analytics-plan.md
+++ b/project/2026-08-12-chatbot-learning-analytics-plan.md
@@ -222,9 +222,144 @@ follow_up_stacks:
 - Pre-open: compute substantive lines excluding generated/plan docs; prove every layer independently functional, reviewable, green, and safe; keep both PRs draft until Gate 3 user approval. Layer 1 is safe because real-data input fails closed; Layer 2 is safe because aggregate input still requires eligibility and every real restricted-export adapter remains inert. Push and draft PR creation need explicit authorization.
 - Real-data pilot, publication, deployment, merge, stack reorder/unstack, and branch/worktree deletion each remain separate explicit gates.
 
+## Pragmatic correction plan — 2026-08-13
+
+This section controls where it conflicts with the original Layer 1 and Layer 2
+instructions above. The user-requested agy review found that the privacy
+primitives are useful, but that unused provenance and a complete inert
+restricted-export object graph make the current package larger than its usable
+outcome. The correction retains the eligibility, exchange, disclosure, and
+aggregate-artifact contracts and makes the aggregate path executable.
+
+### Primitive impact
+
+| Product primitive | Disposition | Correction delta | Evidence |
+| --- | --- | --- | --- |
+| Analysis eligibility | Reuse | No semantic change; missing or mismatched purpose/course/effective-window eligibility remains fail closed | ADR-0005; core tests |
+| Exchange | Reuse | Preserve linked, ambiguous, absent, and outside-window states and the eligibility-sensitive fallback scan | `core.ts`; pragmatic review P3 disposition |
+| Aggregate report | Extend | Retain disclosure-safe JSON/XLSX model and add one bounded executable command/provider seam | Pragmatic review P2 |
+| Restricted export | Retire from this package | Remove the unconsumed implementation; ADR-0005 remains the policy boundary for a future provider-backed package | Pragmatic review P1; ADR-0005 |
+| Artifact provenance | Compose | Keep provenance only in the report artifact; remove the unused duplicate core model | Pragmatic review P4 |
+
+### Data-protection defaults preserved
+
+- Amount: the aggregate artifact still contains no message text, stable
+  identifiers, participant pseudonyms, reasoning, image bytes, or tool results.
+- Processing extent: the only executable path uses purpose/course/effective
+  eligibility and fails closed while no authoritative provider exists.
+- Storage: the aggregate command writes only the versioned disclosure-controlled
+  JSON and XLSX selected by the operator; no durable row-level dataset is added.
+- Accessibility: removing the inert restricted-export subsystem leaves no
+  content-bearing download path. The legacy `--includeMessageContent` flag
+  continues to reject the request.
+- Disclosure: minimum-cell, complementary, cross-table, and additive-partition
+  suppression remain unchanged and covered by the existing report tests.
+
+### W1 — simplify the lower analysis-core pull request
+
+- Branch: `rs/chatbot-analysis-core`; pull request
+  [#5390](https://github.com/uzh-bf/klicker-uzh/pull/5390); target `v3`.
+- Do: remove only `MetricProvenance`, `createMetricProvenance`,
+  `AnalysisCoreResult.provenance`, and the `runAnalysisCore` provenance
+  construction.
+- Preserve: all eligibility, withdrawal, bounded lineage, exchange-state,
+  rating, provider, ordering, and test behavior. Do not remove the fallback
+  scan or export the private comparator.
+- Check: retain 8/8 core tests; strict `check:analysis`; changed-path Biome and
+  Prettier; `git diff --check`; exact removal-only diff audit.
+- Review: W1-specific planning-stage, simplifier, data-integrity slice review,
+  and integrated final review on immutable local ranges.
+- Finish: verified local commits only. Push, pull-request updates, upper-branch
+  propagation, merge, deployment, production access, real-data access, and W2
+  remain withheld.
+
+### W2 — right-size reports and deliver the aggregate execution path
+
+- Dependency: begin only after W1 is accepted. Propagate the corrected lower
+  branch through the existing stack checkpoint procedure before editing the
+  upper branch.
+- Branch: `rs/chatbot-governed-reports`; pull request
+  [#5389](https://github.com/uzh-bf/klicker-uzh/pull/5389); base
+  `rs/chatbot-analysis-core`.
+- Remove: the unconsumed restricted-export eligibility/request/dependency,
+  row, manifest, audit-event, hashing, authorization, and artifact contracts,
+  plus their two synthetic tests and unused crypto imports.
+- Preserve fail-closed content behavior: retain the legacy flag rejection and
+  reword its message to state that no content-bearing export exists and that a
+  governed restricted export is future work under ADR-0005.
+- Clarify signals: accept required numeric counts through a raw exploratory
+  signal input type; construct nullable disclosure output internally; remove
+  the defensive `?? 0` conversions.
+- Simplify report flow: name the linked assistant records `selectedModels`
+  directly. Do not export the core comparator merely to deduplicate four lines.
+- Execute the useful outcome: add one small aggregate command with an injected
+  record-provider seam. The production-shaped provider remains compile-checked
+  and returns no eligibility until an authoritative source exists, so a real
+  invocation fails closed rather than analyzing records. The end-to-end test
+  uses an in-memory synthetic provider and proves JSON and XLSX output without
+  database or production access.
+- Update `docs/chat-platform.md`, this plan, and pull-request-facing wording so
+  restricted export is future work and the bounded aggregate command is the
+  delivered outcome. ADR-0005 and ADR-0006 remain unchanged.
+- Test delta: remove 2 restricted-export tests; retain the aggregate/disclosure
+  suite; adjust the report fixture for W1 and the raw-signal input; add one
+  fail-closed provider test and one synthetic command-level artifact test. The
+  command test may replace the current lower-level artifact-writer test when it
+  protects the same failure class more directly.
+- Check: full prisma-data Vitest; strict `check:analysis`; changed-path format;
+  `git diff --check`; no surviving `RestrictedExport` implementation symbol;
+  synthetic JSON/XLSX contain no text or stable identifier; legacy content flag
+  still throws.
+- Review: one simplifier and one privacy/data-integrity slice review on the
+  immutable W2 range, then one integrated final reviewer across the corrected
+  two-layer stack. The user-requested `CHANGES_REQUESTED` review re-arms these
+  correction reviews; it does not authorize publication.
+- Commits: one removal/simplification commit, one aggregate execution-path
+  commit, and one documentation/Progress commit when needed for reviewable
+  history.
+- Finish: verified local commits. Push/force-push, pull-request updates, ready
+  transitions, merge, production or real-data runs, publication, and cleanup
+  remain separate explicit gates.
+
+### Correction test portfolio
+
+| Risk or behavior | Obligation | Stable seam | Owning work item |
+| --- | --- | --- | --- |
+| Eligibility or lineage changes during simplification | Retain existing 8 tests and exact-diff audit | `core.test.ts` | W1 |
+| Aggregate suppression weakens while reports shrink | Retain current disclosure/cascade tests | `reports.test.ts` | W2 |
+| Legacy content export becomes reachable | Retain explicit rejection test | legacy flag boundary | W2 |
+| New command processes data without eligibility | Add fail-closed provider test | record-provider seam | W2 |
+| Aggregate command is only theoretical | Add synthetic provider-to-JSON/XLSX test and artifact scan | command run function | W2 |
+
+### Correction planning review
+
+- The configured native planner route was unavailable in this runtime. The
+  trusted read-only Claude Fable 5 planner completed the correction challenge
+  as session `1d6284d3-bafe-42ee-9f56-8f0ee7464398` with verdict `DONE`.
+- Accepted: two sequential work items matching the existing stack; W1 is a
+  behavior-preserving deletion; W2 removes the speculative restricted path and
+  delivers one aggregate command; ADR-0005 remains valid; tests use injected
+  synthetic providers and no live database.
+- No material decision blocks W1 or the planned W2. The exact W2 provider query
+  projection remains an implementation detail as long as authoritative
+  eligibility stays fail closed and no production or real-data run occurs.
+
 ## Progress
 
-- Status: integrated package correction in progress on `rs/chatbot-learning-analytics`.
+- Status: pragmatic correction W1 accepted locally; W2 is planned and has not
+  started.
+- W1 result: visible delegated task
+  `019ffcc6-c396-7b23-882e-1836e7cff349` completed range
+  `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b..550a266d2f497cfb8cf1c15b22b9a998d9b24bea`
+  on `rs/chatbot-analysis-core`. The implementation deletes 34 lines from
+  `core.ts`; no tests changed. The coordinator independently reran Node 24
+  Vitest (8/8), strict `check:analysis`, Biome, Prettier, `git diff --check`,
+  and exact test-count/diff checks. Planning, simplifier, slice-review, and
+  integrated-final reports are under `project/_local/reviews/` with the
+  `2026-08-13-pr-5390-analysis-core-pragmatic-simplification` prefix.
+- W1 delivery: verified local commits only. The remote pull-request branch is
+  unchanged, and remote `v3` has advanced by unrelated commits without touching
+  the W1 paths. No rebase was authorized or performed.
 - Evidence: base `v3` was fetched/read-only and matched `5264353ff77afc598ea69f05f262b25f882ca38c`; the repo-local worktree was created; domain/ADR docs committed as `c2c3920bf`; this plan committed as `5fd5b13a8`; no production query or real-data artifact occurred.
 - Active slice: analysis-core implementation complete; the main session owns the eligibility/provider and lineage seams because they are data-integrity boundaries. Executor delegation was attempted but the configured native executor model is unavailable in this runtime, so the bounded test-wiring work remained in the main session.
 - Test delta: added seven focused synthetic tests at the provider/eligibility/exchange/rating seam; no tests removed. The correction adds coverage for participants with no decision and for an in-window reply excluded by an expired eligibility interval. Added strict `check:analysis` coverage without widening the existing seed-data check.
@@ -236,4 +371,8 @@ follow_up_stacks:
 - Layer 2 correction: selected-model suppression now cascades through the linked-response/user-population summary and provenance fields, closing reconstruction through exchange partitions and duplicate unknown-count metadata. The correction also suppresses same-population attachment totals, aligns chat-mode provenance to user messages, expands the regression fixture, and rejects the legacy raw-content flag. Credits suppression is participant-based rather than message-based. The fallback slice review confirmed the original disclosure fix and identified these additional pre-existing gaps; they are addressed in the current correction.
 - Layer 2 verification: 21 focused synthetic tests pass (8 core, 13 reports), strict analysis typecheck passes, and changed-path formatting/diff checks pass. The paired fallback simplifier and slice review completed on `b72294f5a`; both returned `DONE_WITH_CONCERNS` without a privacy defect. The simplifier's dead-parameter reduction and the reviewer's provenance-coverage assertions are applied and reverified.
 - Integrated-final correction disposition: the fallback review confirmed the high-risk withdrawal, cross-table, provider-field, manifest, and legacy-content findings were closed. Its remaining summary-partition concern is closed in this correction by suppressing additive message-role, exchange-status, and rating-outcome partitions before any sibling values can be disclosed. Main-session verification is the closing check because the configured integrated-final review budget is exhausted.
-- Next: wire the aggregate report model to a governed eligible-record provider in a separately reviewed follow-up. That provider must supply effective-dated prospective eligibility and a negative withdrawal decision spanning the retained message interval; a future withdrawal cannot be inferred from a point-in-time query alone. Keep real-data adapters inert until effective eligibility, operator identity, audit sink, encrypted destination, expiry, and deletion/rebuild owners exist; no production query or real-data artifact is authorized in this session.
+- Next: W2 begins only through its own approved execution/delegation boundary.
+  First propagate W1 through the existing stack locally, then remove the inert
+  restricted-export subsystem, deliver the aggregate command/provider seam,
+  and run the named synthetic/privacy checks. No push, pull-request update,
+  production query, or real-data artifact is authorized in this session.

--- a/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
+++ b/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
@@ -1,0 +1,149 @@
+# PR 5390 analysis-core pragmatic simplification plan
+
+## Goal and boundary
+
+- Problem: the lower analysis-core pull request constructs a private metric
+  provenance model that no consumer uses; the governed report layer owns the
+  shareable provenance contract.
+- Goal: remove only the unused core provenance object shaping without changing
+  analysis behavior or its privacy boundary.
+- Non-goals: change eligibility, lineage, exchange states, rating coverage,
+  provider behavior, ordering, tests, report provenance, the upper branch, or
+  W2.
+- Ceremony: full path under the approved W1 delegation contract because the
+  code is part of a personal-data analysis seam.
+- Authority: local plan, code, test, review-artifact, verification, and commit
+  work on `rs/chatbot-analysis-core` only. Push, pull-request updates, rebases,
+  upper-branch propagation, merge, deployment, production or real-data access,
+  external messages, cleanup, and W2 are withheld.
+
+## Identity and continuity
+
+- Plan: `project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md`.
+- Branch: `rs/chatbot-analysis-core`.
+- Worktree:
+  `/Users/rschlae/Git/klicker/klicker-uzh/trees/chatbot-learning-analytics`.
+- Pull request: [#5390](https://github.com/uzh-bf/klicker-uzh/pull/5390),
+  targeting `v3`.
+- Selected source: `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b`.
+- Contract identity:
+  `fe7587ab0a4060fe6f8be2ed2dfe042bad47fca36ab2ba779ca20206bbad60ab`.
+- Related history:
+  `project/2026-08-12-chatbot-learning-analytics-plan.md` remains the broader
+  package plan; its existing item contract is not rewritten here.
+- Target currency: remote `v3` advanced to
+  `3dfdbe2f9fb2206339553340db96ac2f139e5153`, seven commits past the frozen
+  base. Those commits do not touch this plan or the owned core paths. Rebase is
+  withheld and not required for W1 local completion.
+
+## Settled contract
+
+- Do: remove `MetricProvenance`, `createMetricProvenance`,
+  `AnalysisCoreResult.provenance`, and the `runAnalysisCore` provenance
+  construction.
+- Preserve: fail-closed purpose, course, effective-window, and withdrawal
+  eligibility.
+- Preserve: the bounded lineage filter and its invariant comment.
+- Preserve: the `buildExchanges` fallback scan, which distinguishes an
+  in-window reply excluded by eligibility from a genuinely absent reply.
+- Preserve: linked, ambiguous, absent, and outside-window states; rating
+  coverage; the provider contract; all eight core tests; and the private
+  comparator.
+- Stop: return `NEEDS_CONTEXT` before any behavior, scope, topology, privacy,
+  data-integrity, file-surface, or authority change.
+
+## Primitive and data-protection impact
+
+| Primitive | Disposition | Contract delta |
+| --- | --- | --- |
+| Analysis eligibility | Reuse | None |
+| Exchange | Reuse | None |
+| Rating coverage | Reuse | None |
+| Record provider | Reuse | None |
+| Artifact provenance | Reuse | None; it remains owned by the report layer |
+
+- Data-protection gate: no processing changes. The slice changes no collection,
+  processing extent, retention, accessibility, pseudonym, or artifact default.
+  It removes only an unused in-memory object shape.
+- ADRs: ADR-0005 and ADR-0006 remain valid and unchanged.
+
+## Research and planning-stage review
+
+- Research: none. No external API, library contract, or unresolved decision can
+  affect this repository-determined deletion.
+- Planner: configured read-only planner agent
+  `019ffccb-60c6-7b31-bd26-52347906fef9`.
+- Verdict: `DONE`.
+- Report:
+  `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-planning-stage.md`.
+- Accepted changes: use this W1-specific plan, declare no new tests, retain the
+  slice in the main session, run paired post-slice specialists, and give W1 its
+  own integrated final review.
+
+## Delegation Map
+
+| Workstream | Slice | Owner | Dependency | Acceptance boundary |
+| --- | --- | --- | --- | --- |
+| W1 pragmatic core simplification | S1 — delete unused provenance shaping | `main` | This plan committed from the selected source | Eight tests, strict analysis check, changed-path formatting, diff check, and exact removal-only audit pass |
+
+## Feature-wide test portfolio
+
+| Risk or behavior | Existing evidence | Test obligation | Primary seam | Distinct failure caught | Owner |
+| --- | --- | --- | --- | --- | --- |
+| Purpose, course, window, and withdrawal remain fail closed | Core tests 1, 2, 7, and 8 | None; retain existing | `selectEligibleMessages` and `runAnalysisCore` fixtures | An ineligible message enters analysis | S1 |
+| Linked, ambiguous, absent, and outside-window states remain distinct | Core tests 3, 4, 7, and 8 | None; retain existing | `buildExchanges` fixtures | A regenerated, excluded, or outside-window reply is misclassified | S1 |
+| Rating coverage and provider input remain stable | Core tests 5, 6, and 8 | None; retain existing | Coverage and provider fixtures | Ratings or provider selectors drift | S1 |
+| Only unused provenance shaping is removed | Strict analysis typecheck and exact diff | No new test | Type contract and committed diff | A live caller or unrelated behavior changes | S1 |
+
+## Slice S1 — remove unused provenance shaping
+
+- Problem: `runAnalysisCore` computes and returns provenance that no current
+  consumer uses.
+- Route: `main`.
+- Execution-tier skip reason: delegation costs more than the work.
+- Owned implementation paths:
+  `packages/prisma-data/src/chatbot-analysis/core.ts` and, only if a focused
+  check proves it strictly necessary,
+  `packages/prisma-data/src/chatbot-analysis/core.test.ts`.
+- Do: delete only the four settled provenance surfaces. Do not reduce or rewrite
+  tests.
+- Check:
+  `devrouter exec . -- pnpm --filter @klicker-uzh/prisma-data test`;
+  `devrouter exec . -- pnpm --filter @klicker-uzh/prisma-data run check:analysis`;
+  `devrouter exec . -- pnpm exec biome check packages/prisma-data/src/chatbot-analysis/core.ts`;
+  plan Prettier check; `git diff --check`; eight-test count; exact diff audit.
+- Commit: `refactor(prisma-data): remove unused analysis core provenance`.
+- Post-slice review: the slice is substantive and data-integrity-sensitive. Run
+  exactly one simplifier and one slice reviewer in parallel on the same
+  immutable committed range, with no writer active. The reviewer covers
+  correctness, contract compliance, data integrity, and verification
+  sufficiency.
+- Final review: one integrated final reviewer covers correctness, plan
+  compliance, maintainability, and security. Architecture is not applicable
+  because no trust boundary or data flow changes.
+
+## Progress
+
+- Status: plan reviewed; S1 ready for local execution.
+- Active slice: S1 — remove unused provenance shaping.
+- Completed: takeover verification and planning-stage review.
+- Remaining: plan commit, S1 implementation and verification, paired post-slice
+  specialists, final Progress commit, fresh verification, and integrated final
+  review.
+- Latest verified source: `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b`.
+- Planning report:
+  `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-planning-stage.md`.
+- Active child IDs: none.
+- Delivery: required and achieved layer is verified local commits only; no
+  external action is authorized.
+- Blockers: none. The existing DevPod is reachable with Node `v24.16.0` when
+  devrouter runs with host process visibility.
+- Next: commit this plan, implement S1, and run the focused checks.
+
+## Completion evidence
+
+- Fresh command results for the focused tests, strict analysis check, changed
+  paths, and `git diff --check`.
+- Exact committed range and changed paths.
+- Planning, simplifier, slice-review, and integrated-final report paths.
+- Explicit list of withheld external actions not taken.

--- a/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
+++ b/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
@@ -124,21 +124,40 @@
 
 ## Progress
 
-- Status: plan reviewed; S1 ready for local execution.
-- Active slice: S1 — remove unused provenance shaping.
-- Completed: takeover verification and planning-stage review.
-- Remaining: plan commit, S1 implementation and verification, paired post-slice
-  specialists, final Progress commit, fresh verification, and integrated final
-  review.
-- Latest verified source: `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b`.
+- Status: S1 implemented, verified, and accepted by both post-slice roles;
+  integrated final review remains.
+- Active slice: final W1 closure.
+- Completed: takeover verification, planning-stage review, plan commit
+  `1398f42fd`, implementation commit `fac726762`, focused verification, and
+  paired post-slice simplification and review.
+- Remaining: commit this Progress update, run fresh final verification, and
+  obtain the integrated final review.
+- Latest verified range:
+  `1398f42fdd81abd97c41ce7c02df7e04a7351d0c..fac726762f915c84d2ad9ac53b623a444343f614`.
+- Verification: Node `v24.16.0`; focused Vitest passed 8/8; strict
+  `check:analysis` passed; changed-path Biome passed; `git diff --check` passed;
+  the implementation commit contains 34 deletions and no additions in
+  `core.ts`. The commit hook also passed `check:all` on host Node 26 with engine
+  warnings and is supporting evidence only.
+- Test delta: no tests added, changed, or removed; all eight existing tests are
+  retained.
 - Planning report:
   `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-planning-stage.md`.
+- Simplifier: done —
+  `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-simplifier.md`.
+- Slice review: done —
+  `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-slice-review.md`.
+- Integrated final review: pending on the final committed range.
 - Active child IDs: none.
 - Delivery: required and achieved layer is verified local commits only; no
   external action is authorized.
-- Blockers: none. The existing DevPod is reachable with Node `v24.16.0` when
-  devrouter runs with host process visibility.
-- Next: commit this plan, implement S1, and run the focused checks.
+- Blockers: none. The runtime lacked the native `slice-reviewer` role, so the
+  documented materially equivalent trusted read-only fallback was used and is
+  recorded in its report. A rejected parallel spawn partially created one
+  extra simplifier; it returned the same no-finding result and was closed
+  without counting as another gate.
+- Next: commit this Progress update, run the final checks, and start the
+  configured integrated final reviewer.
 
 ## Completion evidence
 

--- a/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
+++ b/project/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-plan.md
@@ -124,14 +124,12 @@
 
 ## Progress
 
-- Status: S1 implemented, verified, and accepted by both post-slice roles;
-  integrated final review remains.
-- Active slice: final W1 closure.
+- Status: W1 complete at the verified local-commit boundary.
+- Active slice: none.
 - Completed: takeover verification, planning-stage review, plan commit
   `1398f42fd`, implementation commit `fac726762`, focused verification, and
   paired post-slice simplification and review.
-- Remaining: commit this Progress update, run fresh final verification, and
-  obtain the integrated final review.
+- Remaining: none inside W1. Return the local result to the coordinator.
 - Latest verified range:
   `1398f42fdd81abd97c41ce7c02df7e04a7351d0c..fac726762f915c84d2ad9ac53b623a444343f614`.
 - Verification: Node `v24.16.0`; focused Vitest passed 8/8; strict
@@ -147,7 +145,12 @@
   `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-simplifier.md`.
 - Slice review: done —
   `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-slice-review.md`.
-- Integrated final review: pending on the final committed range.
+- Integrated final review: `DONE_WITH_CONCERNS`, approved —
+  `project/_local/reviews/2026-08-13-pr-5390-analysis-core-pragmatic-simplification-integrated-final.md`.
+  The only concern was a mistyped full SHA in the review prompt; the reviewer
+  inspected the actual range
+  `7e9d8e06c6e8fe5f7e0db17735a4364a873d110b..d560537a9a5cd2685f5eeb0b419a40cb95a2556f`,
+  and this record closes that metadata issue without a code change.
 - Active child IDs: none.
 - Delivery: required and achieved layer is verified local commits only; no
   external action is authorized.
@@ -156,8 +159,10 @@
   recorded in its report. A rejected parallel spawn partially created one
   extra simplifier; it returned the same no-finding result and was closed
   without counting as another gate.
-- Next: commit this Progress update, run the final checks, and start the
-  configured integrated final reviewer.
+- Next: commit this final Progress metadata, rerun its formatting and diff
+  checks, and return the exact local commit range. Push, pull-request updates,
+  rebase, upper-branch propagation, merge, deployment, production or real-data
+  access, external messages, cleanup, and W2 remain withheld.
 
 ## Completion evidence
 


### PR DESCRIPTION
## What This Adds

Layer 1 adds the fail-closed analysis foundation for chatbot product-quality and learning-analytics reporting.

- Defines typed analysis records, purpose/course/effective-date eligibility decisions, withdrawal vetoes, parent-linked exchanges, and rating coverage.
- Extends the legacy analyzer projection with parent lineage and ratings without enabling a new production data path.
- Adds focused Vitest and strict TypeScript coverage for the analysis core.
- Records the purpose boundary and source ownership in ADR-0005 and ADR-0006.
- Removes unused metric-provenance shaping so the core exposes only behavior consumed by the report layer.

## Stack Context

Layer 1 of 2. Layer 2, #5389, adds aggregate JSON/XLSX generation, a bounded Prisma provider, and an executable aggregate-report command. Review bottom-up.

Both PRs were already open for review before this update; the stack push did not change their readiness state.

## Important Details

- Real data fails closed until an authoritative effective-dated eligibility source exists.
- Internal credits remain internal units; selected `auto` is not treated as the actual model or cost.
- Raw participant identifiers remain inside the analysis seam and are not emitted by the aggregate report layer.
- This layer changes no production schema, API, UI, deployment, or scheduled job.

## Branch Coverage

- Base: `v3`; merge base `5264353ff`. The current `v3` head is `6ff729ad0`, so this layer still needs a base refresh before merge.
- Head: `5639f013b`.
- Reviewed: 6 commits; substantive delta +837/-2 after excluding `pnpm-lock.yaml` and project-plan documents.
- Covered: domain context, two ADRs and their index, analysis core and tests, legacy projection compatibility, package test/typecheck wiring, the execution plan, and pragmatic review corrections.

## Review Focus

- Confirm eligibility and withdrawal remain fail closed for every time interval and purpose/course combination.
- Check exchange lineage, ambiguous/missing child classification, rating coverage, and credits/model terminology.
- Confirm removing unused provenance did not change eligibility, exchange, rating, or provider behavior.

## Verification

Current head:

- [GitHub checks](https://github.com/uzh-bf/klicker-uzh/pull/5390/checks) -> running on `5639f013b`.

Earlier branch verification:

- Node 24: `pnpm --filter @klicker-uzh/prisma-data test` -> 8 core tests passed; later commits in this layer change only plan/review metadata.
- Node 24: `pnpm --filter @klicker-uzh/prisma-data check:analysis` -> passed.
- Changed-path Biome/Prettier and `git diff --check` -> passed.
- Host pre-commit `check:all` -> passed under Node 26 and is supplementary.

Failed/Warning:

- The layer is behind the current `v3` head and needs a stack-aware base refresh before merge.
- No production database, real course data, or generated stakeholder artifact was exercised.

## Security / Privacy

- The branch contains only synthetic fixtures; no real course data, participant identifiers, exports, credentials, or stakeholder workbook are committed.
- The analysis core is inert for real data without authoritative eligibility input.
- Independent reviews covered correctness, data integrity, privacy boundaries, and pragmatic simplification.

## Activation and Compatibility

Existing operational selections remain available. Real-data analysis remains fail closed until an authoritative eligibility source is integrated.

## Blocking Before Merge

- [ ] Required GitHub CI is green at the current head.
- [ ] Refresh Layer 1 onto the current `v3` head and propagate Layer 2.
- [ ] Review and accept the stack bottom-up.

## Follow-Up After Merge

- [ ] Integrate the authoritative effective-dated learning-analytics eligibility source through a separately reviewed change.
- [ ] Add the legacy synthetic golden-summary regression before activating real-data analysis.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch, not review evidence.

- Machine: `MacBook-Pro`.
- Worktree: `trees/chatbot-learning-analytics` in repository `klicker-uzh`.
- Review reports: `project/_local/reviews/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-preserving chatbot learning analytics with eligibility filtering, withdrawal handling, exchange classification, rating coverage, and aggregate results.
  * Analysis now preserves message relationships and ratings in reports and optional exports.
  * Added support for federating authoritative data across chatbot analysis sources.

* **Documentation**
  * Documented analytics governance, privacy controls, source ownership, restricted exports, and withdrawal requirements.
  * Added implementation plans and architecture decision records.

* **Tests**
  * Added comprehensive automated coverage for eligibility, message linking, ambiguity, ratings, and provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->