### PR TITLE
chore(deploy): promote 19f3afbf540b to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -26,7 +26,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+        rollout.klicker.uzh.ch/release: '19f3afbf540b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -48,7 +48,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+        rollout.klicker.uzh.ch/release: '19f3afbf540b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -70,7 +70,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+        rollout.klicker.uzh.ch/release: '19f3afbf540b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -104,7 +104,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -158,7 +158,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -312,7 +312,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -364,7 +364,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -417,7 +417,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -469,7 +469,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -537,7 +537,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -589,7 +589,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
   replicaCount: 1
 
   affinity:
@@ -638,7 +638,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+    rollout.klicker.uzh.ch/release: '19f3afbf540b'
 
   replicaCount: 1
 
@@ -691,7 +691,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+      rollout.klicker.uzh.ch/release: '19f3afbf540b'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -754,7 +754,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+      rollout.klicker.uzh.ch/release: '19f3afbf540b'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -831,7 +831,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'fdae7cd5245a'
+      rollout.klicker.uzh.ch/release: '19f3afbf540b'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `19f3afbf540bc306931371a7aadbc6cc76afc042`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
