### PR TITLE
enhance(chat): render structured video citations

### DIFF
--- a/apps/chat/src/lib/sources/normalizeSources.ts
+++ b/apps/chat/src/lib/sources/normalizeSources.ts
@@ -35,6 +35,8 @@ interface SourceCandidate {
   title: string
   page?: number
   labeledPage?: string
+  startSec?: number
+  endSec?: number
   url?: string
   excerpt?: string
   dedupeKey: string
@@ -102,6 +104,8 @@ export function normalizeSourcesFromParts(
         title: candidate.title,
         page: candidate.page,
         labeledPage: candidate.labeledPage,
+        startSec: candidate.startSec,
+        endSec: candidate.endSec,
         url: candidate.url,
         excerpt: candidate.excerpt,
       })
@@ -203,6 +207,33 @@ function cleanPage(value: unknown): number | undefined {
   return undefined
 }
 
+function cleanSeconds(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? value : undefined
+  }
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function cleanVideoRange(source: Record<string, unknown>): {
+  startSec?: number
+  endSec?: number
+} {
+  const startSec = cleanSeconds(source.start_sec)
+  const endCandidate = cleanSeconds(source.end_sec)
+  const endSec =
+    endCandidate !== undefined &&
+    (startSec === undefined || endCandidate >= startSec)
+      ? endCandidate
+      : undefined
+
+  return { startSec, endSec }
+}
+
 function lastPathSegment(value: string): string | undefined {
   const withoutQuery = value.split(/[?#]/)[0]
   const segments = withoutQuery.split('/').filter(Boolean)
@@ -256,11 +287,16 @@ function buildDedupeKey(params: {
   title: string
   page?: number
   labeledPage?: string
+  startSec?: number
+  endSec?: number
 }): string {
-  const { url, title, page, labeledPage } = params
-  return url
+  const { url, title, page, labeledPage, startSec, endSec } = params
+  const base = url
     ? `url:${url}|${page ?? ''}|${labeledPage ?? ''}`
     : `title:${title}|${page ?? ''}|${labeledPage ?? ''}`
+  return startSec === undefined && endSec === undefined
+    ? base
+    : `${base}|${startSec ?? ''}|${endSec ?? ''}`
 }
 
 function normalizeAnswerModeSources(
@@ -293,6 +329,7 @@ function normalizeAnswerModeSources(
 
     const page = cleanPage(source.page_number)
     const labeledPage = cleanString(source.labeled_page_number)
+    const { startSec, endSec } = cleanVideoRange(source)
     const type = inferSourceType(cleanString(source.source_type), rawUrl)
 
     candidates.push({
@@ -301,7 +338,16 @@ function normalizeAnswerModeSources(
       page,
       labeledPage,
       url,
-      dedupeKey: buildDedupeKey({ url, title, page, labeledPage }),
+      startSec,
+      endSec,
+      dedupeKey: buildDedupeKey({
+        url,
+        title,
+        page,
+        labeledPage,
+        startSec,
+        endSec,
+      }),
     })
   }
 
@@ -341,6 +387,7 @@ function normalizeDocumentsModeSources(
     const excerpt = truncateExcerpt(cleanString(firstChunk?.content))
     const page = cleanPage(firstChunk?.page_number)
     const labeledPage = cleanString(firstChunk?.labeled_page_number)
+    const { startSec, endSec } = cleanVideoRange(firstChunk ?? {})
 
     const typeHint = [
       cleanString(source.source_type),
@@ -357,7 +404,16 @@ function normalizeDocumentsModeSources(
       labeledPage,
       url,
       excerpt,
-      dedupeKey: buildDedupeKey({ url, title, page, labeledPage }),
+      startSec,
+      endSec,
+      dedupeKey: buildDedupeKey({
+        url,
+        title,
+        page,
+        labeledPage,
+        startSec,
+        endSec,
+      }),
     })
   }
 

--- a/apps/chat/src/lib/sources/normalizeSources.ts
+++ b/apps/chat/src/lib/sources/normalizeSources.ts
@@ -329,7 +329,6 @@ function normalizeAnswerModeSources(
 
     const page = cleanPage(source.page_number)
     const labeledPage = cleanString(source.labeled_page_number)
-    const { startSec, endSec } = cleanVideoRange(source)
     const type = inferSourceType(cleanString(source.source_type), rawUrl)
 
     candidates.push({
@@ -338,16 +337,7 @@ function normalizeAnswerModeSources(
       page,
       labeledPage,
       url,
-      startSec,
-      endSec,
-      dedupeKey: buildDedupeKey({
-        url,
-        title,
-        page,
-        labeledPage,
-        startSec,
-        endSec,
-      }),
+      dedupeKey: buildDedupeKey({ url, title, page, labeledPage }),
     })
   }
 

--- a/apps/chat/src/lib/sources/sourceDisplay.ts
+++ b/apps/chat/src/lib/sources/sourceDisplay.ts
@@ -74,15 +74,16 @@ function parseLabeledTimestampSeconds(value: string): number | undefined {
 /**
  * A video position for the card and the hover preview.
  *
- * doc_query has no timestamp field (its source shape is `source_url`,
- * `source_type`, `file_name`, `page_number`, `labeled_page_number`), so this
- * reads the two channels a timestamp can actually arrive in today: a free-form
- * `labeled_page_number` the ingestion side may set to a clock value, and the
- * time parameter a course video URL usually carries. A dedicated field is
- * phase-2 work in the doc-query service; until then a video without either
- * simply shows its type label.
+ * Structured video results provide `startSec` (and optionally `endSec`), while
+ * legacy results may still carry a clock-valued `labeledPage` or a time
+ * parameter in the video URL. The structured start wins so a compatibility
+ * label cannot disagree with the canonical range metadata.
  */
 export function getSourceTimestamp(source: ChatSource): string | undefined {
+  if (source.startSec !== undefined) {
+    return formatTimestamp(source.startSec)
+  }
+
   if (source.labeledPage) {
     const labeled = parseLabeledTimestampSeconds(source.labeledPage)
     if (labeled !== undefined) return formatTimestamp(labeled)

--- a/apps/chat/src/lib/sources/types.ts
+++ b/apps/chat/src/lib/sources/types.ts
@@ -9,6 +9,8 @@ export interface ChatSource {
   title: string
   page?: number
   labeledPage?: string
+  startSec?: number
+  endSec?: number
   url?: string
   excerpt?: string
 }

--- a/apps/chat/test/normalize-sources.test.ts
+++ b/apps/chat/test/normalize-sources.test.ts
@@ -182,6 +182,74 @@ describe('normalizeSourcesFromParts', () => {
     ])
   })
 
+  test('documents mode preserves structured video citation metadata', () => {
+    const result = normalizeSourcesFromParts([
+      toolCallPart('IW_doc_query', {
+        mode: 'documents',
+        sources: [
+          {
+            reference: 'urn:video-ingestion:sha256:video#t=42.0,59.0',
+            reference_type: 'url',
+            source_type: 'video',
+            expert_id: 'IuW Video',
+            title: 'Lecture 1 — 0:42–0:59',
+            video_name: 'lecture-01.mp4',
+            display_name: 'Lecture 1',
+            chunks: [
+              {
+                content: 'Video context',
+                start_sec: 42,
+                end_sec: 59,
+                representative_frame_sec: 50,
+                labeled_page_number: '0:42',
+              },
+            ],
+          },
+        ],
+      }),
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 'title:Lecture 1 — 0:42–0:59||0:42|42|59',
+      index: 1,
+      type: 'video',
+      title: 'Lecture 1 — 0:42–0:59',
+      labeledPage: '0:42',
+      startSec: 42,
+      endSec: 59,
+    })
+  })
+
+  test('structured video ranges participate in source deduplication', () => {
+    const result = normalizeSourcesFromParts([
+      toolCallPart('IW_doc_query', {
+        mode: 'documents',
+        sources: [
+          {
+            reference: 'urn:video-ingestion:sha256:video#t=42.0,59.0',
+            source_type: 'video',
+            title: 'Lecture 1',
+            chunks: [{ content: 'First', start_sec: 42, end_sec: 59 }],
+          },
+          {
+            reference: 'urn:video-ingestion:sha256:video#t=42.0,75.0',
+            source_type: 'video',
+            title: 'Lecture 1',
+            chunks: [{ content: 'Second', start_sec: 42, end_sec: 75 }],
+          },
+        ],
+      }),
+    ])
+
+    expect(
+      result.map(({ startSec, endSec }) => ({ startSec, endSec }))
+    ).toEqual([
+      { startSec: 42, endSec: 59 },
+      { startSec: 42, endSec: 75 },
+    ])
+  })
+
   test('documents mode truncates a long excerpt to ~240 chars', () => {
     const longContent = 'x'.repeat(300)
     const result = normalizeSourcesFromParts([

--- a/apps/chat/test/normalize-sources.test.ts
+++ b/apps/chat/test/normalize-sources.test.ts
@@ -211,7 +211,6 @@ describe('normalizeSourcesFromParts', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({
-      id: 'title:Lecture 1 — 0:42–0:59||0:42|42|59',
       index: 1,
       type: 'video',
       title: 'Lecture 1 — 0:42–0:59',
@@ -219,6 +218,36 @@ describe('normalizeSourcesFromParts', () => {
       startSec: 42,
       endSec: 59,
     })
+  })
+
+  test('documents mode drops a reversed structured end time', () => {
+    const result = normalizeSourcesFromParts([
+      toolCallPart('IW_doc_query', {
+        mode: 'documents',
+        sources: [
+          {
+            reference: 'urn:video-ingestion:sha256:video#t=42.0,41.0',
+            source_type: 'video',
+            title: 'Lecture 1',
+            chunks: [
+              {
+                content: 'Video context',
+                start_sec: 42,
+                end_sec: 41,
+                labeled_page_number: '0:42',
+              },
+            ],
+          },
+        ],
+      }),
+    ])
+
+    expect(result[0]).toMatchObject({
+      type: 'video',
+      startSec: 42,
+      labeledPage: '0:42',
+    })
+    expect(result[0]?.endSec).toBeUndefined()
   })
 
   test('structured video ranges participate in source deduplication', () => {

--- a/apps/chat/test/source-display.test.ts
+++ b/apps/chat/test/source-display.test.ts
@@ -71,6 +71,19 @@ describe('getSourceTimestamp', () => {
     ).toBe('12:34')
   })
 
+  test('structured video start wins over legacy timestamp channels', () => {
+    expect(
+      getSourceTimestamp(
+        source({
+          type: 'video',
+          startSec: 754,
+          labeledPage: '1:15',
+          url: 'https://example.com/v/abc#t=10',
+        })
+      )
+    ).toBe('12:34')
+  })
+
   test('reads a clock-valued labeled page', () => {
     expect(
       getSourceTimestamp(source({ type: 'video', labeledPage: '12:34' }))

--- a/apps/chat/test/source-display.test.ts
+++ b/apps/chat/test/source-display.test.ts
@@ -65,6 +65,12 @@ describe('parseTimestampSeconds', () => {
 })
 
 describe('getSourceTimestamp', () => {
+  test('reads a structured video start timestamp', () => {
+    expect(
+      getSourceTimestamp(source({ type: 'video', startSec: 754, endSec: 800 }))
+    ).toBe('12:34')
+  })
+
   test('reads a clock-valued labeled page', () => {
     expect(
       getSourceTimestamp(source({ type: 'video', labeledPage: '12:34' }))

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -428,14 +428,14 @@ The line under a source's name is per-type, chosen by `getSourceSecondaryLine` i
 documents lead with the page (`p. 12` / `S. 12`, plus the publisher's own label when distinct)
 and fall back to a cleaned display URL when they carry no page; web links always lead with the
 display URL (host kept visible, scheme/`www.`/trailing slash stripped, middle-truncated); videos
-lead with a `12:34`-style position; images keep their type label. **doc_query has no timestamp
-field** — its source shape is `source_url`/`source_type`/`file_name`/`page_number`/
-`labeled_page_number` — so a video position can only come from a clock- or `1m30s`-valued
-`labeled_page_number` or from a `t`/`start`/`time_continue`/`#t=` parameter on the source URL
-(`getSourceTimestamp`). A bare numeric `labeled_page_number` remains a publisher page label,
-never seconds; bare seconds are accepted only from URL time parameters, where their meaning is
-unambiguous. Other labels such as `Kapitel IV` also remain page text. A dedicated timestamp
-field is phase-2 work in the doc-query service. Each card's index badge mirrors the inline chip —
+lead with a `12:34`-style position; images keep their type label. doc_query video results now carry
+structured `start_sec` and optional `end_sec` values in the first chunk, plus a clock-valued
+`labeled_page_number` compatibility field. The source normalizer maps those to `startSec`/`endSec`
+and prefers the structured start for the card and citation preview. Legacy results remain
+supported: a video position can still come from a clock- or `1m30s`-valued `labeled_page_number`
+or from a `t`/`start`/`time_continue`/`#t=` parameter on the source URL (`getSourceTimestamp`).
+A bare numeric `labeled_page_number` remains a publisher page label, never seconds; other labels
+such as `Kapitel IV` also remain page text. Each card's index badge mirrors the inline chip —
 a bare digit in a small `bg-primary/10` rounded square (`sources-section.tsx`), not a
 zero-padded `01` — so the number on the card and the `[n]` in the answer read as the same
 token. Card titles clamp at two lines with the

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -383,9 +383,10 @@ long-name regression case lives in `test/mcp-clients.test.ts`.
 `normalizeSourcesFromParts` is deliberately forgiving and never throws: it unwraps the raw MCP
 `CallToolResult` envelope (`{ content: [{ type: 'text', text: '<json>' }] }`), a JSON string, or
 an already-parsed object; it treats the pipeline's literal `"N/A"` as absent; it dedupes by
-file/page/url and numbers what survives **1..N in first-appearance order across every doc_query
-call in one message**, capped at `MAX_SOURCES`. Two rules follow from that numbering and are easy
-to break independently:
+file/page/url and normalized video range (`startSec`/`endSec`), so citations for different video
+ranges remain separate, then numbers what survives **1..N in first-appearance order across every
+doc_query call in one message**, capped at `MAX_SOURCES`. Two rules follow from that numbering and
+are easy to break independently:
 
 Chatbot MCP configs are optional unless their existing `parameters` JSON contains the reserved
 runtime policy `{ "required": true, "toolAlias": "<name>" }`. A strict config must allow exactly


### PR DESCRIPTION
## What This Adds

This draft PR adapts Klicker’s source normalization and display helpers to consume structured video citations from doc-query documents mode.

- Preserves video title and first-chunk `start_sec`/`end_sec` metadata in `ChatSource`.
- Gives structured video starts precedence over legacy labeled-page and URL timestamp fallbacks.
- Keeps structured ranges in documents mode, including range-aware deduplication; answer-mode behavior remains unchanged.
- Drops reversed end times while retaining a valid start and source label.
- Keeps the existing 1-based source numbering used by the `[n]` citation renderer.

## How It Works

- Documents-mode normalization reads the first returned chunk, cleans numeric range fields, and carries valid values into the source card model.
- Display formatting uses `startSec` first, then the existing label and URL compatibility paths.
- The change is client-side source handling only. It does not alter MCP routing, chatbot provisioning, persistence, authentication, or deployment.

## Branch Coverage

- Base: `v3` at `2bcaddabe3bf3b39e23e71e7cf3eda7179f6291f`
- Head: `caac06472`.
- Reviewed: 2 commits after rebasing onto current `v3`: `4ed5de3dd` and `caac06472`.
- Diff: 6 files, 183 additions and 18 deletions across source normalization, display/types, focused tests, and chat documentation.
- Covered: structured video source mapping, timestamp precedence, range-aware deduplication, invalid-range handling, and review-driven test cleanup.

## Review Focus

- Confirm the documents-mode shape matches the mcp-doc-query video source/chunk contract.
- Confirm stale labels or URL timestamps cannot override a valid structured start.
- Confirm malformed or reversed ranges do not create misleading source cards.
- Confirm the change remains presentation/normalization-only and leaves answer-mode source behavior intact.
- Treat live staging verification as a separate gate after both branches are merged and deployed.

## Verification

Current head:

- `pnpm --filter @klicker-uzh/chat exec vitest run test/normalize-sources.test.ts test/source-display.test.ts` -> 72 passed.
- `pnpm --filter @klicker-uzh/chat exec biome check ...` -> passed.
- `git diff --check` -> passed.
- Pre-push `pnpm` production build -> 22 Turbo build tasks successful.
- Simplifier and slice-review correction gates -> no unresolved local findings; reports are recorded below.

Failed/Warning:

- The production build emitted existing repository warnings, including Node 24 engine warnings under host Node 26, unrelated TypeScript/Rollup warnings, and missing-message warnings in existing management routes. The build exited successfully.
- No live model-backed, staging, or deployment proof was run in this PR.

## Security / Privacy

- No secrets, credentials, private payloads, or personal data are included.
- No authentication, authorization, database, persistence, or deployment surface changed.

## Blocking Before Merge

- [ ] Required GitHub CI checks and reviewer approval must pass.
- [ ] Merge remains separately authorized.

## Follow-Up After Merge

- [ ] Deploy the matching mcp-doc-query and Klicker heads through the active deployment path.
- [ ] Re-run the integrated STG doc-query proof and verify rendered source titles and timestamps in the native Klicker chatbot.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch; these are not review evidence.

- Machine: local macOS workstation.
- Worktree: `klicker-uzh/trees/rs/video-source-normalizer-contract` in repository `klicker-uzh`.
- Review reports: `klicker-uzh/project/_local/reviews/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for video source time ranges, including start and end timestamps.
  * Video citations now display structured start times when available.
  * Distinct video time ranges are preserved during source deduplication.

* **Bug Fixes**
  * Invalid, negative, or reverse-ordered timestamps are safely omitted.

* **Documentation**
  * Updated guidance for structured video timestamps and compatibility with legacy formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->