### PR TITLE
fix(chat): unwrap structured MCP results

### DIFF
--- a/apps/chat/src/lib/sources/normalizeSources.ts
+++ b/apps/chat/src/lib/sources/normalizeSources.ts
@@ -151,7 +151,9 @@ export function parseDocQueryPayload(
         typeof envelope.structuredContent === 'object' &&
         !Array.isArray(envelope.structuredContent)
       ) {
-        return envelope.structuredContent as Record<string, unknown>
+        return parseStructuredContent(
+          envelope.structuredContent as Record<string, unknown>
+        )
       }
 
       const textItem = envelope.content.find(
@@ -167,6 +169,16 @@ export function parseDocQueryPayload(
   }
 
   return parseJsonObject(raw)
+}
+
+function parseStructuredContent(
+  raw: Record<string, unknown>
+): Record<string, unknown> {
+  // FastMCP may wrap the JSON tool result as `{ result: '<json>' }` inside
+  // the MCP envelope. Unwrap that layer before source normalization; direct
+  // structured payloads remain supported for clients that do not wrap them.
+  const nested = parseDocQueryPayload(raw.result)
+  return nested ?? raw
 }
 
 function parseJsonObject(raw: unknown): Record<string, unknown> | undefined {

--- a/apps/chat/test/normalize-sources.test.ts
+++ b/apps/chat/test/normalize-sources.test.ts
@@ -479,6 +479,37 @@ describe('normalizeSourcesFromParts', () => {
     expect(result[0]?.title).toBe('from-structured.pdf')
   })
 
+  test('unwraps the structuredContent result wrapper', () => {
+    const result = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        content: [{ type: 'text', text: '{"mode":"documents","sources":[]}' }],
+        structuredContent: {
+          result: JSON.stringify({
+            mode: 'documents',
+            sources: [
+              {
+                reference: 'urn:video-ingestion:sha256:video#t=42.0,59.0',
+                source_type: 'video',
+                title: 'Lecture 1',
+                chunks: [
+                  { content: 'Video context', start_sec: 42, end_sec: 59 },
+                ],
+              },
+            ],
+          }),
+        },
+      }),
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      type: 'video',
+      title: 'Lecture 1',
+      startSec: 42,
+      endSec: 59,
+    })
+  })
+
   test('envelope with non-JSON text content yields no sources', () => {
     const result = normalizeSourcesFromParts([
       toolCallPart('KB_doc_query', {

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -382,11 +382,12 @@ long-name regression case lives in `test/mcp-clients.test.ts`.
 
 `normalizeSourcesFromParts` is deliberately forgiving and never throws: it unwraps the raw MCP
 `CallToolResult` envelope (`{ content: [{ type: 'text', text: '<json>' }] }`), a JSON string, or
-an already-parsed object; it treats the pipeline's literal `"N/A"` as absent; it dedupes by
-file/page/url and normalized video range (`startSec`/`endSec`), so citations for different video
-ranges remain separate, then numbers what survives **1..N in first-appearance order across every
-doc_query call in one message**, capped at `MAX_SOURCES`. Two rules follow from that numbering and
-are easy to break independently:
+an already-parsed object. FastMCP may put the JSON payload in a `structuredContent.result` string;
+the normalizer unwraps that compatibility layer before applying the same rules. It treats the
+pipeline's literal `"N/A"` as absent; it dedupes by file/page/url and normalized video range
+(`startSec`/`endSec`), so citations for different video ranges remain separate, then numbers what
+survives **1..N in first-appearance order across every doc_query call in one message**, capped at
+`MAX_SOURCES`. Two rules follow from that numbering and are easy to break independently:
 
 Chatbot MCP configs are optional unless their existing `parameters` JSON contains the reserved
 runtime policy `{ "required": true, "toolAlias": "<name>" }`. A strict config must allow exactly


### PR DESCRIPTION
## Summary

- unwrap the `structuredContent.result` JSON string emitted by FastMCP before source normalization
- preserve direct structured payloads for clients that do not use the wrapper
- add a regression test and document the compatibility envelope

This fixes the generic citation-rendering failure observed in the Informatik und Wirtschaft STG chatbot. The live Doc Query result contained valid video title and timestamp metadata, but the deployed native parser treated the wrapper as the payload and therefore rendered no source cards or citation links.

## Validation

- `pnpm --filter @klicker-uzh/chat test:run` — focused source/citation tests pass; the fresh worktree's full suite still has unrelated workspace-resolution failures before affected suites load
- `pnpm exec biome check apps/chat/src/lib/sources/normalizeSources.ts apps/chat/test/normalize-sources.test.ts`
- repository pre-push `pnpm run build` — passed with existing build warnings

## Deployment note

The STG chat image currently contains #5411 and remains unchanged by this PR. Source-card E2E verification should be rerun after this follow-up is merged and deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured content returned by MCP integrations, including nested and JSON-encoded results.
  * Preserved support for direct structured payloads while continuing to normalize, deduplicate, and number sources correctly.
  * Treats `"N/A"` values as absent source information.
* **Tests**
  * Added coverage for video sources with titles and structured time ranges from wrapped results.
* **Documentation**
  * Updated chat platform documentation to reflect the expanded source handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->