### PR TITLE
fix(graphql): decouple assessment results from leaderboard participation

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -25,6 +25,8 @@ Schema sources live in [packages/prisma/src/prisma/schema/](../packages/prisma/s
 
 They are unrelated models — never conflate them. A `Participant` joins a `Course` through **`Participation`** (`@@unique([courseId, participantId])`, carries `isActive`) — the domain word is _Participation_, not "Enrollment". Course names like "Testkurs" are seed data only (`packages/prisma-data/src/data/seedTEST.ts`).
 
+`Participation.isActive` is the **course-leaderboard opt-in**, not an enrollment flag. It defaults to `false`; joining the course leaderboard flips it to `true`, and leaving the leaderboard sets it back to `false` while keeping the row and collected points. Assessment course access and assessment report issuance are backed by the **accepted course invitation** plus an active participant account — never by `Participation.isActive` — so leaderboard-inactive students keep their assessment access.
+
 ## Content hierarchy
 
 - **`Element`** (`element.prisma`) — a question-bank item owned by a `User`; versioned via `version`/`originalId`; `type: ElementType`; options live in a typed `Json` field.

--- a/docs/log/2026-08-19-assessment-results-gate.md
+++ b/docs/log/2026-08-19-assessment-results-gate.md
@@ -1,0 +1,25 @@
+---
+type: Change Log
+title: Assessment results gate no longer depends on the leaderboard opt-in
+description: Decouple assessment course access and report issuance from the course-leaderboard participation flag.
+timestamp: '2026-08-19'
+tags:
+  - backend
+  - graphql
+  - assessment
+---
+
+## 2026-08-19
+
+- **Fix:** Participant access to assessment course results
+  (`getStudentAssessmentResults`) and assessment report issuance
+  (`buildAssessmentReportSnapshotV1`) no longer require
+  `Participation.isActive`. Both gates now rely on the accepted course
+  invitation plus an active participant account. The leaderboard opt-in flag
+  keeps its original meaning and is untouched elsewhere.
+- **Fix:** `calculateAssessmentCourseScores` no longer filters by
+  `participantScope`; report snapshots and the lecturer overview now score
+  all course participants consistently.
+- **Docs:** `docs/domain-model.md` now states explicitly that
+  `Participation.isActive` is the leaderboard opt-in, not an enrollment
+  flag, and that assessment access is invitation-backed.

--- a/packages/graphql/src/services/assessmentReports.ts
+++ b/packages/graphql/src/services/assessmentReports.ts
@@ -314,7 +314,6 @@ export async function buildAssessmentReportSnapshotV1({
       participations: {
         some: {
           participantId,
-          isActive: true,
           participant: { isActive: true },
         },
       },
@@ -346,7 +345,7 @@ export async function buildAssessmentReportSnapshotV1({
   }
 
   const courseResults = await calculateAssessmentCourseScores(
-    { courseId, participantScope: 'ACTIVE' },
+    { courseId },
     { prisma }
   )
   const studentResults = courseResults?.studentResults.find(

--- a/packages/graphql/src/services/assessmentScores.ts
+++ b/packages/graphql/src/services/assessmentScores.ts
@@ -64,26 +64,9 @@ export function getInstanceAvailablePoints({
 }
 
 export async function calculateAssessmentCourseScores(
-  {
-    courseId,
-    participantScope,
-  }: { courseId: string; participantScope: 'ALL' | 'ACTIVE' },
+  { courseId }: { courseId: string },
   ctx: { prisma: PrismaTransactionClient }
 ): Promise<CourseScoreAggregate | null> {
-  const activeParticipationWhere =
-    participantScope === 'ACTIVE'
-      ? { isActive: true, participant: { isActive: true } }
-      : undefined
-  const activeResponseWhere =
-    participantScope === 'ACTIVE'
-      ? {
-          participant: {
-            isActive: true,
-            participations: { some: { courseId, isActive: true } },
-          },
-        }
-      : undefined
-
   const course = await ctx.prisma.course.findUnique({
     where: { id: courseId, isAssessmentEnabled: true },
     select: {
@@ -107,7 +90,6 @@ export async function calculateAssessmentCourseScores(
                   elementType: true,
                   options: true,
                   liveQuizResponses: {
-                    where: activeResponseWhere,
                     select: {
                       participantId: true,
                       elementBlockExecution: true,
@@ -125,7 +107,6 @@ export async function calculateAssessmentCourseScores(
         },
       },
       participations: {
-        where: activeParticipationWhere,
         select: { participantId: true },
       },
     },

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -595,7 +595,6 @@ export async function getStudentAssessmentResults(
       where: {
         courseId,
         participantId,
-        isActive: true,
         participant: { isActive: true },
         course: {
           isAssessmentEnabled: true,
@@ -613,7 +612,7 @@ export async function getStudentAssessmentResults(
 
     if (!participation) {
       throw new Error(
-        'Active assessment participation with an accepted invitation not found'
+        'Assessment participation with an accepted invitation not found'
       )
     }
   }
@@ -853,10 +852,7 @@ export async function getAssessmentResultsCourse(
   }: { courseId: string; preferredAffiliation?: string },
   ctx: ContextWithUser
 ): Promise<AssessmentResultsCourse | null> {
-  const scores = await calculateAssessmentCourseScores(
-    { courseId, participantScope: 'ALL' },
-    ctx
-  )
+  const scores = await calculateAssessmentCourseScores({ courseId }, ctx)
   if (!scores) return null
 
   const participants = await ctx.prisma.participant.findMany({

--- a/packages/graphql/test/verification.test.ts
+++ b/packages/graphql/test/verification.test.ts
@@ -198,8 +198,36 @@ describe('assessment report credential services', () => {
         fixture.participantCtx
       )
     ).rejects.toThrow(
-      'Active assessment participation with an accepted invitation not found'
+      'Assessment participation with an accepted invitation not found'
     )
+  })
+
+  it('allows leaderboard-inactive participants to access their assessment results', async () => {
+    const fixture = await createFixture()
+    await prisma.participation.update({
+      where: {
+        courseId_participantId: {
+          courseId: fixture.course.id,
+          participantId: fixture.participant.id,
+        },
+      },
+      data: { isActive: false },
+    })
+
+    await expect(
+      getStudentAssessmentResults(
+        {
+          courseId: fixture.course.id,
+          participantId: fixture.participant.id,
+        },
+        fixture.participantCtx
+      )
+    ).resolves.toEqual({
+      liveQuizzes: [],
+      practiceQuizzes: [],
+      microLearnings: [],
+      groupActivities: [],
+    })
   })
 
   it('uses the accepted non-UZH course invitation without an Edu-ID scope', async () => {
@@ -267,7 +295,7 @@ describe('assessment report credential services', () => {
     })
   })
 
-  it('rejects inactive participations and inactive participants', async () => {
+  it('passes leaderboard-inactive participants at the participation gate but blocks pending invitations', async () => {
     const fixture = await createFixture()
     await prisma.participation.update({
       where: {
@@ -278,15 +306,29 @@ describe('assessment report credential services', () => {
       },
       data: { isActive: false },
     })
+    await prisma.participantInvitation.updateMany({
+      where: {
+        courseId: fixture.course.id,
+        participantId: fixture.participant.id,
+      },
+      data: {
+        status: InvitationStatus.PENDING,
+        acceptedAt: null,
+        participantId: null,
+      },
+    })
     await expect(
       issueAssessmentReport(
         { courseId: fixture.course.id },
         fixture.participantCtx
       )
     ).rejects.toMatchObject({
-      extensions: { code: 'ASSESSMENT_REPORT_NOT_ELIGIBLE' },
+      extensions: { code: 'ASSESSMENT_REPORT_IDENTITY_UNVERIFIED' },
     })
+  })
 
+  it('issues a report to leaderboard-inactive participants with an accepted invitation', async () => {
+    const fixture = await createFixture()
     await prisma.participation.update({
       where: {
         courseId_participantId: {
@@ -294,12 +336,32 @@ describe('assessment report credential services', () => {
           participantId: fixture.participant.id,
         },
       },
-      data: { isActive: true },
+      data: { isActive: false },
     })
+
+    await expect(
+      issueAssessmentReport(
+        { courseId: fixture.course.id },
+        fixture.participantCtx
+      )
+    ).resolves.toMatchObject({
+      status: CredentialStatus.ACTIVE,
+      snapshot: {
+        subject: {
+          email: fixture.invitationEmail,
+          source: 'COURSE_INVITATION',
+        },
+      },
+    })
+  })
+
+  it('rejects issuance for an inactive participant account', async () => {
+    const fixture = await createFixture()
     await prisma.participant.update({
       where: { id: fixture.participant.id },
       data: { isActive: false },
     })
+
     await expect(
       issueAssessmentReport(
         { courseId: fixture.course.id },


### PR DESCRIPTION
## What This Fixes

Assessment courses on assessment.klicker.uzh.ch showed \"An error occurred while loading the results for the activities in this assessment course\" for all participants after the latest release. Root cause: assessment results queries required \`Participation.isActive = true\` (the course-leaderboard opt-in flag, default false), so students who had not opted into the leaderboard were excluded and the results could not load.

This PR decouples assessment results from leaderboard participation:

1. \`getStudentAssessmentResults\` now gates on an accepted course invitation plus an active participant account (\`participant.isActive\`), no longer on \`Participation.isActive\`; the error message now reads \"Assessment participation with an accepted invitation not found\".
2. \`buildAssessmentReportSnapshotV1\` drops the \`isActive: true\` participation filter and calls \`calculateAssessmentCourseScores({ courseId })\`, so report snapshots and credential issuance include leaderboard-inactive enrolled students.
3. \`calculateAssessmentCourseScores\` loses its \`participantScope\` parameter and both \`isActive\` filters; both remaining call sites (student snapshot, lecturer overview) now compute the same full-course scores.

Access control is preserved: revoked/pending invitations still fail the accepted-invitation gate, and deactivated participant accounts still fail \`participant.isActive\`. No migration needed.

## Branch Coverage

- Base: \`v3\`
- Head: \`5451f30bc\`
- Reviewed: 1 commit, 6 files changed (+97/-32)

## Review Focus

- Participation.isActive remains the course-leaderboard opt-in flag; only leaderboard semantics use it now (audited across services).
- Behavior for participants with a pending invitation and for deactivated accounts is covered by tests.

## Verification

Current head:
- \`pnpm --filter @klicker-uzh/graphql build\` -> passed
- \`pnpm --filter @klicker-uzh/graphql check\` (tsc) -> passed
- \`pnpm exec vitest run test/verification.test.ts\` -> 30/30 passed against a dedicated disposable Postgres
- AGY / gemini-3.7-flash-high (effort high), read-only review of range \`a617a2c87..5451f30bc\` -> APPROVE, no must-fix/should-fix findings

Not run:
- Full CI pipeline on this branch (will run on the PR)

## Security / Privacy

- No secrets, logs, or private payloads included; tests use synthetic participants.
- Review: read-only AGY review + manual audit of remaining \`isActive\` usages.

## Blocking Before Merge

None.

## Follow-Up After Merge

- Deploy to stg, then promote to prd (assessment.klicker.uzh.ch / klicker.uzh.ch).

## Local Session Artifacts

Machine: this host
Worktree: \`trees/fix-assessment-results-gate\` in \`klicker-uzh\`
Review report: \`project/_local/reviews/2026-08-19-assessment-results-gate-agy-gemini37-flash-high.md\` (gitignored)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment results and reports are now available to eligible participants who opt out of the course leaderboard.
  * Access still requires an accepted course invitation and an active participant account.
  * Assessment scores and reports now consistently include all eligible course participants, regardless of leaderboard participation.

* **Documentation**
  * Clarified that leaderboard participation is separate from course enrollment and assessment access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->