### PR TITLE
enhance(pwa): add focused practice quiz embeds

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ['v3', 'v3*']
     paths:
+      - 'apps/frontend-pwa/**'
       - 'apps/chat/**'
       - 'packages/grading/**'
       - 'packages/graphql/**'
@@ -23,6 +24,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'apps/frontend-pwa/**'
       - 'apps/chat/**'
       - 'packages/grading/**'
       - 'packages/graphql/**'
@@ -105,6 +107,10 @@ jobs:
           CHAT_ACCOUNT_USAGE_INTEGRATION: '1'
           CHAT_ACCOUNT_USAGE_ENFORCEMENT_ENABLED: 'false'
           DATABASE_URL: postgresql://klicker:klicker@localhost:5432/klicker-prod
+
+      - name: Test frontend PWA
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/frontend-pwa test:run
 
       - name: Test grading package
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -89,7 +89,8 @@
     "lint": "eslint .",
     "pushTest": "node src/testPush.js",
     "start": "next start --port 3001",
-    "start:test": "cross-env NODE_ENV=test pnpm start"
+    "start:test": "cross-env NODE_ENV=test pnpm start",
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "engines": {
     "node": "=24"

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -90,7 +90,8 @@
     "pushTest": "node src/testPush.js",
     "start": "next start --port 3001",
     "start:test": "cross-env NODE_ENV=test pnpm start",
-    "test": "tsx --test \"src/**/*.test.ts\""
+    "test": "pnpm run test:run",
+    "test:run": "tsx --test \"src/**/*.test.ts\""
   },
   "engines": {
     "node": "=24"

--- a/apps/frontend-pwa/src/components/Layout.tsx
+++ b/apps/frontend-pwa/src/components/Layout.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from '@apollo/client'
 import {
-  Course,
+  type Course,
   SelfDocument,
-  StudentCourse,
+  type StudentCourse,
   UserRole,
 } from '@klicker-uzh/graphql/dist/ops'
 import Head from 'next/head'
-import React, { Dispatch, SetStateAction } from 'react'
+import type React from 'react'
+import type { Dispatch, SetStateAction } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Header from './common/Header'
 
@@ -18,6 +19,7 @@ interface LayoutProps {
   children?: React.ReactNode
   displayName?: string
   embedded?: boolean
+  embeddedAutoResize?: boolean
   course?:
     | Partial<Omit<Course, 'awards' | 'owner' | 'groupActivities'>>
     | (Omit<StudentCourse, 'owner'> & { owner: { shortname: string } })
@@ -40,6 +42,7 @@ function Layout({
   children,
   displayName = 'KlickerUZH',
   embedded = false,
+  embeddedAutoResize = false,
   course,
   mobileMenuItems,
   setActiveMobilePage,
@@ -94,7 +97,9 @@ function Layout({
       <div
         id={LAYOUT_SCROLL_CONTAINER_ID}
         className={twMerge(
-          'flex min-h-0 flex-1 flex-col overflow-y-auto',
+          embeddedAutoResize
+            ? 'flex flex-none flex-col overflow-visible'
+            : 'flex min-h-0 flex-1 flex-col overflow-y-auto',
           embedded ? 'p-0' : 'p-4',
           !embedded && pageInFrame && 'px-0',
           className?.body

--- a/apps/frontend-pwa/src/components/practiceQuiz/embed.test.ts
+++ b/apps/frontend-pwa/src/components/practiceQuiz/embed.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  EMBED_INIT_MESSAGE_TYPE,
+  EMBED_PROTOCOL_VERSION,
+  isEmbedInitMessage,
+  isValidEmbedResizePayload,
+  mergeEmbedCapabilities,
+} from './embed'
+
+describe('embed protocol', () => {
+  it('accepts a bare initialization message', () => {
+    assert.equal(isEmbedInitMessage({ type: EMBED_INIT_MESSAGE_TYPE }), true)
+  })
+
+  it('rejects malformed capability values', () => {
+    assert.equal(
+      isEmbedInitMessage({
+        type: EMBED_INIT_MESSAGE_TYPE,
+        capabilities: { resize: 'true' },
+      }),
+      false
+    )
+    assert.equal(isEmbedInitMessage({ type: 'other' }), false)
+  })
+
+  it('does not revoke a capability on a repeated initialization', () => {
+    assert.deepEqual(
+      mergeEmbedCapabilities({ resize: true }, { resize: false }),
+      { resize: true, hostNavigation: false }
+    )
+  })
+
+  it('validates resize payload version and bounds', () => {
+    assert.equal(
+      isValidEmbedResizePayload({
+        version: EMBED_PROTOCOL_VERSION,
+        height: 480,
+      }),
+      true
+    )
+    assert.equal(isValidEmbedResizePayload({ version: 2, height: 480 }), false)
+    assert.equal(
+      isValidEmbedResizePayload({
+        version: EMBED_PROTOCOL_VERSION,
+        height: Number.POSITIVE_INFINITY,
+      }),
+      false
+    )
+  })
+})

--- a/apps/frontend-pwa/src/components/practiceQuiz/embed.test.ts
+++ b/apps/frontend-pwa/src/components/practiceQuiz/embed.test.ts
@@ -21,6 +21,13 @@ describe('embed protocol', () => {
       }),
       false
     )
+    assert.equal(
+      isEmbedInitMessage({
+        type: EMBED_INIT_MESSAGE_TYPE,
+        capabilities: { futureCapability: true },
+      }),
+      false
+    )
     assert.equal(isEmbedInitMessage({ type: 'other' }), false)
   })
 

--- a/apps/frontend-pwa/src/components/practiceQuiz/embed.ts
+++ b/apps/frontend-pwa/src/components/practiceQuiz/embed.ts
@@ -1,0 +1,65 @@
+export const EMBED_INIT_MESSAGE_TYPE = 'klicker:embed-init'
+export const EMBED_RESIZE_MESSAGE_TYPE = 'klicker:embed-resize'
+export const QUIZ_STATE_MESSAGE_TYPE = 'klicker:quiz-state'
+export const EMBED_PROTOCOL_VERSION = 1
+
+export type EmbedCapabilities = {
+  resize?: boolean
+  hostNavigation?: boolean
+}
+
+export type EmbedInitMessage = {
+  type: typeof EMBED_INIT_MESSAGE_TYPE
+  capabilities?: EmbedCapabilities
+}
+
+export type EmbedResizePayload = {
+  version: typeof EMBED_PROTOCOL_VERSION
+  height: number
+}
+
+/**
+ * Capabilities are negotiated monotonically for the lifetime of one embed.
+ * Hosts retry initialization, so a late message must not revoke an earlier
+ * capability while the child is already using it.
+ */
+export function mergeEmbedCapabilities(
+  current: EmbedCapabilities,
+  requested: EmbedCapabilities
+): EmbedCapabilities {
+  return {
+    resize: current.resize === true || requested.resize === true,
+    hostNavigation:
+      current.hostNavigation === true || requested.hostNavigation === true,
+  }
+}
+
+export function isEmbedInitMessage(data: unknown): data is EmbedInitMessage {
+  if (!isRecord(data) || data.type !== EMBED_INIT_MESSAGE_TYPE) return false
+
+  if (typeof data.capabilities === 'undefined') return true
+  if (!isRecord(data.capabilities)) return false
+
+  return Object.entries(data.capabilities).every(
+    ([key, value]) =>
+      (key === 'resize' || key === 'hostNavigation') &&
+      typeof value === 'boolean'
+  )
+}
+
+export function isValidEmbedResizePayload(
+  data: unknown
+): data is EmbedResizePayload {
+  return (
+    isRecord(data) &&
+    data.version === EMBED_PROTOCOL_VERSION &&
+    typeof data.height === 'number' &&
+    Number.isFinite(data.height) &&
+    data.height >= 200 &&
+    data.height <= 50000
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
@@ -1,66 +1,6 @@
 /**
- * Embedded quiz postMessage protocol (for parent/embedding apps):
- *
- * When loaded with ?embed=true, the parent app must first register itself:
- *   iframe.contentWindow?.postMessage({ type: 'klicker:embed-init' }, iframeOrigin)
- *
- * After receiving that init message, this page posts state updates to the
- * registered parent origin:
- *   {
- *     type: 'klicker:quiz-state',
- *     payload: { version, status, currentStep, totalSteps },
- *   }
- *
- * status values:
- *   'overview'    - quiz not yet started
- *   'in-progress' - student is answering questions
- *   'completed'   - all stacks answered, quiz finished
- *
- * Example listener in the embedding app:
- *
- *   function useKlickerQuizState(iframe: HTMLIFrameElement, iframeOrigin: string) {
- *     const [quizState, setQuizState] = useState({
- *       version: 1,
- *       status: 'overview',
- *       currentStep: 0,
- *       totalSteps: 0,
- *     })
- *     useEffect(() => {
- *       const handler = (e: MessageEvent) => {
- *         if (e.origin !== iframeOrigin) return
- *         if (e.data?.type === 'klicker:quiz-state') {
- *           setQuizState(e.data.payload)
- *         }
- *       }
- *
- *       window.addEventListener('message', handler)
- *
- *       const frame = iframe
- *       if (frame) {
- *         const registerParent = () => {
- *           frame.contentWindow?.postMessage(
- *             { type: 'klicker:embed-init' },
- *             iframeOrigin
- *           )
- *         }
- *
- *         frame.addEventListener('load', registerParent)
- *         registerParent()
- *
- *         return () => {
- *           window.removeEventListener('message', handler)
- *           frame.removeEventListener('load', registerParent)
- *         }
- *       }
- *
- *       return () => window.removeEventListener('message', handler)
- *     }, [iframeOrigin])
- *     return quizState
- *   }
- *
- *   // Usage: hide e-learning "Weiter" until quiz is completed
- *   const quizState = useKlickerQuizState(iframeElement, 'https://pwa.klicker.uzh.ch')
- *   {quizState.status === 'completed' && <button>Weiter</button>}
+ * The shared embed protocol lives in `components/practiceQuiz/embed.ts`.
+ * This page only owns the browser wiring and quiz state projection.
  */
 import { useQuery } from '@apollo/client'
 import {
@@ -75,19 +15,27 @@ import getParticipantToken from '@lib/getParticipantToken'
 import useParticipantToken from '@lib/useParticipantToken'
 import { UserNotification } from '@uzh-bf/design-system'
 import dayjs from 'dayjs'
-import { GetServerSidePropsContext } from 'next'
+import type { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import nookies from 'nookies'
 import { useEffect, useState } from 'react'
+import Footer from '../../../../components/common/Footer'
 import Layout, {
   LAYOUT_SCROLL_CONTAINER_ID,
 } from '../../../../components/Layout'
-import Footer from '../../../../components/common/Footer'
+import {
+  EMBED_PROTOCOL_VERSION,
+  EMBED_RESIZE_MESSAGE_TYPE,
+  type EmbedCapabilities,
+  type EmbedResizePayload,
+  isEmbedInitMessage,
+  isValidEmbedResizePayload,
+  mergeEmbedCapabilities,
+  QUIZ_STATE_MESSAGE_TYPE,
+} from '../../../../components/practiceQuiz/embed'
 import PracticeQuiz from '../../../../components/practiceQuiz/PracticeQuiz'
 
-const EMBED_INIT_MESSAGE_TYPE = 'klicker:embed-init'
-const QUIZ_STATE_MESSAGE_TYPE = 'klicker:quiz-state'
-const QUIZ_STATE_VERSION = 1
+const QUIZ_STATE_VERSION = EMBED_PROTOCOL_VERSION
 
 type EmbedQuizStatus = 'overview' | 'in-progress' | 'completed'
 
@@ -102,7 +50,6 @@ type PracticeQuizProgressState = Record<
   string,
   {
     status: StackFeedbackStatus
-    score?: number | null
   }
 >
 
@@ -122,7 +69,18 @@ function PracticeQuizPage({
   const t = useTranslations()
   const [currentIx, setCurrentIx] = useState(-1)
   const [parentOrigin, setParentOrigin] = useState<string | null>(null)
+  const [embedCapabilities, setEmbedCapabilities] = useState<EmbedCapabilities>(
+    {}
+  )
+  const [resizeHeightValid, setResizeHeightValid] = useState(false)
   const [isCompleted, setIsCompleted] = useState(false)
+
+  const embeddedAutoResize =
+    embedded &&
+    embedCapabilities.resize === true &&
+    typeof window !== 'undefined' &&
+    'ResizeObserver' in window
+  const autoResize = embeddedAutoResize && resizeHeightValid
 
   useParticipantToken({
     participantToken,
@@ -142,6 +100,12 @@ function PracticeQuizPage({
       if (event.source !== window.parent) return
       if (!isEmbedInitMessage(event.data) || event.origin === 'null') return
 
+      setEmbedCapabilities((currentCapabilities) =>
+        mergeEmbedCapabilities(
+          currentCapabilities,
+          event.data.capabilities ?? {}
+        )
+      )
       setParentOrigin((currentOrigin) =>
         currentOrigin === event.origin ? currentOrigin : event.origin
       )
@@ -153,6 +117,73 @@ function PracticeQuizPage({
       window.removeEventListener('message', handleMessage)
     }
   }, [embedded])
+
+  useEffect(() => {
+    if (!autoResize) return
+
+    const previousHtmlOverflow = document.documentElement.style.overflow
+    const previousBodyOverflow = document.body.style.overflow
+    document.documentElement.style.overflow = 'hidden'
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.documentElement.style.overflow = previousHtmlOverflow
+      document.body.style.overflow = previousBodyOverflow
+    }
+  }, [autoResize])
+
+  useEffect(() => {
+    if (!embeddedAutoResize || !parentOrigin) return
+
+    const container = document.getElementById(LAYOUT_SCROLL_CONTAINER_ID)
+    if (!container) return
+
+    let animationFrame: number | null = null
+
+    const postHeight = () => {
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+
+      animationFrame = window.requestAnimationFrame(() => {
+        const payload: EmbedResizePayload = {
+          version: EMBED_PROTOCOL_VERSION,
+          height: Math.ceil(
+            Math.max(
+              container.getBoundingClientRect().height,
+              container.scrollHeight
+            )
+          ),
+        }
+
+        if (!isValidEmbedResizePayload(payload)) {
+          setResizeHeightValid(false)
+          return
+        }
+
+        setResizeHeightValid(true)
+
+        window.parent.postMessage(
+          {
+            type: EMBED_RESIZE_MESSAGE_TYPE,
+            payload,
+          },
+          parentOrigin
+        )
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(postHeight)
+    resizeObserver.observe(container)
+    postHeight()
+
+    return () => {
+      resizeObserver.disconnect()
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+    }
+  }, [embeddedAutoResize, parentOrigin])
 
   useEffect(() => {
     if (!embedded || !data?.practiceQuiz) return
@@ -195,14 +226,14 @@ function PracticeQuizPage({
 
   if (loading)
     return (
-      <Layout embedded={embedded}>
+      <Layout embedded={embedded} embeddedAutoResize={autoResize}>
         <Loader />
       </Layout>
     )
 
   if (!data?.practiceQuiz) {
     return (
-      <Layout embedded={embedded}>
+      <Layout embedded={embedded} embeddedAutoResize={autoResize}>
         <UserNotification
           type="error"
           message={t('pwa.practiceQuiz.notFound')}
@@ -213,7 +244,9 @@ function PracticeQuizPage({
 
   if (error) {
     return (
-      <Layout embedded={embedded}>{t('shared.generic.systemError')}</Layout>
+      <Layout embedded={embedded} embeddedAutoResize={autoResize}>
+        {t('shared.generic.systemError')}
+      </Layout>
     )
   }
 
@@ -225,6 +258,7 @@ function PracticeQuizPage({
     return (
       <Layout
         embedded={embedded}
+        embeddedAutoResize={autoResize}
         displayName={data.practiceQuiz.displayName}
         course={data.practiceQuiz.course ?? undefined}
       >
@@ -249,6 +283,7 @@ function PracticeQuizPage({
   return (
     <Layout
       embedded={embedded}
+      embeddedAutoResize={autoResize}
       displayName={data.practiceQuiz.displayName}
       course={data.practiceQuiz.course ?? undefined}
     >
@@ -388,10 +423,6 @@ function buildQuizStatePayload({
   }
 }
 
-function isEmbedInitMessage(data: unknown): boolean {
-  return isRecord(data) && data.type === EMBED_INIT_MESSAGE_TYPE
-}
-
 function readStoredCompletion(
   quizId: string,
   stackIds: Array<string | number>
@@ -422,8 +453,4 @@ function readStoredCompletion(
     )
     return false
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
 }

--- a/packages/shared-components/src/charts/ElementHistogram.tsx
+++ b/packages/shared-components/src/charts/ElementHistogram.tsx
@@ -148,7 +148,11 @@ function ElementHistogram({
               return null
             }}
           />
-          <Bar dataKey="count" fill="rgb(19, 149, 186)" />
+          <Bar
+            dataKey="count"
+            fill="rgb(19, 149, 186)"
+            isAnimationActive={false}
+          />
           {reference && (
             <ReferenceLine
               className={textSize}

--- a/project/2026-08-30-pr-5442-embedded-practice-quiz-stack-simplification-plan.md
+++ b/project/2026-08-30-pr-5442-embedded-practice-quiz-stack-simplification-plan.md
@@ -1,0 +1,206 @@
+# Embedded practice quiz stack simplification
+
+## Plan identity
+
+- Plan path: `project/2026-08-30-pr-5442-embedded-practice-quiz-stack-simplification-plan.md`
+- Delivery topology: one shared plan carried by the first phase of the existing stacked PRs; later layers carry their own `Progress` updates.
+- PRs: [#5442](https://github.com/uzh-bf/klicker-uzh/pull/5442), [#5456](https://github.com/uzh-bf/klicker-uzh/pull/5456), and [#5536](https://github.com/uzh-bf/klicker-uzh/pull/5536)
+- Branches, bottom to top: `codex/focused-practice-quiz-embed`, `claude/open-pr-search-v0p12i`, and `rs/feat-focused-embed-completed-screen`
+- Target branch: `v3`
+- Execution checkout: isolated local clone at `/private/tmp/klicker-focused-embed-simplification`; the repo-local task worktree and dirty primary checkout remain unchanged until the reconciled commits are ready to transfer.
+- Related history: `project/plans_wip/PLAN-embedded-practice-quiz-host-integration.md` is the earlier cumulative plan and remains history; it is not overwritten.
+
+## Execution contract
+
+- Execution owner: main session. The shared quiz files and stacked topology make separate implementation ownership unsafe.
+- Autonomy model: the user's “proceed” accepts this planner-reviewed plan through local implementation, local commits, repository-native checks, read-only specialist reviews, and local browser/runtime verification.
+- Boundary owner: the user owns publication and integration decisions after local acceptance.
+- Granted actions: create an isolated clone, save recovery refs, rewrite only local copies of the three named branches, edit in-scope Klicker files and this plan, create conventional local commits, run focused checks, use the local devrouter runtime, and collect browser evidence.
+- Withheld actions: do not push, force-push, merge, rebase onto a moving target, update PR metadata, change the eLearning repository, deploy, or alter shared infrastructure.
+- Terminal condition: the plan is the first commit of the bottom layer, all three local layers are contiguous and independently reviewable, focused checks and paired browser evidence pass, required specialist reports are recorded, and the stack is ready for a separately authorized publication pass.
+- Pause conditions: stop for an unprotected recovery point, an existing user change that overlaps an in-scope hunk, a new auth/data/security/infrastructure/public-contract decision, a target-head conflict requiring upstream integration, or an unavailable runtime after the documented focused fallback.
+
+## Resolved design findings
+
+- The planner review returned `DONE_WITH_CONCERNS`; the accepted correction is to keep monotonic capability negotiation in #5442 so repeated initialization cannot revoke an already negotiated capability.
+- URL-only focused mode is presentation state. Host navigation is enabled only after capability negotiation, and the child remains the source of truth for disabled, submitting, and completed states.
+- Completion is an in-session transition from unfinished to finished. A child that loads already finished does not create a new eLearning completion event.
+- No unanswered product ruling blocks this implementation. Reopen the design only if the eLearning host needs a new message version, a new capability, or a different completion/persistence semantic.
+
+## Primitive impact
+
+| Primitive or composition | Disposition | Contract delta and evidence |
+|---|---|---|
+| Embedded practice-quiz session | Extend | Preserve the existing v1 handshake and status messages; add only the minimum resize, focused-navigation, and lifecycle state needed by the existing eLearning host. |
+| Practice-quiz navigation | Reuse and simplify | Keep child navigation for legacy embeds; transfer the single advance action only after negotiated host navigation is active. |
+| Practice-quiz progress and completion | Extend | Keep contiguous progress, resume, retry, and completion summary behavior while removing test-only state. |
+| eLearning host composition | Preserve | Keep the existing embedded URL and host status/advance contract byte-compatible; no eLearning code changes are in scope. |
+
+## ADR gate
+
+- Result: no new ADR. This is a reversible re-layering of an existing cross-system contract, not a new domain primitive, persistence model, authentication boundary, or deployment ownership decision.
+- Re-arm the ADR gate if implementation introduces a new protocol version, a new externally reusable package/context, changed origin or authentication rules, new persisted completion semantics, or a new long-lived ownership boundary.
+
+## Skill routing
+
+- `$rs-product-primitives`: freeze the existing embedded quiz/session and host-navigation contract.
+- `$rs-stacked-change` and `$gh-stack`: preserve the three-PR dependency order and review each layer against its parent.
+- `$rs-sliced-development-workflow`: full-path plan, one slice per meaningful commit, simplifier after each substantive slice, risk review at the cross-system seam, and one integrated final review.
+- `$rs-model-routing` and `$rs-agent-capacity`: select and checkpoint specialist routes before dispatch.
+- `klicker-frontend-ui`, `agent-browser`, `klicker-testing-verification`, and `klicker-playwright-e2e`: implement and verify the UI and browser-only contract.
+- `$rs-local-runtime-lifecycle`: govern devrouter startup, final runtime verification, and shutdown.
+
+## Research
+
+- Question: which exact heads and base relationships are live? Finding: a direct fetch on 2026-08-31 resolved `v3` to `8de87d731af4d0ffa341b6d3591d55db7b0f4b81`, #5442 to `39e163c5e9072e82e9b895a996ef7439008314be`, #5456 to `f59de4cfeb73693ed0ec4c486d7206ddf92e72e3`, and #5536 to `269ef3d209fa6af8e479ff8cb7f6b835eb1df1ce`.
+- Question: can existing host behavior remain unchanged? Finding: the previously verified eLearning host requests the embedded URL and resize/host-navigation capabilities, then consumes child status; no eLearning change is required.
+- Limitation: GitHub CLI authentication is currently invalid, so forge metadata and publication are not used as evidence. Direct Git fetch remains sufficient for the local rewrite; live PR status must be refreshed after authentication is restored.
+
+## Test portfolio
+
+| Consequential behavior | Existing protection | Obligation | Primary seam | Owning slice | Distinct failure caught |
+|---|---|---|---|---|---|
+| Resize handshake and one scroll owner | Existing protocol harness and prior browser evidence | Extend existing | Protocol unit + browser frame | #5442 | Resize-only and long-content embeds do not create nested scrolling. |
+| Capability negotiation and disabled/submitting state | Existing host-navigation tests | Extend existing | Protocol/component contract | #5442 | A stale init cannot revoke capability, and host advance cannot bypass a disabled action. |
+| Focused presentation and linear host navigation | Existing focused embed browser path | Extend existing | Paired browser E2E | #5456 | The host and child do not expose competing continue actions or skip unanswered content. |
+| Progress, resume, completion, and retry | Existing progress/resume/completion tests | Extend existing | PracticeQuiz state tests + browser E2E | #5536 | Completion is emitted once, resume is contiguous, and retry resets only this quiz. |
+| Legacy/non-embedded behavior | Existing PWA suite | None beyond regression run | Existing PWA checks | All layers | Simplification does not change the ordinary practice-quiz flow. |
+
+## Plan-hardening record
+
+- Specialist: planner `01a05418-215a-7261-b86c-1a50b4cddff0` (James), read-only.
+- Outcome: `DONE_WITH_CONCERNS`; the only accepted correction is the #5442 placement of monotonic capability negotiation recorded above.
+- Arbitration: no unresolved concern changes scope, topology, or authority. No second planning round is required.
+
+## Problem
+
+The three-PR focused practice-quiz embedding stack works, but the cumulative
+diff bundled resize, focused UI, host navigation, test routes, platform-only
+plumbing, and completion behavior in one layer. Some correctness fixes only
+exist in later layers, so an intermediate layer is not independently safe.
+
+## Evidence
+
+- The cumulative stack touches 16 files, 1511 additions, and 191 deletions.
+- The base PR mixes a small protocol foundation with a focused quiz rewrite and
+  two test harnesses.
+- The middle PR contains correctness fixes for the base's host navigation and
+  focused behavior.
+- The existing eLearning contract requests the embedded URL and resize/
+  host-navigation capabilities, then responds to child status.
+- The known pairing tests covered resize, one scroll surface, contiguous
+  progress and resume, completion/retry, and linear host navigation.
+
+## Decision
+
+Keep the same three PR URLs, branch names, and dependency order. Re-layer the
+work as small, independently safe slices. Preserve the existing eLearning
+interface and every current user-visible outcome, while deleting all test-only
+production state and dead UI plumbing.
+
+### Layer ownership
+
+| PR | Re-layered responsibility |
+|---|---|
+| #5442 | Resize, handshake parsing, monotonic capability negotiation, scroll ownership |
+| #5456 | Focused presentation and complete negotiated host navigation |
+| #5536 | Progress, resume, completion summary, retry, and narrow storage reset |
+
+### Reasoning
+
+1. The smallest protocol seam is the child-advertised capability plus the host
+   action contract. It does not require a new context, provider, package,
+   ADR, or alternate route.
+2. URL-only focused mode remains a presentation request. Only negotiated host
+   navigation can hide child actions or transfer the Start/Submit/Continue
+   action to the host.
+3. Monotonic negotiation is part of the foundation because a stale repeat
+   message must never revoke a capability. Deferring it would make focused mode
+   unsafe below the lifecycle PR.
+4. A small navigation controller is simpler and less error-prone than the
+   current mixed booleans and hidden-button DOM query.
+5. The host's continue action must depend on the child's visible disabled state,
+   not incidental Button loading semantics.
+6. Emitting `canAdvance: false` after completion is semantically correct.
+   eLearning still proceeds from `status: completed` and does not send another
+   child advance command.
+7. The eLearning host marks itself complete only through an in-session
+   unfinished-to-finished transition. A child that starts finished must not
+   create a new completion event.
+
+## Non-goals
+
+- Do not merge, deploy, publish, or rebase to a protected target.
+- Do not change the eLearning PR surface or its branch base.
+- Do not change auth, gamification, Hatchet, Prisma, small-group reassignment,
+  or non-embedded PracticeQuiz behavior.
+- Do not add a test-only production route, query state, context, dependency,
+  or protocol version.
+
+## Delegation map
+
+All slices are main-session owned because the layers continuously touch the
+same quiz files and one topology owner must preserve each PR boundary. The
+simplifier, slice reviewer, and final reviewer are read-only checks, not
+implementers.
+
+| Slice | Owner | Acceptance |
+|---|---|---|
+| S1 resize foundation | main | #5442 independently renders legacy and resize-only embeds safely |
+| S2 focused host navigation | main | #5456 independently safe and complete for URL and negotiated modes |
+| S3 lifecycle polish | main | #5536 completes the UI without changing #5442/#5456 invariants |
+| Integrated review | main | final reviewer accepts the cumulative stack and paired E2E evidence |
+
+## File disposition
+
+### Delete
+
+- `apps/frontend-pwa/src/pages/.../practiceQuizzes/[id]/embed-test.tsx`
+- `apps/frontend-pwa/src/components/practiceQuiz/embed-advance.test.ts`
+- all `embedTestStep`, `initialEmbeddedStep`, related query parsing, and
+  test-step i18n keys
+- dead `PracticeQuizOverview.hideStartButton`
+
+### Restore
+
+- `PracticeQuizOverview.tsx` to `v3` wherever no other change remains.
+- unrelated import, ordering, comment, and type-only churn.
+
+### Keep
+
+- `Layout.tsx`, `PracticeQuiz.tsx`, `ElementStack.tsx`,
+  `StepProgressWithScoring.tsx`, and one embed protocol module per layer.
+- one static `util/embed-harness` host for deterministic protocol checks.
+- focused completion/retry strings and durable frontend guidance, without the
+  duplicate skill protocol copy.
+
+## Implementation slices
+
+1. Base #5442 on the reconciled live `v3` head, centralize the resize/handshake protocol,
+   add monotonic capability negotiation and layout overflow control, and keep
+   the current v1 state shape.
+2. Base #5456 on the revised #5442, add `embedMode=focused`, auto-start,
+   negotiated navigation, named action handlers, controller-based reporting,
+   corrected feedback, and a minimal completion frame for pre-#5536 safety.
+3. Base #5536 on the revised #5456, add progress derivation, contiguous prefix
+   gating, resume, score/result summary, completion panel, retry, and the
+   narrowed quiz-scoped storage reset.
+
+## Verification
+
+- Focused PWA checks, tests, lint, and production build per layer.
+- Protocol unit coverage for source, origin, version, malformed input,
+  monotonic capability, submitting/disabled state, and completed state.
+- Static harness checks for bare-init and resize-only compatibility and for
+  focused host navigation.
+- Paired Klicker/eLearning browser E2E for resize, one scroll surface,
+  progress/resume, completion/retry, and linear host navigation.
+- For each PR: exact delta, no secrets or user data, and no infra impact.
+
+## Progress
+
+- 2026-08-30: Full plan written after a planner review.
+- 2026-08-30: Planned the bottom-up re-layering and final paired E2E.
+- 2026-08-31: Direct fetch reconciled the live stack as `v3` `8de87d731af4d0ffa341b6d3591d55db7b0f4b81`, #5442 `39e163c5e9072e82e9b895a996ef7439008314be`, #5456 `f59de4cfeb73693ed0ec4c486d7206ddf92e72e3`, and #5536 `269ef3d209fa6af8e479ff8cb7f6b835eb1df1ce`; the three live PR heads are contiguous.
+- 2026-08-31: Saved old visible and hidden local stack heads plus the reconciled live heads under `refs/stack-backup/2026-08-31/` in the isolated clone. The dirty primary checkout remains untouched.
+- 2026-08-31: Next action is to commit this plan as the first bottom-layer commit, then implement and verify the resize foundation before creating the revised middle layer.

--- a/project/2026-08-30-pr-5442-embedded-practice-quiz-stack-simplification-plan.md
+++ b/project/2026-08-30-pr-5442-embedded-practice-quiz-stack-simplification-plan.md
@@ -203,4 +203,4 @@ implementers.
 - 2026-08-30: Planned the bottom-up re-layering and final paired E2E.
 - 2026-08-31: Direct fetch reconciled the live stack as `v3` `8de87d731af4d0ffa341b6d3591d55db7b0f4b81`, #5442 `39e163c5e9072e82e9b895a996ef7439008314be`, #5456 `f59de4cfeb73693ed0ec4c486d7206ddf92e72e3`, and #5536 `269ef3d209fa6af8e479ff8cb7f6b835eb1df1ce`; the three live PR heads are contiguous.
 - 2026-08-31: Saved old visible and hidden local stack heads plus the reconciled live heads under `refs/stack-backup/2026-08-31/` in the isolated clone. The dirty primary checkout remains untouched.
-- 2026-08-31: Next action is to commit this plan as the first bottom-layer commit, then implement and verify the resize foundation before creating the revised middle layer.
+- 2026-08-31: The plan is the first commit on the rewritten bottom layer (`361e77446`). S1 is now active: retain only resize/handshake foundation behavior and remove focused-navigation, test-route, platform, and unrelated documentation churn from #5442.

--- a/util/embed-harness/README.md
+++ b/util/embed-harness/README.md
@@ -5,7 +5,11 @@ Static parent page for verifying the embedded practice-quiz handshake locally.
 ## What it verifies
 
 - parent sends `klicker:embed-init`
+- parent retries initialization after 250 ms and 1 s so child hydration cannot
+  lose the one-time iframe `load` handshake
 - embedded practice quiz emits `klicker:quiz-state`
+- resize-aware parents receive `klicker:embed-resize` and apply the iframe
+  content height
 - payload transitions through `overview`, `in-progress`, and `completed`
 - accepted and rejected events are visible in the harness log
 
@@ -76,6 +80,16 @@ http://127.0.0.1:3101/en/course/test-course/practiceQuizzes/test-quiz?embed=true
   "totalSteps": 1
 }
 ```
+
+### Resize-aware embed
+
+1. Keep `Let the host own vertical scrolling` enabled.
+2. Click `Load iframe` and confirm the harness receives an
+   `embed-resize` message.
+3. Confirm `Viewport height` follows the reported height and the iframe has
+   no independent vertical scrollbar.
+4. Uncheck the option, reload the iframe, and confirm the harness no longer
+   applies resize messages.
 
 ### In-progress payload
 

--- a/util/embed-harness/index.html
+++ b/util/embed-harness/index.html
@@ -351,10 +351,10 @@
       <section class="hero">
         <h1>Klicker Practice Quiz Embed Harness</h1>
         <p>
-          Static parent page for verifying the embedded practice-quiz handshake.
-          Load a quiz URL, send <code>klicker:embed-init</code>, inspect the
-          latest payload, and keep a timestamped log of accepted and rejected
-          messages.
+          Static parent page for verifying the embedded practice-quiz handshake
+          and resize contract. Load a quiz URL, send
+          <code>klicker:embed-init</code>, inspect the latest payload, and keep
+          a timestamped log of accepted and rejected messages.
         </p>
         <p>
           The prefilled URL targets the local branch PWA on
@@ -404,6 +404,11 @@
               <span>Send init automatically after iframe load</span>
             </label>
 
+            <label class="inline-control" for="auto-resize">
+              <input id="auto-resize" type="checkbox" checked />
+              <span>Let the host own vertical scrolling</span>
+            </label>
+
             <div class="stack">
               <legend>Viewport presets</legend>
               <div class="preset-row">
@@ -424,7 +429,7 @@
                 <input
                   id="custom-height"
                   type="number"
-                  min="240"
+                  min="200"
                   step="10"
                   value="720"
                 />
@@ -468,8 +473,8 @@
             </div>
 
             <div class="note">
-              Manual checks: no handshake means no accepted state; valid
-              handshake should surface
+              Manual checks: no handshake means no accepted state; a valid
+              handshake should surface resize and
               <code>overview</code>, then <code>in-progress</code>, then
               <code>completed</code> with
               <code>currentStep === totalSteps</code>.
@@ -490,9 +495,9 @@
             <div class="panel-header">
               <h2>Event log</h2>
               <p>
-                Every outbound init message, inbound quiz-state message, and
-                ignored event is kept here with a timestamp so the protocol is
-                easy to inspect.
+                Every outbound init message, inbound quiz-state or resize
+                message, and ignored event is kept here with a timestamp so the
+                protocol is easy to inspect.
               </p>
             </div>
             <div class="panel-content">
@@ -518,8 +523,11 @@
 
     <script>
       const EMBED_INIT_MESSAGE_TYPE = 'klicker:embed-init'
+      const EMBED_RESIZE_MESSAGE_TYPE = 'klicker:embed-resize'
       const QUIZ_STATE_MESSAGE_TYPE = 'klicker:quiz-state'
+      const PROTOCOL_VERSION = 1
       const DEFAULT_HEIGHT = 720
+      const INIT_RETRY_DELAYS = [250, 1000]
 
       const elements = {
         quizUrl: document.getElementById('quiz-url'),
@@ -528,6 +536,7 @@
         reloadFrame: document.getElementById('reload-frame'),
         clearLog: document.getElementById('clear-log'),
         autoInit: document.getElementById('auto-init'),
+        autoResize: document.getElementById('auto-resize'),
         customHeight: document.getElementById('custom-height'),
         applyHeight: document.getElementById('apply-height'),
         quizFrame: document.getElementById('quiz-frame'),
@@ -551,6 +560,7 @@
         lastAcceptedType: null,
         latestPayload: null,
         logEntries: 0,
+        initRetryTimers: [],
       }
 
       function safeStringify(value) {
@@ -599,7 +609,11 @@
       function setViewportHeight(height) {
         const normalizedHeight = Number(height)
 
-        if (!Number.isFinite(normalizedHeight) || normalizedHeight < 240) {
+        if (
+          !Number.isFinite(normalizedHeight) ||
+          normalizedHeight < 200 ||
+          normalizedHeight > 50000
+        ) {
           appendLog('warning', 'Ignored invalid viewport height.', { height })
           return
         }
@@ -660,6 +674,7 @@
         state.iframeUrl = normalizedUrl.toString()
         state.lastAcceptedType = null
         state.latestPayload = null
+        clearInitRetries()
         setInitState(false)
 
         elements.quizUrl.value = state.iframeUrl
@@ -691,7 +706,12 @@
           return
         }
 
-        const message = { type: EMBED_INIT_MESSAGE_TYPE }
+        const message = {
+          type: EMBED_INIT_MESSAGE_TYPE,
+          capabilities: {
+            resize: elements.autoResize.checked,
+          },
+        }
         frameWindow.postMessage(message, state.iframeOrigin)
         setInitState(true)
         appendLog('outbound', 'Sent embed init message.', {
@@ -700,6 +720,22 @@
           message,
         })
         updateStatus()
+      }
+
+      function clearInitRetries() {
+        state.initRetryTimers.forEach(window.clearTimeout)
+        state.initRetryTimers = []
+      }
+
+      function scheduleInit(reason) {
+        clearInitRetries()
+        sendInit(reason)
+
+        state.initRetryTimers = INIT_RETRY_DELAYS.map((delay) =>
+          window.setTimeout(() => {
+            sendInit(`${reason}-retry-${delay}`)
+          }, delay)
+        )
       }
 
       function clearLog() {
@@ -725,6 +761,7 @@
         }
 
         setInitState(false)
+        clearInitRetries()
         elements.quizFrame.src = elements.quizFrame.src
         appendLog('outbound', 'Reloaded iframe.', {
           iframeUrl: elements.quizFrame.src,
@@ -748,7 +785,7 @@
         })
 
         if (elements.autoInit.checked) {
-          sendInit('auto-init')
+          scheduleInit('auto-init')
         }
       })
 
@@ -800,6 +837,36 @@
           return
         }
 
+        if (event.data.type === EMBED_RESIZE_MESSAGE_TYPE) {
+          const payload = event.data.payload
+          if (
+            !payload ||
+            typeof payload !== 'object' ||
+            payload.version !== PROTOCOL_VERSION ||
+            typeof payload.height !== 'number' ||
+            !Number.isFinite(payload.height) ||
+            payload.height < 200 ||
+            payload.height > 50000
+          ) {
+            appendLog('ignored', 'Ignored invalid resize message.', {
+              origin: event.origin,
+              data: event.data,
+            })
+            return
+          }
+
+          clearInitRetries()
+          setViewportHeight(payload.height)
+          state.lastAcceptedType = event.data.type
+          state.latestPayload = payload
+          appendLog('inbound', 'Accepted embed-resize message.', {
+            origin: event.origin,
+            data: event.data,
+          })
+          updateStatus()
+          return
+        }
+
         if (event.data.type !== QUIZ_STATE_MESSAGE_TYPE) {
           appendLog(
             'ignored',
@@ -814,6 +881,7 @@
 
         state.lastAcceptedType = event.data.type
         state.latestPayload = event.data.payload || null
+        clearInitRetries()
         appendLog('inbound', 'Accepted quiz-state message.', {
           origin: event.origin,
           data: event.data,


### PR DESCRIPTION
## Summary

- add an opt-in focused PracticeQuiz embed mode with host-owned Continue navigation and content-sized iframe resizing
- expose versioned quiz phase, readiness, progress, and completion state through a source- and origin-checked `postMessage` protocol
- keep standalone quizzes and bare-init embeds internally navigable; the URL requests focused presentation, while only `capabilities.hostNavigation: true` transfers control
- reject host advance commands while `canAdvance` is false at both the page protocol and stack action boundaries, and keep response submission disabled until responses initialize
- provide a development embed harness plus matching frontend documentation and skill guidance

## Stack

1. **#5442 — focused embed protocol and base presentation** (this PR, based on `v3`)
2. **#5456 — feedback visibility and negotiated navigation fixes**
3. **#5536 — progress, completion summary, retry, and host-owned progress controls**

Each PR is intended to be reviewed and merged in order.

## Verification

- managed DevPod used Node 24 with the `pwa` profile; only API, auth, and PWA routes were active
- `pnpm --filter @klicker-uzh/frontend-pwa check` passed on the integrated stack head
- `pnpm --filter @klicker-uzh/frontend-pwa test` passed: 15 tests, 0 failures
- focused Biome validation passed; it reported only existing warnings in `ElementStack.tsx`
- browser harness verified disabled host Continue at 1/34; injecting a valid v1 advance command while disabled left the question, step, and completion state unchanged
- browser verification also covered host-driven submission/advance, a completed 34/34 state, hidden child submission controls, and a single host-owned scroll surface

## Verification boundaries

- the companion eLearning host is delivered in a separate GitLab MR; current cross-repository acceptance is not claimed by this PR
- full `check:all` remains blocked locally by the unrelated analytics lint lane selecting Python 3.14 and failing to build pandas 2.2.2
- a clean PWA production build compiled successfully but retained the existing prerender failures for `/de/magicLogin` and `/500` (`NextRouter was not mounted`)

## Local artifacts

- worktree: `trees/feat-focused-embed-completed-screen`
- disabled-command browser proof: `/private/tmp/focused-embed-disabled-advance-802ecff.png` (machine-local)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded practice quizzes can negotiate capabilities with their host and automatically report content height.
  * Host pages can apply quiz height updates without displaying an independent iframe scrollbar.
  * Initialization retries improve reliability when embedded content loads asynchronously.
  * Added harness controls and status feedback for testing resize-aware embeds.

* **Bug Fixes**
  * Prevented repeated initialization from accidentally disabling previously enabled capabilities.
  * Histogram bars now render immediately without entrance animation.

* **Documentation**
  * Added guidance for verifying resize-aware embedded quizzes.

* **Tests**
  * Added validation coverage for embed messages, capabilities, protocol versions, and resize limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->