### PR TITLE
docs(chatbot): HITL lecturer config roadmap and ADRs

### DIFF
--- a/docs/adr/0019-chatbot-config-postgresql-authoritative.md
+++ b/docs/adr/0019-chatbot-config-postgresql-authoritative.md
@@ -1,0 +1,31 @@
+# 19. Chatbot configuration is PostgreSQL-authoritative; runtimes compile it per request
+
+## Status
+
+Accepted
+
+## Context
+
+The lecturer-facing chatbot configuration surface (modes, persona fields,
+few-shot examples, model policy, credit policy, knowledge bindings, publication
+state) is growing just as the chat runtime is expected to migrate (currently a
+Next.js route, later possibly Mastra). A runtime migration that also migrates
+configuration into runtime-native storage would force every HITL feature to be
+rebuilt and would couple the lecturer workflow to the runtime choice.
+
+## Decision
+
+The `Chatbot` model and its satellites in PostgreSQL are the single
+authoritative store for all chatbot configuration. Any runtime — the current
+chat route or a future Mastra agent — reads that configuration and compiles it
+into prompts and policies per request. Configuration is never migrated into or
+duplicated in runtime-native storage; a new runtime reimplements the compile
+step, not the store.
+
+## Consequences
+
+- The manage UI, approval workflow, and analytics never change when the
+  runtime does.
+- Each runtime must implement the same compile semantics (see ADR 0021);
+  drift between compile implementations is the risk to test for during a
+  runtime migration.

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -1,0 +1,43 @@
+# 20. Two-tier approval: account AI capability plus per-chatbot publication
+
+## Status
+
+Accepted
+
+## Context
+
+The tutoring chatbot public beta lets any lecturer request access via a form
+(use case, expected student count, cost center). Chatbot usage is billable, so
+uncontrolled go-live is not acceptable; at the same time, a per-change approval
+queue would make the operating team the bottleneck for every configuration
+tweak and kill the beta feedback loop.
+
+## Decision
+
+Approval is two-tier and both tiers are account- or artifact-level, never
+per-edit:
+
+1. **Account AI capability**: the team approves a lecturer's account and cost
+   center once and enables a feature flag. Lecturers with Catalyst can already
+   see and use the chatbot creation and configuration features beforehand;
+   the flag gates publication, not creation.
+2. **Per-chatbot publication**: each chatbot is created and configured
+   self-service in a non-published state, in which only the owning lecturer
+   can use it. Going live requires an in-app publication request on the bot
+   (use case, expected student count, proposed credit configuration) that the
+   team approves or rejects with a comment.
+
+Configuration edits are free within caps and apply immediately. Only a short
+explicit list of gated changes re-enters review on an already-published bot:
+custom-mode prompt text and the credit/model cost class. Before publication,
+everything is freely editable — the unpublished bot is the draft, so no
+draft/publish snapshot machinery exists.
+
+## Consequences
+
+- The team reviews each bot exactly once before it meets students, at the
+  moment its real configuration and stated use case are visible together.
+- Post-publication edits to non-gated knobs (examples, knowledge, standard-mode
+  fields) take effect without review; this bounded risk is accepted.
+- Draft-config machinery for live bots is deliberately deferred until editing
+  live bots proves painful.

--- a/docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md
+++ b/docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md
@@ -1,0 +1,42 @@
+# 21. Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
+
+## Status
+
+Accepted
+
+## Context
+
+Today a chatbot's `systemPrompts[mode].prompt` fully replaces the built-in
+default prompt, so exposing prompt editing to lecturers would silently drop
+the platform scaffolding (citation behavior, source grounding, safety, tutoring
+stance). Raw prompt access is also the knob most likely to degrade answer
+quality and the main liability surface, yet lecturers legitimately need to aim
+a bot at their course and, in advanced cases, define their own interaction
+styles.
+
+## Decision
+
+Prompt influence is two-tier, and prompt compilation is layered, not
+replacing:
+
+- **Standard modes** (`tutor`, `explainer`) always exist and are maintained by
+  the platform. Lecturers freely edit a small set of constrained persona
+  fields — course name, subject domain, language of instruction, optional
+  scope note — that the server compiles into the standard prompts. No
+  approval, because these fields can only aim the bot, not disarm it.
+- **Custom modes** let a lecturer author a name, description, and free persona
+  text. That text is compiled as the persona section on top of the same
+  scaffolding; publication of a new or edited custom mode requires team
+  review (per ADR 0020).
+- In both tiers the platform scaffolding is non-removable: lecturer-authored
+  content is layered onto it by the compile step, replacing the current
+  replace-semantics.
+- The raw compiled prompt is not displayed to lecturers in the first version.
+
+## Consequences
+
+- Custom-mode review checks pedagogy and scope, not whether scaffolding
+  survived — the compile step guarantees that.
+- The compile step becomes the contract every runtime must honor (ADR 0019).
+- Few-shot examples, not prompt text, are the primary self-service steering
+  lever for behavior.

--- a/docs/adr/0022-no-student-text-in-manage.md
+++ b/docs/adr/0022-no-student-text-in-manage.md
@@ -1,0 +1,31 @@
+# 22. The manage surface shows no student-authored text
+
+## Status
+
+Accepted
+
+## Context
+
+Lecturers improving their chatbot want to see what students asked, especially
+for badly rated answers. But student conversations are personal data with a
+purpose-bound analytics boundary (ADR 0005 on the learning-analytics line),
+and topic aggregation belongs to the future learning-analytics capability with
+its own governance. A partial exception ("only thumbs-down'd questions") would
+blur an otherwise crisp boundary.
+
+## Decision
+
+The lecturer-facing manage surface shows only quantitative aggregates computed
+from the database — conversation and message counts, thumbs ratios and
+reason-tag counts, credits consumed, knowledge-source status. No
+student-authored text, verbatim or paraphrased, and no topic aggregation
+appears in manage. Lecturers diagnose content gaps through their own test
+conversations and reason-tag counts, not through student transcripts.
+
+## Consequences
+
+- Zero tension with the consent and purpose model while the beta scales.
+- Diagnosing a specific content gap is more indirect for lecturers; the
+  reason-tag counts ("12x source missing") must carry that weight.
+- Any future exposure of student content to lecturers is a governance decision
+  inside the learning-analytics track, not a manage feature request.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,8 +19,14 @@ The durable record of **why** — the significant, hard-to-reverse choices behin
 - [0004](./0004-chat-citations-from-tool-call-parts.md) — Chat citations are derived from tool-call parts
 - [0006](./0006-public-catalyst-capability-floor.md) — What public KlickerUZH keeps when Catalyst is absent
 - [0007](./0007-reintegrate-v3-ai-behind-feature-flags.md) — Reintegrate `v3-ai` into `v3` behind feature flags, after VK2
+- [0019](./0019-chatbot-config-postgresql-authoritative.md) — Chatbot configuration is PostgreSQL-authoritative; runtimes compile it per request
+- [0020](./0020-two-tier-chatbot-approval.md) — Two-tier approval: account AI capability plus per-chatbot publication
+- [0021](./0021-templated-standard-modes-reviewed-custom-modes.md) — Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
+- [0022](./0022-no-student-text-in-manage.md) — The manage surface shows no student-authored text
 
 `0001` and `0003` are each used twice — the deployment and chat lines numbered
 independently before this index existed. Numbers are not reassigned, because existing
-records cite them. `0005` is reserved by an open PR. Pick the next free number by
-checking this directory, not by counting entries.
+records cite them. `0005` is reserved by an open PR, and open branches claim numbers through
+`0018` (KB line `0009`–`0016`, feature flags, UZH theming). Pick the next free
+number by checking this directory **and** `docs/adr/` on open branches, not by
+counting entries.

--- a/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
+++ b/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
@@ -1,0 +1,175 @@
+# HITL lecturer chatbot configuration roadmap
+
+Decisions grilled and settled 2026-08-20. Rationale lives in the ADRs — this
+document sequences the work and fixes the v1 scope; it does not restate the
+why. Companion decisions from the same session that are feedback- rather than
+configuration-shaped (thumbs reason tags, milestone lecturer feedback form)
+are listed in phase 3.
+
+Governing ADRs: [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.md)
+(config store), [0020](../docs/adr/0020-two-tier-chatbot-approval.md)
+(approval model), [0021](../docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md)
+(mode tiers and prompt compilation), [0022](../docs/adr/0022-no-student-text-in-manage.md)
+(data boundary in manage).
+
+## Baseline (verified 2026-08-20)
+
+- Chatbots are seed-provisioned only; no create/delete flow or mutation exists.
+  The single lecturer mutation is `updateChatbotModelSettings`
+  (`packages/graphql/src/schema/mutation.ts`, `services/chatbots.ts`).
+- `systemPrompts[mode].prompt` fully **replaces** the built-in default at
+  request time (`apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts`);
+  only `tutor` has a built-in default (`apps/chat/src/lib/config/prompts.ts`).
+- Credits, disclaimer, MCP config are read-only in manage; `systemPrompts` is
+  not even queried by the manage UI.
+- Retrieval/ingestion is an external RAG MCP service referenced by
+  `ChatbotMCPServer`; this repo has no upload or ingest API.
+- An embed mode for the chat app already exists (basis for the lecturer test
+  chat).
+
+## Knob classification (the contract)
+
+| Knob | Lecturer v1 | Gate |
+| --- | --- | --- |
+| Name, description, avatar, course binding | Edit freely | — |
+| Standard-mode persona fields (course name, subject domain, language, scope note) | Edit freely | — |
+| Mode toggles (min 1 active) | Edit freely | — |
+| Few-shot examples (capped, fixed tags) | Edit freely | — |
+| Knowledge sources (upload / re-ingest / delete) | Edit freely (phase 4) | — |
+| Credit configuration | Propose | Approved with publication request |
+| Model allowlist / reasoning efforts | Edit freely (as today) | Cost-class changes on a live bot re-enter review |
+| Custom mode (name, description, persona text) | Author freely pre-publication | Reviewed at publication; edits on a live bot re-enter review |
+| Publication (students can reach the bot) | Request | Per-bot approval + account AI capability flag |
+| Raw compiled prompt | Not shown | — |
+| Disclaimer/legal text | Not editable | Ours |
+| OpenAI key/base URL, MCP wiring, chunking/retrieval parameters | Never exposed | Ours |
+| Confidence / resolution metrics | Not shown (no evaluator exists) | Build evaluator first |
+
+## Phase 0 — schema and approval foundations
+
+Everything else hangs off this; it is backend-only and shippable without UI.
+
+- `Chatbot` gains a status machine (`DRAFT`, `PENDING_APPROVAL`, `PUBLISHED`,
+  `PAUSED`, `REJECTED` with reviewer comment), owning-lecturer semantics, and
+  publication-request fields (use case, expected student count, proposed
+  credit config).
+- Account-level AI capability flag (separate from Catalyst; Catalyst reveals
+  the features, the AI flag permits publication requests). Cost center is
+  recorded per account at approval.
+- Mutations: `createChatbot`, `updateChatbot` (free knobs),
+  `requestChatbotPublication`, admin `approveChatbotPublication` /
+  `rejectChatbotPublication`.
+- Prompt **compile step** replacing today's replace-semantics: scaffolding +
+  standard-mode template + persona fields (+ later: examples, custom-mode
+  persona text). This is the ADR 0021/0019 contract; implement it once in the
+  current chat route with tests that assert scaffolding survival.
+- Approval operations v1 is ops-shaped: status flips via script/Prisma Studio,
+  email notification to the team. (Admin queue UI is phase 6.)
+
+## Phase 1 — creation flow and standard-mode fields in manage
+
+- Create-chatbot form: name, description, avatar, bound courses (required,
+  from the lecturer's own courses), initial mode set. Knowledge attaches later
+  on its own tab.
+- Detail page reorganized into tabs (mockup-inspired): Overview, Persona &
+  modes, Knowledge (status-only until phase 4), Limits & model (existing
+  controls), Access/publication.
+- Standard-mode persona fields editable per mode; mode toggles with min-1
+  enforcement.
+- Lecturer test chat: "Open test chat" via the existing embed mode with a
+  test-thread flag on `ChatThread` — excluded from student-facing analytics,
+  ratable, and the later capture source for examples. Unpublished bots are
+  reachable only this way.
+- In-app publication request form (flips to `PENDING_APPROVAL`); rejected
+  state shows the reviewer comment.
+
+## Phase 2 — examples studio (v1-minimal)
+
+The primary self-service steering lever (ADR 0021).
+
+- `ChatbotExample` model: chatbot + mode scoped, student-turn text, ideal
+  reply text, optional source reference, fixed tag enum (`HINT_NOT_ANSWER`,
+  `WRONG_ANSWER_RECOVERY`, `OFF_TOPIC_REDIRECT`, `CITATION_STYLE`), order,
+  in-prompt flag. Hard cap: 4 in-prompt, ~1k token budget shown in UI.
+- Manual add + capture-from-chat, sourcing **only the lecturer's own test
+  threads** (consistent with ADR 0022).
+- Compile step injects in-prompt examples per mode.
+- Explicitly out: compare sets, re-run-against-bot, import/export — that is
+  the phase-7 eval harness.
+
+## Phase 3 — overview KPIs and the feedback loop
+
+- Overview tab shows DB aggregates only (ADR 0022): conversations/messages
+  over time, thumbs ratio, reason-tag counts, credits consumed, per-source
+  ingest status (once phase 4 lands).
+- Thumbs-down reason tag for students (same vocabulary as example tags plus
+  `SOURCE_MISSING`): migrates the `rating` column to a small feedback table —
+  supersedes part of ADR 0002; record that supersession when implementing.
+- Milestone lecturer product-feedback form (1 week after publication and after
+  ~100 student messages), pre-filled with the bot's aggregates; hosted form →
+  ClickUp for the beta, embedded later only if the question set stabilizes.
+
+## Phase 4 — knowledge self-service
+
+Mandatory for beta scale; dependent on the KB service (kb-poc line) exposing
+upload + per-source status + delete over HTTP. Assumption from the grill: that
+API mostly exists (ingest-button restore is already on the KB roadmap) —
+verify first; if not, the API work joins this phase.
+
+- Knowledge tab actions: upload source, re-ingest, delete; per-source
+  `Ready` / `Processing` / `Stale` status.
+- Chunking, graph, and retrieval parameters are never exposed.
+
+## Phase 5 — custom modes
+
+- Author name, description, persona text; compiled as a layer (ADR 0021),
+  cap 2 per bot.
+- New/edited custom modes on a published bot re-enter review (ADR 0020);
+  pre-publication they are freely editable and testable in the test chat.
+
+## Phase 6 — admin approval queue
+
+- Admin-only manage page listing pending account approvals, publication
+  requests, and custom-mode reviews with approve/reject + comment. Promote
+  early if beta volume reaches double-digit bots per semester — the
+  rejected-with-comment loop needs a surface lecturers can see.
+
+## Phase 7 and later (explicitly deferred)
+
+- Eval harness: compare sets, re-run examples against the bot, starter-question
+  smoke tests as per-course eval sets (pairs with deepeval plans).
+- Draft/publish snapshots for editing live bots (only if live-editing pain
+  materializes; ADR 0020 consequence).
+- Structured persona fields beyond the four (only if example steering proves
+  insufficient).
+- Aggregate topics / any student-content exposure — learning-analytics track
+  governance only (ADR 0022, learning-analytics ADR 0005).
+- Embedded live-preview pane inside manage (test chat via embed mode covers
+  v1).
+- Confidence / resolution-rate metrics — require an evaluator; do not fake.
+
+## Glossary (merge into CONTEXT.md when the stashed glossary lands)
+
+- **Account AI capability**: The per-account approval (cost center recorded,
+  feature flag enabled) that permits publication requests. Distinct from
+  Catalyst, which only reveals the configuration features. _Avoid_: beta flag.
+- **Publication**: The per-chatbot approved transition that makes a bot
+  reachable by students. _Avoid_: go-live, activation.
+- **Publication request**: The in-app form on a bot (use case, expected
+  students, proposed credits) that puts it into review. _Avoid_: access form
+  (that is the account-level external form).
+- **Standard mode**: A platform-maintained mode (`tutor`, `explainer`) aimed
+  via constrained persona fields. _Avoid_: default mode.
+- **Custom mode**: A lecturer-authored mode whose persona text is reviewed at
+  publication. _Avoid_: custom prompt.
+- **Persona field**: A constrained standard-mode input (course name, subject
+  domain, language, scope note) compiled into the prompt. _Avoid_: prompt
+  field.
+- **Scaffolding**: The non-removable platform prompt base (citations,
+  grounding, safety, stance) that lecturer content layers onto. _Avoid_: base
+  prompt.
+- **Example**: A tagged student-turn/ideal-reply pair steering a mode, capped
+  in count and tokens. _Avoid_: few-shot, exemplar.
+- **Test thread**: A lecturer-owned conversation with their own (possibly
+  unpublished) bot, excluded from student-facing analytics and the only
+  capture source for examples. _Avoid_: preview chat.


### PR DESCRIPTION
## What

Reference documentation for the **HITL lecturer chatbot configuration** work — the roadmap and the four governing ADRs produced in the 2026-08-20 design grill. Docs only; no code or schema changes.

## Contents

- `project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md` — knob-classification contract (what lecturers tune freely, what is approval-gated, what we never expose) and phases 0–7.
- `docs/adr/0019` — chatbot configuration stays PostgreSQL-authoritative; runtimes compile it per request (Mastra-neutral).
- `docs/adr/0020` — two-tier approval: account AI capability flag + per-chatbot publication request.
- `docs/adr/0021` — templated standard modes (`tutor`/`explainer`) vs reviewed custom modes; lecturer content layers onto non-removable scaffolding.
- `docs/adr/0022` — the manage surface shows only quantitative aggregates, no student-authored text.
- `docs/adr/README.md` — index + collision note (numbers 0008–0018 are claimed by open branches; these took 0019–0022).

## Context

Grounded in the current chatbot surface: chatbots are seed-provisioned only, the sole lecturer mutation is `updateChatbotModelSettings`, `systemPrompts[mode].prompt` replaces the default at request time, and retrieval/ingestion is an external RAG MCP service. Phase 0 (status machine, account AI capability flag, CRUD mutations, layered prompt-compile step) is the first implementation package and follows in a separate PR.

## Verification

Markdown/YAML only. Prettier `proseWrap` is unset (`preserve`), so prose is not rewrapped; wrapping matches existing ADRs. No build/test impact.
