### PR TITLE
feat(chat): lecturer config + two-tier publication gate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,3 +140,75 @@ and is enforced field-by-field in the API layer.
   results. Editing the source element bumps that element's version and flags
   the instance as outdated; it never rewrites what participants already saw or
   answered.
+## Chatbot usage
+
+These terms define the language for lecturer authorization, model usage, and
+the two usage lanes shown for chatbot accounts.
+
+### Authorization and lifecycle
+
+**AI usage authorization**:
+An account-level approval that requires an approved cost center and permits
+both base and advanced model usage. It is separate from publication approval.
+_Avoid_: base authorization, advanced authorization, per-model approval
+
+**Publication approval**:
+The per-chatbot approval that makes a chatbot reachable by students. It does
+not authorize model usage by itself.
+_Avoid_: usage approval, activation
+
+### Model classes and budgets
+
+**Usage class**:
+The explicit registry classification `BASE` or `ADVANCED` for a model. It
+describes the model lane and is independent of who covers the usage.
+_Avoid_: funding tier, price tier
+
+**Base model usage**:
+Usage from `BASE` models. The teaching center covers a limited amount per
+lecturer, but the covered amount is internal and never shown. Base usage above
+that contribution remains in the base lane and may consume the authorized
+paid budget.
+_Avoid_: Luna usage, unlimited usage, lecturer-funded usage
+
+**Advanced model usage**:
+Usage from `ADVANCED` models. The teaching center does not cover this usage;
+the lecturer's authorized budget applies.
+_Avoid_: premium usage, lecturer-funded usage
+
+**Monthly usage budget**:
+A lecturer-defined, account-wide budget for one usage class. Base and advanced
+budgets reset monthly; a base budget does not state how much the teaching
+center covers.
+_Avoid_: chatbot budget, subsidy allowance
+
+**Usage lane**:
+The lecturer-facing projection of one usage class. The UI has exactly two
+lanes, base model usage and advanced model usage, each showing its configured
+budget, used credits, remaining credits, and reset date.
+_Avoid_: funding lane, cost center lane
+
+**Hidden base contribution**:
+The teaching center's internal base-usage contribution. Its amount, covered
+usage, remaining contribution, and settlement details are never returned to
+lecturer or participant clients.
+_Avoid_: free allowance, unlimited allowance, subsidy balance
+
+### Legacy and boundary terms
+
+**Participant usage credits**:
+The existing per-participant, per-chatbot allowance. It remains separate from
+the account-wide monthly usage budgets; any fallback must stay within the
+same usage class.
+_Avoid_: lecturer budget, account credits
+
+**Auto model**:
+The automatic model choice, classified as `ADVANCED` for the MVP until every
+routed billable step can be attributed to a usage class.
+_Avoid_: base fallback, unclassified model
+
+**Class exhaustion**:
+The state in which one class has reached its monthly budget. It disables only
+that class, never triggers an automatic cross-class switch, and exposes a
+class-specific denial code at the participant API boundary.
+_Avoid_: chatbot exhaustion, global lockout

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,6 +140,7 @@ and is enforced field-by-field in the API layer.
   results. Editing the source element bumps that element's version and flags
   the instance as outdated; it never rewrites what participants already saw or
   answered.
+
 ## Chatbot usage
 
 These terms define the language for lecturer authorization, model usage, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -178,9 +178,10 @@ the lecturer's authorized budget applies.
 _Avoid_: premium usage, lecturer-funded usage
 
 **Monthly usage budget**:
-A lecturer-defined, account-wide budget for one usage class. Base and advanced
-budgets reset monthly; a base budget does not state how much the teaching
-center covers.
+A lecturer-defined, account-wide configured limit for one usage class. The
+limit persists until the lecturer changes it; only used credits reset at the
+Europe/Zurich month boundary. A base budget does not state how much the
+teaching center covers.
 _Avoid_: chatbot budget, subsidy allowance
 
 **Usage lane**:

--- a/apps/analytics/prisma/schema/chat.prisma
+++ b/apps/analytics/prisma/schema/chat.prisma
@@ -15,6 +15,19 @@ enum ChatMessageRating {
   DOWN
 }
 
+// Lifecycle state of a chatbot. A chatbot is reachable by participants only
+// while PUBLISHED (enforced in the participant access path). DRAFT and
+// REJECTED are lecturer-editable pre-publication states; PENDING_APPROVAL awaits
+// team review; PAUSED is an operator-only stop with no self-service transition
+// in phase 0. See docs/adr/0020-two-tier-chatbot-approval.md.
+enum ChatbotStatus {
+  DRAFT
+  PENDING_APPROVAL
+  PUBLISHED
+  PAUSED
+  REJECTED
+}
+
 model ChatUsageCredits {
   total   Decimal @default(0) @db.Decimal(18, 6)
   current Decimal @default(0) @db.Decimal(18, 6)
@@ -129,6 +142,15 @@ model Chatbot {
   // Disclaimer configuration
   disclaimer   ChatbotDisclaimer? @relation(fields: [disclaimerId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   disclaimerId String?            @db.Uuid
+
+  // Lifecycle and publication (see docs/adr/0020-two-tier-chatbot-approval.md).
+  // A new chatbot starts as DRAFT; existing rows are backfilled to PUBLISHED by
+  // the introducing migration so live bots keep serving participants.
+  status               ChatbotStatus @default(DRAFT)
+  publicationUseCase   String?       @db.Text // lecturer's stated use case, set on a publication request
+  expectedStudentCount Int? // lecturer's expected student count, set on a publication request
+  reviewComment        String?       @db.Text // team comment on a rejected request; cleared on re-request
+  publishedAt          DateTime? // when the chatbot was first approved for publication
 
   // Relations
   mcpConfigurations ChatbotMCPConfig[]

--- a/apps/analytics/prisma/schema/user.prisma
+++ b/apps/analytics/prisma/schema/user.prisma
@@ -107,6 +107,14 @@ model User {
   catalystIndividual    Boolean @default(false)
   catalystTier          String?
 
+  // Account-level AI chatbot publishing capability. Approved by the team out of
+  // band (cost center recorded) and checked against this row, never a JWT claim,
+  // when a lecturer requests publication. Separate from Catalyst, which only
+  // reveals the configuration features. See
+  // docs/adr/0020-two-tier-chatbot-approval.md.
+  aiChatbotPublishingEnabled Boolean @default(false)
+  aiChatbotCostCenter        String?
+
   publicPreview  Boolean @default(false)
   privatePreview Boolean @default(false)
 

--- a/apps/chat/src/app/[chatbotId]/layout.tsx
+++ b/apps/chat/src/app/[chatbotId]/layout.tsx
@@ -1,4 +1,5 @@
 import { prisma } from '@klicker-uzh/prisma'
+import { ChatbotStatus } from '@klicker-uzh/prisma/client'
 import { notFound } from 'next/navigation'
 import { Assistant } from '../../components/assistant'
 import {
@@ -22,10 +23,18 @@ export default async function ChatLayout({
 
   const chatbot = await prisma.chatbot.findUnique({
     where: { id: chatbotId },
-    select: { id: true, name: true, avatar: true, systemPrompts: true },
+    select: {
+      id: true,
+      name: true,
+      avatar: true,
+      systemPrompts: true,
+      status: true,
+    },
   })
 
-  if (!chatbot) notFound()
+  // Only a PUBLISHED chatbot is reachable by participants; anything else 404s
+  // exactly like a missing bot (mirrors the API guard in apiGuards.ts).
+  if (!chatbot || chatbot.status !== ChatbotStatus.PUBLISHED) notFound()
 
   const initialModeOptions = resolveModeDescriptions(chatbot.systemPrompts)
   const initialModeOptionsAreFallback = !hasConfiguredModeDescriptions(

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -7,14 +7,13 @@ import {
   getChatModelRegistry,
   type ChatModelConfig,
 } from '@/src/lib/server/chatModelRegistry'
-import { withCitationContract } from '@/src/lib/server/citationInstructions'
 import { ensureImagePreviewBase64 } from '@/src/lib/server/imagePreview'
 import {
   getParentSpanContext,
   getTraceIdForMessage,
   isAiTelemetryEnabled,
 } from '@/src/lib/server/langfuseTracing'
-import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions'
+import { compileSystemPrompt } from '@/src/lib/server/systemPromptCompiler'
 import {
   REQUIRED_MCP_UNAVAILABLE_CODE,
   RequiredMCPUnavailableError,
@@ -686,8 +685,8 @@ export async function POST(
   let currentThreadId = threadId
   let userMessageId: string | null = null
 
-  // fetch chatbot with MCP configurations and system prompt
-  let systemPrompt = ''
+  // fetch the chatbot with its enabled MCP configurations (its stored
+  // systemPrompts feed compileSystemPrompt once the tool set is known below)
   let mcpServersWithConfigs: MCPServerWithConfig[] = []
   let chatbot = null
 
@@ -706,22 +705,6 @@ export async function POST(
         },
       },
     })
-
-    if (chatbot) {
-      // Extract system prompt
-      const systemPrompts = chatbot.systemPrompts as Record<
-        string,
-        Record<string, string>
-      >
-      if (systemPrompts && systemPrompts[selectedMode]) {
-        systemPrompt =
-          systemPrompts[selectedMode].prompt ||
-          DEFAULT_PROMPT[selectedMode]?.prompt ||
-          ''
-      } else {
-        systemPrompt = DEFAULT_PROMPT[selectedMode]?.prompt || ''
-      }
-    }
   } catch (error) {
     console.error('Failed to fetch chatbot configuration:', {
       requestId,
@@ -799,15 +782,16 @@ export async function POST(
 
   const toolNames = Object.keys(mcpTools || {})
 
-  // Append the citation contract only when a doc_query-style RAG tool is
-  // actually available; mutating `systemPrompt` here (rather than deriving a
-  // separate `instructions` variable) keeps the `systemPromptLength` /
-  // `systemPromptHash` telemetry below truthful to what is actually sent to
-  // the model. The language-style contract applies unconditionally: stored
-  // lecturer prompts replace DEFAULT_PROMPT entirely, so Swiss High German
-  // orthography must be enforced here, not in the default prompt text.
-  systemPrompt = withLanguageStyleContract(
-    withCitationContract(systemPrompt, toolNames)
+  // Compile the full system prompt now that `toolNames` is known: the resolved
+  // base prompt plus the layered runtime contracts (conditional citation, then
+  // unconditional Swiss High German language style — see compileSystemPrompt).
+  // Assigning the finished value here (rather than a separate `instructions`
+  // variable) keeps the `systemPromptLength` / `systemPromptHash` telemetry
+  // below truthful to what is actually sent to the model.
+  const systemPrompt = compileSystemPrompt(
+    chatbot.systemPrompts,
+    selectedMode,
+    toolNames
   )
 
   // create a new thread if none exists

--- a/apps/chat/src/lib/server/apiGuards.ts
+++ b/apps/chat/src/lib/server/apiGuards.ts
@@ -92,7 +92,7 @@ export async function getChatbotOr404<TSelect extends Prisma.ChatbotSelect>(
   // Drop the guard-only status field unless the caller explicitly selected it,
   // so routes that serialize the chatbot wholesale (e.g. GET /api/chatbots/:id)
   // never expose owner-only lifecycle metadata on a participant surface (F7).
-  if (!('status' in select)) {
+  if (select.status !== true) {
     delete (row as Record<string, unknown>).status
   }
 

--- a/apps/chat/src/lib/server/apiGuards.ts
+++ b/apps/chat/src/lib/server/apiGuards.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@klicker-uzh/prisma'
-import { Prisma } from '@klicker-uzh/prisma/client'
+import { ChatbotStatus, Prisma } from '@klicker-uzh/prisma/client'
 import { jwtVerify } from 'jose'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -66,12 +66,21 @@ export async function getChatbotOr404<TSelect extends Prisma.ChatbotSelect>(
     }
   }
 
-  const chatbot = await prisma.chatbot.findUnique({
+  const row = (await prisma.chatbot.findUnique({
     where: { id: parsedId.data },
-    select,
-  })
+    // `status` is always selected on top of the caller's projection so this one
+    // guard can enforce publication for every participant route.
+    select: { ...select, status: true },
+  })) as
+    | (Prisma.ChatbotGetPayload<{ select: TSelect }> & {
+        status: ChatbotStatus
+      })
+    | null
 
-  if (!chatbot) {
+  // Participants may only reach a PUBLISHED chatbot. A draft, pending, paused,
+  // or rejected bot 404s exactly like a missing one, so its existence is never
+  // confirmed to a participant.
+  if (!row || row.status !== ChatbotStatus.PUBLISHED) {
     return {
       response: NextResponse.json(
         { error: 'Chatbot not found' },
@@ -80,7 +89,14 @@ export async function getChatbotOr404<TSelect extends Prisma.ChatbotSelect>(
     }
   }
 
-  return { chatbot }
+  // Drop the guard-only status field unless the caller explicitly selected it,
+  // so routes that serialize the chatbot wholesale (e.g. GET /api/chatbots/:id)
+  // never expose owner-only lifecycle metadata on a participant surface (F7).
+  if (!('status' in select)) {
+    delete (row as Record<string, unknown>).status
+  }
+
+  return { chatbot: row }
 }
 
 export async function withChatbotAuth(

--- a/apps/chat/src/lib/server/systemPromptCompiler.ts
+++ b/apps/chat/src/lib/server/systemPromptCompiler.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_PROMPT } from '@/src/lib/config/prompts'
+import { withCitationContract } from '@/src/lib/server/citationInstructions'
+import { withLanguageStyleContract } from '@/src/lib/server/languageInstructions'
+
+/**
+ * Resolve the base system prompt for one chat turn from the chatbot's stored
+ * per-mode prompts, falling back to the built-in `DEFAULT_PROMPT`.
+ *
+ * Behaviour deliberately preserved from the original inline resolution (do not
+ * "tidy" without a behaviour review — the chat route relies on each quirk):
+ * - A stored mode entry whose `prompt` is empty/absent falls through to the
+ *   default for that mode, then to `''`. An empty stored prompt is never sent.
+ * - An unknown mode (no stored entry and no `DEFAULT_PROMPT` entry, e.g.
+ *   `explainer` while the default only defines `tutor`) yields `''`.
+ */
+function resolveBaseSystemPrompt(
+  systemPrompts: unknown,
+  selectedMode: string
+): string {
+  const stored = systemPrompts as
+    | Record<string, Record<string, string> | undefined>
+    | null
+    | undefined
+  if (stored?.[selectedMode]) {
+    return (
+      stored[selectedMode].prompt || DEFAULT_PROMPT[selectedMode]?.prompt || ''
+    )
+  }
+  return DEFAULT_PROMPT[selectedMode]?.prompt || ''
+}
+
+/**
+ * Compile the full system prompt actually sent to the model: the resolved base
+ * prompt with the layered runtime contracts applied in fixed order — citation
+ * (inner) then language style (outer), so the final text reads base, then
+ * citation, then language.
+ *
+ * The citation contract is appended only when a doc_query-style RAG tool is
+ * available for the request (decided inside `withCitationContract` from
+ * `toolNames`). The language-style contract is unconditional, because a stored
+ * lecturer prompt replaces `DEFAULT_PROMPT` entirely and Swiss High German
+ * orthography must still be enforced for every chatbot.
+ */
+export function compileSystemPrompt(
+  systemPrompts: unknown,
+  selectedMode: string,
+  toolNames: readonly string[]
+): string {
+  const base = resolveBaseSystemPrompt(systemPrompts, selectedMode)
+  return withLanguageStyleContract(withCitationContract(base, toolNames))
+}

--- a/apps/chat/src/lib/server/systemPromptCompiler.ts
+++ b/apps/chat/src/lib/server/systemPromptCompiler.ts
@@ -17,14 +17,22 @@ function resolveBaseSystemPrompt(
   systemPrompts: unknown,
   selectedMode: string
 ): string {
-  const stored = systemPrompts as
-    | Record<string, Record<string, string> | undefined>
-    | null
-    | undefined
-  if (stored?.[selectedMode]) {
-    return (
-      stored[selectedMode].prompt || DEFAULT_PROMPT[selectedMode]?.prompt || ''
-    )
+  if (
+    systemPrompts !== null &&
+    typeof systemPrompts === 'object' &&
+    !Array.isArray(systemPrompts)
+  ) {
+    const storedMode = (systemPrompts as Record<string, unknown>)[selectedMode]
+    if (
+      storedMode !== null &&
+      typeof storedMode === 'object' &&
+      !Array.isArray(storedMode)
+    ) {
+      const prompt = (storedMode as Record<string, unknown>).prompt
+      if (typeof prompt === 'string' && prompt.length > 0) {
+        return prompt
+      }
+    }
   }
   return DEFAULT_PROMPT[selectedMode]?.prompt || ''
 }

--- a/apps/chat/src/services/chatbots.ts
+++ b/apps/chat/src/services/chatbots.ts
@@ -1,9 +1,13 @@
 import { prisma } from '@klicker-uzh/prisma'
+import { ChatbotStatus } from '@klicker-uzh/prisma/client'
 
 export class ChatbotsService {
   static async getChatbotById(chatbotId: string) {
-    const chatbot = await prisma.chatbot.findUnique({
-      where: { id: chatbotId },
+    // Participants may only reach a PUBLISHED chatbot; keep this read behind the
+    // same gate as the route handlers so the seam cannot leak a draft or
+    // in-review bot's prompts if it is wired up later.
+    const chatbot = await prisma.chatbot.findFirst({
+      where: { id: chatbotId, status: ChatbotStatus.PUBLISHED },
       select: {
         id: true,
         name: true,

--- a/apps/chat/test/chatbot-published-gate.test.ts
+++ b/apps/chat/test/chatbot-published-gate.test.ts
@@ -47,6 +47,24 @@ describe('getChatbotOr404 publication gate', () => {
     )
   })
 
+  test('does not return guard-only status when the caller disables status', async () => {
+    mocks.findUnique.mockResolvedValue({
+      courseId: 'course-1',
+      status: 'PUBLISHED',
+    })
+
+    const result = await getChatbotOr404(VALID_ID, {
+      courseId: true,
+      status: false,
+    })
+
+    expect('chatbot' in result).toBe(true)
+    if ('chatbot' in result) {
+      expect(result.chatbot).toMatchObject({ courseId: 'course-1' })
+      expect(result.chatbot).not.toHaveProperty('status')
+    }
+  })
+
   // Every non-PUBLISHED lifecycle state must 404 exactly like a missing bot, so
   // a participant can never confirm that a draft/in-review/paused bot exists.
   test.each([

--- a/apps/chat/test/chatbot-published-gate.test.ts
+++ b/apps/chat/test/chatbot-published-gate.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+}))
+
+vi.mock('@klicker-uzh/prisma', () => ({
+  prisma: {
+    chatbot: {
+      findUnique: mocks.findUnique,
+    },
+  },
+}))
+
+import { getChatbotOr404 } from '../src/lib/server/apiGuards'
+
+// A syntactically valid UUID so the guard proceeds to the DB lookup.
+const VALID_ID = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
+
+describe('getChatbotOr404 publication gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns the chatbot when it is PUBLISHED', async () => {
+    mocks.findUnique.mockResolvedValue({
+      courseId: 'course-1',
+      status: 'PUBLISHED',
+    })
+
+    const result = await getChatbotOr404(VALID_ID, { courseId: true })
+
+    expect('chatbot' in result).toBe(true)
+    if ('chatbot' in result) {
+      expect(result.chatbot).toMatchObject({ courseId: 'course-1' })
+      // The guard-only status field is stripped from the returned chatbot when
+      // the caller did not select it, so wholesale-serialized participant
+      // responses never leak owner-only lifecycle metadata (F7).
+      expect(result.chatbot).not.toHaveProperty('status')
+    }
+    // `status` is always requested on top of the caller's projection so the one
+    // guard can enforce publication for every participant route.
+    expect(mocks.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ courseId: true, status: true }),
+      })
+    )
+  })
+
+  // Every non-PUBLISHED lifecycle state must 404 exactly like a missing bot, so
+  // a participant can never confirm that a draft/in-review/paused bot exists.
+  test.each(['DRAFT', 'PENDING_APPROVAL', 'PAUSED', 'REJECTED'])(
+    'returns 404 for a non-PUBLISHED (%s) chatbot',
+    async (status) => {
+      mocks.findUnique.mockResolvedValue({ courseId: 'course-1', status })
+
+      const result = await getChatbotOr404(VALID_ID, { courseId: true })
+
+      expect('response' in result).toBe(true)
+      if ('response' in result) {
+        expect(result.response.status).toBe(404)
+      }
+    }
+  )
+
+  test('returns 404 when the chatbot does not exist', async () => {
+    mocks.findUnique.mockResolvedValue(null)
+
+    const result = await getChatbotOr404(VALID_ID, { courseId: true })
+
+    expect('response' in result).toBe(true)
+    if ('response' in result) {
+      expect(result.response.status).toBe(404)
+    }
+  })
+
+  test('returns 404 for a malformed chatbot id without hitting the DB', async () => {
+    const result = await getChatbotOr404('not-a-uuid', { courseId: true })
+
+    expect('response' in result).toBe(true)
+    if ('response' in result) {
+      expect(result.response.status).toBe(404)
+    }
+    expect(mocks.findUnique).not.toHaveBeenCalled()
+  })
+})

--- a/apps/chat/test/chatbot-published-gate.test.ts
+++ b/apps/chat/test/chatbot-published-gate.test.ts
@@ -49,19 +49,21 @@ describe('getChatbotOr404 publication gate', () => {
 
   // Every non-PUBLISHED lifecycle state must 404 exactly like a missing bot, so
   // a participant can never confirm that a draft/in-review/paused bot exists.
-  test.each(['DRAFT', 'PENDING_APPROVAL', 'PAUSED', 'REJECTED'])(
-    'returns 404 for a non-PUBLISHED (%s) chatbot',
-    async (status) => {
-      mocks.findUnique.mockResolvedValue({ courseId: 'course-1', status })
+  test.each([
+    'DRAFT',
+    'PENDING_APPROVAL',
+    'PAUSED',
+    'REJECTED',
+  ])('returns 404 for a non-PUBLISHED (%s) chatbot', async (status) => {
+    mocks.findUnique.mockResolvedValue({ courseId: 'course-1', status })
 
-      const result = await getChatbotOr404(VALID_ID, { courseId: true })
+    const result = await getChatbotOr404(VALID_ID, { courseId: true })
 
-      expect('response' in result).toBe(true)
-      if ('response' in result) {
-        expect(result.response.status).toBe(404)
-      }
+    expect('response' in result).toBe(true)
+    if ('response' in result) {
+      expect(result.response.status).toBe(404)
     }
-  )
+  })
 
   test('returns 404 when the chatbot does not exist', async () => {
     mocks.findUnique.mockResolvedValue(null)

--- a/apps/chat/test/system-prompt-compiler.test.ts
+++ b/apps/chat/test/system-prompt-compiler.test.ts
@@ -81,6 +81,19 @@ describe('compileSystemPrompt', () => {
     expect(result).toContain(DEFAULT_TUTOR_MARK)
   })
 
+  test.each([
+    ['an object', {}],
+    ['an array', []],
+    ['a number', 42],
+    ['a boolean', true],
+  ])('falls back to the default when a stored prompt is %s', (_, prompt) => {
+    const stored = { tutor: { prompt } }
+
+    const result = compileSystemPrompt(stored, 'tutor', [])
+
+    expect(result).toContain(DEFAULT_TUTOR_MARK)
+  })
+
   test('yields only the language contract for an unknown mode with no default', () => {
     // `explainer` has no DEFAULT_PROMPT entry, so the base resolves to '' and
     // only the unconditional language contract remains.

--- a/apps/chat/test/system-prompt-compiler.test.ts
+++ b/apps/chat/test/system-prompt-compiler.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest'
+import { compileSystemPrompt } from '../src/lib/server/systemPromptCompiler'
+
+// Distinctive, stable fragments of each layer. Asserting on these (rather than
+// the full contract text) keeps the test robust to wording tweaks in the
+// individual contracts while still pinning the compile seam's composition.
+const DEFAULT_TUTOR_MARK = 'KlickerChat' // only in DEFAULT_PROMPT.tutor
+const CITATION_MARK = 'citation markers' // only in the citation contract
+const LANGUAGE_MARK = 'Swiss High German orthography' // only in the language contract
+
+// A doc_query-style tool triggers the (conditional) citation contract; a plain
+// tool name does not (see isDocQueryToolName / DOC_QUERY_TOOL_NAME_RE).
+const DOC_TOOL = 'KB_doc_query'
+const NON_DOC_TOOL = 'get_weather'
+
+describe('compileSystemPrompt', () => {
+  test('uses the stored prompt for a configured mode and layers language only (no doc tool)', () => {
+    const stored = { tutor: { prompt: 'STORED-TUTOR-PROMPT' } }
+
+    const result = compileSystemPrompt(stored, 'tutor', [])
+
+    expect(result.startsWith('STORED-TUTOR-PROMPT')).toBe(true)
+    expect(result).not.toContain(DEFAULT_TUTOR_MARK)
+    expect(result).toContain(LANGUAGE_MARK)
+    expect(result).not.toContain(CITATION_MARK)
+  })
+
+  test('layers citation before language when a doc_query tool is present', () => {
+    const stored = { tutor: { prompt: 'STORED-TUTOR-PROMPT' } }
+
+    const result = compileSystemPrompt(stored, 'tutor', [DOC_TOOL])
+
+    // Fixed layering: base, then citation, then language.
+    const baseIdx = result.indexOf('STORED-TUTOR-PROMPT')
+    const citationIdx = result.indexOf(CITATION_MARK)
+    const languageIdx = result.indexOf(LANGUAGE_MARK)
+    expect(baseIdx).toBeGreaterThanOrEqual(0)
+    expect(citationIdx).toBeGreaterThan(baseIdx)
+    expect(languageIdx).toBeGreaterThan(citationIdx)
+  })
+
+  test('does not add the citation contract for a present but non-doc_query tool', () => {
+    const stored = { tutor: { prompt: 'STORED-TUTOR-PROMPT' } }
+
+    const result = compileSystemPrompt(stored, 'tutor', [NON_DOC_TOOL])
+
+    expect(result).not.toContain(CITATION_MARK)
+    expect(result).toContain(LANGUAGE_MARK)
+  })
+
+  test('falls back to the built-in default prompt when no prompt is stored', () => {
+    const resultNoTool = compileSystemPrompt(null, 'tutor', [])
+    expect(resultNoTool).toContain(DEFAULT_TUTOR_MARK)
+    expect(resultNoTool).toContain(LANGUAGE_MARK)
+    expect(resultNoTool).not.toContain(CITATION_MARK)
+
+    const resultWithTool = compileSystemPrompt(null, 'tutor', [DOC_TOOL])
+    expect(resultWithTool).toContain(DEFAULT_TUTOR_MARK)
+    expect(resultWithTool).toContain(CITATION_MARK)
+    expect(resultWithTool).toContain(LANGUAGE_MARK)
+  })
+
+  test('falls back to the default when a stored mode entry has an empty prompt', () => {
+    // Preserved quirk: an empty stored prompt is treated as absent and the
+    // default for that mode is used instead of sending an empty base.
+    const stored = { tutor: { prompt: '' } }
+
+    const result = compileSystemPrompt(stored, 'tutor', [])
+
+    expect(result).toContain(DEFAULT_TUTOR_MARK)
+  })
+
+  test('falls back to the default when a stored mode entry is null', () => {
+    // A non-null systemPrompts object whose per-mode entry is null (a shape a
+    // partial lecturer write path could produce) is caught by the truthy
+    // guard, so the null is never dereferenced and the mode default is used.
+    const stored = { tutor: null }
+
+    const result = compileSystemPrompt(stored, 'tutor', [])
+
+    expect(result).toContain(DEFAULT_TUTOR_MARK)
+  })
+
+  test('yields only the language contract for an unknown mode with no default', () => {
+    // `explainer` has no DEFAULT_PROMPT entry, so the base resolves to '' and
+    // only the unconditional language contract remains.
+    const result = compileSystemPrompt(null, 'explainer', [])
+
+    expect(result).not.toContain(DEFAULT_TUTOR_MARK)
+    expect(result).not.toContain(CITATION_MARK)
+    expect(result).toContain(LANGUAGE_MARK)
+    // No base text: the result is exactly the language contract, so it starts
+    // with that contract's first sentence.
+    expect(result.startsWith('Language style:')).toBe(true)
+  })
+})

--- a/docs/adr/0019-chatbot-config-postgresql-authoritative.md
+++ b/docs/adr/0019-chatbot-config-postgresql-authoritative.md
@@ -1,0 +1,31 @@
+# 19. Chatbot configuration is PostgreSQL-authoritative; runtimes compile it per request
+
+## Status
+
+Accepted
+
+## Context
+
+The lecturer-facing chatbot configuration surface (modes, persona fields,
+few-shot examples, model policy, credit policy, knowledge bindings, publication
+state) is growing just as the chat runtime is expected to migrate (currently a
+Next.js route, later possibly Mastra). A runtime migration that also migrates
+configuration into runtime-native storage would force every HITL feature to be
+rebuilt and would couple the lecturer workflow to the runtime choice.
+
+## Decision
+
+The `Chatbot` model and its satellites in PostgreSQL are the single
+authoritative store for all chatbot configuration. Any runtime — the current
+chat route or a future Mastra agent — reads that configuration and compiles it
+into prompts and policies per request. Configuration is never migrated into or
+duplicated in runtime-native storage; a new runtime reimplements the compile
+step, not the store.
+
+## Consequences
+
+- The manage UI, approval workflow, and analytics never change when the
+  runtime does.
+- Each runtime must implement the same compile semantics (see ADR 0021);
+  drift between compile implementations is the risk to test for during a
+  runtime migration.

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -24,9 +24,11 @@ per-edit:
    creation and configuration features beforehand; the flag gates publication,
    not creation.
 2. **Per-chatbot publication**: each chatbot is created and configured
-   self-service in a non-published state, in which only the owning lecturer
-   can manage and configure it; it cannot be used or previewed. Going live
-   requires an in-app publication request on the bot
+   self-service in a non-published state. In Phase 0, the owning lecturer can
+   manage and configure it, but no use or preview path exists. A later
+   owner-authenticated test chat may exercise an unpublished bot without making
+   it participant-reachable. Going live requires an in-app publication request
+   on the bot
    (use case, expected student count, proposed participant usage-credit
    configuration) that the team approves or rejects with a comment. This
    legacy per-chatbot allowance is separate from, and does not approve, the

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -18,26 +18,59 @@ Approval is two-tier and both tiers are account- or artifact-level, never
 per-edit:
 
 1. **Account AI capability**: the team approves a lecturer's account and cost
-   center once and enables a feature flag. Lecturers with Catalyst can already
-   see and use the chatbot creation and configuration features beforehand;
-   the flag gates publication, not creation.
+   center once and enables a feature flag. This single AI usage authorization
+   covers both base and advanced model usage; it is not split by model or
+   model class. Lecturers with Catalyst can already see and use the chatbot
+   creation and configuration features beforehand; the flag gates publication,
+   not creation.
 2. **Per-chatbot publication**: each chatbot is created and configured
    self-service in a non-published state, in which only the owning lecturer
    can use it. Going live requires an in-app publication request on the bot
-   (use case, expected student count, proposed credit configuration) that the
-   team approves or rejects with a comment.
+   (use case, expected student count, proposed participant usage-credit
+   configuration) that the team approves or rejects with a comment. This
+   legacy per-chatbot allowance is separate from, and does not approve, the
+   account-wide base and advanced usage budgets.
 
-Configuration edits are free within caps and apply immediately. Only a short
-explicit list of gated changes re-enters review on an already-published bot:
-custom-mode prompt text and the credit/model cost class. Before publication,
-everything is freely editable — the unpublished bot is the draft, so no
-draft/publish snapshot machinery exists.
+Configuration edits are free within the account authorization and the
+lecturer-defined budgets, and apply immediately. Model selection does not
+require a new approval while the account authorization is valid. Publication
+approval remains a separate lifecycle decision; it does not serve as a usage
+funding or per-model approval.
+
+Usage is tracked in two explicit model classes. Registry entries are classified
+as `BASE` or `ADVANCED`; `Auto` is `ADVANCED` for the MVP until every routed
+billable step can be attributed. Fallbacks stay within the selected class, and
+the service never silently switches classes when a class is exhausted.
+
+The lecturer defines one account-wide monthly budget for each class. Both
+budgets reset monthly. The lecturer-facing UI shows exactly two lanes — **base
+model usage** and **advanced model usage** — with the configured budget, used
+credits, remaining credits, and reset date. The teaching center contributes a
+limited, internal amount toward base usage, but the contribution and its
+settlement are never shown. Advanced usage receives no teaching-center
+contribution. Base usage above the hidden contribution remains base usage and
+may consume the authorized paid budget.
+
+The MVP performs an availability pre-check and charges reliable provider usage
+after generation with atomic counters. Bounded final-turn and concurrent
+overruns are accepted; strict reservations, an immutable ledger, automated
+refunds, and invoice generation are deferred. Missing reliable provider usage
+is not charged, and manual corrections remain available. Existing participant
+usage credits remain a separate legacy allowance and cannot cause cross-class
+fallbacks. At migration cutover, new account counters start at zero; historical
+messages and participant credits remain legacy analytics.
 
 ## Consequences
 
 - The team reviews each bot exactly once before it meets students, at the
   moment its real configuration and stated use case are visible together.
 - Post-publication edits to non-gated knobs (examples, knowledge, standard-mode
-  fields) take effect without review; this bounded risk is accepted.
+  fields, and model choices within the account authorization) take effect
+  without another approval; this bounded risk is accepted.
+- Base and advanced budgets are visible as separate usage lanes, while the
+  teaching center's base contribution and internal settlement remain hidden.
+- Class-specific exhaustion does not disable the other class or trigger a
+  silent cross-class switch. Participant clients receive only the stable
+  availability and exhaustion contract, never cost-center or funding details.
 - Draft-config machinery for live bots is deliberately deferred until editing
   live bots proves painful.

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -1,0 +1,43 @@
+# 20. Two-tier approval: account AI capability plus per-chatbot publication
+
+## Status
+
+Accepted
+
+## Context
+
+The tutoring chatbot public beta lets any lecturer request access via a form
+(use case, expected student count, cost center). Chatbot usage is billable, so
+uncontrolled go-live is not acceptable; at the same time, a per-change approval
+queue would make the operating team the bottleneck for every configuration
+tweak and kill the beta feedback loop.
+
+## Decision
+
+Approval is two-tier and both tiers are account- or artifact-level, never
+per-edit:
+
+1. **Account AI capability**: the team approves a lecturer's account and cost
+   center once and enables a feature flag. Lecturers with Catalyst can already
+   see and use the chatbot creation and configuration features beforehand;
+   the flag gates publication, not creation.
+2. **Per-chatbot publication**: each chatbot is created and configured
+   self-service in a non-published state, in which only the owning lecturer
+   can use it. Going live requires an in-app publication request on the bot
+   (use case, expected student count, proposed credit configuration) that the
+   team approves or rejects with a comment.
+
+Configuration edits are free within caps and apply immediately. Only a short
+explicit list of gated changes re-enters review on an already-published bot:
+custom-mode prompt text and the credit/model cost class. Before publication,
+everything is freely editable — the unpublished bot is the draft, so no
+draft/publish snapshot machinery exists.
+
+## Consequences
+
+- The team reviews each bot exactly once before it meets students, at the
+  moment its real configuration and stated use case are visible together.
+- Post-publication edits to non-gated knobs (examples, knowledge, standard-mode
+  fields) take effect without review; this bounded risk is accepted.
+- Draft-config machinery for live bots is deliberately deferred until editing
+  live bots proves painful.

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -25,7 +25,8 @@ per-edit:
    not creation.
 2. **Per-chatbot publication**: each chatbot is created and configured
    self-service in a non-published state, in which only the owning lecturer
-   can use it. Going live requires an in-app publication request on the bot
+   can manage and configure it; it cannot be used or previewed. Going live
+   requires an in-app publication request on the bot
    (use case, expected student count, proposed participant usage-credit
    configuration) that the team approves or rejects with a comment. This
    legacy per-chatbot allowance is separate from, and does not approve, the
@@ -63,10 +64,11 @@ messages and participant credits remain legacy analytics.
 
 ## Consequences
 
-- The team reviews each bot exactly once before it meets students, at the
-  moment its real configuration and stated use case are visible together.
-- Post-publication edits to non-gated knobs (examples, knowledge, standard-mode
-  fields, and model choices within the account authorization) take effect
+- The team reviews each publication request before the bot meets students, at
+  the moment its real configuration and stated use case are visible together.
+  A rejected resubmission receives a new review.
+- Post-publication edits to non-gated knobs (knowledge, standard-mode fields,
+  and model choices within the account authorization) take effect
   without another approval; this bounded risk is accepted.
 - Base and advanced budgets are visible as separate usage lanes, while the
   teaching center's base contribution and internal settlement remain hidden.

--- a/docs/adr/0020-two-tier-chatbot-approval.md
+++ b/docs/adr/0020-two-tier-chatbot-approval.md
@@ -42,14 +42,15 @@ as `BASE` or `ADVANCED`; `Auto` is `ADVANCED` for the MVP until every routed
 billable step can be attributed. Fallbacks stay within the selected class, and
 the service never silently switches classes when a class is exhausted.
 
-The lecturer defines one account-wide monthly budget for each class. Both
-budgets reset monthly. The lecturer-facing UI shows exactly two lanes — **base
-model usage** and **advanced model usage** — with the configured budget, used
-credits, remaining credits, and reset date. The teaching center contributes a
-limited, internal amount toward base usage, but the contribution and its
-settlement are never shown. Advanced usage receives no teaching-center
-contribution. Base usage above the hidden contribution remains base usage and
-may consume the authorized paid budget.
+The lecturer defines one account-wide monthly budget for each class. Each
+configured limit persists until the lecturer changes it; only the used-credit
+counter resets at the Europe/Zurich month boundary. The lecturer-facing UI
+shows exactly two lanes — **base model usage** and **advanced model usage** —
+with the configured budget, used credits, remaining credits, and reset date.
+The teaching center contributes a limited, internal amount toward base usage,
+but the contribution and its settlement are never shown. Advanced usage
+receives no teaching-center contribution. Base usage above the hidden
+contribution remains base usage and may consume the authorized paid budget.
 
 The MVP performs an availability pre-check and charges reliable provider usage
 after generation with atomic counters. Bounded final-turn and concurrent

--- a/docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md
+++ b/docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md
@@ -1,0 +1,42 @@
+# 21. Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
+
+## Status
+
+Accepted
+
+## Context
+
+Today a chatbot's `systemPrompts[mode].prompt` fully replaces the built-in
+default prompt, so exposing prompt editing to lecturers would silently drop
+the platform scaffolding (citation behavior, source grounding, safety, tutoring
+stance). Raw prompt access is also the knob most likely to degrade answer
+quality and the main liability surface, yet lecturers legitimately need to aim
+a bot at their course and, in advanced cases, define their own interaction
+styles.
+
+## Decision
+
+Prompt influence is two-tier, and prompt compilation is layered, not
+replacing:
+
+- **Standard modes** (`tutor`, `explainer`) always exist and are maintained by
+  the platform. Lecturers freely edit a small set of constrained persona
+  fields — course name, subject domain, language of instruction, optional
+  scope note — that the server compiles into the standard prompts. No
+  approval, because these fields can only aim the bot, not disarm it.
+- **Custom modes** let a lecturer author a name, description, and free persona
+  text. That text is compiled as the persona section on top of the same
+  scaffolding; publication of a new or edited custom mode requires team
+  review (per ADR 0020).
+- In both tiers the platform scaffolding is non-removable: lecturer-authored
+  content is layered onto it by the compile step, replacing the current
+  replace-semantics.
+- The raw compiled prompt is not displayed to lecturers in the first version.
+
+## Consequences
+
+- Custom-mode review checks pedagogy and scope, not whether scaffolding
+  survived — the compile step guarantees that.
+- The compile step becomes the contract every runtime must honor (ADR 0019).
+- Few-shot examples, not prompt text, are the primary self-service steering
+  lever for behavior.

--- a/docs/adr/0022-no-student-text-in-manage.md
+++ b/docs/adr/0022-no-student-text-in-manage.md
@@ -1,0 +1,31 @@
+# 22. The manage surface shows no student-authored text
+
+## Status
+
+Accepted
+
+## Context
+
+Lecturers improving their chatbot want to see what students asked, especially
+for badly rated answers. But student conversations are personal data with a
+purpose-bound analytics boundary (ADR 0005 on the learning-analytics line),
+and topic aggregation belongs to the future learning-analytics capability with
+its own governance. A partial exception ("only thumbs-down'd questions") would
+blur an otherwise crisp boundary.
+
+## Decision
+
+The lecturer-facing manage surface shows only quantitative aggregates computed
+from the database — conversation and message counts, thumbs ratios and
+reason-tag counts, credits consumed, knowledge-source status. No
+student-authored text, verbatim or paraphrased, and no topic aggregation
+appears in manage. Lecturers diagnose content gaps through their own test
+conversations and reason-tag counts, not through student transcripts.
+
+## Consequences
+
+- Zero tension with the consent and purpose model while the beta scales.
+- Diagnosing a specific content gap is more indirect for lecturers; the
+  reason-tag counts ("12x source missing") must carry that weight.
+- Any future exposure of student content to lecturers is a governance decision
+  inside the learning-analytics track, not a manage feature request.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+The durable record of **why** — the significant, hard-to-reverse choices behind this codebase. The [engineering wiki](../index.md) explains _what_ and _how_ (non-obvious concepts) and links here for the _why_; the wiki is not itself the decision record.
+
+## Convention
+
+- One decision per file, `NNNN-kebab-slug.md`, numbered sequentially from `0001`.
+- Minimal by default: **Status + Context + Decision**, plus **Considered options** / **Consequences** only when they earn their place.
+- Supersede, don't rewrite: mark an outdated ADR `Superseded by ADR-NNNN` and add a new one instead of editing the decision away.
+- Gate — record an ADR only when the decision is **hard to reverse**, **surprising without context**, and the result of a **real trade-off**. All three must hold.
+
+## Index
+
+- [0001](./0001-automate-db-migrations-via-argocd-presync-hook.md) — Automate database migrations via an ArgoCD PreSync hook
+- [0001](./0001-chat-locale-from-cookie.md) — Chat resolves its locale from a cookie, in a chat-local `getRequestConfig`
+- [0002](./0002-message-feedback-as-a-rating-field.md) — Message feedback is a nullable field on `ChatMessage`
+- [0003](./0003-promote-stg-via-release-annotation-write-back.md) — Promote to staging by writing the built commit into a release annotation
+- [0003](./0003-chat-framework-upgrade.md) — Fold the chat framework upgrade into the v3 student-chat branch
+- [0004](./0004-chat-citations-from-tool-call-parts.md) — Chat citations are derived from tool-call parts
+- [0006](./0006-public-catalyst-capability-floor.md) — What public KlickerUZH keeps when Catalyst is absent
+- [0007](./0007-reintegrate-v3-ai-behind-feature-flags.md) — Reintegrate `v3-ai` into `v3` behind feature flags, after VK2
+- [0019](./0019-chatbot-config-postgresql-authoritative.md) — Chatbot configuration is PostgreSQL-authoritative; runtimes compile it per request
+- [0020](./0020-two-tier-chatbot-approval.md) — Two-tier approval: account AI capability plus per-chatbot publication
+- [0021](./0021-templated-standard-modes-reviewed-custom-modes.md) — Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
+- [0022](./0022-no-student-text-in-manage.md) — The manage surface shows no student-authored text
+
+`0001` and `0003` are each used twice — the deployment and chat lines numbered
+independently before this index existed. Numbers are not reassigned, because existing
+records cite them. `0005` is reserved by an open PR, and open branches claim numbers through
+`0018` (KB line `0009`–`0016`, feature flags, UZH theming). Pick the next free
+number by checking this directory **and** `docs/adr/` on open branches, not by
+counting entries.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,14 +19,16 @@ The durable record of **why** — the significant, hard-to-reverse choices behin
 - [0004](./0004-chat-citations-from-tool-call-parts.md) — Chat citations are derived from tool-call parts
 - [0006](./0006-public-catalyst-capability-floor.md) — What public KlickerUZH keeps when Catalyst is absent
 - [0007](./0007-reintegrate-v3-ai-behind-feature-flags.md) — Reintegrate `v3-ai` into `v3` behind feature flags, after VK2
+- [0008](./0008-assessment-identity-boundary-and-public-projection.md) — Keep assessment identity course-scoped and minimize public credential identity
+- [0008](./0008-use-growthbook-for-feature-flags.md) — Use GrowthBook for shared feature flags
 - [0019](./0019-chatbot-config-postgresql-authoritative.md) — Chatbot configuration is PostgreSQL-authoritative; runtimes compile it per request
 - [0020](./0020-two-tier-chatbot-approval.md) — Two-tier approval: account AI capability plus per-chatbot publication
 - [0021](./0021-templated-standard-modes-reviewed-custom-modes.md) — Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
 - [0022](./0022-no-student-text-in-manage.md) — The manage surface shows no student-authored text
 
-`0001` and `0003` are each used twice — the deployment and chat lines numbered
-independently before this index existed. Numbers are not reassigned, because existing
-records cite them. `0005` is reserved by an open PR, and open branches claim numbers through
-`0018` (KB line `0009`–`0016`, feature flags, UZH theming). Pick the next free
-number by checking this directory **and** `docs/adr/` on open branches, not by
-counting entries.
+`0001`, `0003`, and `0008` are each used twice — their lines were numbered
+independently before this index existed. Numbers are not reassigned, because
+existing records cite them. `0005` is reserved by an open PR, and open branches
+claim numbers through `0018` (KB line `0009`–`0016`, feature flags, UZH
+theming). Pick the next free number by checking this directory **and**
+`docs/adr/` on open branches, not by counting entries.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ The durable record of **why** — the significant, hard-to-reverse choices behin
 - [0020](./0020-two-tier-chatbot-approval.md) — Two-tier approval: account AI capability plus per-chatbot publication
 - [0021](./0021-templated-standard-modes-reviewed-custom-modes.md) — Standard modes are templated, custom modes are reviewed; both layer over fixed scaffolding
 - [0022](./0022-no-student-text-in-manage.md) — The manage surface shows no student-authored text
+- [0037](./0037-standard-activity-formats.md) — Practice quizzes, microlearnings, and group activities are standard capabilities
 
 `0001`, `0003`, and `0008` are each used twice — their lines were numbered
 independently before this index existed. Numbers are not reassigned, because

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -320,9 +320,10 @@ and renders an "AI tutor" button (`data-cy="student-course-chatbot-link"`) next
 to the home/back button when the caller is a participant of the course. The
 button is a real anchor (`<Link target="_blank" rel="noopener">` wrapping the
 design-system `Button`, the same pattern as the sibling home button), so
-middle-click and copy-link behave as expected. It links `courseChatbots[0]`:
-courses are deliberately limited to a single chatbot for now, which is also why
-`Chatbot` carries no ordering field. It does carry a publication `status`
+middle-click and copy-link behave as expected. The data model and query can
+return multiple published chatbots, ordered by name and then creation time, but
+the current PWA exposes only `courseChatbots[0]` as its single header
+button. `Chatbot` carries no ordering field. It does carry a publication `status`
 (`DRAFT`/`PENDING_APPROVAL`/`PUBLISHED`/`PAUSED`/`REJECTED`, see
 [ADR 0020](./adr/0020-two-tier-chatbot-approval.md)) that gates participant
 visibility — only `PUBLISHED` bots are reachable — but that is a visibility

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -177,8 +177,34 @@ policy. The deployed LiteLLM configuration is external; a local summary proves
 the development path only, and staging still needs a Responses + tool-loop
 smoke test before a production compatibility claim.
 
+The approved account-usage policy is a follow-up to the Phase 0 lifecycle
+foundations. One account-level AI usage authorization, backed by an approved
+cost center, covers both model classes. Registry entries will carry explicit
+`BASE` or `ADVANCED` metadata; `Auto` is `ADVANCED` until every routed billable
+step can be attributed. Lecturers will define account-wide monthly budgets for
+both classes, and the manage UI will show exactly two lanes — base model usage
+and advanced model usage — with budget, used, remaining, and reset date. The
+teaching center's limited base contribution is internal and hidden; advanced
+usage receives no contribution. Class exhaustion disables only that class and
+never triggers an automatic cross-class switch. Participant-facing APIs must
+return stable class-specific exhaustion codes without cost-center or hidden
+funding fields.
+
+This Phase 0 branch does not implement those account counters or lanes. The
+existing `ChatUsageCredits` balance remains a separate participant usage
+credit, and its current fallback behavior is legacy. The follow-up must use a
+same-class fallback only, charge reliable provider usage after generation with
+atomic counters, and accept the documented bounded final/concurrent overrun;
+strict reservations, immutable ledgers, automated refunds, invoices,
+per-chatbot allocation, and participant-credit migration are deferred.
+
 - Omitted `supportsImageAttachments` defaults to **false** — every image-capable model must set it explicitly in deployment values or the attach button disappears.
-- Zero-credit course chatbots need a usable fallback model (`CHAT_FALLBACK_MODEL_ID`, default `gpt-4.1-mini`) AND explicit chatbot `allowedModelIds` must include it. Audit/fix with `packages/prisma-data/src/scripts/2026-06-15_ensure_chatbot_fallback_model.ts`.
+- The legacy zero-credit participant path needs a usable fallback model
+  (`CHAT_FALLBACK_MODEL_ID`, default `gpt-4.1-mini`) AND explicit chatbot
+  `allowedModelIds` must include it. The account-usage follow-up must replace
+  this with a same-class fallback and stop when no model in the selected class
+  is available. Audit the legacy path with
+  `packages/prisma-data/src/scripts/2026-06-15_ensure_chatbot_fallback_model.ts`.
 - OpenAI Responses backends: keep `CHAT_OPENAI_STORE_RESPONSES=true` in shared/staged deployments — with `store: false`, LiteLLM/Azure can return "item not found" when a model references prior response items across tool-call steps. Local OpenRouter-style setups can leave it false.
 
 Credit fields are Prisma `Decimal` — never truthy-check them ([Data & Migrations](./data-and-migrations.md)).
@@ -195,9 +221,11 @@ selection state uses the same plain-language contract. Known Tutor and Explainer
 localized purpose descriptions in `src/components/mode-switcher.tsx`; custom modes fall back to
 their configured description.
 
-In the sidebar layout, `src/components/credits-footer.tsx:MobileCreditsBar` keeps the current
-balance visible below the header at mobile widths, even while the design-system sidebar drawer
-is closed. When the balance reaches zero it also states that new messages use the smaller model.
+In the sidebar layout, `src/components/credits-footer.tsx:MobileCreditsBar` keeps the legacy
+participant usage-credit balance visible below the header at mobile widths, even while the
+design-system sidebar drawer is closed. When the balance reaches zero, the legacy path states
+that new messages use the smaller model; the account-usage follow-up must not silently switch
+between base and advanced classes.
 The bar is rendered only by `SidebarMain`; embedded mode continues to use its existing
 `EmbeddedCreditsBar` so the two compact readouts are never shown together.
 

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -117,7 +117,7 @@ cache hits, latency, or cost savings.
 
 ## Auth guard pattern (route handlers)
 
-Three steps: `getParticipantId` → `getChatbotOr404` → `requireParticipation`. The composed helper `withChatbotAuth(req, chatbotId)` (`src/lib/server/apiGuards.ts`) covers the standard `{ courseId: true }` case — use it for new routes; fall back to the individual guards only for a custom chatbot `select`. Participant identity comes from the same participant JWT cookies as the PWA ([Auth Model](./auth-model.md)); local chat dev therefore needs the backend's `APP_SECRET` and `DATABASE_URL` visible to the chat app, or cookies won't verify and Prisma can't load chatbots.
+Three steps: `getParticipantId` → `getChatbotOr404` → `requireParticipation`. The composed helper `withChatbotAuth(req, chatbotId)` (`src/lib/server/apiGuards.ts`) covers the standard `{ courseId: true }` case — use it for new routes; fall back to the individual guards only for a custom chatbot `select`. `getChatbotOr404` returns 404 for any non-`PUBLISHED` chatbot (`DRAFT`, `PENDING_APPROVAL`, `PAUSED`, `REJECTED`) and reads `status` as a guard-only field, so a participant can never reach an unpublished bot regardless of the projection a caller passes — the publication gate holds on every route (see [ADR 0020](./adr/0020-two-tier-chatbot-approval.md)). Participant identity comes from the same participant JWT cookies as the PWA ([Auth Model](./auth-model.md)); local chat dev therefore needs the backend's `APP_SECRET` and `DATABASE_URL` visible to the chat app, or cookies won't verify and Prisma can't load chatbots.
 
 ## Model registry and credits
 
@@ -294,7 +294,11 @@ button is a real anchor (`<Link target="_blank" rel="noopener">` wrapping the
 design-system `Button`, the same pattern as the sibling home button), so
 middle-click and copy-link behave as expected. It links `courseChatbots[0]`:
 courses are deliberately limited to a single chatbot for now, which is also why
-`Chatbot` carries no ordering or visibility field. Lifting that limit means
+`Chatbot` carries no ordering field. It does carry a publication `status`
+(`DRAFT`/`PENDING_APPROVAL`/`PUBLISHED`/`PAUSED`/`REJECTED`, see
+[ADR 0020](./adr/0020-two-tier-chatbot-approval.md)) that gates participant
+visibility — only `PUBLISHED` bots are reachable — but that is a visibility
+gate, not a way to order or select among multiple bots. Lifting that limit means
 deciding the multi-chatbot affordance first — the header row does not wrap and
 the design-system button is `shrink-0`, so several buttons would squeeze the
 course title on a narrow viewport.

--- a/packages/graphql/src/graphql/ops/QGetChatbotsInfo.graphql
+++ b/packages/graphql/src/graphql/ops/QGetChatbotsInfo.graphql
@@ -4,6 +4,7 @@ query GetChatbotsInfo {
     name
     description
     avatar
+    status
     modelSelection
     allowedModelIds
     allowedReasoningEffortsByModel {

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -1966,6 +1966,7 @@ type Mutation {
   addUserToUserGroup(asAdmin: Boolean, groupId: Int!, shortnameOrEmail: String!): UserInfo
   applyActivityBatchOperations(activityIds: [String!]!, basePoints: Int, bonusPoints: Int, correctnessPoints: Int, courseId: String, multiplier: Int, timeToZeroBonus: Int): Int!
   applyElementBatchOperations(archive: Boolean!, basePoints: Boolean, elementIds: [Int!]!, multiplier: Int, status: ElementStatus, unarchive: Boolean!, updateInstances: Boolean!, updateTemplateInstances: Boolean!): Int!
+  approveChatbotPublication(id: String!): Chatbot
   approveObjectSharingRequest(permissionLevel: PermissionLevel!, propagation: Boolean!, requestId: Int!, userId: String!): Boolean!
   bookmarkElementStack(bookmarked: Boolean!, courseId: String!, stackId: Int!): [Int!]
   cancelLiveQuiz(id: String!): LiveQuiz
@@ -2079,6 +2080,7 @@ type Mutation {
   publishMicroLearning(id: String!): MicroLearning
   publishPracticeQuiz(availableFrom: Date, id: String!): PracticeQuiz
   rateElement(elementId: Int!, elementInstanceId: Int!, rating: Int!): ElementFeedback
+  rejectChatbotPublication(comment: String!, id: String!): Chatbot
   removeCatalogObjectAssignment(assignmentId: Int!): Boolean!
   removeObject(objectId: String!, objectType: ObjectType!): String
   removeUserFromGroup(groupId: Int!, userId: String!): Boolean!
@@ -2086,6 +2088,7 @@ type Mutation {
   requestCatalogCollection(catalogCollectionId: String!, requestedPermissionLevel: PermissionLevel): CatalogCollection
   requestCatalogObject(catalogCollectionId: String, objectId: String!, objectType: ObjectType!, requestedPermissionLevel: PermissionLevel): Boolean!
   requestCatalystAccess(institution: String!, useCase: String!): Boolean!
+  requestChatbotPublication(expectedStudentCount: Int!, id: String!, proposedCredits: Int!, useCase: String!): Chatbot
   resetAssessmentLiveQuiz(id: String!): ActivityInfo
   resolveActivityLogEntry(id: Int!): ActivityLogEntry
   resolveFeedback(id: Int!, isResolved: Boolean!, liveQuizId: String!): Feedback

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -727,10 +727,15 @@ type Chatbot {
   creditResetPeriod: CreditResetPeriod!
   description: String
   disclaimerSummary: ChatbotDisclaimerSummary
+  expectedStudentCount: Int
   id: ID!
   mcpConfigurations: [ChatbotMcpConfigurationSummary!]!
   modelSelection: Boolean!
   name: String!
+  publicationUseCase: String
+  publishedAt: Date
+  reviewComment: String
+  status: ChatbotStatus!
   updatedAt: Date
   usageSummary: ChatbotUsageSummary
 }
@@ -770,6 +775,14 @@ type ChatbotReasoningConfig {
 input ChatbotReasoningConfigInput {
   efforts: [String!]!
   modelId: String!
+}
+
+enum ChatbotStatus {
+  DRAFT
+  PAUSED
+  PENDING_APPROVAL
+  PUBLISHED
+  REJECTED
 }
 
 type ChatbotUsageSummary {
@@ -1977,6 +1990,7 @@ type Mutation {
   createAnswerCollection(answers: [String!]!, description: String!, name: String!): AnswerCollection
   createAssessmentParticipantInvitations(courseId: String!, invitations: [AssessmentParticipantInvitationInput!]!): CreateAssessmentParticipantInvitationsPayload
   createCatalogCollection(access: ObjectAccess!, name: String!): CatalogCollection
+  createChatbot(avatar: String, courseId: String!, description: String, name: String!): Chatbot!
   createCourse(color: String, description: String, displayName: String!, duplicateGroupActivities: Boolean, duplicateLiveQuizzes: Boolean, duplicateMicrolearnings: Boolean, duplicatePracticeQuizzes: Boolean, endDate: Date!, groupDeadlineDate: Date!, isGamificationEnabled: Boolean!, isGroupCreationEnabled: Boolean!, language: LocaleType!, maxGroupSize: Int!, name: String!, notificationEmail: String, preferredGroupSize: Int!, sourceCourseId: String, startDate: Date!): Course
   createFeedback(content: String!, quizId: String!): Feedback
   createGroupActivity(clues: [GroupActivityClueInput!]!, courseId: String!, description: String, displayName: String!, endDate: Date!, multiplier: Int!, name: String!, stack: ElementStackInput!, startDate: Date!): ActivityInfo
@@ -2098,6 +2112,7 @@ type Mutation {
   unpublishMicroLearning(id: String!): MicroLearning
   unpublishPracticeQuiz(id: String!): PracticeQuiz
   unsubscribeFromPush(courseId: String!, endpoint: String!): Boolean
+  updateChatbot(avatar: String, description: String, id: String!, name: String): Chatbot
   updateChatbotModelSettings(allowedModelIds: [String!]!, allowedReasoningEffortsByModel: [ChatbotReasoningConfigInput!], chatbotId: String!, modelSelection: Boolean!): Chatbot
   updateCourseSettings(color: String, description: String, displayName: String, endDate: Date, groupDeadlineDate: Date, id: String!, isGamificationEnabled: Boolean, isGroupCreationEnabled: Boolean, language: LocaleType!, name: String, notificationEmail: String, startDate: Date): Course
   updateElementInstances(elementId: Int!, includeTemplates: Boolean!): [ElementInstance!]

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1456,6 +1456,33 @@ export const Mutation = builder.mutationType({
         },
       }),
 
+      createChatbot: t.withAuth(asUserWithCatalyst).field({
+        type: Chatbot,
+        args: {
+          name: t.arg.string({ required: true }),
+          description: t.arg.string({ required: false }),
+          avatar: t.arg.string({ required: false }),
+          courseId: t.arg.string({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ChatbotsService.createChatbot(args, ctx)
+        },
+      }),
+
+      updateChatbot: t.withAuth(asUserWithCatalyst).field({
+        nullable: true,
+        type: Chatbot,
+        args: {
+          id: t.arg.string({ required: true }),
+          name: t.arg.string({ required: false }),
+          description: t.arg.string({ required: false }),
+          avatar: t.arg.string({ required: false }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ChatbotsService.updateChatbot(args, ctx)
+        },
+      }),
+
       updateWeeklyTimelineEntriesCourse: t.withAuth(asUserFullAccess).boolean({
         nullable: true,
         args: { courseId: t.arg.string({ required: true }) },

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1495,9 +1495,18 @@ export const Mutation = builder.mutationType({
           type: Chatbot,
           args: {
             id: t.arg.string({ required: true }),
-            useCase: t.arg.string({ required: true }),
-            expectedStudentCount: t.arg.int({ required: true }),
-            proposedCredits: t.arg.int({ required: true }),
+            useCase: t.arg.string({
+              required: true,
+              validate: { minLength: 1, maxLength: 2000 },
+            }),
+            expectedStudentCount: t.arg.int({
+              required: true,
+              validate: { min: 1 },
+            }),
+            proposedCredits: t.arg.int({
+              required: true,
+              validate: { min: 1 },
+            }),
           },
           resolve: async (_, args, ctx) => {
             return await ChatbotsService.requestChatbotPublication(args, ctx)

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1535,7 +1535,10 @@ export const Mutation = builder.mutationType({
         type: Chatbot,
         args: {
           id: t.arg.string({ required: true }),
-          comment: t.arg.string({ required: true }),
+          comment: t.arg.string({
+            required: true,
+            validate: { minLength: 1, regex: /\S/ },
+          }),
         },
         resolve: async (_, args, ctx) => {
           return await ChatbotsService.rejectChatbotPublication(args, ctx)

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1462,7 +1462,10 @@ export const Mutation = builder.mutationType({
         .field({
           type: Chatbot,
           args: {
-            name: t.arg.string({ required: true }),
+            name: t.arg.string({
+              required: true,
+              validate: { minLength: 1 },
+            }),
             description: t.arg.string({ required: false }),
             avatar: t.arg.string({ required: false }),
             courseId: t.arg.string({ required: true }),
@@ -1479,7 +1482,10 @@ export const Mutation = builder.mutationType({
           type: Chatbot,
           args: {
             id: t.arg.string({ required: true }),
-            name: t.arg.string({ required: false }),
+            name: t.arg.string({
+              required: false,
+              validate: { minLength: 1 },
+            }),
             description: t.arg.string({ required: false }),
             avatar: t.arg.string({ required: false }),
           },

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1456,7 +1456,9 @@ export const Mutation = builder.mutationType({
         },
       }),
 
-      createChatbot: t.withAuth(asUserWithCatalyst).field({
+      createChatbot: t
+        .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
+        .field({
         type: Chatbot,
         args: {
           name: t.arg.string({ required: true }),
@@ -1469,7 +1471,9 @@ export const Mutation = builder.mutationType({
         },
       }),
 
-      updateChatbot: t.withAuth(asUserWithCatalyst).field({
+      updateChatbot: t
+        .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
+        .field({
         nullable: true,
         type: Chatbot,
         args: {

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -117,6 +117,7 @@ export const Mutation = builder.mutationType({
     }
     const asUser = { authenticated: true, role: DB.UserRole.USER }
     const asAdmin = { authenticated: true, role: DB.UserRole.ADMIN }
+    const asUserWithCatalyst = { ...asUser, catalyst: true }
     const asUserSessionExec = {
       ...asUser,
       scope: DB.UserLoginScope.SESSION_EXEC,
@@ -1484,6 +1485,45 @@ export const Mutation = builder.mutationType({
         },
         resolve: async (_, args, ctx) => {
           return await ChatbotsService.updateChatbot(args, ctx)
+        },
+      }),
+
+      requestChatbotPublication: t
+        .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
+        .field({
+        nullable: true,
+        type: Chatbot,
+        args: {
+          id: t.arg.string({ required: true }),
+          useCase: t.arg.string({ required: true }),
+          expectedStudentCount: t.arg.int({ required: true }),
+          proposedCredits: t.arg.int({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ChatbotsService.requestChatbotPublication(args, ctx)
+        },
+      }),
+
+      approveChatbotPublication: t.withAuth(asAdmin).field({
+        nullable: true,
+        type: Chatbot,
+        args: {
+          id: t.arg.string({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ChatbotsService.approveChatbotPublication(args, ctx)
+        },
+      }),
+
+      rejectChatbotPublication: t.withAuth(asAdmin).field({
+        nullable: true,
+        type: Chatbot,
+        args: {
+          id: t.arg.string({ required: true }),
+          comment: t.arg.string({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ChatbotsService.rejectChatbotPublication(args, ctx)
         },
       }),
 

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -1460,49 +1460,49 @@ export const Mutation = builder.mutationType({
       createChatbot: t
         .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
         .field({
-        type: Chatbot,
-        args: {
-          name: t.arg.string({ required: true }),
-          description: t.arg.string({ required: false }),
-          avatar: t.arg.string({ required: false }),
-          courseId: t.arg.string({ required: true }),
-        },
-        resolve: async (_, args, ctx) => {
-          return await ChatbotsService.createChatbot(args, ctx)
-        },
-      }),
+          type: Chatbot,
+          args: {
+            name: t.arg.string({ required: true }),
+            description: t.arg.string({ required: false }),
+            avatar: t.arg.string({ required: false }),
+            courseId: t.arg.string({ required: true }),
+          },
+          resolve: async (_, args, ctx) => {
+            return await ChatbotsService.createChatbot(args, ctx)
+          },
+        }),
 
       updateChatbot: t
         .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
         .field({
-        nullable: true,
-        type: Chatbot,
-        args: {
-          id: t.arg.string({ required: true }),
-          name: t.arg.string({ required: false }),
-          description: t.arg.string({ required: false }),
-          avatar: t.arg.string({ required: false }),
-        },
-        resolve: async (_, args, ctx) => {
-          return await ChatbotsService.updateChatbot(args, ctx)
-        },
-      }),
+          nullable: true,
+          type: Chatbot,
+          args: {
+            id: t.arg.string({ required: true }),
+            name: t.arg.string({ required: false }),
+            description: t.arg.string({ required: false }),
+            avatar: t.arg.string({ required: false }),
+          },
+          resolve: async (_, args, ctx) => {
+            return await ChatbotsService.updateChatbot(args, ctx)
+          },
+        }),
 
       requestChatbotPublication: t
         .withAuth({ ...asUserWithCatalyst, ...asUserFullAccess })
         .field({
-        nullable: true,
-        type: Chatbot,
-        args: {
-          id: t.arg.string({ required: true }),
-          useCase: t.arg.string({ required: true }),
-          expectedStudentCount: t.arg.int({ required: true }),
-          proposedCredits: t.arg.int({ required: true }),
-        },
-        resolve: async (_, args, ctx) => {
-          return await ChatbotsService.requestChatbotPublication(args, ctx)
-        },
-      }),
+          nullable: true,
+          type: Chatbot,
+          args: {
+            id: t.arg.string({ required: true }),
+            useCase: t.arg.string({ required: true }),
+            expectedStudentCount: t.arg.int({ required: true }),
+            proposedCredits: t.arg.int({ required: true }),
+          },
+          resolve: async (_, args, ctx) => {
+            return await ChatbotsService.requestChatbotPublication(args, ctx)
+          },
+        }),
 
       approveChatbotPublication: t.withAuth(asAdmin).field({
         nullable: true,

--- a/packages/graphql/src/schema/resource.ts
+++ b/packages/graphql/src/schema/resource.ts
@@ -94,6 +94,10 @@ export const CreditResetPeriod = builder.enumType('CreditResetPeriod', {
   values: Object.values(DB.CreditResetPeriod),
 })
 
+export const ChatbotStatus = builder.enumType('ChatbotStatus', {
+  values: Object.values(DB.ChatbotStatus),
+})
+
 export interface IChatbotReasoningConfig {
   modelId: string
   efforts: string[]
@@ -160,6 +164,11 @@ export interface IChatbot {
   creditResetPeriod: DB.CreditResetPeriod
   creditResetAmount: number
   creditMaxCredits: number
+  status: DB.ChatbotStatus
+  publicationUseCase?: string | null
+  expectedStudentCount?: number | null
+  reviewComment?: string | null
+  publishedAt?: Date | null
   courses?: ICourseListEntry[]
   createdAt?: Date | null
   updatedAt?: Date | null
@@ -287,6 +296,15 @@ export const Chatbot = ChatbotRef.implement({
     }),
     creditResetAmount: t.exposeInt('creditResetAmount'),
     creditMaxCredits: t.exposeInt('creditMaxCredits'),
+    status: t.expose('status', { type: ChatbotStatus }),
+    publicationUseCase: t.exposeString('publicationUseCase', {
+      nullable: true,
+    }),
+    expectedStudentCount: t.exposeInt('expectedStudentCount', {
+      nullable: true,
+    }),
+    reviewComment: t.exposeString('reviewComment', { nullable: true }),
+    publishedAt: t.expose('publishedAt', { type: 'Date', nullable: true }),
     courses: t.field({
       type: [CourseListEntryRef],
       resolve: (chatbot) => chatbot.courses ?? [],

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -627,3 +627,158 @@ export async function updateChatbot(
     courses: updated.course ? [updated.course] : [],
   }
 }
+
+type RequestChatbotPublicationArgs = {
+  id: string
+  useCase: string
+  expectedStudentCount: number
+  proposedCredits: number
+}
+
+export async function requestChatbotPublication(
+  args: RequestChatbotPublicationArgs,
+  ctx: ContextWithUser
+) {
+  // Ownership/existence first: a non-owner gets null (not found) and never
+  // learns anything about the account capability below.
+  const chatbot = await ctx.prisma.chatbot.findFirst({
+    where: { id: args.id, ownerId: ctx.user.sub },
+    select: { id: true, status: true },
+  })
+  if (!chatbot) {
+    return null
+  }
+
+  // Account-level capability gate (D1, ADR 0020): read the live User row, never
+  // a JWT claim — ops flips this flag out of band after the token was issued.
+  const owner = await ctx.prisma.user.findUniqueOrThrow({
+    where: { id: ctx.user.sub },
+    select: { aiChatbotPublishingEnabled: true },
+  })
+  if (!owner.aiChatbotPublishingEnabled) {
+    throw new GraphQLError('Account is not approved for chatbot publishing')
+  }
+
+  // Only a DRAFT or a previously REJECTED bot may (re-)enter review.
+  if (
+    chatbot.status !== DB.ChatbotStatus.DRAFT &&
+    chatbot.status !== DB.ChatbotStatus.REJECTED
+  ) {
+    throw new GraphQLError(
+      `Cannot request publication from status ${chatbot.status}`
+    )
+  }
+
+  const updated = await ctx.prisma.chatbot.update({
+    where: { id: chatbot.id },
+    data: {
+      status: DB.ChatbotStatus.PENDING_APPROVAL,
+      publicationUseCase: args.useCase,
+      expectedStudentCount: args.expectedStudentCount,
+      reviewComment: null, // clear any prior rejection note on re-request
+      // Proposed credit budget (gated cost class, D2): flat model — initial =
+      // reset amount = max = proposedCredits; the reset period keeps its
+      // configured value. Student-inert until PUBLISHED (S4 gates access).
+      creditInitialCredits: args.proposedCredits,
+      creditResetAmount: args.proposedCredits,
+      creditMaxCredits: args.proposedCredits,
+    },
+    select: {
+      ...chatbotOwnerSelect,
+      course: { select: { id: true, name: true } },
+    },
+  })
+
+  return {
+    ...updated,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      updated.allowedReasoningEffortsByModel
+    ),
+    courses: updated.course ? [updated.course] : [],
+  }
+}
+
+export async function approveChatbotPublication(
+  args: { id: string },
+  ctx: ContextWithUser
+) {
+  // Service-level admin check (D3): the schema layer already gates on asAdmin,
+  // but service tests bypass Pothos, so this is the check the admin-authz test
+  // exercises.
+  if (ctx.user.role !== DB.UserRole.ADMIN) {
+    throw new GraphQLError('Not authorized')
+  }
+
+  const chatbot = await ctx.prisma.chatbot.findUnique({
+    where: { id: args.id },
+    select: { id: true, status: true, publishedAt: true },
+  })
+  if (!chatbot) {
+    return null
+  }
+  if (chatbot.status !== DB.ChatbotStatus.PENDING_APPROVAL) {
+    throw new GraphQLError(`Cannot approve from status ${chatbot.status}`)
+  }
+
+  const updated = await ctx.prisma.chatbot.update({
+    where: { id: chatbot.id },
+    data: {
+      status: DB.ChatbotStatus.PUBLISHED,
+      // Stamp the first go-live only; a later re-approval keeps the original.
+      publishedAt: chatbot.publishedAt ?? new Date(),
+      reviewComment: null,
+    },
+    select: {
+      ...chatbotOwnerSelect,
+      course: { select: { id: true, name: true } },
+    },
+  })
+
+  return {
+    ...updated,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      updated.allowedReasoningEffortsByModel
+    ),
+    courses: updated.course ? [updated.course] : [],
+  }
+}
+
+export async function rejectChatbotPublication(
+  args: { id: string; comment: string },
+  ctx: ContextWithUser
+) {
+  if (ctx.user.role !== DB.UserRole.ADMIN) {
+    throw new GraphQLError('Not authorized')
+  }
+
+  const chatbot = await ctx.prisma.chatbot.findUnique({
+    where: { id: args.id },
+    select: { id: true, status: true },
+  })
+  if (!chatbot) {
+    return null
+  }
+  if (chatbot.status !== DB.ChatbotStatus.PENDING_APPROVAL) {
+    throw new GraphQLError(`Cannot reject from status ${chatbot.status}`)
+  }
+
+  const updated = await ctx.prisma.chatbot.update({
+    where: { id: chatbot.id },
+    data: {
+      status: DB.ChatbotStatus.REJECTED,
+      reviewComment: args.comment,
+    },
+    select: {
+      ...chatbotOwnerSelect,
+      course: { select: { id: true, name: true } },
+    },
+  })
+
+  return {
+    ...updated,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      updated.allowedReasoningEffortsByModel
+    ),
+    courses: updated.course ? [updated.course] : [],
+  }
+}

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -711,13 +711,28 @@ export async function approveChatbotPublication(
 
   const chatbot = await ctx.prisma.chatbot.findUnique({
     where: { id: args.id },
-    select: { id: true, status: true, publishedAt: true },
+    select: {
+      id: true,
+      status: true,
+      publishedAt: true,
+      // Re-check the owner's account-level publishing capability at approval
+      // time (S3 review): the manual queue can sit for days, and ops may revoke
+      // aiChatbotPublishingEnabled while a request is pending. Checking only at
+      // request time would let an unaware admin publish a bot under an account
+      // that no longer holds the capability. See ADR 0020 (two-tier approval).
+      owner: { select: { aiChatbotPublishingEnabled: true } },
+    },
   })
   if (!chatbot) {
     return null
   }
   if (chatbot.status !== DB.ChatbotStatus.PENDING_APPROVAL) {
     throw new GraphQLError(`Cannot approve from status ${chatbot.status}`)
+  }
+  if (!chatbot.owner.aiChatbotPublishingEnabled) {
+    throw new GraphQLError(
+      'Account is no longer approved for chatbot publishing'
+    )
   }
 
   const updated = await ctx.prisma.chatbot.update({

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -671,8 +671,15 @@ export async function requestChatbotPublication(
     )
   }
 
-  const updated = await ctx.prisma.chatbot.update({
-    where: { id: chatbot.id },
+  const transition = await ctx.prisma.chatbot.updateMany({
+    where: {
+      id: chatbot.id,
+      ownerId: ctx.user.sub,
+      status: {
+        in: [DB.ChatbotStatus.DRAFT, DB.ChatbotStatus.REJECTED],
+      },
+      owner: { aiChatbotPublishingEnabled: true },
+    },
     data: {
       status: DB.ChatbotStatus.PENDING_APPROVAL,
       publicationUseCase: args.useCase,
@@ -685,6 +692,16 @@ export async function requestChatbotPublication(
       creditResetAmount: args.proposedCredits,
       creditMaxCredits: args.proposedCredits,
     },
+  })
+
+  if (transition.count === 0) {
+    throw new GraphQLError(
+      'Chatbot publication request could not be completed because its status or account capability changed concurrently'
+    )
+  }
+
+  const updated = await ctx.prisma.chatbot.findUniqueOrThrow({
+    where: { id: chatbot.id },
     select: {
       ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -591,8 +591,8 @@ export async function updateChatbot(
   args: UpdateChatbotArgs,
   ctx: ContextWithUser
 ) {
-  // Ownership guard: scope the lookup by ownerId so a non-owner cannot target
-  // another lecturer's chatbot. Returns null (not found) when the guard fails.
+  // Ownership guard: a failed ownerId-scoped lookup returns null rather than a
+  // throw, so a non-owner cannot distinguish "not yours" from "does not exist".
   const existing = await ctx.prisma.chatbot.findFirst({
     where: { id: args.id, ownerId: ctx.user.sub },
     select: { id: true },

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -221,7 +221,9 @@ export async function getParticipantCourseChatbots(
       description: true,
       avatar: true,
     },
-    where: { courseId },
+    // Participants only see PUBLISHED bots; drafts and in-review bots stay hidden
+    // in the course overview (F2, mirrors the chat-app access gate).
+    where: { courseId, status: DB.ChatbotStatus.PUBLISHED },
   })
 
   return chatbots.map(({ id, name, description, avatar }) => ({

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -737,14 +737,27 @@ export async function approveChatbotPublication(
     )
   }
 
-  const updated = await ctx.prisma.chatbot.update({
-    where: { id: chatbot.id },
+  const transition = await ctx.prisma.chatbot.updateMany({
+    where: {
+      id: chatbot.id,
+      status: DB.ChatbotStatus.PENDING_APPROVAL,
+      owner: { aiChatbotPublishingEnabled: true },
+    },
     data: {
       status: DB.ChatbotStatus.PUBLISHED,
       // Stamp the first go-live only; a later re-approval keeps the original.
       publishedAt: chatbot.publishedAt ?? new Date(),
       reviewComment: null,
     },
+  })
+  if (transition.count === 0) {
+    throw new GraphQLError(
+      'Chatbot approval could not be completed because its status or account capability changed'
+    )
+  }
+
+  const updated = await ctx.prisma.chatbot.findUniqueOrThrow({
+    where: { id: chatbot.id },
     select: {
       ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },
@@ -779,12 +792,24 @@ export async function rejectChatbotPublication(
     throw new GraphQLError(`Cannot reject from status ${chatbot.status}`)
   }
 
-  const updated = await ctx.prisma.chatbot.update({
-    where: { id: chatbot.id },
+  const transition = await ctx.prisma.chatbot.updateMany({
+    where: {
+      id: chatbot.id,
+      status: DB.ChatbotStatus.PENDING_APPROVAL,
+    },
     data: {
       status: DB.ChatbotStatus.REJECTED,
       reviewComment: args.comment,
     },
+  })
+  if (transition.count === 0) {
+    throw new GraphQLError(
+      'Chatbot rejection could not be completed because its status changed'
+    )
+  }
+
+  const updated = await ctx.prisma.chatbot.findUniqueOrThrow({
+    where: { id: chatbot.id },
     select: {
       ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -1,6 +1,7 @@
 import * as DB from '@klicker-uzh/prisma/client'
 import { Prisma } from '@klicker-uzh/prisma/client'
 import { z } from 'zod'
+import { GraphQLError } from 'graphql'
 import type { Context, ContextWithUser } from '../lib/context.js'
 
 const chatModelSchema = z
@@ -231,23 +232,36 @@ export async function getParticipantCourseChatbots(
   }))
 }
 
+// Owner-facing column projection shared by every service that returns the
+// full (lecturer) Chatbot shape. Keeping it in one place ensures newly added
+// owner fields (e.g. lifecycle status) are selected everywhere IChatbot is
+// returned, so the GraphQL type never sees a missing non-nullable field.
+const chatbotOwnerSelect = {
+  id: true,
+  name: true,
+  description: true,
+  avatar: true,
+  modelSelection: true,
+  allowedModelIds: true,
+  allowedReasoningEffortsByModel: true,
+  creditInitialCredits: true,
+  creditResetPeriod: true,
+  creditResetAmount: true,
+  creditMaxCredits: true,
+  status: true,
+  publicationUseCase: true,
+  expectedStudentCount: true,
+  reviewComment: true,
+  publishedAt: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.ChatbotSelect
+
 export async function getChatbotsInfo(ctx: ContextWithUser) {
   const chatbots = await ctx.prisma.chatbot.findMany({
     where: { ownerId: ctx.user.sub },
     select: {
-      id: true,
-      name: true,
-      description: true,
-      avatar: true,
-      modelSelection: true,
-      allowedModelIds: true,
-      allowedReasoningEffortsByModel: true,
-      creditInitialCredits: true,
-      creditResetPeriod: true,
-      creditResetAmount: true,
-      creditMaxCredits: true,
-      createdAt: true,
-      updatedAt: true,
+      ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },
       disclaimer: { select: { id: true, name: true, title: true } },
       mcpConfigurations: {
@@ -419,19 +433,7 @@ export async function updateChatbotModelSettings(
       ownerId: ctx.user.sub,
     },
     select: {
-      id: true,
-      name: true,
-      description: true,
-      avatar: true,
-      modelSelection: true,
-      allowedModelIds: true,
-      allowedReasoningEffortsByModel: true,
-      creditInitialCredits: true,
-      creditResetPeriod: true,
-      creditResetAmount: true,
-      creditMaxCredits: true,
-      createdAt: true,
-      updatedAt: true,
+      ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },
     },
   })
@@ -514,19 +516,105 @@ export async function updateChatbotModelSettings(
           : Prisma.DbNull,
     },
     select: {
-      id: true,
-      name: true,
-      description: true,
-      avatar: true,
-      modelSelection: true,
-      allowedModelIds: true,
-      allowedReasoningEffortsByModel: true,
-      creditInitialCredits: true,
-      creditResetPeriod: true,
-      creditResetAmount: true,
-      creditMaxCredits: true,
-      createdAt: true,
-      updatedAt: true,
+      ...chatbotOwnerSelect,
+      course: { select: { id: true, name: true } },
+    },
+  })
+
+  return {
+    ...updated,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      updated.allowedReasoningEffortsByModel
+    ),
+    courses: updated.course ? [updated.course] : [],
+  }
+}
+
+type CreateChatbotArgs = {
+  name: string
+  description?: string | null
+  avatar?: string | null
+  courseId: string
+}
+
+export async function createChatbot(
+  args: CreateChatbotArgs,
+  ctx: ContextWithUser
+) {
+  // Resource-level authorization: the target course must belong to the
+  // requesting lecturer. Pothos already checked authenticate + catalyst; this
+  // is the third (execute-time ownership) layer of the auth model.
+  const course = await ctx.prisma.course.findFirst({
+    where: { id: args.courseId, ownerId: ctx.user.sub },
+    select: { id: true },
+  })
+  if (!course) {
+    throw new GraphQLError('Course not found')
+  }
+
+  const created = await ctx.prisma.chatbot.create({
+    data: {
+      name: args.name,
+      description: args.description ?? null,
+      avatar: args.avatar ?? null,
+      status: DB.ChatbotStatus.DRAFT,
+      owner: { connect: { id: ctx.user.sub } },
+      course: { connect: { id: args.courseId } },
+      // systemPrompts intentionally left unset (null): when no modes are
+      // configured, the chat runtime derives a tutor-only default from
+      // DEFAULT_PROMPT (getSupportedChatModes). Custom modes are added and
+      // reviewed post-approval — see docs/adr/0021.
+    },
+    select: {
+      ...chatbotOwnerSelect,
+      course: { select: { id: true, name: true } },
+    },
+  })
+
+  return {
+    ...created,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      created.allowedReasoningEffortsByModel
+    ),
+    courses: created.course ? [created.course] : [],
+  }
+}
+
+type UpdateChatbotArgs = {
+  id: string
+  name?: string | null
+  description?: string | null
+  avatar?: string | null
+}
+
+export async function updateChatbot(
+  args: UpdateChatbotArgs,
+  ctx: ContextWithUser
+) {
+  // Ownership guard: scope the lookup by ownerId so a non-owner cannot target
+  // another lecturer's chatbot. Returns null (not found) when the guard fails.
+  const existing = await ctx.prisma.chatbot.findFirst({
+    where: { id: args.id, ownerId: ctx.user.sub },
+    select: { id: true },
+  })
+  if (!existing) {
+    return null
+  }
+
+  const updated = await ctx.prisma.chatbot.update({
+    where: { id: existing.id },
+    data: {
+      // name is a required column, so only overwrite it when a value is given.
+      ...(args.name != null ? { name: args.name } : {}),
+      // description/avatar are nullable: an explicit null clears them, an
+      // omitted (undefined) arg leaves them untouched.
+      ...(args.description !== undefined
+        ? { description: args.description }
+        : {}),
+      ...(args.avatar !== undefined ? { avatar: args.avatar } : {}),
+    },
+    select: {
+      ...chatbotOwnerSelect,
       course: { select: { id: true, name: true } },
     },
   })

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -558,6 +558,9 @@ export async function createChatbot(
   if (!course) {
     throw new GraphQLError('Course not found')
   }
+  if (args.name === '') {
+    throw new GraphQLError('Chatbot name must not be empty')
+  }
 
   const created = await ctx.prisma.chatbot.create({
     data: {
@@ -600,6 +603,9 @@ export async function updateChatbot(
   })
   if (!existing) {
     return null
+  }
+  if (args.name === '') {
+    throw new GraphQLError('Chatbot name must not be empty')
   }
 
   const updated = await ctx.prisma.chatbot.update({

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -817,6 +817,9 @@ export async function rejectChatbotPublication(
   if (!chatbot) {
     return null
   }
+  if (args.comment.trim().length === 0) {
+    throw new GraphQLError('Review comment must not be empty')
+  }
   if (chatbot.status !== DB.ChatbotStatus.PENDING_APPROVAL) {
     throw new GraphQLError(`Cannot reject from status ${chatbot.status}`)
   }

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -650,11 +650,11 @@ export async function requestChatbotPublication(
     return null
   }
 
-  if (
-    typeof args.useCase !== 'string' ||
-    args.useCase.length < 1 ||
-    args.useCase.length > 2000
-  ) {
+  if (typeof args.useCase !== 'string') {
+    throw new GraphQLError('useCase must be between 1 and 2000 characters long')
+  }
+  const normalizedUseCase = args.useCase.trim()
+  if (normalizedUseCase.length < 1 || normalizedUseCase.length > 2000) {
     throw new GraphQLError('useCase must be between 1 and 2000 characters long')
   }
 
@@ -706,7 +706,7 @@ export async function requestChatbotPublication(
     },
     data: {
       status: DB.ChatbotStatus.PENDING_APPROVAL,
-      publicationUseCase: args.useCase,
+      publicationUseCase: normalizedUseCase,
       expectedStudentCount: args.expectedStudentCount,
       reviewComment: null, // clear any prior rejection note on re-request
       // Proposed credit budget (gated cost class, D2): flat model — initial =

--- a/packages/graphql/src/services/chatbots.ts
+++ b/packages/graphql/src/services/chatbots.ts
@@ -1,7 +1,7 @@
 import * as DB from '@klicker-uzh/prisma/client'
 import { Prisma } from '@klicker-uzh/prisma/client'
-import { z } from 'zod'
 import { GraphQLError } from 'graphql'
+import { z } from 'zod'
 import type { Context, ContextWithUser } from '../lib/context.js'
 
 const chatModelSchema = z
@@ -259,6 +259,21 @@ const chatbotOwnerSelect = {
   updatedAt: true,
 } satisfies Prisma.ChatbotSelect
 
+type ChatbotWithOwnerCourse = {
+  allowedReasoningEffortsByModel: unknown
+  course: { id: string; name: string } | null
+}
+
+function shapeChatbotResponse<T extends ChatbotWithOwnerCourse>(chatbot: T) {
+  return {
+    ...chatbot,
+    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
+      chatbot.allowedReasoningEffortsByModel
+    ),
+    courses: chatbot.course ? [chatbot.course] : [],
+  }
+}
+
 export async function getChatbotsInfo(ctx: ContextWithUser) {
   const chatbots = await ctx.prisma.chatbot.findMany({
     where: { ownerId: ctx.user.sub },
@@ -403,11 +418,7 @@ export async function getChatbotsInfo(ctx: ContextWithUser) {
     }))
 
     return {
-      ...chatbot,
-      allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-        chatbot.allowedReasoningEffortsByModel
-      ),
-      courses: chatbot.course ? [chatbot.course] : [],
+      ...shapeChatbotResponse(chatbot),
       usageSummary,
       disclaimerSummary,
       mcpConfigurations,
@@ -523,13 +534,7 @@ export async function updateChatbotModelSettings(
     },
   })
 
-  return {
-    ...updated,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      updated.allowedReasoningEffortsByModel
-    ),
-    courses: updated.course ? [updated.course] : [],
-  }
+  return shapeChatbotResponse(updated)
 }
 
 type CreateChatbotArgs = {
@@ -573,13 +578,7 @@ export async function createChatbot(
     },
   })
 
-  return {
-    ...created,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      created.allowedReasoningEffortsByModel
-    ),
-    courses: created.course ? [created.course] : [],
-  }
+  return shapeChatbotResponse(created)
 }
 
 type UpdateChatbotArgs = {
@@ -621,13 +620,7 @@ export async function updateChatbot(
     },
   })
 
-  return {
-    ...updated,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      updated.allowedReasoningEffortsByModel
-    ),
-    courses: updated.course ? [updated.course] : [],
-  }
+  return shapeChatbotResponse(updated)
 }
 
 type RequestChatbotPublicationArgs = {
@@ -649,6 +642,31 @@ export async function requestChatbotPublication(
   })
   if (!chatbot) {
     return null
+  }
+
+  if (
+    typeof args.useCase !== 'string' ||
+    args.useCase.length < 1 ||
+    args.useCase.length > 2000
+  ) {
+    throw new GraphQLError('useCase must be between 1 and 2000 characters long')
+  }
+
+  const isPositiveSignedInt32 = (value: unknown): value is number =>
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 2_147_483_647
+
+  if (!isPositiveSignedInt32(args.expectedStudentCount)) {
+    throw new GraphQLError(
+      'expectedStudentCount must be a positive signed 32-bit integer'
+    )
+  }
+  if (!isPositiveSignedInt32(args.proposedCredits)) {
+    throw new GraphQLError(
+      'proposedCredits must be a positive signed 32-bit integer'
+    )
   }
 
   // Account-level capability gate (D1, ADR 0020): read the live User row, never
@@ -708,13 +726,7 @@ export async function requestChatbotPublication(
     },
   })
 
-  return {
-    ...updated,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      updated.allowedReasoningEffortsByModel
-    ),
-    courses: updated.course ? [updated.course] : [],
-  }
+  return shapeChatbotResponse(updated)
 }
 
 export async function approveChatbotPublication(
@@ -781,13 +793,7 @@ export async function approveChatbotPublication(
     },
   })
 
-  return {
-    ...updated,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      updated.allowedReasoningEffortsByModel
-    ),
-    courses: updated.course ? [updated.course] : [],
-  }
+  return shapeChatbotResponse(updated)
 }
 
 export async function rejectChatbotPublication(
@@ -833,11 +839,5 @@ export async function rejectChatbotPublication(
     },
   })
 
-  return {
-    ...updated,
-    allowedReasoningEffortsByModel: parseAllowedReasoningEffortsByModel(
-      updated.allowedReasoningEffortsByModel
-    ),
-    courses: updated.course ? [updated.course] : [],
-  }
+  return shapeChatbotResponse(updated)
 }

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -206,6 +206,31 @@ describe('Integration tests for the chatbot publication workflow', () => {
       expect(result?.publishedAt).toBeInstanceOf(Date)
     })
 
+    it('allows only one concurrent approval to publish a PENDING bot', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL, {
+        reviewComment: null,
+      })
+
+      const results = await Promise.allSettled([
+        approveChatbotPublication({ id: bot.id }, adminCtx),
+        approveChatbotPublication({ id: bot.id }, adminCtx),
+      ])
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      expect(
+        results.find((result) => result.status === 'rejected')?.reason.message
+      ).toContain('approval could not be completed')
+      await expect(
+        prisma.chatbot.findUniqueOrThrow({
+          where: { id: bot.id },
+          select: { status: true },
+        })
+      ).resolves.toMatchObject({ status: ChatbotStatus.PUBLISHED })
+    })
+
     it('refuses to publish when the owner lost publishing capability while pending', async () => {
       // The bot reached PENDING via a request that required the capability, but
       // ops revoked aiChatbotPublishingEnabled before the admin acted. The

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -212,9 +212,51 @@ describe('Integration tests for the chatbot publication workflow', () => {
         reviewComment: null,
       })
 
+      let initialReads = 0
+      let releaseInitialReads!: () => void
+      const initialReadsReady = new Promise<void>((resolve) => {
+        releaseInitialReads = resolve
+      })
+      const chatbotDelegate = adminCtx.prisma.chatbot
+      const gatedChatbotDelegate = new Proxy(chatbotDelegate, {
+        get(target, property, receiver) {
+          const value = Reflect.get(target, property, receiver)
+          if (property !== 'findUnique') {
+            return typeof value === 'function' ? value.bind(target) : value
+          }
+
+          const findUnique = target.findUnique.bind(target)
+          return async (
+            ...args: Parameters<typeof chatbotDelegate.findUnique>
+          ) => {
+            const result = await findUnique(...args)
+            const select = args[0]?.select as unknown as
+              | {
+                  owner?: {
+                    select?: { aiChatbotPublishingEnabled?: boolean }
+                  }
+                }
+              | undefined
+            if (select?.owner?.select?.aiChatbotPublishingEnabled) {
+              initialReads += 1
+              if (initialReads === 2) releaseInitialReads()
+              await initialReadsReady
+            }
+            return result
+          }
+        },
+      })
+      const gatedPrisma = new Proxy(adminCtx.prisma, {
+        get(target, property, receiver) {
+          if (property === 'chatbot') return gatedChatbotDelegate
+          return Reflect.get(target, property, receiver)
+        },
+      })
+      const gatedAdminCtx = { ...adminCtx, prisma: gatedPrisma }
+
       const results = await Promise.allSettled([
-        approveChatbotPublication({ id: bot.id }, adminCtx),
-        approveChatbotPublication({ id: bot.id }, adminCtx),
+        approveChatbotPublication({ id: bot.id }, gatedAdminCtx),
+        approveChatbotPublication({ id: bot.id }, gatedAdminCtx),
       ])
 
       expect(

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -134,7 +134,12 @@ describe('Integration tests for the chatbot publication workflow', () => {
 
       await expect(
         requestChatbotPublication(
-          { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+          {
+            id: bot.id,
+            useCase: 'x',
+            expectedStudentCount: 1,
+            proposedCredits: 1,
+          },
           userOneCtx
         )
       ).rejects.toThrow('Cannot request publication from status PUBLISHED')
@@ -146,7 +151,12 @@ describe('Integration tests for the chatbot publication workflow', () => {
 
       await expect(
         requestChatbotPublication(
-          { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+          {
+            id: bot.id,
+            useCase: 'x',
+            expectedStudentCount: 1,
+            proposedCredits: 1,
+          },
           userOneCtx
         )
       ).rejects.toThrow('not approved')
@@ -163,7 +173,12 @@ describe('Integration tests for the chatbot publication workflow', () => {
       const bot = await seedChatbot(ChatbotStatus.DRAFT)
 
       const result = await requestChatbotPublication(
-        { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+        {
+          id: bot.id,
+          useCase: 'x',
+          expectedStudentCount: 1,
+          proposedCredits: 1,
+        },
         userTwoCtx
       )
 

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -217,6 +217,74 @@ describe('Integration tests for the chatbot publication workflow', () => {
       ).rejects.toThrow('Cannot request publication from status PUBLISHED')
     })
 
+    it.each([
+      ['empty', ''],
+      ['overlong', 'x'.repeat(2001)],
+    ])('rejects a %s use case', async (_, useCase) => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      await expect(
+        requestChatbotPublication(
+          {
+            id: bot.id,
+            useCase,
+            expectedStudentCount: 1,
+            proposedCredits: 1,
+          },
+          userOneCtx
+        )
+      ).rejects.toThrow('useCase must be between 1 and 2000 characters long')
+    })
+
+    it.each([
+      ['zero', 0],
+      ['negative', -1],
+      ['non-integer', 1.5],
+      ['overflow', 2_147_483_648],
+    ])('rejects %s expected student count', async (_, value) => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      await expect(
+        requestChatbotPublication(
+          {
+            id: bot.id,
+            useCase: 'Course Q&A',
+            expectedStudentCount: value,
+            proposedCredits: 1,
+          },
+          userOneCtx
+        )
+      ).rejects.toThrow(
+        'expectedStudentCount must be a positive signed 32-bit integer'
+      )
+    })
+
+    it.each([
+      ['zero', 0],
+      ['negative', -1],
+      ['non-integer', 1.5],
+      ['overflow', 2_147_483_648],
+    ])('rejects %s proposed credit count', async (_, value) => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      await expect(
+        requestChatbotPublication(
+          {
+            id: bot.id,
+            useCase: 'Course Q&A',
+            expectedStudentCount: 1,
+            proposedCredits: value,
+          },
+          userOneCtx
+        )
+      ).rejects.toThrow(
+        'proposedCredits must be a positive signed 32-bit integer'
+      )
+    })
+
     it('rejects when the account is not approved for publishing', async () => {
       // aiChatbotPublishingEnabled defaults to false — do not enable it.
       const bot = await seedChatbot(ChatbotStatus.DRAFT)

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -128,6 +128,78 @@ describe('Integration tests for the chatbot publication workflow', () => {
       expect(result?.reviewComment).toBeNull()
     })
 
+    it('allows only one concurrent request to move a bot into review', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      let initialReads = 0
+      let releaseInitialReads!: () => void
+      const initialReadsReady = new Promise<void>((resolve) => {
+        releaseInitialReads = resolve
+      })
+      const chatbotDelegate = userOneCtx.prisma.chatbot
+      const gatedChatbotDelegate = new Proxy(chatbotDelegate, {
+        get(target, property, receiver) {
+          const value = Reflect.get(target, property, receiver)
+          if (property !== 'findFirst') {
+            return typeof value === 'function' ? value.bind(target) : value
+          }
+
+          const findFirst = target.findFirst.bind(target)
+          return async (
+            ...args: Parameters<typeof chatbotDelegate.findFirst>
+          ) => {
+            const result = await findFirst(...args)
+            initialReads += 1
+            if (initialReads === 2) releaseInitialReads()
+            await initialReadsReady
+            return result
+          }
+        },
+      })
+      const gatedPrisma = new Proxy(userOneCtx.prisma, {
+        get(target, property, receiver) {
+          if (property === 'chatbot') return gatedChatbotDelegate
+          return Reflect.get(target, property, receiver)
+        },
+      })
+      const gatedCtx = { ...userOneCtx, prisma: gatedPrisma }
+
+      const results = await Promise.allSettled([
+        requestChatbotPublication(
+          {
+            id: bot.id,
+            useCase: 'Course Q&A',
+            expectedStudentCount: 10,
+            proposedCredits: 5,
+          },
+          gatedCtx
+        ),
+        requestChatbotPublication(
+          {
+            id: bot.id,
+            useCase: 'Course Q&A',
+            expectedStudentCount: 10,
+            proposedCredits: 5,
+          },
+          gatedCtx
+        ),
+      ])
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      expect(
+        results.find((result) => result.status === 'rejected')?.reason.message
+      ).toContain('status or account capability changed concurrently')
+      await expect(
+        prisma.chatbot.findUniqueOrThrow({
+          where: { id: bot.id },
+          select: { status: true },
+        })
+      ).resolves.toMatchObject({ status: ChatbotStatus.PENDING_APPROVAL })
+    })
+
     it('rejects a request from a non-requestable status (PUBLISHED)', async () => {
       await enablePublishing()
       const bot = await seedChatbot(ChatbotStatus.PUBLISHED)

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -90,7 +90,7 @@ describe('Integration tests for the chatbot publication workflow', () => {
       const result = await requestChatbotPublication(
         {
           id: bot.id,
-          useCase: 'Course Q&A',
+          useCase: '  Course Q&A\n',
           expectedStudentCount: 120,
           proposedCredits: 50,
         },
@@ -219,6 +219,7 @@ describe('Integration tests for the chatbot publication workflow', () => {
 
     it.each([
       ['empty', ''],
+      ['blank', ' \n\t '],
       ['overlong', 'x'.repeat(2001)],
     ])('rejects a %s use case', async (_, useCase) => {
       await enablePublishing()

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -230,18 +230,9 @@ describe('Integration tests for the chatbot publication workflow', () => {
             ...args: Parameters<typeof chatbotDelegate.findUnique>
           ) => {
             const result = await findUnique(...args)
-            const select = args[0]?.select as unknown as
-              | {
-                  owner?: {
-                    select?: { aiChatbotPublishingEnabled?: boolean }
-                  }
-                }
-              | undefined
-            if (select?.owner?.select?.aiChatbotPublishingEnabled) {
-              initialReads += 1
-              if (initialReads === 2) releaseInitialReads()
-              await initialReadsReady
-            }
+            initialReads += 1
+            if (initialReads === 2) releaseInitialReads()
+            await initialReadsReady
             return result
           }
         },

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -1,0 +1,235 @@
+import type { Hatchet } from '@hatchet-dev/typescript-sdk'
+import {
+  ChatbotStatus,
+  PrismaClient,
+  UserRole,
+} from '@klicker-uzh/prisma/client'
+import { EventEmitter } from 'events'
+import type { ContextWithUser } from '../src/lib/context.js'
+import {
+  approveChatbotPublication,
+  rejectChatbotPublication,
+  requestChatbotPublication,
+} from '../src/services/chatbots.js'
+import {
+  initializePrisma,
+  seedCourse,
+  testCleanup,
+  testInitialization,
+} from './helpers.js'
+
+describe('Integration tests for the chatbot publication workflow', () => {
+  let prisma: PrismaClient
+  let hatchet: Hatchet
+  let emitter: EventEmitter
+  let userOneCtx: ContextWithUser
+  let userTwoCtx: ContextWithUser
+  let adminCtx: ContextWithUser
+
+  beforeAll(async () => {
+    const {
+      prisma: newPrisma,
+      hatchet: newHatchet,
+      emitter: newEmitter,
+    } = await initializePrisma()
+    prisma = newPrisma
+    hatchet = newHatchet
+    emitter = newEmitter
+  })
+
+  afterAll(async () => {
+    await testCleanup(prisma)
+    await prisma.$disconnect()
+  })
+
+  beforeEach(async () => {
+    const { userOneCtx: ctx1, userTwoCtx: ctx2 } = await testInitialization(
+      prisma,
+      hatchet,
+      emitter
+    )
+    userOneCtx = ctx1
+    userTwoCtx = ctx2
+    // A distinct ADMIN caller (same identity plumbing, elevated role).
+    adminCtx = {
+      ...userOneCtx,
+      user: { ...userOneCtx.user, role: UserRole.ADMIN },
+    }
+  })
+
+  afterEach(async () => await testCleanup(prisma))
+
+  async function enablePublishing() {
+    await prisma.user.update({
+      where: { id: userOneCtx.user.sub },
+      data: { aiChatbotPublishingEnabled: true },
+    })
+  }
+
+  async function seedChatbot(
+    status: ChatbotStatus,
+    extra: Record<string, unknown> = {}
+  ) {
+    const course = await seedCourse({}, userOneCtx)
+    return prisma.chatbot.create({
+      data: {
+        name: 'Bot',
+        courseId: course.id,
+        ownerId: userOneCtx.user.sub,
+        status,
+        ...extra,
+      },
+    })
+  }
+
+  describe('requestChatbotPublication', () => {
+    it('moves a DRAFT bot to PENDING_APPROVAL and records the request', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      const result = await requestChatbotPublication(
+        {
+          id: bot.id,
+          useCase: 'Course Q&A',
+          expectedStudentCount: 120,
+          proposedCredits: 50,
+        },
+        userOneCtx
+      )
+
+      expect(result).toMatchObject({
+        status: 'PENDING_APPROVAL',
+        publicationUseCase: 'Course Q&A',
+        expectedStudentCount: 120,
+        creditInitialCredits: 50,
+        creditResetAmount: 50,
+        creditMaxCredits: 50,
+        reviewComment: null,
+      })
+    })
+
+    it('clears the prior review comment when re-requesting from REJECTED', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.REJECTED, {
+        reviewComment: 'needs a clearer scope',
+      })
+
+      const result = await requestChatbotPublication(
+        {
+          id: bot.id,
+          useCase: 'Revised scope',
+          expectedStudentCount: 30,
+          proposedCredits: 10,
+        },
+        userOneCtx
+      )
+
+      expect(result?.status).toBe('PENDING_APPROVAL')
+      expect(result?.reviewComment).toBeNull()
+    })
+
+    it('rejects a request from a non-requestable status (PUBLISHED)', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.PUBLISHED)
+
+      await expect(
+        requestChatbotPublication(
+          { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+          userOneCtx
+        )
+      ).rejects.toThrow('Cannot request publication from status PUBLISHED')
+    })
+
+    it('rejects when the account is not approved for publishing', async () => {
+      // aiChatbotPublishingEnabled defaults to false — do not enable it.
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      await expect(
+        requestChatbotPublication(
+          { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+          userOneCtx
+        )
+      ).rejects.toThrow('not approved')
+
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: bot.id },
+        select: { status: true },
+      })
+      expect(row.status).toBe('DRAFT')
+    })
+
+    it('returns null and makes no change for a non-owner', async () => {
+      await enablePublishing()
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      const result = await requestChatbotPublication(
+        { id: bot.id, useCase: 'x', expectedStudentCount: 1, proposedCredits: 1 },
+        userTwoCtx
+      )
+
+      expect(result).toBeNull()
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: bot.id },
+        select: { status: true },
+      })
+      expect(row.status).toBe('DRAFT')
+    })
+  })
+
+  describe('approveChatbotPublication', () => {
+    it('publishes a PENDING bot and stamps publishedAt', async () => {
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL, {
+        reviewComment: null,
+      })
+
+      const result = await approveChatbotPublication({ id: bot.id }, adminCtx)
+
+      expect(result?.status).toBe('PUBLISHED')
+      expect(result?.publishedAt).toBeInstanceOf(Date)
+    })
+
+    it('rejects approving a bot that is not pending (DRAFT)', async () => {
+      const bot = await seedChatbot(ChatbotStatus.DRAFT)
+
+      await expect(
+        approveChatbotPublication({ id: bot.id }, adminCtx)
+      ).rejects.toThrow('Cannot approve from status DRAFT')
+    })
+
+    it('rejects a non-admin caller and makes no change', async () => {
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
+
+      await expect(
+        approveChatbotPublication({ id: bot.id }, userOneCtx)
+      ).rejects.toThrow('Not authorized')
+
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: bot.id },
+        select: { status: true },
+      })
+      expect(row.status).toBe('PENDING_APPROVAL')
+    })
+  })
+
+  describe('rejectChatbotPublication', () => {
+    it('moves a PENDING bot to REJECTED with a review comment', async () => {
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
+
+      const result = await rejectChatbotPublication(
+        { id: bot.id, comment: 'scope too broad' },
+        adminCtx
+      )
+
+      expect(result?.status).toBe('REJECTED')
+      expect(result?.reviewComment).toBe('scope too broad')
+    })
+
+    it('rejects a non-admin caller', async () => {
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
+
+      await expect(
+        rejectChatbotPublication({ id: bot.id, comment: 'no' }, userOneCtx)
+      ).rejects.toThrow('Not authorized')
+    })
+  })
+})

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -178,6 +178,9 @@ describe('Integration tests for the chatbot publication workflow', () => {
 
   describe('approveChatbotPublication', () => {
     it('publishes a PENDING bot and stamps publishedAt', async () => {
+      // A real PENDING bot got there via a request, which required the owner's
+      // capability; keep it enabled so the approval-time re-check passes.
+      await enablePublishing()
       const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL, {
         reviewComment: null,
       })
@@ -186,6 +189,24 @@ describe('Integration tests for the chatbot publication workflow', () => {
 
       expect(result?.status).toBe('PUBLISHED')
       expect(result?.publishedAt).toBeInstanceOf(Date)
+    })
+
+    it('refuses to publish when the owner lost publishing capability while pending', async () => {
+      // The bot reached PENDING via a request that required the capability, but
+      // ops revoked aiChatbotPublishingEnabled before the admin acted. The
+      // account-level gate must still hold at the moment the bot goes live, so
+      // enablePublishing() is deliberately NOT called here.
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
+
+      await expect(
+        approveChatbotPublication({ id: bot.id }, adminCtx)
+      ).rejects.toThrow('no longer approved')
+
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: bot.id },
+        select: { status: true },
+      })
+      expect(row.status).toBe('PENDING_APPROVAL')
     })
 
     it('rejects approving a bot that is not pending (DRAFT)', async () => {

--- a/packages/graphql/test/chatbotPublication.test.ts
+++ b/packages/graphql/test/chatbotPublication.test.ts
@@ -458,12 +458,42 @@ describe('Integration tests for the chatbot publication workflow', () => {
       expect(result?.reviewComment).toBe('scope too broad')
     })
 
+    it.each([
+      ['empty', ''],
+      ['whitespace-only', ' \t\n'],
+    ])('rejects a %s review comment without changing the bot', async (_, comment) => {
+      const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
+
+      await expect(
+        rejectChatbotPublication({ id: bot.id, comment }, adminCtx)
+      ).rejects.toThrow('Review comment must not be empty')
+
+      await expect(
+        prisma.chatbot.findUniqueOrThrow({
+          where: { id: bot.id },
+          select: { status: true, reviewComment: true },
+        })
+      ).resolves.toMatchObject({
+        status: ChatbotStatus.PENDING_APPROVAL,
+        reviewComment: null,
+      })
+    })
+
     it('rejects a non-admin caller', async () => {
       const bot = await seedChatbot(ChatbotStatus.PENDING_APPROVAL)
 
       await expect(
-        rejectChatbotPublication({ id: bot.id, comment: 'no' }, userOneCtx)
+        rejectChatbotPublication({ id: bot.id, comment: ' ' }, userOneCtx)
       ).rejects.toThrow('Not authorized')
+    })
+
+    it('returns null for a missing bot before validating the comment', async () => {
+      await expect(
+        rejectChatbotPublication(
+          { id: '00000000-0000-0000-0000-000000000000', comment: ' ' },
+          adminCtx
+        )
+      ).resolves.toBeNull()
     })
   })
 })

--- a/packages/graphql/test/courseChatbots.test.ts
+++ b/packages/graphql/test/courseChatbots.test.ts
@@ -102,7 +102,7 @@ describe('Integration tests for the public courseChatbots query', () => {
   it('returns an empty list for a participant that is not enrolled in the course', async () => {
     const { course } = await seedCourseWithChatbot()
     const participant = await prisma.participant.create({
-      data: { username: 'chatbotParticipantUnenrolled', password: 'abcdabcd' },
+      data: { username: 'chatbotParticipantUnenrolled', password: 'not-used' },
     })
 
     const chatbots = await getParticipantCourseChatbots(
@@ -118,7 +118,7 @@ describe('Integration tests for the public courseChatbots query', () => {
     const participant = await prisma.participant.create({
       data: {
         username: 'chatbotParticipantEnrolled',
-        password: 'abcdabcd',
+        password: 'not-used',
         participations: { create: [{ courseId: course.id }] },
       },
     })
@@ -153,7 +153,7 @@ describe('Integration tests for the public courseChatbots query', () => {
     const participant = await prisma.participant.create({
       data: {
         username: 'chatbotParticipantDraft',
-        password: 'abcdabcd',
+        password: 'not-used',
         participations: { create: [{ courseId: course.id }] },
       },
     })

--- a/packages/graphql/test/courseChatbots.test.ts
+++ b/packages/graphql/test/courseChatbots.test.ts
@@ -1,5 +1,5 @@
 import type { Hatchet } from '@hatchet-dev/typescript-sdk'
-import { PrismaClient, UserRole } from '@klicker-uzh/prisma/client'
+import { ChatbotStatus, PrismaClient, UserRole } from '@klicker-uzh/prisma/client'
 import { EventEmitter } from 'events'
 import type { Context, ContextWithUser } from '../src/lib/context.js'
 import { getParticipantCourseChatbots } from '../src/services/chatbots.js'
@@ -51,6 +51,10 @@ describe('Integration tests for the public courseChatbots query', () => {
         name: 'Course Tutor',
         courseId: course.id,
         ownerId: userOneCtx.user.sub,
+        // The participant course-list query only returns PUBLISHED bots, so the
+        // visibility tests below seed a published bot explicitly (new bots
+        // default to DRAFT).
+        status: ChatbotStatus.PUBLISHED,
       },
     })
 
@@ -128,5 +132,33 @@ describe('Integration tests for the public courseChatbots query', () => {
         avatar: null,
       },
     ])
+  })
+
+  it('hides an unpublished chatbot from an enrolled participant', async () => {
+    const course = await seedCourse({}, userOneCtx)
+    // A DRAFT (unpublished) bot must never surface in a participant's course
+    // overview, mirroring the chat-app access gate (S4 publication boundary).
+    await prisma.chatbot.create({
+      data: {
+        name: 'Draft Tutor',
+        courseId: course.id,
+        ownerId: userOneCtx.user.sub,
+        status: ChatbotStatus.DRAFT,
+      },
+    })
+    const participant = await prisma.participant.create({
+      data: {
+        username: 'chatbotParticipantDraft',
+        password: 'abcdabcd',
+        participations: { create: [{ courseId: course.id }] },
+      },
+    })
+
+    const chatbots = await getParticipantCourseChatbots(
+      { courseId: course.id },
+      participantContext(participant.id)
+    )
+
+    expect(chatbots).toEqual([])
   })
 })

--- a/packages/graphql/test/courseChatbots.test.ts
+++ b/packages/graphql/test/courseChatbots.test.ts
@@ -1,5 +1,9 @@
 import type { Hatchet } from '@hatchet-dev/typescript-sdk'
-import { ChatbotStatus, PrismaClient, UserRole } from '@klicker-uzh/prisma/client'
+import {
+  ChatbotStatus,
+  PrismaClient,
+  UserRole,
+} from '@klicker-uzh/prisma/client'
 import { EventEmitter } from 'events'
 import type { Context, ContextWithUser } from '../src/lib/context.js'
 import { getParticipantCourseChatbots } from '../src/services/chatbots.js'

--- a/packages/graphql/test/manageChatbots.test.ts
+++ b/packages/graphql/test/manageChatbots.test.ts
@@ -92,6 +92,22 @@ describe('Integration tests for lecturer chatbot create/update', () => {
       })
       expect(count).toBe(0)
     })
+
+    it('rejects an empty name after checking course ownership', async () => {
+      const course = await seedCourse({}, userOneCtx)
+
+      await expect(
+        createChatbot({ name: '', courseId: course.id }, userOneCtx)
+      ).rejects.toThrow('Chatbot name must not be empty')
+    })
+
+    it('keeps the course ownership error for an empty name', async () => {
+      const course = await seedCourse({}, userOneCtx)
+
+      await expect(
+        createChatbot({ name: '', courseId: course.id }, userTwoCtx)
+      ).rejects.toThrow('Course not found')
+    })
   })
 
   describe('updateChatbot', () => {
@@ -125,11 +141,19 @@ describe('Integration tests for lecturer chatbot create/update', () => {
       })
     })
 
+    it('rejects an empty name after checking chatbot ownership', async () => {
+      const { chatbot } = await seedOwnedChatbot()
+
+      await expect(
+        updateChatbot({ id: chatbot.id, name: '' }, userOneCtx)
+      ).rejects.toThrow('Chatbot name must not be empty')
+    })
+
     it('returns null and makes no change for a non-owner', async () => {
       const { chatbot } = await seedOwnedChatbot()
 
       const result = await updateChatbot(
-        { id: chatbot.id, name: 'Hijacked' },
+        { id: chatbot.id, name: '' },
         userTwoCtx
       )
 

--- a/packages/graphql/test/manageChatbots.test.ts
+++ b/packages/graphql/test/manageChatbots.test.ts
@@ -116,17 +116,13 @@ describe('Integration tests for lecturer chatbot create/update', () => {
         userOneCtx
       )
 
+      // update() returns the persisted row, so the return value is proof of
+      // the write; the non-owner test below covers the no-write case.
       expect(updated).toMatchObject({
         id: chatbot.id,
         name: 'Renamed',
         description: 'after',
       })
-
-      const row = await prisma.chatbot.findUniqueOrThrow({
-        where: { id: chatbot.id },
-        select: { name: true, description: true },
-      })
-      expect(row).toEqual({ name: 'Renamed', description: 'after' })
     })
 
     it('returns null and makes no change for a non-owner', async () => {

--- a/packages/graphql/test/manageChatbots.test.ts
+++ b/packages/graphql/test/manageChatbots.test.ts
@@ -1,0 +1,149 @@
+import type { Hatchet } from '@hatchet-dev/typescript-sdk'
+import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { EventEmitter } from 'events'
+import type { ContextWithUser } from '../src/lib/context.js'
+import { createChatbot, updateChatbot } from '../src/services/chatbots.js'
+import {
+  initializePrisma,
+  seedCourse,
+  testCleanup,
+  testInitialization,
+} from './helpers.js'
+
+describe('Integration tests for lecturer chatbot create/update', () => {
+  let prisma: PrismaClient
+  let hatchet: Hatchet
+  let emitter: EventEmitter
+  let userOneCtx: ContextWithUser
+  let userTwoCtx: ContextWithUser
+
+  beforeAll(async () => {
+    const {
+      prisma: newPrisma,
+      hatchet: newHatchet,
+      emitter: newEmitter,
+    } = await initializePrisma()
+    prisma = newPrisma
+    hatchet = newHatchet
+    emitter = newEmitter
+  })
+
+  afterAll(async () => {
+    await testCleanup(prisma)
+    await prisma.$disconnect()
+  })
+
+  beforeEach(async () => {
+    const { userOneCtx: ctx1, userTwoCtx: ctx2 } = await testInitialization(
+      prisma,
+      hatchet,
+      emitter
+    )
+    userOneCtx = ctx1
+    userTwoCtx = ctx2
+  })
+
+  afterEach(async () => await testCleanup(prisma))
+
+  describe('createChatbot', () => {
+    it('creates a DRAFT tutor-only chatbot owned by the caller', async () => {
+      const course = await seedCourse({}, userOneCtx)
+
+      const chatbot = await createChatbot(
+        { name: 'My Tutor', courseId: course.id },
+        userOneCtx
+      )
+
+      expect(chatbot).toMatchObject({
+        name: 'My Tutor',
+        description: null,
+        status: 'DRAFT',
+        courses: [{ id: course.id }],
+      })
+
+      // Row is persisted with the caller as owner, DRAFT, no custom modes
+      // (systemPrompts null -> tutor-only default at runtime).
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: chatbot.id },
+        select: {
+          ownerId: true,
+          courseId: true,
+          status: true,
+          systemPrompts: true,
+        },
+      })
+      expect(row).toEqual({
+        ownerId: userOneCtx.user.sub,
+        courseId: course.id,
+        status: 'DRAFT',
+        systemPrompts: null,
+      })
+    })
+
+    it('rejects creation against a course the caller does not own', async () => {
+      const course = await seedCourse({}, userOneCtx)
+
+      await expect(
+        createChatbot({ name: 'Sneaky', courseId: course.id }, userTwoCtx)
+      ).rejects.toThrow('Course not found')
+
+      const count = await prisma.chatbot.count({
+        where: { courseId: course.id },
+      })
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('updateChatbot', () => {
+    async function seedOwnedChatbot() {
+      const course = await seedCourse({}, userOneCtx)
+      const chatbot = await prisma.chatbot.create({
+        data: {
+          name: 'Original',
+          description: 'before',
+          courseId: course.id,
+          ownerId: userOneCtx.user.sub,
+        },
+      })
+      return { course, chatbot }
+    }
+
+    it('updates free knobs for the owner', async () => {
+      const { chatbot } = await seedOwnedChatbot()
+
+      const updated = await updateChatbot(
+        { id: chatbot.id, name: 'Renamed', description: 'after' },
+        userOneCtx
+      )
+
+      expect(updated).toMatchObject({
+        id: chatbot.id,
+        name: 'Renamed',
+        description: 'after',
+      })
+
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: chatbot.id },
+        select: { name: true, description: true },
+      })
+      expect(row).toEqual({ name: 'Renamed', description: 'after' })
+    })
+
+    it('returns null and makes no change for a non-owner', async () => {
+      const { chatbot } = await seedOwnedChatbot()
+
+      const result = await updateChatbot(
+        { id: chatbot.id, name: 'Hijacked' },
+        userTwoCtx
+      )
+
+      expect(result).toBeNull()
+
+      const row = await prisma.chatbot.findUniqueOrThrow({
+        where: { id: chatbot.id },
+        select: { name: true },
+      })
+      expect(row).toEqual({ name: 'Original' })
+    })
+  })
+})

--- a/packages/prisma-data/src/data/seedChatbots.ts
+++ b/packages/prisma-data/src/data/seedChatbots.ts
@@ -51,6 +51,8 @@ Der Chatbot soll **kursbezogene Fragen** im Kurs "Banking and Finance I/II" bean
     update: {
       modelSelection: true,
       allowedModelIds: ['auto', 'gpt-5.6-luna', 'gpt-4.1-mini'],
+      // Repair status on reseed of an existing DB so the bot stays reachable.
+      status: 'PUBLISHED',
     },
     create: {
       id: CHATBOT_ID_TEST,
@@ -77,6 +79,7 @@ Der Chatbot soll **kursbezogene Fragen** im Kurs "Banking and Finance I/II" bean
       modelSelection: true, // Allow model selection for testing
       allowedModelIds: ['auto', 'gpt-5.6-luna', 'gpt-4.1-mini'],
       disclaimerId: testDisclaimer.id,
+      status: 'PUBLISHED', // seeded bot is live for participants
     },
   })
 

--- a/packages/prisma/src/prisma/schema/chat.prisma
+++ b/packages/prisma/src/prisma/schema/chat.prisma
@@ -15,6 +15,19 @@ enum ChatMessageRating {
   DOWN
 }
 
+// Lifecycle state of a chatbot. A chatbot is reachable by participants only
+// while PUBLISHED (enforced in the participant access path). DRAFT and
+// REJECTED are lecturer-editable pre-publication states; PENDING_APPROVAL awaits
+// team review; PAUSED is an operator-only stop with no self-service transition
+// in phase 0. See docs/adr/0020-two-tier-chatbot-approval.md.
+enum ChatbotStatus {
+  DRAFT
+  PENDING_APPROVAL
+  PUBLISHED
+  PAUSED
+  REJECTED
+}
+
 model ChatUsageCredits {
   total   Decimal @default(0) @db.Decimal(18, 6)
   current Decimal @default(0) @db.Decimal(18, 6)
@@ -129,6 +142,15 @@ model Chatbot {
   // Disclaimer configuration
   disclaimer   ChatbotDisclaimer? @relation(fields: [disclaimerId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   disclaimerId String?            @db.Uuid
+
+  // Lifecycle and publication (see docs/adr/0020-two-tier-chatbot-approval.md).
+  // A new chatbot starts as DRAFT; existing rows are backfilled to PUBLISHED by
+  // the introducing migration so live bots keep serving participants.
+  status               ChatbotStatus @default(DRAFT)
+  publicationUseCase   String?       @db.Text // lecturer's stated use case, set on a publication request
+  expectedStudentCount Int? // lecturer's expected student count, set on a publication request
+  reviewComment        String?       @db.Text // team comment on a rejected request; cleared on re-request
+  publishedAt          DateTime? // when the chatbot was first approved for publication
 
   // Relations
   mcpConfigurations ChatbotMCPConfig[]

--- a/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
@@ -11,7 +11,7 @@ ADD COLUMN     "status" "ChatbotStatus" NOT NULL DEFAULT 'DRAFT';
 -- Backfill: every chatbot that existed before this migration is already live for
 -- participants, so publish it. The DEFAULT 'DRAFT' above applies only to rows
 -- inserted after this point (new self-service chatbots start as drafts).
-UPDATE "Chatbot" SET "status" = 'PUBLISHED';
+UPDATE "Chatbot" SET "status" = 'PUBLISHED' WHERE "status" = 'DRAFT';
 
 -- AlterTable
 ALTER TABLE "User" ADD COLUMN     "aiChatbotCostCenter" TEXT,

--- a/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 -- CreateEnum
 CREATE TYPE "ChatbotStatus" AS ENUM ('DRAFT', 'PENDING_APPROVAL', 'PUBLISHED', 'PAUSED', 'REJECTED');
 
@@ -16,3 +18,5 @@ UPDATE "Chatbot" SET "status" = 'PUBLISHED' WHERE "status" = 'DRAFT';
 -- AlterTable
 ALTER TABLE "User" ADD COLUMN     "aiChatbotCostCenter" TEXT,
 ADD COLUMN     "aiChatbotPublishingEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+COMMIT;

--- a/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260820151622_chatbot_lifecycle_and_ai_capability/migration.sql
@@ -1,0 +1,18 @@
+-- CreateEnum
+CREATE TYPE "ChatbotStatus" AS ENUM ('DRAFT', 'PENDING_APPROVAL', 'PUBLISHED', 'PAUSED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "Chatbot" ADD COLUMN     "expectedStudentCount" INTEGER,
+ADD COLUMN     "publicationUseCase" TEXT,
+ADD COLUMN     "publishedAt" TIMESTAMP(3),
+ADD COLUMN     "reviewComment" TEXT,
+ADD COLUMN     "status" "ChatbotStatus" NOT NULL DEFAULT 'DRAFT';
+
+-- Backfill: every chatbot that existed before this migration is already live for
+-- participants, so publish it. The DEFAULT 'DRAFT' above applies only to rows
+-- inserted after this point (new self-service chatbots start as drafts).
+UPDATE "Chatbot" SET "status" = 'PUBLISHED';
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "aiChatbotCostCenter" TEXT,
+ADD COLUMN     "aiChatbotPublishingEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/src/prisma/schema/user.prisma
+++ b/packages/prisma/src/prisma/schema/user.prisma
@@ -107,6 +107,14 @@ model User {
   catalystIndividual    Boolean @default(false)
   catalystTier          String?
 
+  // Account-level AI chatbot publishing capability. Approved by the team out of
+  // band (cost center recorded) and checked against this row, never a JWT claim,
+  // when a lecturer requests publication. Separate from Catalyst, which only
+  // reveals the configuration features. See
+  // docs/adr/0020-two-tier-chatbot-approval.md.
+  aiChatbotPublishingEnabled Boolean @default(false)
+  aiChatbotCostCenter        String?
+
   publicPreview  Boolean @default(false)
   privatePreview Boolean @default(false)
 

--- a/playwright/util/chat.ts
+++ b/playwright/util/chat.ts
@@ -89,8 +89,14 @@ export async function ensureChatbotSeeded() {
       creditMaxCredits: 100,
       modelSelection: true,
       disclaimerId: DISCLAIMER_ID,
+      // Participants can only reach a PUBLISHED bot (apiGuards.getChatbotOr404).
+      status: 'PUBLISHED',
     },
-    update: { modelSelection: true, disclaimerId: DISCLAIMER_ID },
+    update: {
+      modelSelection: true,
+      disclaimerId: DISCLAIMER_ID,
+      status: 'PUBLISHED',
+    },
   })
 }
 
@@ -137,7 +143,12 @@ export async function resetChatState(participantId: string) {
   })
   await prisma.chatbot.update({
     where: { id: CHATBOT_ID },
-    data: { disclaimerId: DISCLAIMER_ID, modelSelection: true },
+    data: {
+      disclaimerId: DISCLAIMER_ID,
+      modelSelection: true,
+      // Restore PUBLISHED in case a test flipped it (participant access gate).
+      status: 'PUBLISHED',
+    },
   })
 }
 

--- a/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
+++ b/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
@@ -1,0 +1,175 @@
+# HITL lecturer chatbot configuration roadmap
+
+Decisions grilled and settled 2026-08-20. Rationale lives in the ADRs — this
+document sequences the work and fixes the v1 scope; it does not restate the
+why. Companion decisions from the same session that are feedback- rather than
+configuration-shaped (thumbs reason tags, milestone lecturer feedback form)
+are listed in phase 3.
+
+Governing ADRs: [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.md)
+(config store), [0020](../docs/adr/0020-two-tier-chatbot-approval.md)
+(approval model), [0021](../docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md)
+(mode tiers and prompt compilation), [0022](../docs/adr/0022-no-student-text-in-manage.md)
+(data boundary in manage).
+
+## Baseline (verified 2026-08-20)
+
+- Chatbots are seed-provisioned only; no create/delete flow or mutation exists.
+  The single lecturer mutation is `updateChatbotModelSettings`
+  (`packages/graphql/src/schema/mutation.ts`, `services/chatbots.ts`).
+- `systemPrompts[mode].prompt` fully **replaces** the built-in default at
+  request time (`apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts`);
+  only `tutor` has a built-in default (`apps/chat/src/lib/config/prompts.ts`).
+- Credits, disclaimer, MCP config are read-only in manage; `systemPrompts` is
+  not even queried by the manage UI.
+- Retrieval/ingestion is an external RAG MCP service referenced by
+  `ChatbotMCPServer`; this repo has no upload or ingest API.
+- An embed mode for the chat app already exists (basis for the lecturer test
+  chat).
+
+## Knob classification (the contract)
+
+| Knob | Lecturer v1 | Gate |
+| --- | --- | --- |
+| Name, description, avatar, course binding | Edit freely | — |
+| Standard-mode persona fields (course name, subject domain, language, scope note) | Edit freely | — |
+| Mode toggles (min 1 active) | Edit freely | — |
+| Few-shot examples (capped, fixed tags) | Edit freely | — |
+| Knowledge sources (upload / re-ingest / delete) | Edit freely (phase 4) | — |
+| Credit configuration | Propose | Approved with publication request |
+| Model allowlist / reasoning efforts | Edit freely (as today) | Cost-class changes on a live bot re-enter review |
+| Custom mode (name, description, persona text) | Author freely pre-publication | Reviewed at publication; edits on a live bot re-enter review |
+| Publication (students can reach the bot) | Request | Per-bot approval + account AI capability flag |
+| Raw compiled prompt | Not shown | — |
+| Disclaimer/legal text | Not editable | Ours |
+| OpenAI key/base URL, MCP wiring, chunking/retrieval parameters | Never exposed | Ours |
+| Confidence / resolution metrics | Not shown (no evaluator exists) | Build evaluator first |
+
+## Phase 0 — schema and approval foundations
+
+Everything else hangs off this; it is backend-only and shippable without UI.
+
+- `Chatbot` gains a status machine (`DRAFT`, `PENDING_APPROVAL`, `PUBLISHED`,
+  `PAUSED`, `REJECTED` with reviewer comment), owning-lecturer semantics, and
+  publication-request fields (use case, expected student count, proposed
+  credit config).
+- Account-level AI capability flag (separate from Catalyst; Catalyst reveals
+  the features, the AI flag permits publication requests). Cost center is
+  recorded per account at approval.
+- Mutations: `createChatbot`, `updateChatbot` (free knobs),
+  `requestChatbotPublication`, admin `approveChatbotPublication` /
+  `rejectChatbotPublication`.
+- Prompt **compile step** replacing today's replace-semantics: scaffolding +
+  standard-mode template + persona fields (+ later: examples, custom-mode
+  persona text). This is the ADR 0021/0019 contract; implement it once in the
+  current chat route with tests that assert scaffolding survival.
+- Approval operations v1 is ops-shaped: status flips via script/Prisma Studio,
+  email notification to the team. (Admin queue UI is phase 6.)
+
+## Phase 1 — creation flow and standard-mode fields in manage
+
+- Create-chatbot form: name, description, avatar, bound courses (required,
+  from the lecturer's own courses), initial mode set. Knowledge attaches later
+  on its own tab.
+- Detail page reorganized into tabs (mockup-inspired): Overview, Persona &
+  modes, Knowledge (status-only until phase 4), Limits & model (existing
+  controls), Access/publication.
+- Standard-mode persona fields editable per mode; mode toggles with min-1
+  enforcement.
+- Lecturer test chat: "Open test chat" via the existing embed mode with a
+  test-thread flag on `ChatThread` — excluded from student-facing analytics,
+  ratable, and the later capture source for examples. Unpublished bots are
+  reachable only this way.
+- In-app publication request form (flips to `PENDING_APPROVAL`); rejected
+  state shows the reviewer comment.
+
+## Phase 2 — examples studio (v1-minimal)
+
+The primary self-service steering lever (ADR 0021).
+
+- `ChatbotExample` model: chatbot + mode scoped, student-turn text, ideal
+  reply text, optional source reference, fixed tag enum (`HINT_NOT_ANSWER`,
+  `WRONG_ANSWER_RECOVERY`, `OFF_TOPIC_REDIRECT`, `CITATION_STYLE`), order,
+  in-prompt flag. Hard cap: 4 in-prompt, ~1k token budget shown in UI.
+- Manual add + capture-from-chat, sourcing **only the lecturer's own test
+  threads** (consistent with ADR 0022).
+- Compile step injects in-prompt examples per mode.
+- Explicitly out: compare sets, re-run-against-bot, import/export — that is
+  the phase-7 eval harness.
+
+## Phase 3 — overview KPIs and the feedback loop
+
+- Overview tab shows DB aggregates only (ADR 0022): conversations/messages
+  over time, thumbs ratio, reason-tag counts, credits consumed, per-source
+  ingest status (once phase 4 lands).
+- Thumbs-down reason tag for students (same vocabulary as example tags plus
+  `SOURCE_MISSING`): migrates the `rating` column to a small feedback table —
+  supersedes part of ADR 0002; record that supersession when implementing.
+- Milestone lecturer product-feedback form (1 week after publication and after
+  ~100 student messages), pre-filled with the bot's aggregates; hosted form →
+  ClickUp for the beta, embedded later only if the question set stabilizes.
+
+## Phase 4 — knowledge self-service
+
+Mandatory for beta scale; dependent on the KB service (kb-poc line) exposing
+upload + per-source status + delete over HTTP. Assumption from the grill: that
+API mostly exists (ingest-button restore is already on the KB roadmap) —
+verify first; if not, the API work joins this phase.
+
+- Knowledge tab actions: upload source, re-ingest, delete; per-source
+  `Ready` / `Processing` / `Stale` status.
+- Chunking, graph, and retrieval parameters are never exposed.
+
+## Phase 5 — custom modes
+
+- Author name, description, persona text; compiled as a layer (ADR 0021),
+  cap 2 per bot.
+- New/edited custom modes on a published bot re-enter review (ADR 0020);
+  pre-publication they are freely editable and testable in the test chat.
+
+## Phase 6 — admin approval queue
+
+- Admin-only manage page listing pending account approvals, publication
+  requests, and custom-mode reviews with approve/reject + comment. Promote
+  early if beta volume reaches double-digit bots per semester — the
+  rejected-with-comment loop needs a surface lecturers can see.
+
+## Phase 7 and later (explicitly deferred)
+
+- Eval harness: compare sets, re-run examples against the bot, starter-question
+  smoke tests as per-course eval sets (pairs with deepeval plans).
+- Draft/publish snapshots for editing live bots (only if live-editing pain
+  materializes; ADR 0020 consequence).
+- Structured persona fields beyond the four (only if example steering proves
+  insufficient).
+- Aggregate topics / any student-content exposure — learning-analytics track
+  governance only (ADR 0022, learning-analytics ADR 0005).
+- Embedded live-preview pane inside manage (test chat via embed mode covers
+  v1).
+- Confidence / resolution-rate metrics — require an evaluator; do not fake.
+
+## Glossary (merge into CONTEXT.md when the stashed glossary lands)
+
+- **Account AI capability**: The per-account approval (cost center recorded,
+  feature flag enabled) that permits publication requests. Distinct from
+  Catalyst, which only reveals the configuration features. _Avoid_: beta flag.
+- **Publication**: The per-chatbot approved transition that makes a bot
+  reachable by students. _Avoid_: go-live, activation.
+- **Publication request**: The in-app form on a bot (use case, expected
+  students, proposed credits) that puts it into review. _Avoid_: access form
+  (that is the account-level external form).
+- **Standard mode**: A platform-maintained mode (`tutor`, `explainer`) aimed
+  via constrained persona fields. _Avoid_: default mode.
+- **Custom mode**: A lecturer-authored mode whose persona text is reviewed at
+  publication. _Avoid_: custom prompt.
+- **Persona field**: A constrained standard-mode input (course name, subject
+  domain, language, scope note) compiled into the prompt. _Avoid_: prompt
+  field.
+- **Scaffolding**: The non-removable platform prompt base (citations,
+  grounding, safety, stance) that lecturer content layers onto. _Avoid_: base
+  prompt.
+- **Example**: A tagged student-turn/ideal-reply pair steering a mode, capped
+  in count and tokens. _Avoid_: few-shot, exemplar.
+- **Test thread**: A lecturer-owned conversation with their own (possibly
+  unpublished) bot, excluded from student-facing analytics and the only
+  capture source for examples. _Avoid_: preview chat.

--- a/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
+++ b/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
@@ -36,8 +36,8 @@ Governing ADRs: [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.
 | Mode toggles (min 1 active) | Edit freely | — |
 | Few-shot examples (capped, fixed tags) | Edit freely | — |
 | Knowledge sources (upload / re-ingest / delete) | Edit freely (phase 4) | — |
-| Credit configuration | Propose | Approved with publication request |
-| Model allowlist / reasoning efforts | Edit freely (as today) | Cost-class changes on a live bot re-enter review |
+| Participant usage-credit configuration | Propose | Approved with publication request; separate from account-wide usage budgets |
+| Model allowlist / reasoning efforts | Edit freely within the shared account AI authorization and monthly budgets | — |
 | Custom mode (name, description, persona text) | Author freely pre-publication | Reviewed at publication; edits on a live bot re-enter review |
 | Publication (students can reach the bot) | Request | Per-bot approval + account AI capability flag |
 | Raw compiled prompt | Not shown | — |
@@ -52,19 +52,42 @@ Everything else hangs off this; it is backend-only and shippable without UI.
 - `Chatbot` gains a status machine (`DRAFT`, `PENDING_APPROVAL`, `PUBLISHED`,
   `PAUSED`, `REJECTED` with reviewer comment), owning-lecturer semantics, and
   publication-request fields (use case, expected student count, proposed
-  credit config).
+  participant usage-credit configuration).
 - Account-level AI capability flag (separate from Catalyst; Catalyst reveals
-  the features, the AI flag permits publication requests). Cost center is
-  recorded per account at approval.
+  the features, the AI flag permits publication requests). One approved cost
+  center authorizes both base and advanced usage. Account-wide budget counters
+  and usage lanes are an implementation follow-up, not part of this Phase 0
+  PR.
 - Mutations: `createChatbot`, `updateChatbot` (free knobs),
   `requestChatbotPublication`, admin `approveChatbotPublication` /
   `rejectChatbotPublication`.
-- Prompt **compile step** replacing today's replace-semantics: scaffolding +
-  standard-mode template + persona fields (+ later: examples, custom-mode
-  persona text). This is the ADR 0021/0019 contract; implement it once in the
-  current chat route with tests that assert scaffolding survival.
-- Approval operations v1 is ops-shaped: status flips via script/Prisma Studio,
-  email notification to the team. (Admin queue UI is phase 6.)
+- Prompt **compile seam** preserving today's replacement behavior in Phase 0;
+  later phases add scaffolding, standard-mode fields, examples, and
+  custom-mode persona text according to ADR 0021. Characterization tests keep
+  this first extraction behavior-preserving.
+- Approval operations v1 is ops-shaped: status flips via script/Prisma Studio;
+  ops watches `PENDING_APPROVAL` manually. Team notification and the admin
+  queue UI are deferred to later phases.
+
+### Approved usage-funding MVP (implementation follow-up)
+
+- The shared account AI authorization requires an approved cost center for both
+  model classes; lecturers choose models without a new approval per model.
+- Registry entries carry explicit `BASE` or `ADVANCED` metadata. `Auto` is
+  `ADVANCED` until routed usage is attributable, and fallback never crosses
+  classes.
+- Lecturers define one monthly base budget and one monthly advanced budget for
+  the account. Both reset monthly. The UI has exactly two usage lanes — base
+  model usage and advanced model usage — each showing budget, used, remaining,
+  and reset date.
+- The teaching center's limited base contribution is internal and hidden. It
+  is not a third lane, is not shown as an allowance, and does not reclassify
+  base usage. Advanced usage receives no teaching-center contribution.
+- The pragmatic first implementation pre-checks availability and charges
+  reliable provider usage after generation with atomic counters. It accepts
+  bounded final/concurrent overruns and defers strict reservations, immutable
+  ledgers, automated refunds, invoice generation, per-chatbot allocations,
+  tariff versioning, Auto attribution, and participant-credit migration.
 
 ## Phase 1 — creation flow and standard-mode fields in manage
 
@@ -148,7 +171,9 @@ verify first; if not, the API work joins this phase.
   v1).
 - Confidence / resolution-rate metrics — require an evaluator; do not fake.
 
-## Glossary (merge into CONTEXT.md when the stashed glossary lands)
+## Configuration glossary
+
+Usage and funding terms are defined in the repository [CONTEXT.md](../CONTEXT.md).
 
 - **Account AI capability**: The per-account approval (cost center recorded,
   feature flag enabled) that permits publication requests. Distinct from
@@ -156,8 +181,9 @@ verify first; if not, the API work joins this phase.
 - **Publication**: The per-chatbot approved transition that makes a bot
   reachable by students. _Avoid_: go-live, activation.
 - **Publication request**: The in-app form on a bot (use case, expected
-  students, proposed credits) that puts it into review. _Avoid_: access form
-  (that is the account-level external form).
+  students, proposed participant usage-credit configuration) that puts it into
+  review. This legacy allowance is separate from account-wide usage budgets.
+  _Avoid_: access form (that is the account-level external form).
 - **Standard mode**: A platform-maintained mode (`tutor`, `explainer`) aimed
   via constrained persona fields. _Avoid_: default mode.
 - **Custom mode**: A lecturer-authored mode whose persona text is reviewed at

--- a/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
+++ b/project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md
@@ -2,9 +2,9 @@
 
 Decisions grilled and settled 2026-08-20. Rationale lives in the ADRs — this
 document sequences the work and fixes the v1 scope; it does not restate the
-why. Companion decisions from the same session that are feedback- rather than
-configuration-shaped (thumbs reason tags, milestone lecturer feedback form)
-are listed in phase 3.
+why. Companion decisions from the same session that are feedback-related rather
+than configuration-shaped (thumbs reason tags, milestone lecturer feedback
+form) are listed in phase 2.
 
 Governing ADRs: [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.md)
 (config store), [0020](../docs/adr/0020-two-tier-chatbot-approval.md)
@@ -34,8 +34,7 @@ Governing ADRs: [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.
 | Name, description, avatar, course binding | Edit freely | — |
 | Standard-mode persona fields (course name, subject domain, language, scope note) | Edit freely | — |
 | Mode toggles (min 1 active) | Edit freely | — |
-| Few-shot examples (capped, fixed tags) | Edit freely | — |
-| Knowledge sources (upload / re-ingest / delete) | Edit freely (phase 4) | — |
+| Knowledge sources (upload / re-ingest / delete) | Edit freely (phase 3) | — |
 | Participant usage-credit configuration | Propose | Approved with publication request; separate from account-wide usage budgets |
 | Model allowlist / reasoning efforts | Edit freely within the shared account AI authorization and monthly budgets | — |
 | Custom mode (name, description, persona text) | Author freely pre-publication | Reviewed at publication; edits on a live bot re-enter review |
@@ -62,12 +61,12 @@ Everything else hangs off this; it is backend-only and shippable without UI.
   `requestChatbotPublication`, admin `approveChatbotPublication` /
   `rejectChatbotPublication`.
 - Prompt **compile seam** preserving today's replacement behavior in Phase 0;
-  later phases add scaffolding, standard-mode fields, examples, and
-  custom-mode persona text according to ADR 0021. Characterization tests keep
+  later phases add scaffolding, standard-mode fields, and custom-mode persona
+  text according to ADR 0021. Characterization tests keep
   this first extraction behavior-preserving.
-- Approval operations v1 is ops-shaped: status flips via script/Prisma Studio;
-  ops watches `PENDING_APPROVAL` manually. Team notification and the admin
-  queue UI are deferred to later phases.
+- GraphQL mutations are the sole authoritative mechanism for lifecycle
+  transitions. The manage and admin UIs are deferred; ops watches
+  `PENDING_APPROVAL` manually in Phase 0.
 
 ### Approved usage-funding MVP (implementation follow-up)
 
@@ -95,44 +94,30 @@ Everything else hangs off this; it is backend-only and shippable without UI.
   from the lecturer's own courses), initial mode set. Knowledge attaches later
   on its own tab.
 - Detail page reorganized into tabs (mockup-inspired): Overview, Persona &
-  modes, Knowledge (status-only until phase 4), Limits & model (existing
+  modes, Knowledge (status-only until phase 3), Limits & model (existing
   controls), Access/publication.
 - Standard-mode persona fields editable per mode; mode toggles with min-1
   enforcement.
 - Lecturer test chat: "Open test chat" via the existing embed mode with a
-  test-thread flag on `ChatThread` — excluded from student-facing analytics,
-  ratable, and the later capture source for examples. Unpublished bots are
-  reachable only this way.
+  test-thread flag on `ChatThread`. Test threads are excluded from
+  student-facing analytics and ratings. Unpublished bots are reachable only
+  through this owner-authenticated path.
 - In-app publication request form (flips to `PENDING_APPROVAL`); rejected
   state shows the reviewer comment.
 
-## Phase 2 — examples studio (v1-minimal)
-
-The primary self-service steering lever (ADR 0021).
-
-- `ChatbotExample` model: chatbot + mode scoped, student-turn text, ideal
-  reply text, optional source reference, fixed tag enum (`HINT_NOT_ANSWER`,
-  `WRONG_ANSWER_RECOVERY`, `OFF_TOPIC_REDIRECT`, `CITATION_STYLE`), order,
-  in-prompt flag. Hard cap: 4 in-prompt, ~1k token budget shown in UI.
-- Manual add + capture-from-chat, sourcing **only the lecturer's own test
-  threads** (consistent with ADR 0022).
-- Compile step injects in-prompt examples per mode.
-- Explicitly out: compare sets, re-run-against-bot, import/export — that is
-  the phase-7 eval harness.
-
-## Phase 3 — overview KPIs and the feedback loop
+## Phase 2 — overview KPIs and the feedback loop
 
 - Overview tab shows DB aggregates only (ADR 0022): conversations/messages
   over time, thumbs ratio, reason-tag counts, credits consumed, per-source
-  ingest status (once phase 4 lands).
-- Thumbs-down reason tag for students (same vocabulary as example tags plus
-  `SOURCE_MISSING`): migrates the `rating` column to a small feedback table —
+  ingest status (once phase 3 lands).
+- Thumbs-down reason tag for students (including `SOURCE_MISSING`): migrates
+  the `rating` column to a small feedback table —
   supersedes part of ADR 0002; record that supersession when implementing.
 - Milestone lecturer product-feedback form (1 week after publication and after
   ~100 student messages), pre-filled with the bot's aggregates; hosted form →
   ClickUp for the beta, embedded later only if the question set stabilizes.
 
-## Phase 4 — knowledge self-service
+## Phase 3 — knowledge self-service
 
 Mandatory for beta scale; dependent on the KB service (kb-poc line) exposing
 upload + per-source status + delete over HTTP. Assumption from the grill: that
@@ -143,28 +128,28 @@ verify first; if not, the API work joins this phase.
   `Ready` / `Processing` / `Stale` status.
 - Chunking, graph, and retrieval parameters are never exposed.
 
-## Phase 5 — custom modes
+## Phase 4 — custom modes
 
 - Author name, description, persona text; compiled as a layer (ADR 0021),
   cap 2 per bot.
 - New/edited custom modes on a published bot re-enter review (ADR 0020);
   pre-publication they are freely editable and testable in the test chat.
 
-## Phase 6 — admin approval queue
+## Phase 5 — admin approval queue
 
 - Admin-only manage page listing pending account approvals, publication
   requests, and custom-mode reviews with approve/reject + comment. Promote
   early if beta volume reaches double-digit bots per semester — the
   rejected-with-comment loop needs a surface lecturers can see.
 
-## Phase 7 and later (explicitly deferred)
+## Phase 6 and later (explicitly deferred)
 
-- Eval harness: compare sets, re-run examples against the bot, starter-question
-  smoke tests as per-course eval sets (pairs with deepeval plans).
+- Eval harness: starter-question smoke tests as per-course eval sets (pairs
+  with deepeval plans).
 - Draft/publish snapshots for editing live bots (only if live-editing pain
   materializes; ADR 0020 consequence).
-- Structured persona fields beyond the four (only if example steering proves
-  insufficient).
+- Structured persona fields beyond the four (only if the existing persona
+  controls prove insufficient).
 - Aggregate topics / any student-content exposure — learning-analytics track
   governance only (ADR 0022, learning-analytics ADR 0005).
 - Embedded live-preview pane inside manage (test chat via embed mode covers
@@ -194,8 +179,6 @@ Usage and funding terms are defined in the repository [CONTEXT.md](../CONTEXT.md
 - **Scaffolding**: The non-removable platform prompt base (citations,
   grounding, safety, stance) that lecturer content layers onto. _Avoid_: base
   prompt.
-- **Example**: A tagged student-turn/ideal-reply pair steering a mode, capped
-  in count and tokens. _Avoid_: few-shot, exemplar.
 - **Test thread**: A lecturer-owned conversation with their own (possibly
-  unpublished) bot, excluded from student-facing analytics and the only
-  capture source for examples. _Avoid_: preview chat.
+  unpublished) bot, excluded from student-facing analytics. _Avoid_: preview
+  chat.

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -213,10 +213,13 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 - Status: S1–S5 code-complete. S4 slice-reviewer PASS + real-route browser
   smoke DONE (F7 confirmed at HTTP layer). S5 compile-seam extraction and its
-  simplifier/slice-review gates are DONE. The staged GraphQL selection fix,
-  migration backfill guard, and synthetic-password cleanup are committed and
-  pushed at `3e0bf1b13` for [PR #5460](https://github.com/uzh-bf/klicker-uzh/pull/5460);
-  fresh CI and the integrated final-review gate remain in progress.
+  simplifier/slice-review gates are DONE. The GraphQL selection fix, migration
+  backfill guard, and synthetic-fixture cleanup are committed and pushed in
+  [PR #5460](https://github.com/uzh-bf/klicker-uzh/pull/5460). Current-head CI
+  is terminal with 44 successful checks and one historical GitGuardian failure;
+  the integrated final-reviewer pass is DONE_WITH_CONCERNS with two medium
+  approval-boundary findings and two low documentation findings. No merge,
+  readiness change, issue closure, or history rewrite was performed.
 - S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
   backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
 - S2 (create/update mutations + owner-type exposure): DONE.
@@ -370,16 +373,20 @@ No separate tasks; nothing crosses a boundary warranting one.
   (`origin/HEAD`): 4 behind, 13 ahead, and none of v3's 4 new commits touch my
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
-- Base reconciliation (2026-08-21): the authoritative `git ls-remote` refs show
-  `origin/v3` at `65b4ac4a9` and this branch at `2de6c9988`, 1 behind / 21 ahead.
-  The new v3 commit is #5449 (draft-activity course deletion), which overlaps
-  generated GraphQL artifacts but not the chatbot implementation; GitHub reports
-  the PR mergeable. No rebase was performed. The common Git `FETCH_HEAD` file is
-  not writable in this linked worktree, so freshness was verified with
-  `git ls-remote` rather than inferred from local fetch state.
-- Remaining: fresh CI classification, the integrated final-reviewer pass, and
-  an updated whole-branch PR description. Marking the PR ready and merging it
-  remain outside this task's authority.
+- Base reconciliation (2026-08-21): the latest authoritative `git ls-remote`
+  refs show `origin/v3` at `df10f524e` and this branch at `029dd921d`, 2 behind /
+  22 ahead. The target-only commits since the earlier snapshot are #5449
+  (draft-activity course deletion) and #5461 (staging promotion); the current
+  three-dot PR diff remains 33 paths and the new target files do not overlap the
+  chatbot implementation. GitHub reports the PR mergeable but behind. No rebase
+  was performed. The common Git `FETCH_HEAD` file is not writable in this linked
+  worktree, so freshness was verified with `git ls-remote` rather than inferred
+  from fetch state.
+- Remaining: resolve or explicitly disposition the two medium final-review
+  findings, handle GitGuardian incident 36437584, reconcile the branch with the
+  current `v3` head before merge, and correct the roadmap/plan documentation.
+  Marking the PR ready, merging it, and closing #5453 remain outside this task's
+  authority.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -211,10 +211,20 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 ## Progress
 
-- Status: plan finalized (planner edits folded). Worktree from `origin/v3`.
-  Devcontainer stack starting. No slices started.
-- Remaining: S1–S5.
-- Runtime: worktree devcontainer stack coming up.
+- Status: S2 committed. Worktree from `origin/v3`, devcontainer up.
+- S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
+  backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
+- S2 (create/update mutations + owner-type exposure): DONE.
+  `ChatbotStatus` GraphQL enum + owner-facing `Chatbot` fields (status +
+  publication) exposed; `ChatbotPublic` left clean (F7). `createChatbot`
+  (asUserWithCatalyst, course-ownership check, DRAFT, tutor-only via null
+  systemPrompts) + `updateChatbot` (ownership filter, free knobs name/desc/
+  avatar). Shared `chatbotOwnerSelect` prevents projection drift. Codegen +
+  typecheck green; 4 service tests pass (create/update happy-path + non-owner
+  rejection). Slice-reviewer (contract+authz risk) pending.
+- Remaining: S3–S5.
+- Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
+  dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 
 ## MR/PR evidence expected
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -309,8 +309,38 @@ No separate tasks; nothing crosses a boundary warranting one.
   minimal (13+/29-, imports swapped in place) after reverting an accidental
   whole-file `organizeImports` churn from `biome check --write` (patch
   discipline; CI gate is `biome format`, which does not reorder imports).
-  Pending: per-slice simplifier + slice-reviewer (architecture risk).
-- Remaining: final-reviewer on integrated outcome, then draft PR against v3.
+- S5 gates: DONE. Simplifier → NO-CHANGE (two-function split proportionate,
+  single call site still nets a testability win, `DEFAULT_PROMPT` import live at
+  route.ts:174, `systemPrompts: unknown` param fine). Slice-reviewer
+  (architecture) → PASS with one low finding, **refuted with evidence**: it
+  claimed a `{ tutor: null }` per-mode entry now 500s uncaught (was swallowed by
+  the findUnique `try`), but the `.prompt` access is truthy-guarded in BOTH the
+  original (`if (systemPrompts && systemPrompts[selectedMode])`) and the
+  refactor (`if (stored?.[selectedMode])`) — the null value is falsy, so the
+  guard fails and both fall through to the mode default without dereferencing.
+  No behaviour delta, no latent 500. Residual valid point (the shape was
+  untested) closed with one **test-only** characterization case
+  (`{ tutor: null }` → default); production files unchanged. S5 commit amended
+  `babe4a87f` → `520afeabd`; 7/7 compiler tests, chat tsc + biome format clean.
+  Reports: `project/_local/reviews/2026-08-20-chatbot-s5-slice.md`.
+- Integrated verification: DONE and clean. chat 346/346; graphql + chat tsc
+  clean; my 3 graphql files pass in isolation, in the 3-file batch, and inside
+  the full CI-faithful suite. The only full-suite failures are pre-existing,
+  local-only, and in files I never touched: `assessmentRestrictions` (helpers.ts
+  hardcodes Redis to 127.0.0.1:6379/6380 — the CI port-map convention,
+  unreachable in the local devcontainer where Redis is at
+  `redis_exec`/`redis_assessment`) and, once Redis is bridged,
+  `activitySharing` (shared-live-DB collision). Proven not mine by an
+  exclude-my-3-files bridged run reproducing the identical `activitySharing`
+  failure with my files never loaded. CI resets a dedicated Postgres once, runs
+  a deterministic order, and is green on v3. Report:
+  `project/_local/reviews/2026-08-20-chatbot-phase0-integrated-verify.md`.
+- Substantive size = **1195 added / 80 deleted** (`git diff --numstat`, excl.
+  codegen ops.ts/ops.schema.json/public schema, pnpm-lock, plan/ADR docs) —
+  full-path package, well above the floor.
+- Remaining: final-reviewer on integrated outcome (`9f38b4e9a..520afeabd`, 6
+  code slices) — DISPATCHED (read-only). Then draft PR against v3 — WITHHELD
+  pending explicit push/PR authorization.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -338,9 +338,39 @@ No separate tasks; nothing crosses a boundary warranting one.
 - Substantive size = **1195 added / 80 deleted** (`git diff --numstat`, excl.
   codegen ops.ts/ops.schema.json/public schema, pnpm-lock, plan/ADR docs) —
   full-path package, well above the floor.
-- Remaining: final-reviewer on integrated outcome (`9f38b4e9a..520afeabd`, 6
-  code slices) — DISPATCHED (read-only). Then draft PR against v3 — WITHHELD
-  pending explicit push/PR authorization.
+- Final-reviewer (integrated `9f38b4e9a..520afeabd`): **CHANGES-REQUESTED,
+  mechanical only** — no correctness/authz/data-integrity defect. It positively
+  verified the three-layer auth on create/update, the admin gate on
+  approve/reject, the approval-time `aiChatbotPublishingEnabled` re-read, the
+  participant published-gate across all 11 apps/chat route handlers + layout +
+  `getParticipantCourseChatbots`, the migration ordering (CREATE TYPE → ADD
+  COLUMN DEFAULT DRAFT → UPDATE existing to PUBLISHED, one txn), and the
+  compile-seam extraction. Four findings, all dispositioned:
+  - #1 [med] 4 files failed `biome format` (repo-wide `format:check` CI gate) →
+    FIXED. `biome format --write` on exactly those files;
+    `format:check` now green ("Checked 1674 files. No fixes applied."). `git
+    diff -w` confirmed line-reflow only. Commit `672c9e292`.
+  - #2 [med] `docs/chat-platform.md` contradicted the code ("no visibility
+    field"; auth-guard section omitted the gate) → FIXED. Commit `9ee8e635b`.
+  - #3 [low] `apps/chat/src/services/chatbots.ts` `getChatbotById` (unused, no
+    callers) had no status filter → FIXED with a `findFirst` + PUBLISHED filter
+    so the seam can't leak a draft if wired up later. Commit `bdc597192`.
+  - #4 [low] schema/service comments cite `docs/adr/0020`/`0021`, which live on
+    branch `docs/chatbot-hitl-config-roadmap` (draft PR #5453), not an ancestor
+    → known merge-order dependency; state it in the PR description (merge #5453
+    first, or cherry-pick ADRs 0019-0022). No code change.
+  Corrections were mechanical (format, dead-code one-liner, docs); verified
+  directly (format:check green, chat tsc green, reformatted tests 14/14 + 11/11
+  + 5/5) rather than re-running the heavy final-reviewer. Report:
+  `project/_local/reviews/` (final-review captured in the integrated-verify doc
+  context).
+- Base drift: the resume hook flagged `origin/dev`, but `dev` is a stale
+  divergent branch (3559 commits apart), NOT the base. Branch targets `v3`
+  (`origin/HEAD`): 4 behind, 13 ahead, and none of v3's 4 new commits touch my
+  changed files (overlap empty excl. codegen) — a rebase would be a clean
+  codegen-only re-run.
+- Remaining: draft PR against v3 — WITHHELD pending explicit push/PR
+  authorization. HEAD `9ee8e635b`.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -221,7 +221,10 @@ No separate tasks; nothing crosses a boundary warranting one.
   systemPrompts) + `updateChatbot` (ownership filter, free knobs name/desc/
   avatar). Shared `chatbotOwnerSelect` prevents projection drift. Codegen +
   typecheck green; 4 service tests pass (create/update happy-path + non-owner
-  rejection). Slice-reviewer (contract+authz risk) pending.
+  rejection). Reviews DONE: slice-reviewer (contract+authz) CHANGES-REQUIRED
+  -> fixed (added asUserFullAccess scope to both mutations, matching the 23
+  sibling catalyst mutations); simplifier #2/#3 applied, #1 (defer pub fields)
+  rejected as plan-directed. Re-verified: codegen/typecheck/4 tests green.
 - Remaining: S3–S5.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -225,7 +225,15 @@ No separate tasks; nothing crosses a boundary warranting one.
   -> fixed (added asUserFullAccess scope to both mutations, matching the 23
   sibling catalyst mutations); simplifier #2/#3 applied, #1 (defer pub fields)
   rejected as plan-directed. Re-verified: codegen/typecheck/4 tests green.
-- Remaining: S3–S5.
+- S3 (publication workflow): DONE. `requestChatbotPublication`
+  (catalyst+full-access, ownership -> DB-row capability gate -> DRAFT/REJECTED
+  ->PENDING, clears reviewComment, writes useCase/count + flat credit budget),
+  admin `approveChatbotPublication` (PENDING->PUBLISHED, stamps publishedAt once)
+  + `rejectChatbotPublication` (PENDING->REJECTED + comment) — both asAdmin with
+  a service-level role check (D3). Codegen+typecheck green; 10 service tests
+  pass (legal/illegal transitions, capability gate, admin gate, non-owner).
+  Per-slice reviewers pending.
+- Remaining: S4–S5.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -232,7 +232,21 @@ No separate tasks; nothing crosses a boundary warranting one.
   + `rejectChatbotPublication` (PENDING->REJECTED + comment) — both asAdmin with
   a service-level role check (D3). Codegen+typecheck green; 10 service tests
   pass (legal/illegal transitions, capability gate, admin gate, non-owner).
-  Per-slice reviewers pending.
+  Reviews DONE: slice-reviewer (authz/state-machine) CHANGES-REQUIRED -> fixed
+  in `f57cf865c` (re-check owner capability at approval time + regression test;
+  11 tests green, typecheck green). Simplifier terminated without a flushed
+  verdict; adopted disposition recorded in `_local/reviews/2026-08-20-chatbot-s3-slice.md`.
+- Deferred cleanup (from S3 simplifier): extract shared `toChatbotInfo(row)`
+  mapper for the repeated return-tail across ~7 owner-facing functions. Deferred
+  (not folded into phase 0) because it edits already-reviewed S2 code for a
+  behavior-preserving DRY win — own micro-refactor or follow-up.
+- Carry to S4 (S3 LOW findings): gate participant access on `status ===
+  'PUBLISHED'`, never `publishedAt != null` (TOCTOU); credit path must not
+  assume `proposedCredits > 0` (no validation in phase 0).
+- Dependency: ADR 0020 lives only on `docs/chatbot-hitl-config-roadmap`
+  (draft PR #5453). It must merge before/with the phase-0 PR or the ADR
+  references (commit messages + prisma schema comments) dangle — record in the
+  phase-0 PR description.
 - Remaining: S4–S5.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -211,7 +211,11 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 ## Progress
 
-- Status: S2 committed. Worktree from `origin/v3`, devcontainer up.
+- Status: S1–S5 code-complete. S4 slice-reviewer PASS + real-route browser
+  smoke DONE (F7 confirmed at HTTP layer). S5 (compile-seam extraction) done +
+  verified, pending its simplifier + slice-reviewer. Worktree from `origin/v3`
+  (4 behind, benign codegen-only rebase — see Base drift). Remaining after S5
+  gates: final-reviewer on integrated outcome, then draft PR against v3.
 - S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
   backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
 - S2 (create/update mutations + owner-type exposure): DONE.
@@ -247,7 +251,66 @@ No separate tasks; nothing crosses a boundary warranting one.
   (draft PR #5453). It must merge before/with the phase-0 PR or the ADR
   references (commit messages + prisma schema comments) dangle — record in the
   phase-0 PR description.
-- Remaining: S4–S5.
+- Base drift (checked 2026-08-20, session resume): branch is 4 behind / 8 ahead
+  of `origin/v3` (the resume hook's "62 behind origin/dev" is a false alarm —
+  `dev` is an unrelated long-lived line, not this branch's base). The 4 new v3
+  commits are GrowthBook feature-flags (#5444) + manage pagination (#5451) +
+  two deploy promotes. They touch NONE of my hand-written source (apiGuards,
+  chatbots.ts, chat.prisma, the migration, resolvers all clean). The only real
+  overlap is 3 generated GraphQL codegen artifacts — `packages/graphql/src/
+  ops.ts`, `ops.schema.json`, `public/schema.graphql` — which both branches
+  regenerated. Rebase resolution = accept both, re-run
+  `pnpm --filter @klicker-uzh/graphql generate`, not a hand-merge. Rebase at
+  PR-open time (one rebase after S5), not mid-slice. Note in the PR body.
+- S4 (participant access gate): DONE (`c3ca4cd9b`). Single guard
+  `getChatbotOr404` always selects `status` and 404s any non-PUBLISHED bot
+  (existence never confirmed); guard-only `status` stripped from the returned
+  row unless the caller selected it, so the one wholesale-serializing route
+  (`GET /api/chatbots/[id]` -> `NextResponse.json`) never leaks owner-only
+  lifecycle metadata (F7). `layout.tsx` mirrors the check at page render;
+  `getParticipantCourseChatbots` filters the course overview to PUBLISHED.
+  Honored S3 carry-forwards: gate on `status`, not `publishedAt` (no TOCTOU on
+  the gate); no `proposedCredits > 0` assumption added. Tests: chat gate unit
+  (7 — PUBLISHED renders + status stripped; each non-PUBLISHED state + missing +
+  malformed 404) + graphql `courseChatbots` DRAFT-hidden participant test; chat
+  `tsc` clean; full graphql suite 560 pass (1 unrelated pre-existing
+  `assessmentRestrictions` flake, fails in isolation, no assessment code touched
+  by phase-0). Reviews DONE: slice-reviewer (security) PASS — all 6 properties
+  CONFIRMED (no-bypass audit of all 9 `[chatbotId]` routes; `chat/route.ts:695`
+  refetch is post-auth + field-by-field, no leak; F7 strip sound, no
+  shared-object/cache risk; 404-not-403 ordering). Sub-threshold, no action: the
+  "caller selects status" strip branch is untested (no caller selects it — YAGNI).
+  Data-hygiene gate false-positive on the documented local test password (a
+  fixture value, not a real credential) bypassed once with user approval.
+- S4 browser smoke: DONE. Real-route HTTP verification against the worktree
+  stack — `GET /api/chatbots/8f9c2e1d-…` (the wholesale-serializing route,
+  auth-exempt per middleware) returned HTTP 200 for the seeded PUBLISHED Benibot
+  with the full participant projection and **zero `status` tokens** in the body
+  (F7 strip confirmed at the live wire layer, not just in unit mocks). The
+  negative path (missing/malformed id, every non-PUBLISHED state) is covered by
+  the 7 gate unit tests + the graphql DRAFT-hidden integration test; the
+  host→Traefik loop for the linked-worktree hostname stayed 404 the whole run
+  (route never re-registered after the recompile restart — known environmental
+  flake, not the app), so the app-level negative case is unit/integration
+  evidence, not live. Authenticated participant chat page covered by Y-chat e2e
+  in CI on the draft-PR push.
+- S5 (compile seam): DONE (this commit). Extracted `compileSystemPrompt` into
+  `apps/chat/src/lib/server/systemPromptCompiler.ts`, capturing both original
+  seam blocks — base resolution from stored `systemPrompts`/`DEFAULT_PROMPT`
+  plus the layered `withLanguageStyleContract(withCitationContract(...))`.
+  `chat/route.ts` now calls it once after `toolNames` is known, dropping the
+  mid-function `let systemPrompt` mutation (the two blocks were separated only
+  because `toolNames` is resolved late; `systemPrompt` is never read between
+  them, verified). Behaviour-preserving — every quirk kept: empty stored prompt
+  falls back to the mode default then '', unknown mode yields '', citation
+  contract conditional on a doc_query tool, language contract unconditional.
+  6 characterization tests (D4 matrix) + the existing contract/gate suites green
+  (26/26 across 4 files); chat `tsc` clean; `biome format` clean. Diff is
+  minimal (13+/29-, imports swapped in place) after reverting an accidental
+  whole-file `organizeImports` churn from `biome check --write` (patch
+  discipline; CI gate is `biome format`, which does not reorder imports).
+  Pending: per-slice simplifier + slice-reviewer (architecture risk).
+- Remaining: final-reviewer on integrated outcome, then draft PR against v3.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -1,0 +1,225 @@
+# Phase 0 — chatbot lecturer HITL foundations (implementation plan)
+
+Roadmap: [`project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md`](2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md)
+(docs PR #5453). ADRs
+[0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.md),
+[0020](../docs/adr/0020-two-tier-chatbot-approval.md),
+[0021](../docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md),
+[0022](../docs/adr/0022-no-student-text-in-manage.md).
+
+Planner pass complete (2026-08-20): verdict "ready with named edits"; F1–F7
+folded in below. D3 resolved from code.
+
+## Goal
+
+Backend foundations that make lecturer self-service chatbots real and safe:
+a per-chatbot lifecycle status machine, an account-level AI publishing
+capability, chatbot create/update/publication-request/approve/reject mutations
+with three-layer auth enforced in the services, a participant-access gate that
+only serves `PUBLISHED` chatbots, and a behavior-preserving prompt-compile seam
+that later phases layer persona fields onto.
+
+## Non-goals
+
+- No manage UI (Phase 1) beyond what GraphQL exposes. Verified via GraphQL
+  service-seam tests + typecheck + a single participant browser smoke.
+- No persona-field editing, examples, knowledge self-service, custom modes,
+  admin queue UI (Phases 1–6).
+- No behavior change to existing chatbots' prompts — the compile seam is
+  extracted behavior-preserving; persona layering lands in Phase 1.
+- **No team email on publication request in Phase 0 code** (F6 ruling, veto-able):
+  ops watch the `PENDING_APPROVAL` state via query/Prisma Studio in the
+  first-cut ops flow; the notification lands with Phase 1's in-app request form.
+  Roadmap Phase 0 listed it under ops-shaped approvals; deferring the send is
+  ops-convenience, not correctness.
+
+## Execution contract
+
+- **Owner**: main session, autonomous through Phase 0's terminal condition per
+  the user's "begin the implementation" go-ahead.
+- **Authority granted**: worktree (done), local commits on
+  `feat/chatbot-lecturer-config-phase0`, bring up the worktree devcontainer
+  stack for verification, author the migration incl. backfill. **Withheld**:
+  push/PR until slices are green (then draft PR), merge, deploy, deletion.
+- **Terminal**: all slices committed and verified in-container; draft PR against
+  `v3` with the plan as first commit; runtime stopped per
+  `$rs-local-runtime-lifecycle`.
+- **Pause** (needs user): a GraphQL-contract change beyond this plan; the
+  compile refactor proving not behavior-preserving; admin-auth ambiguity risking
+  privilege escalation (mitigated — D3 resolved).
+
+## Plan identity
+
+- Plan: `project/2026-08-20-chatbot-hitl-phase0-plan.md`
+- Branch: `feat/chatbot-lecturer-config-phase0`, target `v3`, worktree
+  `trees/feat-chatbot-lecturer-config-phase0`. PR: none yet.
+
+## Grounding facts (verified 2026-08-20)
+
+- `Chatbot` has required `owner` (`ownerId`) + `course`. Sole mutation
+  `updateChatbotModelSettings` authorizes via `t.withAuth(asUser)` +
+  `where: { id, ownerId: ctx.user.sub }` (services/chatbots.ts:416-419).
+- `UserRole { ADMIN, USER }`; `User.role @default(USER)`; Catalyst flags exist
+  (user.prisma:106-108). Admin scope `asAdmin = { authenticated: true, role:
+  ADMIN }` at mutation.ts:110, spent via `t.withAuth(asAdmin)` (mutation.ts:1638,
+  query.ts:250). Role resolver builder.ts:66-79 — an ADMIN also passes `asUser`.
+- Catalyst scope `asUserWithCatalyst` (mutation.ts:111) used on ~23 mutations.
+- Chat is participant-facing (`participant_token`, apiGuards.ts:10); no User
+  auth path. Shared guard `getChatbotOr404`/`withChatbotAuth`
+  (apiGuards.ts:52-113) fronts all 9 participant API routes; server shell fetch
+  at `app/[chatbotId]/layout.tsx:23`; participant listing
+  `getParticipantCourseChatbots` (services/chatbots.ts:215-231) powers the PWA
+  course-page link.
+- Prompt resolution inline in route.ts:710-724 (resolve) + :809-811 (contracts);
+  `systemPrompt` unused between → extractable as one call. Only `tutor` has a
+  `DEFAULT_PROMPT` (prompts.ts:3-17). Seed prompts are already-full text
+  (`prisma-data/src/data/data/tutorMode.txt`, `explainerMode.txt`).
+- GraphQL tests call **service functions with a forged ctx**, bypassing Pothos
+  (test/courseChatbots.test.ts:61-77), and `testCleanup` deleteMany's core
+  tables against the dev `DATABASE_URL` (test/helpers.ts:341-369) — the run
+  wipes the dev DB; reseed after.
+
+## Resolved decisions (was D1–D4)
+
+- **D1 Account AI capability**: two `User` columns
+  `aiChatbotPublishingEnabled Boolean @default(false)` + `aiChatbotCostCenter
+  String?`, separate from Catalyst. The capability check reads the **`User` DB
+  row inside the service**, never a JWT claim (ops flips the flag after token
+  issuance); no new token claim in Phase 0.
+- **D2 Publication-request fields**: columns on `Chatbot`
+  (`publicationUseCase String?`, `expectedStudentCount Int?`,
+  `reviewComment String?`, `publishedAt DateTime?`). `proposedCredits` writes the
+  existing `creditInitial/ResetPeriod/ResetAmount/MaxCredits` columns
+  (chat.prisma:115-118) at request time — student-inert until PUBLISHED once S4
+  lands.
+- **D3 Admin authz**: use `t.withAuth(asAdmin)` at the schema layer **and** a
+  service-level `ctx.user.role !== UserRole.ADMIN → reject` (tests bypass Pothos,
+  so the service check is what the "admin authz" test can actually fail).
+- **D4 Compile seam**: behavior-preserving extraction of
+  `compileSystemPrompt(chatbot, mode, toolNames)`; acceptance is
+  **characterization tests** (no pre-refactor function to snapshot), matrix:
+  (a) `systemPrompts[mode]` present, (b) absent → `DEFAULT_PROMPT` (tutor only),
+  (c) unknown mode → `''`; each × {doc_query tool present / absent}. Preserve
+  quirks (empty-prompt fallback, unconditional language contract, conditional
+  citation contract); do not fix them here.
+
+## F6 rulings (veto-able, made to avoid blocking)
+
+- `createChatbot`/`updateChatbot` use `t.withAuth(asUserWithCatalyst)` (ADR 0020
+  "Catalyst reveals creation"; repo precedent). `updateChatbotModelSettings`
+  stays `asUser` (grandfathered).
+- Team email deferred (see Non-goals).
+
+## Primitive impact
+
+| Primitive | Disposition | Contract delta |
+| --- | --- | --- |
+| Chatbot | Extend | Lifecycle status, ownership-gated CRUD, publication fields |
+| Account AI capability | Create | Account-level publish gate (DB-row check) |
+| Publication (go-live) | Create | Approved transition; participant access gated on it |
+| System-prompt compilation | Extend (seam) | Behavior-preserving extraction; Phase-1 layering seam |
+
+## ADR gate
+
+Decisions recorded in ADRs 0019–0022 (docs PR #5453). No new Phase 0 ADR.
+
+## Test portfolio (feature-wide) — seam = service functions (Pothos bypassed)
+
+| Risk / behavior | Obligation | Seam | Distinct failure | Slice |
+| --- | --- | --- | --- | --- |
+| Lifecycle transitions legal + illegal (incl. REJECTED→PENDING) | add new | GraphQL service test (live DB) | PUBLISHED without approval; illegal transition allowed | S3 |
+| Ownership authz | add new | service test | non-owner mutates another lecturer's bot | S2/S3 |
+| Admin authz (service-level role check) | add new | service test | lecturer self-approves | S3 |
+| Account capability gate (DB-row) | add new | service test | ungated account publishes | S3 |
+| Participant access gate | add new | `getChatbotOr404` unit/route test + Y-chat e2e | draft bot answers/leaks to students | S4 |
+| Compile seam behavior-preserving | add new | unit test on `compileSystemPrompt` | scaffolding dropped / prompt changed | S5 |
+
+Every test run reseeds afterward (`prisma-data seed:raw`) before any
+route/browser verification (F4).
+
+## Delegation Map
+
+| Item | Assignee | Depends on | Acceptance |
+| --- | --- | --- | --- |
+| S1 schema+migration+backfill+seed status | main | — | migration applies; existing rows backfilled PUBLISHED; prisma:sync + typecheck green |
+| S2 create/update mutations + owner-type exposure | main | S1 | service tests: happy path, non-owner rejected; codegen green |
+| S3 publication workflow (capability gate, asAdmin+service role check, DRAFT/REJECTED→PENDING) | main | S1, S2 | service tests: each legal/illegal transition, non-admin rejected, ungated rejected |
+| S4 participant gate (getChatbotOr404 + layout + getParticipantCourseChatbots + playwright fixtures) | main | S1 | non-PUBLISHED 404 test; Y-chat green; browser smoke on seeded bot |
+| S5 compile-seam extraction + characterization tests | main | none (merge last) | characterization matrix green; diff shows moved-not-changed |
+| planner (done); per-slice simplifier + slice-reviewer (S1 data-integrity, S2/S3 contract+authz, S4 security, S5 architecture); final-reviewer pre-PR | native subagent roles | per workflow | reports; advice verified by main |
+
+No separate tasks; nothing crosses a boundary warranting one.
+
+## Slices (tracer bullets)
+
+- **S1 — Schema + migration + backfill.** `ChatbotStatus` enum
+  (DRAFT, PENDING_APPROVAL, PUBLISHED, PAUSED, REJECTED); Chatbot columns
+  `status @default(DRAFT)`, `publicationUseCase`, `expectedStudentCount`,
+  `reviewComment`, `publishedAt`; User columns `aiChatbotPublishingEnabled`,
+  `aiChatbotCostCenter`. **Migration backfills existing rows
+  `UPDATE "Chatbot" SET status='PUBLISHED'`** (F1 — prevents prod outage);
+  `seedChatbots.ts` sets `status: PUBLISHED` in **both** create and update
+  branches. `prisma:sync` (analytics mirror), regenerate client. `PAUSED` has no
+  Phase 0 transition (ops-flip only) — intentional, not dead code.
+  Acceptance: migration applies on worktree DB; existing-row backfill verified;
+  `prisma generate` clean; typecheck green.
+  Commit: `feat(prisma): chatbot lifecycle status and account AI capability`.
+  Risk: data-integrity → slice-reviewer.
+
+- **S2 — createChatbot + updateChatbot + owner-type exposure.** Pothos: expose
+  `status` + publication fields on the **owner-facing** Chatbot type only
+  (getChatbotsInfo shape), never the participant course-chatbot type (F7).
+  `createChatbot(name, description?, avatar?, courseId)` — `asUserWithCatalyst`,
+  service verifies the course is owned by ctx user, sets owner=ctx user,
+  status=DRAFT, tutor-only default (no `initialModes` in Phase 0, F7).
+  `updateChatbot(id, free knobs)` — `asUserWithCatalyst` + service ownership
+  filter. Codegen. Acceptance: service tests (create/update happy-path +
+  non-owner rejection); codegen + typecheck green.
+  Commit: `feat(graphql): lecturer chatbot create and update`.
+  Risk: public contract + authz → slice-reviewer.
+
+- **S3 — Publication workflow.** `requestChatbotPublication(id, useCase,
+  expectedStudentCount, proposedCredits)` — `asUserWithCatalyst` + service
+  ownership + **DB-row capability check** (`aiChatbotPublishingEnabled`); source
+  states **DRAFT and REJECTED** → PENDING_APPROVAL, clearing `reviewComment`,
+  writing publication + credit columns (F5, D2). Admin
+  `approveChatbotPublication(id)` (PENDING→PUBLISHED, set publishedAt) and
+  `rejectChatbotPublication(id, comment)` (PENDING→REJECTED) — `asAdmin` +
+  service `role !== ADMIN → reject` (D3). Acceptance: service tests for each
+  legal/illegal transition, capability gate, admin gate.
+  Commit: `feat(graphql): chatbot publication workflow`.
+  Risk: authz/state machine → slice-reviewer.
+
+- **S4 — Participant access gate.** Gate once in `getChatbotOr404` (select
+  `status`, **404** for non-PUBLISHED to avoid confirming existence) — covers all
+  9 participant routes; add `status: PUBLISHED` to `layout.tsx:23` fetch and the
+  `getParticipantCourseChatbots` where-clause (F2). No owner bypass (chat auth is
+  participant-only; lecturer test chat is Phase 1). Update Playwright
+  `ensureChatbotSeeded` + `resetChatState` to `PUBLISHED` (F3). Acceptance:
+  non-PUBLISHED 404 test; Y-chat green (local or CI); one `agent-browser` smoke
+  that a seeded PUBLISHED bot still chats (mandatory browser rule; reseeded DB).
+  Commit: `feat(chat): gate participant access on published chatbots`.
+  Risk: security boundary → slice-reviewer.
+
+- **S5 — Compile seam.** Extract `compileSystemPrompt(chatbot, mode, toolNames)`
+  capturing today's exact resolution + contract composition (route.ts:710-724 +
+  :809-811), behavior-preserving; single call after `toolNames` exist replaces
+  both blocks. Characterization unit tests per D4. Acceptance: matrix green; diff
+  shows moved-not-changed composition.
+  Commit: `refactor(chat): extract layered system-prompt compile seam`.
+  Risk: architecture → slice-reviewer.
+
+## Progress
+
+- Status: plan finalized (planner edits folded). Worktree from `origin/v3`.
+  Devcontainer stack starting. No slices started.
+- Remaining: S1–S5.
+- Runtime: worktree devcontainer stack coming up.
+
+## MR/PR evidence expected
+
+- GraphQL service-test output (transitions + authz + capability).
+- Migration diff + existing-row backfill proof; `prisma generate` clean.
+- Y-chat e2e result + one participant browser smoke.
+- Compile-seam characterization matrix.
+- Substantive size stated at the pre-open gate.

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -212,10 +212,11 @@ No separate tasks; nothing crosses a boundary warranting one.
 ## Progress
 
 - Status: S1–S5 code-complete. S4 slice-reviewer PASS + real-route browser
-  smoke DONE (F7 confirmed at HTTP layer). S5 (compile-seam extraction) done +
-  verified, pending its simplifier + slice-reviewer. Worktree from `origin/v3`
-  (4 behind, benign codegen-only rebase — see Base drift). Remaining after S5
-  gates: final-reviewer on integrated outcome, then draft PR against v3.
+  smoke DONE (F7 confirmed at HTTP layer). S5 compile-seam extraction and its
+  simplifier/slice-review gates are DONE. The staged GraphQL selection fix,
+  migration backfill guard, and synthetic-password cleanup are committed and
+  pushed at `3e0bf1b13` for [PR #5460](https://github.com/uzh-bf/klicker-uzh/pull/5460);
+  fresh CI and the integrated final-review gate remain in progress.
 - S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
   backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
 - S2 (create/update mutations + owner-type exposure): DONE.
@@ -247,10 +248,10 @@ No separate tasks; nothing crosses a boundary warranting one.
 - Carry to S4 (S3 LOW findings): gate participant access on `status ===
   'PUBLISHED'`, never `publishedAt != null` (TOCTOU); credit path must not
   assume `proposedCredits > 0` (no validation in phase 0).
-- Dependency: ADR 0020 lives only on `docs/chatbot-hitl-config-roadmap`
-  (draft PR #5453). It must merge before/with the phase-0 PR or the ADR
-  references (commit messages + prisma schema comments) dangle — record in the
-  phase-0 PR description.
+- Dependency: ADR 0020 and ADRs 0019–0022 were folded into this branch by merge
+  commit `1fd19330f`, so the former [PR #5453](https://github.com/uzh-bf/klicker-uzh/pull/5453)
+  merge-order dependency is resolved. Closing #5453 remains a separate,
+  explicitly authorized repository action.
 - Base drift (checked 2026-08-20, session resume): branch is 4 behind / 8 ahead
   of `origin/v3` (the resume hook's "62 behind origin/dev" is a false alarm —
   `dev` is an unrelated long-lived line, not this branch's base). The 4 new v3
@@ -369,8 +370,14 @@ No separate tasks; nothing crosses a boundary warranting one.
   (`origin/HEAD`): 4 behind, 13 ahead, and none of v3's 4 new commits touch my
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
-- Remaining: draft PR against v3 — WITHHELD pending explicit push/PR
-  authorization. HEAD `9ee8e635b`.
+- Base reconciliation (2026-08-21): the authoritative `git ls-remote` refs show
+  `origin/v3` at `784469db3` and this branch at `3e0bf1b13`, 0 behind / 20 ahead.
+  The common Git `FETCH_HEAD` file is not writable in this linked worktree, so
+  remote freshness was verified with `git ls-remote` rather than inferred from
+  local fetch state.
+- Remaining: fresh CI classification, the integrated final-reviewer pass, and
+  an updated whole-branch PR description. Marking the PR ready and merging it
+  remain outside this task's authority.
 - Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
   dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 

--- a/project/2026-08-20-chatbot-hitl-phase0-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-plan.md
@@ -371,10 +371,12 @@ No separate tasks; nothing crosses a boundary warranting one.
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
 - Base reconciliation (2026-08-21): the authoritative `git ls-remote` refs show
-  `origin/v3` at `784469db3` and this branch at `3e0bf1b13`, 0 behind / 20 ahead.
-  The common Git `FETCH_HEAD` file is not writable in this linked worktree, so
-  remote freshness was verified with `git ls-remote` rather than inferred from
-  local fetch state.
+  `origin/v3` at `65b4ac4a9` and this branch at `2de6c9988`, 1 behind / 21 ahead.
+  The new v3 commit is #5449 (draft-activity course deletion), which overlaps
+  generated GraphQL artifacts but not the chatbot implementation; GitHub reports
+  the PR mergeable. No rebase was performed. The common Git `FETCH_HEAD` file is
+  not writable in this linked worktree, so freshness was verified with
+  `git ls-remote` rather than inferred from local fetch state.
 - Remaining: fresh CI classification, the integrated final-reviewer pass, and
   an updated whole-branch PR description. Marking the PR ready and merging it
   remain outside this task's authority.

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -478,6 +478,14 @@ pre-commit hook also passes, including the secret scan, staged formatting, all
 25 package checks, lint, syncpack, agent checks, and Prisma sync. This note does
 not claim a push, fresh CI, or merge.
 
+### Progress — 2026-08-26 (final review correction)
+
+The final integrated stack review found that publication requests accepted a
+whitespace-only use case. The Phase 0 service now validates the trimmed value,
+persists that normalized value, and covers both whitespace-only rejection and
+normalization in the existing publication workflow test. This correction does
+not change the publication state machine or authorization boundary.
+
 - GraphQL service-test output (transitions + authz + capability).
 - Migration diff + existing-row backfill proof; `prisma generate` clean.
 - Y-chat e2e result + one participant browser smoke.

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -219,9 +219,19 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 - Active follow-up slice: make publication approval and rejection conditional
   lifecycle transitions, with a deterministic concurrent-approval regression
-  test. The implementation, correction review, and local commit are complete;
-  the remaining work is the final package review and delivery-boundary check.
-- Status: S1–S5 code-complete. S4 slice-reviewer PASS + real-route browser
+  test. The implementation, correction review, and local commits are complete.
+  The remaining work is to cascade the bottom-layer correction through the
+  stack, run the integrated final review, republish, and obtain fresh CI. Merge
+  remains outside this plan's authority.
+
+### Historical execution record
+
+The entries below preserve the evidence captured while Phase 0 was developed.
+Commit IDs and forge snapshots in this subsection are pre-rebase identifiers,
+not claims about the current branch head or current CI.
+
+- Status at the pre-rebase review point: S1–S5 code-complete. S4
+  slice-reviewer PASS + real-route browser
   smoke DONE (F7 confirmed at HTTP layer). S5 compile-seam extraction and its
   simplifier/slice-review gates are DONE. The GraphQL selection fix, migration
   backfill guard, and synthetic-fixture cleanup are committed and pushed in
@@ -442,10 +452,23 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 ## MR/PR evidence expected
 
-### Progress — 2026-08-24
+### Progress — 2026-08-24 (post-rebase repair)
 
-The bottom layer was rebased onto `v3`, and the verified review fixes were
-applied. This note does not claim a push or CI result.
+The bottom layer was rebased onto `v3`. The post-rebase repair range starts at
+`dc5262745`; commit `a747a9ca2` applies the verified PR-comment fixes to the
+publication-request transition, participant status projection, validation,
+tests, ADR, roadmap, and this plan. The configured specialist providers could
+not read the encrypted review task, so native-model continuity fallbacks ran
+the required gates. The simplifier returned no changes. The risk review found
+no defect in the status projection, conditional transition, or concurrency
+barrier; its participant/test-chat wording concern is resolved in ADR 0020.
+
+Focused verification passed: the chat publication-gate test is **8/8**, the
+GraphQL publication workflow test is **13/13**, and the chat, GraphQL, and
+frontend-manage package checks pass in the exact Node 24 DevPod. The repository
+pre-commit hook also passes, including the secret scan, staged formatting, all
+25 package checks, lint, syncpack, agent checks, and Prisma sync. This note does
+not claim a push, fresh CI, or merge.
 
 - GraphQL service-test output (transitions + authz + capability).
 - Migration diff + existing-row backfill proof; `prisma generate` clean.

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -256,6 +256,15 @@ No separate tasks; nothing crosses a boundary warranting one.
   determinism gap; the read barrier above fixed it. The fallback found no
   implementation defect. This route limitation remains an evidence caveat
   for the final package review.
+- Final-review correction: the native final reviewer found one medium
+  data-integrity issue in the lifecycle migration: the schema changes and
+  existing-row backfill were not explicitly transactional despite the plan's
+  one-transaction claim. Commit `ffd447811` adds `BEGIN`/`COMMIT` around the
+  complete PostgreSQL migration. The planner fallback reviewed the immutable
+  migration and PASSed; the Prisma package check and repository pre-commit
+  hook also pass. The native final-reviewer rerun then PASSed over current
+  `ffd447811`; no actionable code, authorization, data-integrity, policy,
+  documentation, test-portfolio, or plan-compliance findings remain.
 - S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
   backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
 - S2 (create/update mutations + owner-type exposure): DONE.
@@ -409,18 +418,20 @@ No separate tasks; nothing crosses a boundary warranting one.
   (`origin/HEAD`): 4 behind, 13 ahead, and none of v3's 4 new commits touch my
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
-- Forge snapshot (2026-08-21, read-only `gh`): `v3` is at
-  `3f3af82953ab91c6c51a38dfef44f6bc8e72bc85`, the remote PR head remains
-  `ab8d1424d`, and PR #5460 is open, non-draft, mergeable, but **BEHIND**. Its
-  current checks are 42 successful, 3 failed (GitGuardian and the Playwright
-  shard/status pair), and 1 skipped. The local commits through `ec71b5222`
-  are not on the remote PR yet. The SSH `git ls-remote` freshness path was
-  unavailable during this readback (connection closed), so the GitHub API is
-  the authoritative ref source for this snapshot. No rebase or push was
-  performed.
-- Remaining: complete the native final package review, handle GitGuardian
-  incident 36437584, and reconcile the branch with the current `v3` head
-  before merge. The approved usage-funding policy is documented for its
+- Forge snapshot (2026-08-21, read-only `gh`): current `v3` is at
+  `f58986faa8cfa4ff78d20a1ebeb1666473343d38`; the remote PR head remains
+  `ab8d1424d`, and PR #5460 is open, non-draft, mergeable, but **BEHIND**.
+  GitHub compare reports the remote PR branch 23 commits ahead and 6 behind
+  `v3`; the local reviewed head `ffd447811` adds 7 unpushed commits, for 30
+  local commits ahead and 6 behind. The remote PR checks are 42 successful,
+  3 failed (GitGuardian and the Playwright shard/status pair), and 1 skipped;
+  they do not cover the unpushed local commits. The SSH `git ls-remote`
+  freshness path was unavailable during this readback (connection closed), so
+  the GitHub API is the authoritative ref source for this snapshot. No rebase
+  or push was performed.
+- Remaining: handle GitGuardian incident 36437584, reconcile the branch with
+  current `v3`, publish the reviewed local commits, and obtain fresh CI before
+  merge. The approved usage-funding policy is documented for its
   implementation follow-up. The PR is already non-draft; merging it and
   closing #5453 remain outside this task's authority.
 - Runtime: worktree devcontainer stack stopped after verification. Start it

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -1,7 +1,7 @@
 # Phase 0 — chatbot lecturer HITL foundations (implementation plan)
 
 Roadmap: [`project/2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md`](2026-08-20-chatbot-hitl-lecturer-configuration-roadmap.md)
-(docs PR #5453). ADRs
+(roadmap source; implementation PR #5460). ADRs
 [0019](../docs/adr/0019-chatbot-config-postgresql-authoritative.md),
 [0020](../docs/adr/0020-two-tier-chatbot-approval.md),
 [0021](../docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md),
@@ -25,6 +25,10 @@ that later phases layer persona fields onto.
   service-seam tests + typecheck + a single participant browser smoke.
 - No persona-field editing, examples, knowledge self-service, custom modes,
   admin queue UI (Phases 1–6).
+- No account-wide base/advanced usage counters, usage lanes, or class-aware
+  charging in this Phase 0 PR. The approved pragmatic usage-funding MVP is
+  recorded in ADR 0020 and the roadmap for its implementation follow-up;
+  existing participant usage credits remain a separate legacy allowance.
 - No behavior change to existing chatbots' prompts — the compile seam is
   extracted behavior-preserving; persona layering lands in Phase 1.
 - **No team email on publication request in Phase 0 code** (F6 ruling, veto-able):
@@ -40,8 +44,8 @@ that later phases layer persona fields onto.
 - **Authority granted**: worktree (done), local commits on
   `feat/chatbot-lecturer-config-phase0`, bring up the worktree devcontainer
   stack for verification, author the migration incl. backfill. **Withheld**:
-  push/PR until slices are green (then draft PR), merge, deploy, deletion.
-- **Terminal**: all slices committed and verified in-container; draft PR against
+  merge, deploy, deletion.
+- **Terminal**: all slices committed and verified in-container; PR #5460 against
   `v3` with the plan as first commit; runtime stopped per
   `$rs-local-runtime-lifecycle`.
 - **Pause** (needs user): a GraphQL-contract change beyond this plan; the
@@ -50,9 +54,9 @@ that later phases layer persona fields onto.
 
 ## Plan identity
 
-- Plan: `project/2026-08-20-chatbot-hitl-phase0-plan.md`
+- Plan: `project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md`
 - Branch: `feat/chatbot-lecturer-config-phase0`, target `v3`, worktree
-  `trees/feat-chatbot-lecturer-config-phase0`. PR: none yet.
+  `trees/feat-chatbot-lecturer-config-phase0`. PR: [#5460](https://github.com/uzh-bf/klicker-uzh/pull/5460).
 
 ## Grounding facts (verified 2026-08-20)
 
@@ -211,15 +215,46 @@ No separate tasks; nothing crosses a boundary warranting one.
 
 ## Progress
 
+- Active follow-up slice: make publication approval and rejection conditional
+  lifecycle transitions, with a deterministic concurrent-approval regression
+  test. The implementation, correction review, and local commit are complete;
+  the remaining work is the final package review and delivery-boundary check.
 - Status: S1–S5 code-complete. S4 slice-reviewer PASS + real-route browser
   smoke DONE (F7 confirmed at HTTP layer). S5 compile-seam extraction and its
   simplifier/slice-review gates are DONE. The GraphQL selection fix, migration
   backfill guard, and synthetic-fixture cleanup are committed and pushed in
-  [PR #5460](https://github.com/uzh-bf/klicker-uzh/pull/5460). Current-head CI
-  is terminal with 44 successful checks and one historical GitGuardian failure;
-  the integrated final-reviewer pass is DONE_WITH_CONCERNS with two medium
-  approval-boundary findings and two low documentation findings. No merge,
-  readiness change, issue closure, or history rewrite was performed.
+  [PR #5460](https://github.com/uzh-bf/klicker-uzh/pull/5460). At the reviewed
+  head `ab8d1424d`, CI is terminal with 42 successful checks, 3 failures, and
+  1 skipped check: historical GitGuardian content plus the unrelated
+  `P-pagination-show-all.spec.ts:47` Playwright shard and aggregate status.
+  The integrated final-reviewer pass was DONE_WITH_CONCERNS with one medium
+  approval-boundary finding: the approval transition was not an atomic
+  conditional write. That finding is addressed in commits `3640a3abe` and
+  `7154564f2`; the former model-cost re-review finding is superseded by the
+  approved shared-authorization policy. No merge, readiness change, issue
+  closure, or history rewrite was performed.
+- Follow-up code correction: approval and rejection now use conditional
+  `updateMany` transitions keyed by the expected lifecycle state; approval
+  also rechecks the account publishing capability in the same write. The
+  concurrency regression test now gates both initial reads before releasing
+  the writes, so exactly one caller must win the conditional transition. The
+  focused publication file passed **12/12** tests before the barrier-only test
+  correction, and the GraphQL package typecheck passes after it
+  (`CHECK_RC:0`). The repository pre-commit hook passed for the correction,
+  including secret scan, staged formatting, all 25 package checks, lint,
+  syncpack, agent checks, and Prisma sync. The full GraphQL suite passed
+  **562/564** tests across 33 files; the two failures are the existing
+  `activitySharing` audit-message ID collisions, in an untouched file. The
+  runtime's internal Redis services were reached through a temporary local
+  verification proxy because the repository test helpers intentionally use
+  loopback ports; the proxy was removed after the run.
+- Correction review: the configured native simplifier and slice-reviewer
+  routes were unavailable because their `combo/gemini-3.7-flash` dispatch
+  rejected the inherited reasoning configuration. A planner-role fallback
+  reviewed the immutable two-file correction range and found one medium test
+  determinism gap; the read barrier above fixed it. The fallback found no
+  implementation defect. This route limitation remains an evidence caveat
+  for the final package review.
 - S1 (schema + capability + backfill): DONE + slice-reviewer PASS (no findings;
   backfill guarantee confirmed — report in `_local/reviews/`). Benibot=PUBLISHED.
 - S2 (create/update mutations + owner-type exposure): DONE.
@@ -374,21 +409,21 @@ No separate tasks; nothing crosses a boundary warranting one.
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
 - Base reconciliation (2026-08-21): the latest authoritative `git ls-remote`
-  refs show `origin/v3` at `df10f524e` and this branch at `029dd921d`, 2 behind /
-  22 ahead. The target-only commits since the earlier snapshot are #5449
-  (draft-activity course deletion) and #5461 (staging promotion); the current
-  three-dot PR diff remains 33 paths and the new target files do not overlap the
-  chatbot implementation. GitHub reports the PR mergeable but behind. No rebase
-  was performed. The common Git `FETCH_HEAD` file is not writable in this linked
-  worktree, so freshness was verified with `git ls-remote` rather than inferred
-  from fetch state.
-- Remaining: resolve or explicitly disposition the two medium final-review
-  findings, handle GitGuardian incident 36437584, reconcile the branch with the
-  current `v3` head before merge, and correct the roadmap/plan documentation.
-  Marking the PR ready, merging it, and closing #5453 remain outside this task's
-  authority.
-- Runtime: worktree devcontainer stack running. NOTE: graphql tests wipe the
-  dev DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
+  refs show `origin/v3` at `4e5f1d368e` and this branch at `ab8d1424d`, 4 behind /
+  23 ahead. The target-only commits still do not overlap the chatbot
+  implementation. GitHub previously reported the open, non-draft PR mergeable
+  but behind; re-read mergeability before any merge decision because the target
+  can move again. No rebase was performed. The common Git `FETCH_HEAD` file is
+  not writable in this linked worktree, so freshness was verified with
+  `git ls-remote` rather than inferred from fetch state.
+- Remaining: complete the native final package review, handle GitGuardian
+  incident 36437584, and reconcile the branch with the current `v3` head
+  before merge. The approved usage-funding policy is documented for its
+  implementation follow-up. The PR is already non-draft; merging it and
+  closing #5453 remain outside this task's authority.
+- Runtime: worktree devcontainer stack stopped after verification. Start it
+  again only for an authorized runtime check. NOTE: graphql tests wipe the dev
+  DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 
 ## MR/PR evidence expected
 

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -223,6 +223,14 @@ No separate tasks; nothing crosses a boundary warranting one.
   The remaining work is to cascade the bottom-layer correction through the
   stack, run the integrated final review, republish, and obtain fresh CI. Merge
   remains outside this plan's authority.
+- 2026-08-25: the latest PR feedback follow-up now validates publication input
+  at the service boundary, centralizes owner-facing chatbot response shaping,
+  safely rejects malformed stored prompt values, and documents the current
+  first-chatbot PWA entry behavior without imposing a new database cardinality
+  constraint. Focused
+  prompt tests passed 11/11, publication workflow tests passed 23/23 after the
+  seeded local database was cleaned, and the Chat and GraphQL package checks
+  pass in the exact Node 24 DevPod. Publication and fresh CI remain pending.
 
 ### Historical execution record
 

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -229,10 +229,11 @@ No separate tasks; nothing crosses a boundary warranting one.
   `P-pagination-show-all.spec.ts:47` Playwright shard and aggregate status.
   The integrated final-reviewer pass was DONE_WITH_CONCERNS with one medium
   approval-boundary finding: the approval transition was not an atomic
-  conditional write. That finding is addressed in commits `3640a3abe` and
-  `7154564f2`; the former model-cost re-review finding is superseded by the
-  approved shared-authorization policy. No merge, readiness change, issue
-  closure, or history rewrite was performed.
+  conditional write. That finding is addressed in commits `3640a3abe`,
+  `7154564f2`, and the follow-up barrier simplification `45e3281ff`; the
+  former model-cost re-review finding is superseded by the approved
+  shared-authorization policy. No merge, readiness change, issue closure, or
+  history rewrite was performed.
 - Follow-up code correction: approval and rejection now use conditional
   `updateMany` transitions keyed by the expected lifecycle state; approval
   also rechecks the account publishing capability in the same write. The
@@ -408,14 +409,15 @@ No separate tasks; nothing crosses a boundary warranting one.
   (`origin/HEAD`): 4 behind, 13 ahead, and none of v3's 4 new commits touch my
   changed files (overlap empty excl. codegen) — a rebase would be a clean
   codegen-only re-run.
-- Base reconciliation (2026-08-21): the latest authoritative `git ls-remote`
-  refs show `origin/v3` at `4e5f1d368e` and this branch at `ab8d1424d`, 4 behind /
-  23 ahead. The target-only commits still do not overlap the chatbot
-  implementation. GitHub previously reported the open, non-draft PR mergeable
-  but behind; re-read mergeability before any merge decision because the target
-  can move again. No rebase was performed. The common Git `FETCH_HEAD` file is
-  not writable in this linked worktree, so freshness was verified with
-  `git ls-remote` rather than inferred from fetch state.
+- Forge snapshot (2026-08-21, read-only `gh`): `v3` is at
+  `3f3af82953ab91c6c51a38dfef44f6bc8e72bc85`, the remote PR head remains
+  `ab8d1424d`, and PR #5460 is open, non-draft, mergeable, but **BEHIND**. Its
+  current checks are 42 successful, 3 failed (GitGuardian and the Playwright
+  shard/status pair), and 1 skipped. The local commits through `ec71b5222`
+  are not on the remote PR yet. The SSH `git ls-remote` freshness path was
+  unavailable during this readback (connection closed), so the GitHub API is
+  the authoritative ref source for this snapshot. No rebase or push was
+  performed.
 - Remaining: complete the native final package review, handle GitGuardian
   incident 36437584, and reconcile the branch with the current `v3` head
   before merge. The approved usage-funding policy is documented for its

--- a/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
+++ b/project/2026-08-20-chatbot-hitl-phase0-pr-5460-plan.md
@@ -173,18 +173,20 @@ No separate tasks; nothing crosses a boundary warranting one.
 - **S2 — createChatbot + updateChatbot + owner-type exposure.** Pothos: expose
   `status` + publication fields on the **owner-facing** Chatbot type only
   (getChatbotsInfo shape), never the participant course-chatbot type (F7).
-  `createChatbot(name, description?, avatar?, courseId)` — `asUserWithCatalyst`,
+  `createChatbot(name, description?, avatar?, courseId)` —
+  `asUserWithCatalyst` + `FULL_ACCESS`,
   service verifies the course is owned by ctx user, sets owner=ctx user,
   status=DRAFT, tutor-only default (no `initialModes` in Phase 0, F7).
-  `updateChatbot(id, free knobs)` — `asUserWithCatalyst` + service ownership
-  filter. Codegen. Acceptance: service tests (create/update happy-path +
-  non-owner rejection); codegen + typecheck green.
+  `updateChatbot(id, free knobs)` — `asUserWithCatalyst` + `FULL_ACCESS` +
+  service ownership filter. Codegen. Acceptance: service tests (create/update
+  happy-path + non-owner rejection); codegen + typecheck green.
   Commit: `feat(graphql): lecturer chatbot create and update`.
   Risk: public contract + authz → slice-reviewer.
 
 - **S3 — Publication workflow.** `requestChatbotPublication(id, useCase,
-  expectedStudentCount, proposedCredits)` — `asUserWithCatalyst` + service
-  ownership + **DB-row capability check** (`aiChatbotPublishingEnabled`); source
+  expectedStudentCount, proposedCredits)` — `asUserWithCatalyst` +
+  `FULL_ACCESS` + service ownership + **DB-row capability check**
+  (`aiChatbotPublishingEnabled`); source
   states **DRAFT and REJECTED** → PENDING_APPROVAL, clearing `reviewComment`,
   writing publication + credit columns (F5, D2). Admin
   `approveChatbotPublication(id)` (PENDING→PUBLISHED, set publishedAt) and
@@ -294,12 +296,12 @@ No separate tasks; nothing crosses a boundary warranting one.
   (not folded into phase 0) because it edits already-reviewed S2 code for a
   behavior-preserving DRY win — own micro-refactor or follow-up.
 - Carry to S4 (S3 LOW findings): gate participant access on `status ===
-  'PUBLISHED'`, never `publishedAt != null` (TOCTOU); credit path must not
-  assume `proposedCredits > 0` (no validation in phase 0).
-- Dependency: ADR 0020 and ADRs 0019–0022 were folded into this branch by merge
-  commit `1fd19330f`, so the former [PR #5453](https://github.com/uzh-bf/klicker-uzh/pull/5453)
-  merge-order dependency is resolved. Closing #5453 remains a separate,
-  explicitly authorized repository action.
+  'PUBLISHED'`, never `publishedAt != null` (TOCTOU).
+- Validation now rejects empty or overlong use cases and non-positive student
+  counts or proposed credits at the GraphQL boundary.
+- ADR 0020 and ADRs 0019–0022 are folded into this branch's ancestry; the
+  former ADR merge-order note is resolved. Closing the related documentation
+  work remains a separate, explicitly authorized repository action.
 - Base drift (checked 2026-08-20, session resume): branch is 4 behind / 8 ahead
   of `origin/v3` (the resume hook's "62 behind origin/dev" is a false alarm —
   `dev` is an unrelated long-lived line, not this branch's base). The 4 new v3
@@ -439,6 +441,11 @@ No separate tasks; nothing crosses a boundary warranting one.
   DB — reseed (`prisma-data seed:raw`) before S4 browser smoke.
 
 ## MR/PR evidence expected
+
+### Progress — 2026-08-24
+
+The bottom layer was rebased onto `v3`, and the verified review fixes were
+applied. This note does not claim a push or CI result.
 
 - GraphQL service-test output (transitions + authz + capability).
 - Migration diff + existing-row backfill proof; `prisma generate` clean.


### PR DESCRIPTION
## Stack Context

- Layer: 1 of 4 in [stack #5476](https://github.com/uzh-bf/klicker-uzh/stacks/5476)
- Base: `v3@b02c0c436`
- Delivery state: open and ready for review; merge and deployment remain separately withheld

## What This Adds

Phase 0 adds the backend foundations for lecturer-managed tutoring chatbots and a two-tier publication gate:

1. New chatbots start as drafts and move through request, approve, reject, pause, and publish lifecycle states.
2. Account-level publishing capability and per-chatbot publication approval are enforced independently.
3. Participants can reach only `PUBLISHED` chatbots; other lifecycle states remain not-found through participant routes and listings.
4. The existing system-prompt resolution is extracted behind `compileSystemPrompt` without changing language, citation, or stored-prompt behavior.
5. The roadmap and ADRs define the separate `BASE` and `ADVANCED` usage classes and the persistent monthly-budget contract used by the upper M1 layers.

## How It Works

- Prisma adds `ChatbotStatus`, publication request/review fields, and the account-level publishing capability. The migration preserves existing bots as `PUBLISHED` while new bots default to `DRAFT`.
- Lecturer mutations require Catalyst plus full-access scope and owner checks. Publication approval/rejection uses conditional lifecycle writes; approval re-checks the live account capability.
- Participant access uses the shared chatbot guard and course-list filtering. Owner-only lifecycle fields are not serialized through participant projections.
- `compileSystemPrompt` preserves the existing default/stored prompt matrix and composes the language and citation contracts after the available tool set is known.
- A configured owner/class monthly usage limit carries into later Europe/Zurich months until an authorized owner changes it. Only used credits reset at the month boundary.

## Important Details

- Account publishing capability is read from the live database row, never trusted from a JWT claim.
- Published cost-affecting configuration changes re-enter the defined review boundary; concurrent lifecycle transitions use conditional updates.
- [ADR 0019](https://github.com/uzh-bf/klicker-uzh/blob/feat/chatbot-lecturer-config-phase0/docs/adr/0019-chatbot-config-postgresql-authoritative.md), [ADR 0020](https://github.com/uzh-bf/klicker-uzh/blob/feat/chatbot-lecturer-config-phase0/docs/adr/0020-two-tier-chatbot-approval.md), [ADR 0021](https://github.com/uzh-bf/klicker-uzh/blob/feat/chatbot-lecturer-config-phase0/docs/adr/0021-templated-standard-modes-reviewed-custom-modes.md), and [ADR 0022](https://github.com/uzh-bf/klicker-uzh/blob/feat/chatbot-lecturer-config-phase0/docs/adr/0022-no-student-text-in-manage.md) record the decisions.
- The M1-R1 correction changes only Phase 0 documentation. Runtime carry-forward and lecturer projection remain in PRs #5480 and #5490.

## Branch Coverage

- Base: `v3` at `b02c0c436`
- Head: `d64425db2`
- Reviewed: 31 commits; 35 files, +2,757/-94 raw lines
- Substantive size: +1,623/-90 lines across 27 files after excluding generated GraphQL output, analytics schema mirrors, the lockfile, and committed project artifacts
- Covered: implementation plan, lifecycle schema/migration, lecturer and admin GraphQL flows, participant visibility gate, prompt compiler seam, tests and generated operations, ADR/wiki guidance, review corrections, roadmap contract, base reconciliation, and the monthly-budget clarification

## Review Focus

- Confirm the account capability and per-chatbot publication state remain independent authorization gates.
- Check conditional approve/reject transitions, capability revocation, and migration backfill integrity.
- Confirm every participant route/listing hides non-published chatbots and does not expose owner-only lifecycle metadata.
- Confirm prompt extraction preserves existing stored/default prompt, language, and citation behavior.
- Confirm the persistent budget wording is policy only in this layer; charging and lecturer controls belong to upper stack layers.

## Verification

Current head:

- Final recascade onto `v3@b02c0c436` -> 63 of 64 stack commits patch-identical; the sole changed commit has an identical non-lockfile code patch and base-context lockfile regeneration.
- Frozen offline lockfile, Prisma source/analytics mirror, Syncpack, and affected Chat, GraphQL, and Manage checks -> pass.
- Integrated Ox Alpha review `resp_de3e5510b95543f38665a76d7deb80c2` -> `PASS`, no required finding.
- Serialized Phase 5 response `resp_060d827c10fe4c05a63071821dbfb66a` -> `REVIEWED / ACCEPT`.
- GitHub checks on `d64425db2` -> terminal: 44 passed, 1 known historical GitGuardian failure, and 0 pending.

Earlier branch verification that still applies to the patch-equivalent implementation:

- Focused participant-gate, publication lifecycle, compiler, and migration tests -> pass.
- Chat suite -> 346/346 at the Phase 0 boundary; later unchanged-stack verification passes 371 with 9 expected skips.
- GraphQL and Chat typechecks/builds -> pass; the full stack builds 23/23 tasks.
- Real participant route smoke -> seeded published bot returned 200 with no owner-only `status` token in the response.
- Previous ready head passed the full Playwright matrix.

Warnings:

- The historical synthetic fixture once triggered GitGuardian; the fixture was replaced with an explicit non-credential marker and current Gitleaks scans are clean.
- Root `check:all` is blocked only in unrelated analytics lint because the image selects Python 3.14 and lacks a C compiler for pandas 2.2.2. All non-analytics package checks and lints pass.
- Devrouter route readiness hit a host curl certificate error after bootstrap; the exact DevPod is stopped with zero routes.

## Security / Privacy

- Dedicated authorization, data-integrity, participant-projection, Claude Opus full-stack, and Ox Alpha final reviews cover the changed boundaries.
- Non-published states return not-found to participants; owner-only lifecycle metadata stays out of participant projections.
- No live credential, real participant record, export, or personal data is included. Test fixtures are synthetic.
- No secret write, provider call, deployment, or live-traffic action is part of this PR.

## Activation and Compatibility

- Existing chatbots are backfilled to `PUBLISHED`; new chatbots default to `DRAFT`.
- The GraphQL and schema additions are additive. Participant visibility changes only for non-published lifecycle states.
- The branch is unmerged and has no deployment or live-runtime effect.

## Blocking Before Merge

- [x] Gate 3 authorized opening the M1 stack for review.
- [x] Current-head GitHub checks completed and were classified.
- [ ] Review the dependent M1 layers in stack order.
- [ ] Merge requires separate explicit authorization.

## Follow-Up After Merge

None within Phase 0. PRs #5475, #5480, and #5490 carry the complete M1 usage capability as separate reviewable layers.

## Out of Scope

- Provider/deployment selection, payment/settlement flows, live operations, response-example/ground-truth work, and later roadmap milestones.
- Merge, deployment, live verification, PR closure, cleanup, and deletion.

## Local Session Artifacts

Machine-local pointers on `Mac`; confirm them before reuse:

- Handoff: `~/.handoffs/klicker-uzh/2026-08-21-chatbot-hitl-roadmap-orchestrator-handoff.md`
- Worktree: `trees/feat-chatbot-lecturer-config-phase0` in `klicker-uzh`
- Review reports: `project/_local/reviews/`
- Environment: DevPod workspace `feat-chatbot-lecturer-config-pha` is stopped with zero active routes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chatbot lifecycle states, including draft, pending approval, published, paused, and rejected.
  * Added lecturer chatbot creation, editing, publication requests, and resubmission support.
  * Added administrative approval and rejection workflows with review comments.
  * Added account-level AI chatbot publishing controls.
  * Added consistent prompt compilation for language style and citation behavior.

* **Bug Fixes**
  * Unpublished chatbots are now hidden from participants and inaccessible through direct links.
  * Chat streaming now stops reliably when cancelled.

* **Documentation**
  * Added documentation covering chatbot approval, usage, configuration, and implementation decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->