### PR TITLE
feat(backup): add guarded PRD-to-STG database refresh

### DIFF
--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -77,7 +77,9 @@ than ambient configuration. During an approved
 execution it acquires and renews one expiring Kubernetes Lease, creates and
 verifies an encrypted custom-format dump, disables ArgoCD automated sync, binds
 the original replicas to the run receipt, and scales the exact `app-klicker`
-Deployments to zero. Azure's administration role owns `public`,
+Deployments to zero. Lease renewal uses bounded retries, publishes the current
+receipt phase, and terminates through the signal-aware fail-safe cleanup path
+if ownership can no longer be maintained. Azure's administration role owns `public`,
 while the Klicker application role owns its contents. The refresh therefore
 preserves the schema and its grants, removes only application-owned objects in
 one transaction, and filters schema creation/ownership entries from the restore

--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -2,7 +2,7 @@
 type: Data Layer
 title: Data & Migrations
 description: Split Prisma schema, the migrate→sync→build ritual, seeding paths, typed Json fields, and schema-level gotchas.
-timestamp: '2026-08-04'
+timestamp: '2026-08-21'
 tags:
   - backend
   - prisma
@@ -51,11 +51,111 @@ The Python twin (`apps/analytics/prisma/schema/py.prisma`) uses `prisma-client-p
 
 Where `migrate deploy` is invoked in deployment is now the PreSync hook above (see [CI & Deployment → Deployment migrations](./ci-and-deployment.md#deployment-migrations)). Rationale and rejected alternatives: [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md).
 
+### Refreshing STG from PRD
+
+The operator-run
+[`util/backup/refresh-stg-from-prd.sh`](../util/backup/refresh-stg-from-prd.sh)
+replaces the disposable Klicker STG PostgreSQL database with a consistent
+logical PRD dump. It does not copy Redis, Blob Storage, Hatchet state, or other
+components. The dump is not sanitized, so the workflow requires an explicit
+acknowledgement that STG may contain raw PRD data. Environment-owner approval
+must cover restricted access, synthetic or disabled outbound integrations,
+logs, backup/PITR retention, and deletion of the local encrypted archive; the
+operator checklist is in the backup README. Live execution fails before any
+credential lookup unless it receives both a bounded approval reference and an
+explicit outbound-isolation acknowledgement. Those values are bound to the
+local receipts and Kubernetes Lease.
+
+The script is read-only by default. Its preflight validates exact database
+host/port/name/TLS and server identities, the migrator Secret target, ordered
+Prisma migration names/checksums, immutable STG cluster/namespace/Application
+identities, write RBAC, fresh Azure storage/free/WAL metrics with conservative
+restore headroom, and a visible sorted Deployment set. The Infisical locations,
+database endpoints, Azure server, Kubernetes and ArgoCD identities, Git source,
+workload selector, migrator, and Lease name are checked-in constants rather
+than ambient configuration. During an approved
+execution it acquires and renews one expiring Kubernetes Lease, creates and
+verifies an encrypted custom-format dump, disables ArgoCD automated sync, binds
+the original replicas to the run receipt, and scales the exact `app-klicker`
+Deployments to zero. Azure's administration role owns `public`,
+while the Klicker application role owns its contents. The refresh therefore
+preserves the schema and its grants, removes only application-owned objects in
+one transaction, and filters schema creation/ownership entries from the restore
+catalog. Preflight rejects unowned or unsupported objects, non-public
+application schemas, and PostgreSQL large objects before maintenance mode. An
+app-scoped deny window on the bound AppProject blocks manual and automated syncs
+throughout reset/restore. After the snapshot is verified, the exact prior
+windows are restored and a hook-based sync submitted directly through the
+self-hosted ArgoCD `Application` custom resource reapplies the existing
+`PreSync` hook; this is intentional because ArgoCD runs hooks on a requested
+sync even if the rendered manifests are unchanged. The script submits the
+operation with a Kubernetes resource-version compare-and-swap and identifies it
+by its run-scoped initiator. A timeout terminates that owned operation through
+the status subresource and waits for terminal state rather than returning while
+it can still reconcile. Success is bound to the exact Argo Git revision and to
+a newly observed migrator Job/Pod whose executed `imageID` contains the expected
+repository's immutable digest; the post-hook migration history must preserve
+the complete PRD name/checksum prefix. The terminal receipt is written only
+after the exact original automated policy is restored, ArgoCD remains
+`Synced`/`Healthy` across two observations, and every bound Deployment is ready.
+This is control-plane/database evidence. The operator must still inspect the
+migrator logs, confirm outbound isolation, verify backend behavior, and perform
+one isolated synthetic STG request before declaring the environment usable.
+This path uses `kubectl`; it does not require the local `argocd` CLI.
+
+PostgreSQL client commands go through
+`util/backup/refresh-stg-from-prd/database.sh:run_database_command`, which
+validates and decomposes each URL into libpq connection variables. Do not put a
+full URI in `PGDATABASE`: libpq treats that environment value as the database
+name and can fall back to the local Unix socket. The wrapper keeps the URL out
+of process arguments while preserving the remote host, credentials, and supported SSL
+settings. `pg_restore` is the exception for database selection: it does not use
+`PGDATABASE` unless direct-to-database mode is selected, so the script also
+passes the already-validated, non-secret STG database name through `--dbname`.
+
+This command and resource selection are fake-tested, including missing
+governance gates, ambient target-override attempts, wrong database, wrong
+cluster, RBAC denial, Lease contention/loss, migrator-target mismatch,
+operation compare-and-swap races/timeouts, stale migrator Jobs, invalid image
+digests, partial scaling, injected cleanup API failures, divergent migrations,
+metadata failure, health failure, and policy-restore failure. A disposable
+PostgreSQL integration test executes the reset SQL to prove that
+application-owned objects are removed while schema ownership, grants, and
+administrator-owned objects survive. The implementation workflow does not
+execute a real environment refresh.
+
+The source schema must not be newer than the STG release. Prisma migrations are
+forward-only: copying a newer PRD database into an older STG release is not a
+downgrade strategy. On a pre-mutation scale failure, the script compensates the
+replicas and policy. Once the target may have changed, failure cleanup
+reinstalls the app-scoped deny window, drains its accepted Argo operation,
+disables automated sync, and forces both recorded and currently selected
+Deployments to zero. If any invariant cannot be proven before the cleanup
+timeout, `state.json` records `cleanupIncomplete: true`, the Lease is not
+released, and the script does not claim the environment is safe. A normal
+subsequent run
+refuses to adopt that unfinished state. When reset completed but restore did
+not, the operator must not trigger an ArgoCD sync against the incomplete
+database. `RESUME_FAILED_RUN_ID` enables a receipt-bound retry only while ArgoCD
+is still manual, the exact receipt-bound deny window is present, the exact
+recorded Deployment set remains stopped, the receipt matches the current
+endpoints and prior automated policy, and no successful after receipt exists.
+The retry creates a fresh encrypted dump and restores the saved policy only
+after restore verification and the hook-based sync succeed.
+The complete operator procedure, confirmation gates, prerequisites, receipts,
+and recovery behavior
+are documented in the [backup README](../util/backup/README.md#refresh-the-stg-database-from-prd).
+
 ### Recovering a failed migration hook
 
 A failed hook blocks **every** sync to that environment, by design. Recovery order:
 
-Nothing alerts on hook failure — detection is whoever is watching ArgoCD, so a blocked environment stays blocked silently until someone looks. (The df-cloud staging Prometheus rules now provide early detection of stuck operations and failed syncs; see the linked solution doc below.)
+The refresh Lease retains run ID, phase, and `success`/`failed` result
+annotations, and local `state.json` records the target and last phase. There is
+no refresh-specific paging integration, so the operator must monitor the run
+and route a failed result through the environment's incident channel.
+Independently, the df-cloud staging Prometheus rules provide early detection of
+stuck operations and failed syncs; see the linked solution document below.
 
 1. **Get the logs first.** Find the Job with `kubectl get jobs -n <ns> -l app.kubernetes.io/component=migrate` (it is named `<helm-release>-klicker-uzh-v2-migrate` unless the release name already contains the chart name), then `kubectl logs job/<name> -n <ns>` — with the default values, both successful and failed Jobs are kept until the next sync (`hook-delete-policy: BeforeHookCreation`, no TTL by default). Keeping successful jobs prevents an upstream ArgoCD finalizer race from deadlocking the sync (see the [df-cloud incident analysis](https://gitlab.uzh.ch/uzh-bf/cloud/df-cloud-klickeruzh/-/blob/stg/docs/solutions/integration/argocd-hook-job-finalizer-update.md)). Treat the output as potentially containing row data from backfill migrations; scrub before pasting it anywhere.
 2. **Classify the failure.** Image pull (`ImagePullBackOff` → the rendered tag has no migrator image, see bootstrap above); connection error (DB unreachable — `backoffLimit: 1` gives little retry, so a failover during the hook simply needs a re-sync); or a SQL error inside a migration.

--- a/project/plans_archive/PLAN-prd-to-stg-database-refresh-hardening.md
+++ b/project/plans_archive/PLAN-prd-to-stg-database-refresh-hardening.md
@@ -1,0 +1,106 @@
+# PRD-to-STG database refresh hardening
+
+## Goal
+
+Make the draft PRD-to-STG refresh workflow fail closed against the exact Klicker
+databases and STG cluster, serialize destructive runs, prove that the ArgoCD
+migrator uses the restored target, and leave an unambiguous recoverable state
+after every injected failure.
+
+## Non-goals
+
+- Run another live PRD-to-STG refresh during implementation.
+- Change Prisma models, GraphQL, application UI, auth, gamification, Hatchet
+  behavior, or deployment manifests.
+- Process or inspect any production rows or PII.
+- Turn the manual operator workflow into a scheduled service.
+
+## Domain and layer footprint
+
+- Source snapshot: the exact read-only Klicker PRD database.
+- Replacement target: the exact disposable Klicker STG database.
+- Refresh run: one receipt-bound, lease-owning execution with explicit phases.
+- Migration operation: the existing `app-klicker` ArgoCD `PreSync` hook, bound
+  to its exact Application, destination namespace, image revision, and database
+  Secret.
+- Files: `util/backup/refresh-stg-from-prd.sh`, its fake-tool and disposable
+  PostgreSQL tests, `util/backup/README.md`, and `docs/data-and-migrations.md`.
+
+There is no application auth, UI, i18n, fixture, gamification, or application
+async-workflow impact. Operator authority remains Infisical access plus narrowly
+scoped STG Kubernetes RBAC.
+
+## Safety design
+
+1. Require the normalized PRD/STG host, port, database name, TLS mode, live
+   `current_database()`, and server identity to match the configured contract.
+2. Bind both Kubernetes contexts to the expected API server, `kube-system` UID,
+   Argo Application UID, Argo namespace, destination namespace, and exact
+   workload namespace allowlist.
+3. Acquire and renew one expiring Kubernetes Lease before the long dump. Every
+   destructive/state-changing phase verifies lease ownership; cleanup releases
+   only the lease revision still owned by this run.
+4. Capture the exact sorted Deployment set and original replicas once. Reject
+   drift before mutation, track each scale transition, and compensate a partial
+   pre-mutation scale failure.
+5. Install a receipt-bound, app-scoped AppProject deny window before reset so
+   manual and automated Argo syncs are rejected throughout reset/restore. Submit
+   the owned sync after restore with a resource-version compare-and-swap.
+6. Record explicit run phases. Cleanup is idempotent, reinstalls the deny window,
+   drains Argo, and forces workloads to zero whenever the target was mutated.
+   Record `cleanupIncomplete` and do not release the Lease when those invariants
+   cannot all be proven.
+7. Treat the Argo timeout as a monitoring escalation, not a terminal failure:
+   do not scale or return while the owned operation remains non-terminal.
+8. Read the migrator Secret without logging it, connect through that URL, and
+   prove it reaches the same database/server identity as the restore target.
+9. Fingerprint ordered Prisma migration names/checksums and bind post-sync
+   evidence to the exact Argo revision plus a new migrator Job/Pod and executed
+   immutable image digest.
+10. Keep all receipts/dumps gitignored and free of connection URLs, row data,
+    and secret values. Live execution requires an environment-approval
+    reference and explicit outbound-isolation acknowledgement, both bound to
+    the metadata receipts and refresh Lease.
+
+## Test level and evidence
+
+- Extend the fake-tool suite first for wrong database, wrong cluster/namespace,
+  write-RBAC denial, Lease contention/loss, target-Secret mismatch, Argo soft
+  timeout, metadata-read failure, partial scale failure, policy-restore failure,
+  migration-history divergence, and exact workload-set drift.
+- Add a disposable PostgreSQL integration test for the owner-safe reset SQL;
+  skip with a clear reason when Docker/PostgreSQL is unavailable.
+- Run `bash -n`, ShellCheck when available, the focused test suite,
+  `pnpm run check:all`, and `pnpm run build`.
+- No browser or UI evidence is applicable.
+- Do not execute the live destructive path.
+
+## Slices
+
+1. Confirm the current cluster/Application/namespace contract and official Lease
+   and Argo operation semantics.
+2. Add identity, TLS, namespace, RBAC, and workload-set preflight guards.
+3. Add the expiring run Lease and phase receipts.
+4. Refactor scale, Argo monitoring, cleanup, and terminal receipt handling.
+5. Add migrator-target and migration-history proof.
+6. Resolve GitGuardian synthetic-credential findings without weakening scans.
+7. Expand fake and disposable-PostgreSQL tests.
+8. Update the runbook/wiki and complete exact-head verification.
+
+## Progress
+
+- [x] Production-readiness review triaged against exact head `300f1b5ea`.
+- [x] GitGuardian findings confirmed as five synthetic PostgreSQL test URLs.
+- [x] Current infrastructure identity contract recorded without secret values.
+- [x] Safety guards and failure-state refactor implemented.
+- [x] AppProject maintenance fence, atomic sync submission, cleanup-incomplete
+      state, immutable migrator evidence, and terminal post-policy health proof
+      implemented.
+- [x] Refresh script and fake harness split into focused sub-1k-line modules.
+- [x] Expanded fake suite passes all 32 cases; disposable PostgreSQL integration
+      is added and skips locally when Docker is unavailable.
+- [x] Operator and engineering documentation updated.
+- [x] Full repository verification and independent exact-working-tree review
+      complete.
+- [x] Follow-up readiness review added governance gates, immutable checked-in
+      target identities, and the post-success application smoke-test boundary.

--- a/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
+++ b/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
@@ -20,7 +20,7 @@ deployed STG release before workloads resume.
 
 ## Domain and layer footprint
 
-- Source: the Klicker PRD PostgreSQL database, read only.
+- Source: the Klicker PRD PostgreSQL database, read-only.
 - Target: the Klicker STG PostgreSQL database, fully replaced.
 - Infrastructure: `util/backup`, the `app-klicker` ArgoCD application, and STG
   Deployments selected by `app.kubernetes.io/instance=app-klicker`.

--- a/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
+++ b/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
@@ -1,0 +1,106 @@
+# PRD-to-STG database refresh
+
+## Goal
+
+Provide one operator-run script that replaces the Klicker STG PostgreSQL data
+with a consistent logical dump of PRD, then triggers the existing ArgoCD sync so
+the STG `PreSync` migrator applies every migration required by the currently
+deployed STG release before workloads resume.
+
+## Non-goals
+
+- Preserve or back up the previous STG data; the user explicitly declared it
+  disposable.
+- Copy Redis, Blob Storage, Hatchet state, or any external integration.
+- Sanitize PRD data. The script instead requires an explicit raw-data approval
+  gate and keeps the dump encrypted at rest.
+- Change Prisma schema, GraphQL, application UI, gamification behavior, or
+  deployment manifests.
+- Run against PRD as a mutation target.
+
+## Domain and layer footprint
+
+- Source: the Klicker PRD PostgreSQL database, read only.
+- Target: the Klicker STG PostgreSQL database, fully replaced.
+- Infrastructure: `util/backup`, the `app-klicker` ArgoCD application, and STG
+  Deployments selected by `app.kubernetes.io/instance=app-klicker`.
+- Migrations: the existing
+  `deploy/charts/klicker-uzh-v3/templates/job-migrate.yaml` ArgoCD `PreSync`
+  hook. The script does not duplicate `prisma migrate deploy` logic.
+- Documentation: `util/backup/README.md` for the operator procedure and
+  `docs/data-and-migrations.md` for the durable deployment contract.
+
+No application authorization surface is added. Execution authority comes from
+Infisical read access to both environments, STG Kubernetes access, and
+Kubernetes RBAC to read and patch the self-hosted ArgoCD `Application`.
+
+## Safety contract
+
+- `DRY_RUN` defaults to `true`. Mutations require `DRY_RUN=false`.
+- Execution additionally requires the exact destructive confirmation and a
+  separate acknowledgement that raw PRD data is allowed in STG.
+- PRD and STG connection hosts are fail-closed against their expected Azure
+  Flexible Server hostnames and must differ.
+- The dump is streamed directly into a GPG-encrypted custom archive; no
+  plaintext dump is written to disk or passed as a process argument.
+- The encrypted archive is listed with `pg_restore` before STG is touched.
+- ArgoCD automated sync/self-heal is disabled before scaling workloads down.
+- Application-owned objects in `public` are removed only after all STG
+  workloads report zero replicas; the Azure-owned schema and its grants are
+  preserved.
+- `pg_restore` uses `--exit-on-error` and `--single-transaction`; restore errors
+  cannot be converted into success.
+- A hook-based `Application.operation.sync` submitted through Kubernetes runs
+  the existing `PreSync` hook. A failed hook prevents the Sync phase, leaving
+  workloads stopped.
+- Automated sync policy is restored only after post-sync database verification.
+- Receipts contain aggregate metadata and archive hashes only, never row data or
+  connection strings. Reusing a run ID is refused.
+
+## Async and external-state impact
+
+All STG workloads in the release, including Hatchet workers and response APIs,
+are stopped during replacement. PRD remains online and is only read by
+`pg_dump`. The resulting STG database contains raw production data, so this
+workflow is permitted only when STG is approved for that data classification.
+
+## Verification
+
+- Shell syntax (`bash -n`) and ShellCheck when available.
+- A self-contained fake-tool test proves dry-run immutability, host and approval
+  guards, phase ordering, encrypted-archive verification, fail-closed restore,
+  direct Kubernetes sync submission, exact-operation polling, policy
+  restoration, and receipt generation.
+- Helm render verifies the hook remains enabled for STG and uses the expected
+  migrator image/secret.
+- The implementation agent does not execute the real PRD/STG refresh; operator
+  runs are used separately to validate the guarded workflow and feed failures
+  back into the fake-tool regression suite.
+
+## Slices
+
+1. Add the plan and safety contract.
+2. Implement `util/backup/refresh-stg-from-prd.sh`.
+3. Add the fake-tool shell test.
+4. Document prerequisites, execution, failure behavior, and limitations.
+5. Run focused formatting/static tests and inspect the final diff.
+6. Replace the ArgoCD API-server CLI dependency with direct Kubernetes
+   `Application` operations for the self-hosted installation.
+7. Route all credential reads through the production self-hosted Infisical
+   endpoint and script-specific project, and cover that boundary with a
+   regression test.
+8. Decompose database URLs into libpq connection variables so PostgreSQL tools
+   connect remotely without exposing credentials in process arguments.
+
+## Progress
+
+- [x] Repository, deployment hook, and legacy backup scripts inspected.
+- [x] Safety and operational design fixed.
+- [x] Script implemented.
+- [x] Tests implemented and passing.
+- [x] Documentation updated and verified.
+- [x] Direct Kubernetes sync implemented and verified.
+- [x] Self-hosted Infisical credential loading for project
+      `d071be96-5136-4f23-a6cb-e0c7f9b9a6c8` implemented and verified.
+- [x] Secure libpq connection handoff and immediate connection-error propagation
+      implemented and verified.

--- a/project/plans_archive/PLAN-prd-to-stg-readiness-reconciliation.md
+++ b/project/plans_archive/PLAN-prd-to-stg-readiness-reconciliation.md
@@ -1,0 +1,82 @@
+# PRD-to-STG refresh readiness reconciliation
+
+## Goal
+
+Reconcile the hardened PRD-to-STG database refresh with current `v3` and the
+useful governance requirements from stacked PR #5472, without regressing the
+stronger modular safety implementation in PR #5465.
+
+## Non-goals
+
+- Execute another live PRD-to-STG refresh during implementation.
+- Merge or retain the obsolete monolithic implementation from PR #5472.
+- Copy, inspect, or sanitize production rows or personal data.
+- Change Prisma, GraphQL, application auth, UI, i18n, gamification, Hatchet
+  workflows, seeds, or deployment manifests.
+
+## Domain and layer footprint
+
+- **Refresh run:** one destructive, receipt-bound replacement of the exact
+  Klicker STG PostgreSQL database from the exact Klicker PRD database.
+- **Environment approval:** the recorded owner-approved ticket or ADR that
+  authorizes raw PRD data in STG for this run.
+- **Outbound isolation:** the operator's explicit acknowledgement that STG
+  integrations are disabled, synthetic-only, or routed to approved sinks.
+- **Target contract:** checked-in database, Infisical, Azure, Kubernetes, and
+  ArgoCD identities that ambient environment variables cannot redefine.
+- **Files:** `util/backup/refresh-stg-from-prd.sh`, its Kubernetes module and
+  fake tests, the backup runbook, and `docs/data-and-migrations.md`.
+
+Operator authority remains Infisical, Azure, and narrowly scoped Kubernetes
+access. There is no application auth, UI, i18n, fixture, gamification, or new
+async-workflow impact; the existing ArgoCD `PreSync` operation remains the only
+asynchronous boundary.
+
+## Safety design
+
+1. Keep read-only preflight available without approval variables.
+2. Require a bounded approval reference and explicit outbound-isolation
+   acknowledgement before any live command or credential lookup.
+3. Bind those values to `state.json`, `before.json`, `after.json`, and the
+   refresh Lease; Lease ownership assertions also verify the binding.
+4. Make production target identities checked-in read-only constants. Only
+   mutable kubectl context aliases remain configurable, and live cluster UIDs,
+   API server identity, namespaces, Application, AppProject, repository, and
+   database metadata still prove the target.
+5. Keep fresh Azure capacity metrics from PR #5465; do not port the weaker
+   manually supplied free-storage value from PR #5472.
+6. Treat script success as control-plane/database success. Require a separate
+   operator check of the migrator logs, backend behavior, outbound isolation,
+   and one isolated synthetic STG request before declaring STG usable.
+
+## Test level and evidence
+
+- Extend the fake Bash suite for missing approval, missing isolation, ambient
+  target-override resistance, receipt/Lease governance binding, and the
+  post-success operator reminder.
+- Run `bash -n`, ShellCheck when available, the fake suite, the disposable
+  PostgreSQL reset integration, `pnpm run check:all`, and `pnpm run build`.
+- No browser evidence is applicable. Do not execute the destructive live path.
+
+## Slices
+
+1. Rebase #5465 onto current `v3` and preserve both migration documentation
+   intents.
+2. Add governance gates, immutable target constants, evidence binding, and
+   regression coverage.
+3. Update the operator runbook and engineering wiki with the post-refresh
+   application verification boundary.
+4. Run exact-head verification and a strict maintainability review.
+5. Publish #5465, update its whole-branch PR description, and close #5472 as
+   superseded with the selectively ported requirements recorded.
+
+## Progress
+
+- [x] Rebased both feature commits onto current `v3`.
+- [x] Resolved migration documentation conflict without dropping either intent.
+- [x] Governance and immutable-target changes implemented.
+- [x] Focused verification completed with 36 fake cases; the disposable
+      PostgreSQL test was skipped because Docker was unavailable.
+- [x] Repository-wide `check:all` and build completed successfully.
+- [x] Strict maintainability and public-history hygiene review completed.
+- [x] PR #5465 prepared as the single reconciled change; PR #5472 is superseded.

--- a/util/backup/README.md
+++ b/util/backup/README.md
@@ -90,7 +90,11 @@ the integration review above is complete; it does not configure or disable the
 integrations itself.
 
 The script first acquires and renews the exclusive
-`argo/app-klicker-prd-to-stg-refresh` Lease. It streams `pg_dump` directly into
+`argo/app-klicker-prd-to-stg-refresh` Lease. The default five-minute Lease is
+renewed every 30 seconds with bounded retries. Each renewal reads the current
+phase from the run directory rather than a fork-time shell value. Repeated
+renewal failure signals the main process, and `SIGINT`/`SIGTERM` enter the same
+fail-safe cleanup path as any other error. It streams `pg_dump` directly into
 an AES-256 GPG archive and never writes a plaintext dump. Before changing STG it
 validates the archive, disables ArgoCD automated sync/self-heal, binds the exact
 Deployment set and original replica counts to the run receipt, and scales those

--- a/util/backup/README.md
+++ b/util/backup/README.md
@@ -2,6 +2,230 @@
 
 Production-ready backup and restore scripts for PostgreSQL databases and Redis data across development, staging, and production environments.
 
+## Refresh the STG database from PRD
+
+[`refresh-stg-from-prd.sh`](./refresh-stg-from-prd.sh) replaces the Klicker STG
+PostgreSQL database with a transactionally consistent logical dump of PRD. It
+then submits a hook-based sync directly to the self-hosted `app-klicker` ArgoCD
+`Application` resource, which runs the existing STG `PreSync` migration hook
+before restoring the desired Deployment replicas. The local `argocd` CLI is not
+required.
+
+This is a **database-only** operation. It does not copy Redis, Hatchet state,
+Azure Blob Storage, or other services, and it does not preserve the previous STG
+database. It also does not sanitize the dump: after a successful run, raw PRD
+data—including personal data—is present in STG. Run it only when STG is approved
+for that data classification and its outbound integrations are safely isolated.
+
+### Prerequisites
+
+- Private-network access to both Azure PostgreSQL Flexible Servers.
+- `infisical` access to `DIRECT_DATABASE_URL` in the `prd` and `stg`
+  environments and `BACKUP_ENCRYPTION_KEY` in `prd` on the self-hosted
+  `https://inf.prd.df-app.ch/api` instance, project
+  `d071be96-5136-4f23-a6cb-e0c7f9b9a6c8`. The environments, project, and
+  secret path `/` are checked-in target constants.
+- A working `aks-stg-apps` kubectl context with permission to list and scale the
+  exact `stg-klicker` release Deployments and read its migrator Secret.
+- Kubernetes access to the ArgoCD control-plane cluster, with `get` and `patch`
+  permission (including the `status` subresource) for
+  `applications.argoproj.io/app-klicker`, `get` and `patch` permission for its
+  `stg-apps-klicker` AppProject, and `get`/`create`/`update` permission for its
+  refresh Lease in the `argo` namespace. The workload identity also needs
+  `list`/`watch` on Pods so the run can capture migrator execution evidence. The
+  default control-plane context is also `aks-stg-apps`.
+- PostgreSQL client tools (`pg_dump`, `pg_restore`, and `psql`) version 17 or
+  newer, plus `az`, `gpg`, `jq`, `base64`, Node.js, and standard Unix utilities.
+  The Azure CLI identity needs read access to `DF_Klicker_RG/db-server-stg-apps`
+  and its Azure Monitor metrics.
+- A STG release whose database schema is the same as or newer than PRD. The hook
+  can migrate forward; it cannot downgrade a newer PRD schema for an older app.
+
+Before approving raw PRD data in STG, record the environment owner's evidence
+that all of the following are true for the refresh window:
+
+- STG access is limited to people approved for production-classified data.
+- Email, webhook, LTI/OLAT, analytics, AI, and other outbound integrations are
+  disabled, synthetic-only, or point to approved non-production sinks.
+- STG backups/PITR and logs have an approved retention and deletion policy for
+  production data; the local encrypted archive follows the same policy.
+- The operator owns the run until its Lease records `success` or the environment
+  is visibly in fail-safe maintenance. Record the approval as a ticket or ADR
+  reference suitable for `RAW_PRD_DATA_APPROVAL_REF`. The script emits durable
+  run ID, phase, approval, outbound-isolation, target, and result evidence, but
+  it does not page a remote alerting system by itself.
+
+Run the read-only preflight first from the repository root:
+
+```bash
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The preflight validates the exact source and target host, port, database name,
+TLS mode, live database identity, PostgreSQL client compatibility, source size
+against the configured capacity and fresh Azure `storage_used`, `storage_free`,
+and `txlogs_storage_used` metrics, ordered Prisma migration names/checksums, STG
+object ownership, the migrator Secret's target identity, write RBAC, immutable
+cluster/namespace/Application identities, ArgoCD state, and the sorted set of
+STG Deployments. The database must use only the `public` application schema and
+must not contain PostgreSQL large objects. It requires current Azure CLI access,
+rejects metrics older than 30 minutes, and requires free storage of at least
+three times the PRD database size for restore, WAL, and migration headroom. It
+creates no dump, acquires no Lease, and changes no external state.
+
+After reviewing that output, execute the refresh with all five gates:
+
+```bash
+DRY_RUN=false \
+CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+ALLOW_RAW_PRD_DATA_IN_STG=true \
+RAW_PRD_DATA_APPROVAL_REF=APPROVED-TICKET-OR-ADR \
+STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The approval reference is a bounded identifier or URL, not approval prose or a
+secret. `STG_OUTBOUND_INTEGRATIONS_ISOLATED=true` is an operator assertion that
+the integration review above is complete; it does not configure or disable the
+integrations itself.
+
+The script first acquires and renews the exclusive
+`argo/app-klicker-prd-to-stg-refresh` Lease. It streams `pg_dump` directly into
+an AES-256 GPG archive and never writes a plaintext dump. Before changing STG it
+validates the archive, disables ArgoCD automated sync/self-heal, binds the exact
+Deployment set and original replica counts to the run receipt, and scales those
+Deployments to zero. Azure owns the `public` schema, so the script preserves the
+schema and its grants, transactionally removes only objects owned by the STG
+application role, and excludes `public` schema creation/ownership entries from
+the restore catalog. Immediately before the reset it rechecks the Lease, exact
+Deployment set, `current_database()`, and restore/migrator server identity. An
+app-scoped ArgoCD deny window then blocks automated and manual syncs throughout
+the destructive reset and restore; the exact prior AppProject windows are
+receipt-bound and restored only after the snapshot is verified. The script
+restores with an explicit
+`pg_restore --dbname=<STG-database> --exit-on-error --single-transaction`,
+verifies the exact restored Prisma migration history, removes the deny window,
+and submits `Application.operation.sync` with a resource-version compare-and-swap.
+The operation is pinned to the exact 40-character Git comparison revision
+observed during preflight, so a moving `v3` branch cannot change the release
+during the refresh. The script waits for the operation carrying this run's
+unique initiator to reach `Succeeded` and clear from the Application. A soft
+timeout requests termination through the Application status subresource and
+does not return until that owned operation is terminal. Success additionally
+requires evidence from a new migrator Job and Pod, the executed image's
+immutable `imageID` digest, an exact PRD migration-history prefix, restoration
+of the exact original automated policy, two stable ArgoCD `Synced`/`Healthy`
+observations, and every bound Deployment ready. Only then is `after.json`
+written.
+
+The database URLs are validated and decomposed into libpq's `PGHOST`, `PGPORT`,
+`PGUSER`, `PGPASSWORD`, `PGDATABASE`, and supported SSL environment variables.
+The URLs are never placed in process arguments, and `PGDATABASE` receives only
+the database name rather than the full URI. PostgreSQL's `pg_restore` does not
+use `PGDATABASE` to select direct-to-database mode, so the non-secret database
+name is also supplied explicitly with `--dbname`; the host, username, and
+password remain environment-only.
+
+The checked-in target constants pin the Infisical locations, database
+endpoints, Azure server, STG cluster and namespace UIDs, Argo Application and
+AppProject, Git source, workload selector, migrator, and Lease. Ambient
+environment variables cannot redefine them. A replacement resource requires a
+reviewed script change; changing only a mutable context alias cannot bypass the
+live identity checks. For a separately configured control-plane context that
+reaches the same pinned cluster, use:
+
+```bash
+ARGOCD_KUBE_CONTEXT=aks-platform \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The Infisical endpoint defaults to the production self-hosted instance. If the
+CLI is authenticated against another host, log in to this instance before the
+preflight:
+
+```bash
+infisical login --domain=https://inf.prd.df-app.ch/api
+```
+
+Metadata-only receipts (`before.json`, `state.json`, `deployments.tsv`, scale
+observations, approval/isolation evidence, migrator Job/Pod/digest evidence,
+and terminal `after.json`) are written below
+`util/backup/dumps/prd-to-stg-refresh/<run-id>/`, which is gitignored. The
+encrypted archive is deleted after the run unless
+`KEEP_ENCRYPTED_ARCHIVE=true` is explicitly set. None of these files may be
+committed; verify `git status` before staging changes.
+
+If anything fails after the database may have changed, cleanup first terminates
+and drains any accepted operation owned by the run, reinstalls the persistent
+app-scoped deny window, disables automated sync, and forces both the
+receipt-bound and currently selected Deployments to zero.
+Before database mutation, a partial scale failure is instead compensated back
+to the original replicas and policy. Preserve `state.json`, `before.json`, the
+Lease annotations, and migrator logs before any recovery action. Do not simply
+restart workloads. If the restore was not verified, do **not** submit an ArgoCD
+hook sync against the incomplete database. Then validate the guarded resume in
+read-only mode with a fresh default `RUN_ID`:
+
+```bash
+RESUME_FAILED_RUN_ID=<failed-run-id> \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The resume is accepted only when the failed run has no `after.json`, its source
+and target match the current fixed endpoints, its saved policy was automated,
+the exact receipt-bound AppProject deny window is still present, ArgoCD is still
+manual with no active operation, and the exact recorded Deployment set remains
+at zero desired and running replicas. After reviewing that preflight, rerun
+with the same failed-run ID and all five execution gates:
+
+```bash
+RESUME_FAILED_RUN_ID=<failed-run-id> \
+DRY_RUN=false \
+CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+ALLOW_RAW_PRD_DATA_IN_STG=true \
+RAW_PRD_DATA_APPROVAL_REF=APPROVED-TICKET-OR-ADR \
+STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The resume creates and validates a fresh encrypted PRD dump under a new run ID;
+it never reuses a partial archive. It resets any remaining application-owned
+STG objects, restores the snapshot, runs the PreSync hook, and only then
+restores the exact automated-sync policy saved by the failed run. A normal
+refresh still refuses to adopt an unfinished manual Argo state, and a failed
+run never mutates PRD.
+
+A successful script exit proves the database, migration hook, ArgoCD policy,
+and Deployment readiness checks described above. Before declaring STG usable,
+the operator must still inspect the ArgoCD Application and migrator Job logs,
+confirm outbound integrations remain isolated, verify backend behavior, and
+complete one isolated synthetic STG request. The terminal receipt is
+control-plane evidence; it is not cross-service application validation.
+
+If cleanup cannot prove the deny window, terminal Argo state, manual policy, and
+zero replicas before its timeout, `state.json` records
+`cleanupIncomplete: true`, the Lease is deliberately not released, and the
+script does **not** claim fail-safe maintenance. Treat STG as unavailable and
+restore all four invariants before recovery.
+
+The entrypoint is split into focused sourced modules under
+`util/backup/refresh-stg-from-prd/`: `database.sh` owns PostgreSQL/Azure and
+dump/restore logic, `kubernetes.sh` owns target/workload/Lease behavior, and
+`argocd.sh` owns the maintenance fence, operation, migrator evidence, and health
+proof. The executable owns configuration, receipts, cleanup orchestration, and
+the top-level state machine.
+
+Maintainers can verify the fail-closed orchestration and owner-safe reset from
+the repository root without connecting to PRD or STG:
+
+```bash
+bash util/backup/tests/refresh-stg-from-prd.test.sh
+bash util/backup/tests/reset-stg-owned-objects.integration.sh
+```
+
+The second command uses a disposable local PostgreSQL container and reports a
+TAP skip when Docker is unavailable.
+
 **Main Interface:** Use `dump.sh` and `restore.sh` for all operations - these unified wrappers provide consistent commands for both database and Redis operations.
 
 ## Prerequisites

--- a/util/backup/refresh-stg-from-prd.sh
+++ b/util/backup/refresh-stg-from-prd.sh
@@ -70,8 +70,10 @@ CLEANUP_TIMEOUT_SECONDS="${CLEANUP_TIMEOUT_SECONDS:-300}"
 MIGRATOR_EVIDENCE_TIMEOUT_SECONDS="${MIGRATOR_EVIDENCE_TIMEOUT_SECONDS:-10}"
 
 readonly REFRESH_LEASE_NAME=app-klicker-prd-to-stg-refresh
-REFRESH_LEASE_DURATION_SECONDS="${REFRESH_LEASE_DURATION_SECONDS:-120}"
+REFRESH_LEASE_DURATION_SECONDS="${REFRESH_LEASE_DURATION_SECONDS:-300}"
 REFRESH_LEASE_RENEW_INTERVAL_SECONDS="${REFRESH_LEASE_RENEW_INTERVAL_SECONDS:-30}"
+REFRESH_LEASE_RENEW_RETRY_ATTEMPTS="${REFRESH_LEASE_RENEW_RETRY_ATTEMPTS:-3}"
+REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS="${REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS:-2}"
 
 CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}"
 ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}"
@@ -94,6 +96,7 @@ DEPLOYMENT_RECEIPT=""
 SCALE_OBSERVATION_RECEIPT=""
 STATE_RECEIPT=""
 LEASE_FAILURE_FILE=""
+RUN_PHASE_FILE=""
 
 ARGOCD_POLICY_PAUSED=false
 MAINTENANCE_FENCE_ACTIVE=false
@@ -208,8 +211,10 @@ Important configuration variables:
   STG_STORAGE_GIB                     default: 32
   MAX_SOURCE_STORAGE_PERCENT          default: 75
   MIN_STG_FREE_SPACE_MULTIPLIER       default: 3
-  REFRESH_LEASE_DURATION_SECONDS      default: 120
+  REFRESH_LEASE_DURATION_SECONDS      default: 300
   REFRESH_LEASE_RENEW_INTERVAL_SECONDS default: 30
+  REFRESH_LEASE_RENEW_RETRY_ATTEMPTS  default: 3
+  REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS default: 2
   CLEANUP_TIMEOUT_SECONDS             default: 300
   MIGRATOR_EVIDENCE_TIMEOUT_SECONDS   default: 10
   RUN_ID                              unique receipt identifier
@@ -291,7 +296,7 @@ source "$SCRIPT_DIR/refresh-stg-from-prd/kubernetes.sh"
 source "$SCRIPT_DIR/refresh-stg-from-prd/argocd.sh"
 
 cleanup() {
-  local exit_code=$?
+  local exit_code="${1:-$?}"
   local cleanup_complete=true
 
   trap - EXIT INT TERM
@@ -376,6 +381,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
 
 load_failed_run_receipt() {
   local failed_run_dir="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID"
@@ -476,6 +483,7 @@ prepare_run_directory() {
   SCALE_OBSERVATION_RECEIPT="$RUN_DIR/scale-observations.tsv"
   STATE_RECEIPT="$RUN_DIR/state.json"
   LEASE_FAILURE_FILE="$RUN_DIR/lease-renewal-failed"
+  RUN_PHASE_FILE="$RUN_DIR/phase"
   MIGRATOR_EVIDENCE_FILE="$RUN_DIR/migrator-evidence.json"
 
   [[ ! -e "$RUN_DIR" ]] || die "Run directory already exists; choose a new RUN_ID: $RUN_DIR"
@@ -486,6 +494,11 @@ prepare_run_directory() {
 set_run_phase() {
   local phase="$1"
   RUN_PHASE="$phase"
+  if [[ -n "$RUN_PHASE_FILE" ]]; then
+    local temporary_phase_file="$RUN_PHASE_FILE.tmp"
+    printf '%s\n' "$RUN_PHASE" >"$temporary_phase_file"
+    mv -- "$temporary_phase_file" "$RUN_PHASE_FILE"
+  fi
   [[ -n "$STATE_RECEIPT" ]] || return 0
   local temporary_receipt="$STATE_RECEIPT.tmp"
   jq -n \
@@ -735,6 +748,8 @@ validate_configuration() {
   validate_positive_integer MIGRATOR_EVIDENCE_TIMEOUT_SECONDS "$MIGRATOR_EVIDENCE_TIMEOUT_SECONDS"
   validate_positive_integer REFRESH_LEASE_DURATION_SECONDS "$REFRESH_LEASE_DURATION_SECONDS"
   validate_positive_integer REFRESH_LEASE_RENEW_INTERVAL_SECONDS "$REFRESH_LEASE_RENEW_INTERVAL_SECONDS"
+  validate_positive_integer REFRESH_LEASE_RENEW_RETRY_ATTEMPTS "$REFRESH_LEASE_RENEW_RETRY_ATTEMPTS"
+  validate_positive_integer REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS "$REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS"
   validate_run_id
   validate_resume_failed_run_id
   (( STG_STORAGE_GIB > 0 )) || die "STG_STORAGE_GIB must be greater than zero"
@@ -748,12 +763,32 @@ validate_configuration() {
     || die "POST_SYNC_HEALTH_TIMEOUT_SECONDS must be greater than zero"
   (( REFRESH_LEASE_RENEW_INTERVAL_SECONDS > 0 )) \
     || die "REFRESH_LEASE_RENEW_INTERVAL_SECONDS must be greater than zero"
+  (( REFRESH_LEASE_RENEW_RETRY_ATTEMPTS > 0 )) \
+    || die "REFRESH_LEASE_RENEW_RETRY_ATTEMPTS must be greater than zero"
   (( REFRESH_LEASE_DURATION_SECONDS > REFRESH_LEASE_RENEW_INTERVAL_SECONDS * 2 )) \
     || die "REFRESH_LEASE_DURATION_SECONDS must exceed twice the renewal interval"
   (( MAX_SOURCE_STORAGE_PERCENT > 0 && MAX_SOURCE_STORAGE_PERCENT <= 95 )) \
     || die "MAX_SOURCE_STORAGE_PERCENT must be between 1 and 95"
   [[ "$KUBECTL_REQUEST_TIMEOUT" =~ ^[1-9][0-9]*[smh]$ ]] \
     || die "KUBECTL_REQUEST_TIMEOUT must be a positive Kubernetes duration such as 30s"
+  local kubectl_timeout_magnitude="${KUBECTL_REQUEST_TIMEOUT%?}"
+  local kubectl_timeout_multiplier
+  case "${KUBECTL_REQUEST_TIMEOUT: -1}" in
+    s) kubectl_timeout_multiplier=1 ;;
+    m) kubectl_timeout_multiplier=60 ;;
+    h) kubectl_timeout_multiplier=3600 ;;
+  esac
+  local kubectl_timeout_seconds=$((
+    kubectl_timeout_magnitude * kubectl_timeout_multiplier
+  ))
+  local lease_renewal_failure_budget=$((
+    REFRESH_LEASE_RENEW_INTERVAL_SECONDS +
+      REFRESH_LEASE_RENEW_RETRY_ATTEMPTS * kubectl_timeout_seconds * 2 +
+      (REFRESH_LEASE_RENEW_RETRY_ATTEMPTS - 1) *
+        REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS
+  ))
+  (( REFRESH_LEASE_DURATION_SECONDS > lease_renewal_failure_budget )) \
+    || die "REFRESH_LEASE_DURATION_SECONDS must exceed the worst-case Lease renewal retry window ($lease_renewal_failure_budget seconds)"
 
   local required_value
   for required_value in \

--- a/util/backup/refresh-stg-from-prd.sh
+++ b/util/backup/refresh-stg-from-prd.sh
@@ -1,0 +1,894 @@
+#!/usr/bin/env bash
+
+# Replace the Klicker STG PostgreSQL database with a logical copy of PRD, then
+# run the existing ArgoCD PreSync migration hook by submitting a sync operation
+# directly to the self-hosted ArgoCD Application custom resource.
+#
+# Safety defaults:
+# - DRY_RUN=true performs read-only validation only.
+# - Execution requires explicit destructive, data-approval, and isolation gates.
+# - The PRD dump is encrypted while streaming; no plaintext dump is written.
+# - STG workloads stay stopped and ArgoCD auto-sync stays disabled on failure.
+
+set -Eeuo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DRY_RUN="${DRY_RUN:-true}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RESUME_FAILED_RUN_ID="${RESUME_FAILED_RUN_ID:-}"
+REFRESH_ROOT_DIR="${REFRESH_ROOT_DIR:-$SCRIPT_DIR/dumps/prd-to-stg-refresh}"
+KEEP_ENCRYPTED_ARCHIVE="${KEEP_ENCRYPTED_ARCHIVE:-false}"
+
+# Production target contract. Ambient variables must not be able to redefine
+# the source, target, or identities that the safety checks are meant to prove.
+# Replacing any of these resources requires a reviewed script change.
+readonly PRD_INFISICAL_ENV=prd
+readonly STG_INFISICAL_ENV=stg
+readonly INFISICAL_API_URL=https://inf.prd.df-app.ch/api
+readonly INFISICAL_PROJECT_ID=d071be96-5136-4f23-a6cb-e0c7f9b9a6c8
+readonly INFISICAL_SECRET_PATH=/
+
+readonly EXPECTED_PRD_DB_HOST=db-server-prd-apps.postgres.database.azure.com
+readonly EXPECTED_STG_DB_HOST=db-server-stg-apps.postgres.database.azure.com
+readonly EXPECTED_PRD_DB_PORT=6432
+readonly EXPECTED_STG_DB_PORT=6432
+readonly EXPECTED_PRD_DB_NAME=klicker-prod-prd
+readonly EXPECTED_STG_DB_NAME=klicker-qa-stg
+STG_STORAGE_GIB="${STG_STORAGE_GIB:-32}"
+MAX_SOURCE_STORAGE_PERCENT="${MAX_SOURCE_STORAGE_PERCENT:-75}"
+readonly STG_AZURE_RESOURCE_GROUP=DF_Klicker_RG
+readonly STG_AZURE_SERVER_NAME=db-server-stg-apps
+MIN_STG_FREE_SPACE_MULTIPLIER="${MIN_STG_FREE_SPACE_MULTIPLIER:-3}"
+
+KUBE_CONTEXT="${KUBE_CONTEXT:-aks-stg-apps}"
+ARGOCD_KUBE_CONTEXT="${ARGOCD_KUBE_CONTEXT:-$KUBE_CONTEXT}"
+readonly ARGOCD_NAMESPACE=argo
+readonly ARGOCD_APP=app-klicker
+readonly EXPECTED_ARGOCD_PROJECT=stg-apps-klicker
+readonly WORKLOAD_NAMESPACE=stg-klicker
+readonly EXPECTED_KUBE_TLS_SERVER_NAME=stg-apps-vhziuhfl.hcp.switzerlandnorth.azmk8s.io
+readonly EXPECTED_KUBE_SYSTEM_UID=207f1b0e-5ad7-4de6-94d1-2b4564a41fe7
+readonly EXPECTED_WORKLOAD_NAMESPACE_UID=ae9b8ae9-d3df-4078-820d-1ef69d4cf816
+readonly EXPECTED_ARGOCD_APP_UID=9f936f7f-58ff-4a72-8c75-eb969ac3bd6f
+readonly EXPECTED_ARGOCD_PROJECT_UID=6faae3ef-2736-45ee-a2d5-8fd4cfd41b16
+readonly EXPECTED_ARGOCD_DESTINATION_SERVER=https://kubernetes.default.svc
+readonly EXPECTED_ARGOCD_REPO_URL=https://github.com/uzh-bf/klicker-uzh.git
+readonly EXPECTED_ARGOCD_TARGET_REVISION=v3
+readonly MIGRATOR_SECRET_NAME=app-klicker-klicker-uzh-v2-secret-backend-graphql
+readonly MIGRATOR_SECRET_KEY=DATABASE_URL
+readonly MIGRATOR_JOB_NAME=app-klicker-klicker-uzh-v2-migrate
+readonly EXPECTED_MIGRATOR_IMAGE_REPOSITORY=ghcr.io/uzh-bf/klicker-uzh/backend-docker-migrator-arm
+KUBECTL_REQUEST_TIMEOUT="${KUBECTL_REQUEST_TIMEOUT:-30s}"
+ARGOCD_TIMEOUT_SECONDS="${ARGOCD_TIMEOUT_SECONDS:-1200}"
+ARGOCD_POLL_SECONDS="${ARGOCD_POLL_SECONDS:-2}"
+readonly WORKLOAD_SELECTOR=app.kubernetes.io/instance=app-klicker
+WORKLOAD_DRAIN_TIMEOUT_SECONDS="${WORKLOAD_DRAIN_TIMEOUT_SECONDS:-300}"
+POST_SYNC_HEALTH_TIMEOUT_SECONDS="${POST_SYNC_HEALTH_TIMEOUT_SECONDS:-600}"
+CLEANUP_TIMEOUT_SECONDS="${CLEANUP_TIMEOUT_SECONDS:-300}"
+MIGRATOR_EVIDENCE_TIMEOUT_SECONDS="${MIGRATOR_EVIDENCE_TIMEOUT_SECONDS:-10}"
+
+readonly REFRESH_LEASE_NAME=app-klicker-prd-to-stg-refresh
+REFRESH_LEASE_DURATION_SECONDS="${REFRESH_LEASE_DURATION_SECONDS:-120}"
+REFRESH_LEASE_RENEW_INTERVAL_SECONDS="${REFRESH_LEASE_RENEW_INTERVAL_SECONDS:-30}"
+
+CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}"
+ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}"
+RAW_PRD_DATA_APPROVAL_REF="${RAW_PRD_DATA_APPROVAL_REF:-}"
+STG_OUTBOUND_INTEGRATIONS_ISOLATED="${STG_OUTBOUND_INTEGRATIONS_ISOLATED:-false}"
+
+PRD_DATABASE_URL="${PRD_DATABASE_URL:-}"
+STG_DATABASE_URL="${STG_DATABASE_URL:-}"
+BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
+MIGRATOR_DATABASE_URL=""
+export -n PRD_DATABASE_URL STG_DATABASE_URL BACKUP_ENCRYPTION_KEY
+
+RUN_DIR=""
+ARCHIVE_PATH=""
+ARCHIVE_CHECKSUM_PATH=""
+ARCHIVE_CATALOG_PATH=""
+BEFORE_RECEIPT=""
+AFTER_RECEIPT=""
+DEPLOYMENT_RECEIPT=""
+SCALE_OBSERVATION_RECEIPT=""
+STATE_RECEIPT=""
+LEASE_FAILURE_FILE=""
+
+ARGOCD_POLICY_PAUSED=false
+MAINTENANCE_FENCE_ACTIVE=false
+WORKLOADS_SCALED=false
+TARGET_MUTATED=false
+RESTORE_VERIFIED=false
+RESUMING_MAINTENANCE=false
+TERMINAL_SUCCESS=false
+ARGO_OPERATION_ACCEPTED=false
+RUN_PHASE="initializing"
+FAILURE_ORIGIN_PHASE=""
+CLEANUP_INCOMPLETE=false
+
+LEASE_ACQUIRED=false
+LEASE_HOLDER_ID="prd-to-stg-refresh-$RUN_ID"
+LEASE_RENEWAL_PID=""
+
+ORIGINAL_AUTOMATED_SYNC=false
+ORIGINAL_AUTOMATED_JSON="null"
+ORIGINAL_SYNC_WINDOWS_JSON="[]"
+PREFLIGHT_DEPLOYMENTS_JSON=""
+ARGO_OPERATION_INITIATOR=""
+ARGO_OPERATION_REVISION=""
+PINNED_ARGOCD_REVISION=""
+OBSERVED_MIGRATOR_IMAGE=""
+OBSERVED_MIGRATOR_IMAGE_ID=""
+OBSERVED_MIGRATOR_JOB_UID=""
+OBSERVED_MIGRATOR_POD_UID=""
+PRE_SYNC_MIGRATOR_JOB_UID=""
+MIGRATOR_EVIDENCE_FILE=""
+MIGRATOR_EVIDENCE_WATCH_PID=""
+
+PRD_DB_HOST=""
+PRD_DB_PORT=""
+PRD_DB_NAME=""
+STG_DB_HOST=""
+STG_DB_PORT=""
+STG_DB_NAME=""
+PRD_DATABASE_IDENTITY=""
+STG_DATABASE_IDENTITY=""
+MIGRATOR_DATABASE_IDENTITY=""
+PRD_MIGRATION_HISTORY=""
+PRD_MIGRATION_FINGERPRINT=""
+MIGRATED_MIGRATION_FINGERPRINT=""
+MIGRATED_METADATA=""
+POST_SYNC_DEPLOYMENTS_JSON=""
+
+PRD_VERSION_NUM=""
+PRD_SIZE_BYTES=""
+PRD_TABLE_COUNT=""
+PRD_APPLIED_MIGRATIONS=""
+PRD_FAILED_MIGRATIONS=""
+PRD_EXTRA_SCHEMA_COUNT=""
+PRD_LARGE_OBJECT_COUNT=""
+
+STG_BEFORE_VERSION_NUM=""
+STG_BEFORE_SIZE_BYTES=""
+STG_BEFORE_TABLE_COUNT=""
+STG_BEFORE_APPLIED_MIGRATIONS=""
+STG_BEFORE_FAILED_MIGRATIONS=""
+STG_EXTRA_SCHEMA_COUNT=""
+STG_LARGE_OBJECT_COUNT=""
+STG_AZURE_RESOURCE_ID=""
+STG_AZURE_STORAGE_USED_BYTES=""
+STG_AZURE_STORAGE_FREE_BYTES=""
+STG_AZURE_TXLOG_STORAGE_BYTES=""
+STG_AZURE_STORAGE_METRIC_TIME=""
+
+STG_CONNECTED_ROLE=""
+STG_PUBLIC_SCHEMA_OWNER=""
+STG_CAN_CREATE_IN_PUBLIC=""
+STG_SUPPORTED_OBJECT_COUNT=""
+STG_UNOWNED_OBJECT_COUNT=""
+STG_UNSUPPORTED_OBJECT_COUNT=""
+
+print_help() {
+  cat <<'EOF'
+Usage: util/backup/refresh-stg-from-prd.sh
+
+Copies the Klicker PRD PostgreSQL database to STG, then runs the existing
+ArgoCD PreSync migration hook by patching the self-hosted app-klicker
+Application resource through the Kubernetes API. The argocd CLI is not
+required.
+
+The script is read-only by default:
+
+  ./util/backup/refresh-stg-from-prd.sh
+
+Execution requires all five explicit gates:
+
+  DRY_RUN=false \
+  CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+  ALLOW_RAW_PRD_DATA_IN_STG=true \
+  RAW_PRD_DATA_APPROVAL_REF=APPROVED-TICKET-OR-ADR \
+  STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+  ./util/backup/refresh-stg-from-prd.sh
+
+Credentials are loaded from Infisical by default:
+
+  prd: DIRECT_DATABASE_URL + BACKUP_ENCRYPTION_KEY
+  stg: DIRECT_DATABASE_URL
+
+For CI or controlled testing, provide PRD_DATABASE_URL, STG_DATABASE_URL, and
+BACKUP_ENCRYPTION_KEY as environment variables instead. Never pass connection
+URLs as command-line arguments.
+
+Important configuration variables:
+
+  KUBE_CONTEXT                       STG workload context; default: aks-stg-apps
+  ARGOCD_KUBE_CONTEXT                ArgoCD control-plane context; defaults to KUBE_CONTEXT
+  KUBECTL_REQUEST_TIMEOUT             default: 30s
+  STG_STORAGE_GIB                     default: 32
+  MAX_SOURCE_STORAGE_PERCENT          default: 75
+  MIN_STG_FREE_SPACE_MULTIPLIER       default: 3
+  REFRESH_LEASE_DURATION_SECONDS      default: 120
+  REFRESH_LEASE_RENEW_INTERVAL_SECONDS default: 30
+  CLEANUP_TIMEOUT_SECONDS             default: 300
+  MIGRATOR_EVIDENCE_TIMEOUT_SECONDS   default: 10
+  RUN_ID                              unique receipt identifier
+  RESUME_FAILED_RUN_ID                failed run receipt to resume while STG is stopped
+  KEEP_ENCRYPTED_ARCHIVE              default: false
+
+The Infisical environments/project/path, PRD and STG database endpoints, Azure
+server, Kubernetes and ArgoCD identities, workload selector, migrator, Git
+repository/revision, and Lease name are checked-in target constants. Ambient
+environment variables cannot redefine them. Changing the target contract
+requires a reviewed script change.
+
+Failure after target mutation keeps the app-scoped ArgoCD deny window, disables
+auto-sync, and stops STG workloads. If cleanup cannot prove every invariant,
+state.json records cleanupIncomplete=true. If reset completed but restore did
+not, do not submit an ArgoCD sync. Re-run with
+RESUME_FAILED_RUN_ID=<failed-run-id>, a fresh RUN_ID, and the same five
+execution gates after inspecting the retained receipt.
+EOF
+}
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >&2
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+validate_boolean() {
+  local name="$1"
+  local value="$2"
+
+  case "$value" in
+    true|false) ;;
+    *) die "$name must be exactly 'true' or 'false' (received '$value')" ;;
+  esac
+}
+
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  [[ "$value" =~ ^[0-9]+$ ]] || die "$name must be a non-negative integer"
+}
+
+validate_run_id() {
+  [[ "$RUN_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] \
+    || die "RUN_ID must be 1-128 characters and contain only letters, numbers, dots, underscores, or hyphens"
+}
+
+validate_resume_failed_run_id() {
+  [[ -z "$RESUME_FAILED_RUN_ID" ]] && return 0
+  [[ "$RESUME_FAILED_RUN_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] \
+    || die "RESUME_FAILED_RUN_ID must be 1-128 characters and contain only letters, numbers, dots, underscores, or hyphens"
+  [[ "$RESUME_FAILED_RUN_ID" != "$RUN_ID" ]] \
+    || die "RESUME_FAILED_RUN_ID must differ from the new RUN_ID"
+}
+
+validate_raw_data_approval_ref() {
+  [[ -z "$RAW_PRD_DATA_APPROVAL_REF" ]] && return 0
+  local approval_ref_pattern='^[A-Za-z0-9][A-Za-z0-9._:/?&=%+#-]{0,199}$'
+  [[ "$RAW_PRD_DATA_APPROVAL_REF" =~ $approval_ref_pattern ]] \
+    || die "RAW_PRD_DATA_APPROVAL_REF must be a 1-200 character ticket, URL, or ADR reference without spaces"
+}
+
+# Focused modules keep destructive database, Kubernetes, and Argo behavior
+# independently reviewable. Each module documents its shared-state contract.
+# shellcheck source=refresh-stg-from-prd/database.sh
+source "$SCRIPT_DIR/refresh-stg-from-prd/database.sh"
+# shellcheck source=refresh-stg-from-prd/kubernetes.sh
+source "$SCRIPT_DIR/refresh-stg-from-prd/kubernetes.sh"
+# shellcheck source=refresh-stg-from-prd/argocd.sh
+source "$SCRIPT_DIR/refresh-stg-from-prd/argocd.sh"
+
+cleanup() {
+  local exit_code=$?
+  local cleanup_complete=true
+
+  trap - EXIT INT TERM
+  set +e
+  stop_migrator_evidence_watch
+
+  if [[ $exit_code -ne 0 ]]; then
+    TERMINAL_SUCCESS=false
+    FAILURE_ORIGIN_PHASE="$RUN_PHASE"
+    log "Refresh failed during phase '$RUN_PHASE'; entering fail-safe cleanup"
+
+    if [[ "$TARGET_MUTATED" == "true" ]]; then
+      establish_fail_safe_maintenance || cleanup_complete=false
+    else
+      if [[ "$ARGOCD_POLICY_PAUSED" == "true" ]]; then
+        restore_original_workloads_for_cleanup || cleanup_complete=false
+        restore_original_argocd_policy_for_cleanup || cleanup_complete=false
+      fi
+      if [[ "$MAINTENANCE_FENCE_ACTIVE" == "true" ]]; then
+        remove_argocd_maintenance_fence || cleanup_complete=false
+      fi
+    fi
+
+    if [[ "$cleanup_complete" == "true" ]]; then
+      CLEANUP_INCOMPLETE=false
+      set_run_phase failed
+    else
+      CLEANUP_INCOMPLETE=true
+      set_run_phase cleanup-incomplete
+    fi
+  fi
+
+  if [[ "$CLEANUP_INCOMPLETE" == "true" ]]; then
+    stop_refresh_lease_renewal
+    log "CRITICAL: Cleanup is incomplete; the Lease was not released and will expire naturally."
+  else
+    release_refresh_lease
+  fi
+
+  if [[ "$KEEP_ENCRYPTED_ARCHIVE" != "true" ]]; then
+    if [[ -n "$ARCHIVE_PATH" && -f "$ARCHIVE_PATH" ]]; then
+      rm -f -- "$ARCHIVE_PATH"
+    fi
+    if [[ -n "$ARCHIVE_CHECKSUM_PATH" && -f "$ARCHIVE_CHECKSUM_PATH" ]]; then
+      rm -f -- "$ARCHIVE_CHECKSUM_PATH"
+    fi
+    if [[ -n "$ARCHIVE_CATALOG_PATH" && -f "$ARCHIVE_CATALOG_PATH" ]]; then
+      rm -f -- "$ARCHIVE_CATALOG_PATH"
+    fi
+  fi
+
+  unset PRD_DATABASE_URL STG_DATABASE_URL BACKUP_ENCRYPTION_KEY \
+    MIGRATOR_DATABASE_URL
+
+  if [[ $exit_code -ne 0 && "$TARGET_MUTATED" == "true" ]]; then
+    if [[ "$CLEANUP_INCOMPLETE" == "true" ]]; then
+      log "CRITICAL: STG safety could not be fully proven. Treat the environment as unavailable and inspect state.json."
+      log "Do not remove the AppProject deny window or re-enable workloads until ArgoCD is terminal, automated sync is disabled, and every selected Deployment is at zero replicas."
+    else
+      log "Verified fail-safe maintenance: the app-scoped ArgoCD deny window is active, automated sync is disabled, no operation is active, and all selected Deployments are at zero replicas."
+    fi
+    log "The STG database was modified; inspect restore and migration state before recovery."
+    if [[ "$RESTORE_VERIFIED" != "true" ]]; then
+      local resumable_run_id=""
+      if [[ -n "$BEFORE_RECEIPT" && -s "$BEFORE_RECEIPT" ]]; then
+        resumable_run_id="$RUN_ID"
+      elif [[ -n "$RESUME_FAILED_RUN_ID" ]]; then
+        resumable_run_id="$RESUME_FAILED_RUN_ID"
+      fi
+      log "Do not submit an ArgoCD sync: a complete restored database has not been verified."
+      if [[ -n "$resumable_run_id" ]]; then
+        log "Retry the refresh with RESUME_FAILED_RUN_ID=$resumable_run_id, a fresh RUN_ID, and all five execution gates."
+      else
+        log "No resumable before receipt exists; inspect STG and restore it before re-enabling workloads."
+      fi
+    else
+      log "Resume through this script with RESUME_FAILED_RUN_ID; it removes the deny window only after another verified restore and then submits the pinned Argo operation atomically."
+    fi
+  fi
+
+  exit "$exit_code"
+}
+
+trap cleanup EXIT
+
+load_failed_run_receipt() {
+  local failed_run_dir="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID"
+  local failed_before_receipt="$failed_run_dir/before.json"
+  local failed_after_receipt="$failed_run_dir/after.json"
+  local failed_deployment_receipt="$failed_run_dir/deployments.tsv"
+
+  [[ -s "$failed_before_receipt" ]] \
+    || die "Resume receipt does not exist or is empty: $failed_before_receipt"
+  [[ ! -e "$failed_after_receipt" ]] \
+    || die "Run '$RESUME_FAILED_RUN_ID' has an after receipt and cannot be resumed"
+  [[ -s "$failed_deployment_receipt" ]] \
+    || die "Resume deployment receipt does not exist or is empty: $failed_deployment_receipt"
+
+  jq -e \
+    --arg runId "$RESUME_FAILED_RUN_ID" \
+    --arg sourceHost "$PRD_DB_HOST" \
+    --arg sourcePort "$PRD_DB_PORT" \
+    --arg sourceDatabase "$PRD_DB_NAME" \
+    --arg sourceMigrationFingerprint "$PRD_MIGRATION_FINGERPRINT" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetPort "$STG_DB_PORT" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    --arg kubeSystemUid "$EXPECTED_KUBE_SYSTEM_UID" \
+    --arg workloadNamespace "$WORKLOAD_NAMESPACE" \
+    --arg workloadNamespaceUid "$EXPECTED_WORKLOAD_NAMESPACE_UID" \
+    --arg argocdApplicationUid "$EXPECTED_ARGOCD_APP_UID" \
+    --arg argocdProject "$EXPECTED_ARGOCD_PROJECT" \
+    --arg argocdProjectUid "$EXPECTED_ARGOCD_PROJECT_UID" \
+    --arg argocdRevision "$PINNED_ARGOCD_REVISION" \
+    '
+      .runId == $runId and
+      .source.host == $sourceHost and
+      .source.port == $sourcePort and
+      .source.database == $sourceDatabase and
+      .source.migrationFingerprint == $sourceMigrationFingerprint and
+      .targetBefore.host == $targetHost and
+      .targetBefore.port == $targetPort and
+      .targetBefore.database == $targetDatabase and
+      .kubernetes.kubeSystemUid == $kubeSystemUid and
+      .kubernetes.workloadNamespace == $workloadNamespace and
+      .kubernetes.workloadNamespaceUid == $workloadNamespaceUid and
+      .kubernetes.argocdApplicationUid == $argocdApplicationUid and
+      .kubernetes.argocdProject == $argocdProject and
+      .kubernetes.argocdProjectUid == $argocdProjectUid and
+      .argocdRevision == $argocdRevision and
+      (.argocdProjectOriginalSyncWindows | type) == "array" and
+      (.argocdAutomatedPolicy | type) == "object" and
+      ((.argocdAutomatedPolicy.enabled // true) != false)
+    ' "$failed_before_receipt" >/dev/null \
+    || die "Resume receipt does not match the current source, target, or prior automated-sync state"
+
+  local failed_deployments_json receipt_deployments_json
+  failed_deployments_json="$(jq -c '.deployments | sort_by(.namespace, .name)' "$failed_before_receipt")"
+  receipt_deployments_json="$(
+    jq -Rsc '
+      split("\n") | map(select(length > 0) | split("\t") |
+        {namespace: .[0], name: .[1], replicas: (.[2] | tonumber)}) |
+      sort_by(.namespace, .name)
+    ' <"$failed_deployment_receipt"
+  )"
+  [[ "$failed_deployments_json" == "$receipt_deployments_json" ]] \
+    || die "Resume Deployment receipt does not match the failed-run before receipt"
+
+  ORIGINAL_AUTOMATED_JSON="$(jq -c '.argocdAutomatedPolicy' "$failed_before_receipt")"
+  ORIGINAL_SYNC_WINDOWS_JSON="$(jq -c '.argocdProjectOriginalSyncWindows' "$failed_before_receipt")"
+  ORIGINAL_AUTOMATED_SYNC=true
+  RESUMING_MAINTENANCE=true
+  ARGOCD_POLICY_PAUSED=true
+}
+
+print_preflight_summary() {
+  local deployment_count="$1"
+  log "Preflight complete"
+  log "Source: $PRD_DB_HOST/$PRD_DB_NAME (PostgreSQL $((PRD_VERSION_NUM / 10000)), $PRD_SIZE_BYTES bytes, $PRD_TABLE_COUNT tables)"
+  log "Target: $STG_DB_HOST/$STG_DB_NAME (PostgreSQL $((STG_BEFORE_VERSION_NUM / 10000)), current size $STG_BEFORE_SIZE_BYTES bytes)"
+  log "ArgoCD Application: $ARGOCD_NAMESPACE/$ARGOCD_APP via context $ARGOCD_KUBE_CONTEXT"
+  log "Pinned ArgoCD revision: $PINNED_ARGOCD_REVISION"
+  log "STG deployments to stop: $deployment_count"
+  while IFS= read -r deployment; do
+    [[ -z "$deployment" ]] || log "  - $deployment"
+  done < <(
+    jq -r '.items[] | "\(.metadata.namespace)/deployment/\(.metadata.name)"' \
+      <<<"$PREFLIGHT_DEPLOYMENTS_JSON" | sort
+  )
+  log "STG reset: remove $STG_SUPPORTED_OBJECT_COUNT objects owned by $STG_CONNECTED_ROLE; preserve public schema owned by $STG_PUBLIC_SCHEMA_OWNER"
+  log "Raw PRD data, including personal data, will be present in STG after execution."
+}
+
+prepare_run_directory() {
+  RUN_DIR="$REFRESH_ROOT_DIR/$RUN_ID"
+  ARCHIVE_PATH="$RUN_DIR/prd.dump.gpg"
+  ARCHIVE_CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
+  ARCHIVE_CATALOG_PATH="$RUN_DIR/prd.dump.list"
+  BEFORE_RECEIPT="$RUN_DIR/before.json"
+  AFTER_RECEIPT="$RUN_DIR/after.json"
+  DEPLOYMENT_RECEIPT="$RUN_DIR/deployments.tsv"
+  SCALE_OBSERVATION_RECEIPT="$RUN_DIR/scale-observations.tsv"
+  STATE_RECEIPT="$RUN_DIR/state.json"
+  LEASE_FAILURE_FILE="$RUN_DIR/lease-renewal-failed"
+  MIGRATOR_EVIDENCE_FILE="$RUN_DIR/migrator-evidence.json"
+
+  [[ ! -e "$RUN_DIR" ]] || die "Run directory already exists; choose a new RUN_ID: $RUN_DIR"
+  mkdir -p "$RUN_DIR"
+  chmod 700 "$RUN_DIR"
+}
+
+set_run_phase() {
+  local phase="$1"
+  RUN_PHASE="$phase"
+  [[ -n "$STATE_RECEIPT" ]] || return 0
+  local temporary_receipt="$STATE_RECEIPT.tmp"
+  jq -n \
+    --arg runId "$RUN_ID" \
+    --arg phase "$RUN_PHASE" \
+    --arg failedFromPhase "$FAILURE_ORIGIN_PHASE" \
+    --arg updatedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetPort "$STG_DB_PORT" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+    --arg leaseHolder "$LEASE_HOLDER_ID" \
+    --arg argoInitiator "$ARGO_OPERATION_INITIATOR" \
+    --arg pinnedArgoRevision "$PINNED_ARGOCD_REVISION" \
+    --arg argoRevision "$ARGO_OPERATION_REVISION" \
+    --arg migratorImage "$OBSERVED_MIGRATOR_IMAGE" \
+    --arg migratorImageId "$OBSERVED_MIGRATOR_IMAGE_ID" \
+    --arg migratorJobUid "$OBSERVED_MIGRATOR_JOB_UID" \
+    --arg migratorPodUid "$OBSERVED_MIGRATOR_POD_UID" \
+    --argjson targetMutated "$TARGET_MUTATED" \
+    --argjson restoreVerified "$RESTORE_VERIFIED" \
+    --argjson maintenanceFenceActive "$MAINTENANCE_FENCE_ACTIVE" \
+    --argjson cleanupIncomplete "$CLEANUP_INCOMPLETE" \
+    --argjson outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
+    --argjson terminalSuccess "$TERMINAL_SUCCESS" \
+    '{
+      runId: $runId,
+      phase: $phase,
+      failedFromPhase: (if $failedFromPhase == "" then null else $failedFromPhase end),
+      updatedAt: $updatedAt,
+      target: {
+        host: $targetHost,
+        port: $targetPort,
+        database: $targetDatabase
+      },
+      governance: {
+        rawPrdDataApprovalRef: $approvalRef,
+        stgOutboundIntegrationsIsolated: $outboundIntegrationsIsolated
+      },
+      leaseHolder: $leaseHolder,
+      argoOperation: {
+        initiator: (if $argoInitiator == "" then null else $argoInitiator end),
+        pinnedRevision: (if $pinnedArgoRevision == "" then null else $pinnedArgoRevision end),
+        revision: (if $argoRevision == "" then null else $argoRevision end),
+        migratorImage: (if $migratorImage == "" then null else $migratorImage end),
+        migratorImageId: (if $migratorImageId == "" then null else $migratorImageId end),
+        migratorJobUid: (if $migratorJobUid == "" then null else $migratorJobUid end),
+        migratorPodUid: (if $migratorPodUid == "" then null else $migratorPodUid end)
+      },
+      targetMutated: $targetMutated,
+      restoreVerified: $restoreVerified,
+      maintenanceFenceActive: $maintenanceFenceActive,
+      cleanupIncomplete: $cleanupIncomplete,
+      terminalSuccess: $terminalSuccess
+    }' >"$temporary_receipt"
+  mv -- "$temporary_receipt" "$STATE_RECEIPT"
+}
+
+prepare_deployment_receipt() {
+  if [[ -n "$RESUME_FAILED_RUN_ID" ]]; then
+    local failed_receipt="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID/deployments.tsv"
+    cp -- "$failed_receipt" "$DEPLOYMENT_RECEIPT"
+  else
+    jq -r '.items[] | [.metadata.namespace, .metadata.name, (.spec.replicas // 1)] | @tsv' \
+      <<<"$PREFLIGHT_DEPLOYMENTS_JSON" | sort >"$DEPLOYMENT_RECEIPT"
+  fi
+  [[ -s "$DEPLOYMENT_RECEIPT" ]] || die "Deployment receipt is empty"
+}
+
+deployment_receipt_json() {
+  jq -Rn '
+    [inputs | select(length > 0) | split("\t") |
+      {namespace: .[0], name: .[1], replicas: (.[2] | tonumber)}]
+    | sort_by(.namespace, .name)
+  ' <"$DEPLOYMENT_RECEIPT"
+}
+
+write_before_receipt() {
+  local archive_checksum deployments_json
+  archive_checksum="$(awk '{print $1}' "$ARCHIVE_CHECKSUM_PATH")"
+  deployments_json="$(deployment_receipt_json)"
+
+  jq -n \
+    --arg runId "$RUN_ID" \
+    --arg resumedFromRunId "$RESUME_FAILED_RUN_ID" \
+    --arg createdAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg sourceHost "$PRD_DB_HOST" \
+    --arg sourcePort "$PRD_DB_PORT" \
+    --arg sourceDatabase "$PRD_DB_NAME" \
+    --arg sourceMigrationFingerprint "$PRD_MIGRATION_FINGERPRINT" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetPort "$STG_DB_PORT" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+    --arg kubeSystemUid "$EXPECTED_KUBE_SYSTEM_UID" \
+    --arg workloadNamespace "$WORKLOAD_NAMESPACE" \
+    --arg workloadNamespaceUid "$EXPECTED_WORKLOAD_NAMESPACE_UID" \
+    --arg argocdApplicationUid "$EXPECTED_ARGOCD_APP_UID" \
+    --arg argocdProject "$EXPECTED_ARGOCD_PROJECT" \
+    --arg argocdProjectUid "$EXPECTED_ARGOCD_PROJECT_UID" \
+    --arg argocdRevision "$PINNED_ARGOCD_REVISION" \
+    --arg archiveSha256 "$archive_checksum" \
+    --arg azureResourceId "$STG_AZURE_RESOURCE_ID" \
+    --arg azureMetricTime "$STG_AZURE_STORAGE_METRIC_TIME" \
+    --argjson sourceSizeBytes "$PRD_SIZE_BYTES" \
+    --argjson sourceTableCount "$PRD_TABLE_COUNT" \
+    --argjson sourceAppliedMigrations "$PRD_APPLIED_MIGRATIONS" \
+    --argjson targetBeforeSizeBytes "$STG_BEFORE_SIZE_BYTES" \
+    --argjson targetBeforeTableCount "$STG_BEFORE_TABLE_COUNT" \
+    --argjson targetBeforeAppliedMigrations "$STG_BEFORE_APPLIED_MIGRATIONS" \
+    --argjson azureStorageUsedBytes "$STG_AZURE_STORAGE_USED_BYTES" \
+    --argjson azureStorageFreeBytes "$STG_AZURE_STORAGE_FREE_BYTES" \
+    --argjson azureTxlogStorageBytes "$STG_AZURE_TXLOG_STORAGE_BYTES" \
+    --argjson argocdAutomatedPolicy "$ORIGINAL_AUTOMATED_JSON" \
+    --argjson argocdProjectOriginalSyncWindows "$ORIGINAL_SYNC_WINDOWS_JSON" \
+    --argjson deployments "$deployments_json" \
+    --argjson outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
+    '{
+      runId: $runId,
+      resumedFromRunId: (if $resumedFromRunId == "" then null else $resumedFromRunId end),
+      createdAt: $createdAt,
+      source: {
+        host: $sourceHost,
+        port: $sourcePort,
+        database: $sourceDatabase,
+        sizeBytes: $sourceSizeBytes,
+        tableCount: $sourceTableCount,
+        appliedMigrations: $sourceAppliedMigrations,
+        migrationFingerprint: $sourceMigrationFingerprint
+      },
+      targetBefore: {
+        host: $targetHost,
+        port: $targetPort,
+        database: $targetDatabase,
+        sizeBytes: $targetBeforeSizeBytes,
+        tableCount: $targetBeforeTableCount,
+        appliedMigrations: $targetBeforeAppliedMigrations,
+        azureStorage: {
+          resourceId: $azureResourceId,
+          measuredAt: $azureMetricTime,
+          usedBytes: $azureStorageUsedBytes,
+          freeBytes: $azureStorageFreeBytes,
+          transactionLogBytes: $azureTxlogStorageBytes
+        }
+      },
+      governance: {
+        rawPrdDataApprovalRef: $approvalRef,
+        stgOutboundIntegrationsIsolated: $outboundIntegrationsIsolated
+      },
+      kubernetes: {
+        kubeSystemUid: $kubeSystemUid,
+        workloadNamespace: $workloadNamespace,
+        workloadNamespaceUid: $workloadNamespaceUid,
+        argocdApplicationUid: $argocdApplicationUid,
+        argocdProject: $argocdProject,
+        argocdProjectUid: $argocdProjectUid
+      },
+      argocdRevision: $argocdRevision,
+      deployments: $deployments,
+      archiveSha256: $archiveSha256,
+      argocdAutomatedPolicy: $argocdAutomatedPolicy,
+      argocdProjectOriginalSyncWindows: $argocdProjectOriginalSyncWindows
+    }' >"$BEFORE_RECEIPT"
+}
+
+write_after_receipt() {
+  local database_name version_num size_bytes table_count applied_migrations
+  local failed_migrations extra_schema_count large_object_count deployments_json
+  IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
+    failed_migrations extra_schema_count large_object_count <<<"$MIGRATED_METADATA"
+  deployments_json="$(
+    jq -c '[.items[] | {
+      namespace: .metadata.namespace,
+      name: .metadata.name,
+      desiredReplicas: (.spec.replicas // 1),
+      readyReplicas: (.status.readyReplicas // 0),
+      observedGeneration: (.status.observedGeneration // 0)
+    }] | sort_by(.namespace, .name)' <<<"$POST_SYNC_DEPLOYMENTS_JSON"
+  )"
+
+  local temporary_receipt="$AFTER_RECEIPT.tmp"
+  jq -n \
+    --arg runId "$RUN_ID" \
+    --arg completedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetPort "$STG_DB_PORT" \
+    --arg targetDatabase "$database_name" \
+    --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+    --arg migrationFingerprint "$MIGRATED_MIGRATION_FINGERPRINT" \
+    --arg argocdRevision "$ARGO_OPERATION_REVISION" \
+    --arg migratorImage "$OBSERVED_MIGRATOR_IMAGE" \
+    --arg migratorImageId "$OBSERVED_MIGRATOR_IMAGE_ID" \
+    --arg migratorJobUid "$OBSERVED_MIGRATOR_JOB_UID" \
+    --arg migratorPodUid "$OBSERVED_MIGRATOR_POD_UID" \
+    --argjson targetSizeBytes "$size_bytes" \
+    --argjson targetTableCount "$table_count" \
+    --argjson targetAppliedMigrations "$applied_migrations" \
+    --argjson deployments "$deployments_json" \
+    --argjson outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
+    '{
+      runId: $runId,
+      completedAt: $completedAt,
+      terminalSuccess: true,
+      targetAfter: {
+        host: $targetHost,
+        port: $targetPort,
+        database: $targetDatabase,
+        sizeBytes: $targetSizeBytes,
+        tableCount: $targetTableCount,
+        appliedMigrations: $targetAppliedMigrations,
+        unresolvedMigrations: 0,
+        migrationFingerprint: $migrationFingerprint
+      },
+      governance: {
+        rawPrdDataApprovalRef: $approvalRef,
+        stgOutboundIntegrationsIsolated: $outboundIntegrationsIsolated
+      },
+      argocd: {
+        revision: $argocdRevision,
+        migratorImage: $migratorImage,
+        migratorImageId: $migratorImageId,
+        migratorJobUid: $migratorJobUid,
+        migratorPodUid: $migratorPodUid,
+        sync: "Synced",
+        health: "Healthy",
+        originalPolicyRestored: true
+      },
+      deployments: $deployments
+    }' >"$temporary_receipt"
+  mv -- "$temporary_receipt" "$AFTER_RECEIPT"
+}
+
+validate_configuration() {
+  validate_boolean DRY_RUN "$DRY_RUN"
+  validate_boolean KEEP_ENCRYPTED_ARCHIVE "$KEEP_ENCRYPTED_ARCHIVE"
+  validate_boolean ALLOW_RAW_PRD_DATA_IN_STG "$ALLOW_RAW_PRD_DATA_IN_STG"
+  validate_boolean STG_OUTBOUND_INTEGRATIONS_ISOLATED "$STG_OUTBOUND_INTEGRATIONS_ISOLATED"
+  validate_raw_data_approval_ref
+  validate_positive_integer STG_STORAGE_GIB "$STG_STORAGE_GIB"
+  validate_positive_integer MAX_SOURCE_STORAGE_PERCENT "$MAX_SOURCE_STORAGE_PERCENT"
+  validate_positive_integer MIN_STG_FREE_SPACE_MULTIPLIER "$MIN_STG_FREE_SPACE_MULTIPLIER"
+  validate_positive_integer ARGOCD_TIMEOUT_SECONDS "$ARGOCD_TIMEOUT_SECONDS"
+  validate_positive_integer ARGOCD_POLL_SECONDS "$ARGOCD_POLL_SECONDS"
+  validate_positive_integer WORKLOAD_DRAIN_TIMEOUT_SECONDS "$WORKLOAD_DRAIN_TIMEOUT_SECONDS"
+  validate_positive_integer POST_SYNC_HEALTH_TIMEOUT_SECONDS "$POST_SYNC_HEALTH_TIMEOUT_SECONDS"
+  validate_positive_integer CLEANUP_TIMEOUT_SECONDS "$CLEANUP_TIMEOUT_SECONDS"
+  validate_positive_integer MIGRATOR_EVIDENCE_TIMEOUT_SECONDS "$MIGRATOR_EVIDENCE_TIMEOUT_SECONDS"
+  validate_positive_integer REFRESH_LEASE_DURATION_SECONDS "$REFRESH_LEASE_DURATION_SECONDS"
+  validate_positive_integer REFRESH_LEASE_RENEW_INTERVAL_SECONDS "$REFRESH_LEASE_RENEW_INTERVAL_SECONDS"
+  validate_run_id
+  validate_resume_failed_run_id
+  (( STG_STORAGE_GIB > 0 )) || die "STG_STORAGE_GIB must be greater than zero"
+  (( MIN_STG_FREE_SPACE_MULTIPLIER >= 2 )) \
+    || die "MIN_STG_FREE_SPACE_MULTIPLIER must be at least 2"
+  (( ARGOCD_TIMEOUT_SECONDS > 0 )) || die "ARGOCD_TIMEOUT_SECONDS must be greater than zero"
+  (( ARGOCD_POLL_SECONDS > 0 )) || die "ARGOCD_POLL_SECONDS must be greater than zero"
+  (( WORKLOAD_DRAIN_TIMEOUT_SECONDS > 0 )) \
+    || die "WORKLOAD_DRAIN_TIMEOUT_SECONDS must be greater than zero"
+  (( POST_SYNC_HEALTH_TIMEOUT_SECONDS > 0 )) \
+    || die "POST_SYNC_HEALTH_TIMEOUT_SECONDS must be greater than zero"
+  (( REFRESH_LEASE_RENEW_INTERVAL_SECONDS > 0 )) \
+    || die "REFRESH_LEASE_RENEW_INTERVAL_SECONDS must be greater than zero"
+  (( REFRESH_LEASE_DURATION_SECONDS > REFRESH_LEASE_RENEW_INTERVAL_SECONDS * 2 )) \
+    || die "REFRESH_LEASE_DURATION_SECONDS must exceed twice the renewal interval"
+  (( MAX_SOURCE_STORAGE_PERCENT > 0 && MAX_SOURCE_STORAGE_PERCENT <= 95 )) \
+    || die "MAX_SOURCE_STORAGE_PERCENT must be between 1 and 95"
+  [[ "$KUBECTL_REQUEST_TIMEOUT" =~ ^[1-9][0-9]*[smh]$ ]] \
+    || die "KUBECTL_REQUEST_TIMEOUT must be a positive Kubernetes duration such as 30s"
+
+  local required_value
+  for required_value in \
+    "$EXPECTED_PRD_DB_HOST" "$EXPECTED_STG_DB_HOST" \
+    "$EXPECTED_PRD_DB_PORT" "$EXPECTED_STG_DB_PORT" \
+    "$EXPECTED_PRD_DB_NAME" "$EXPECTED_STG_DB_NAME" \
+    "$KUBE_CONTEXT" "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" \
+    "$ARGOCD_APP" "$WORKLOAD_NAMESPACE" "$EXPECTED_KUBE_TLS_SERVER_NAME" \
+    "$EXPECTED_KUBE_SYSTEM_UID" "$EXPECTED_WORKLOAD_NAMESPACE_UID" \
+    "$EXPECTED_ARGOCD_APP_UID" "$MIGRATOR_SECRET_NAME" \
+    "$MIGRATOR_SECRET_KEY" "$MIGRATOR_JOB_NAME" \
+    "$EXPECTED_MIGRATOR_IMAGE_REPOSITORY" "$STG_AZURE_RESOURCE_GROUP" \
+    "$STG_AZURE_SERVER_NAME"; do
+    [[ -n "$required_value" ]] \
+      || die "Pinned target configuration values must not be empty"
+  done
+}
+
+validate_execution_gates() {
+  [[ "$DRY_RUN" == "false" ]] || return 0
+
+  [[ "$CONFIRM_PRD_TO_STG_REFRESH" == "ERASE_STG_AND_COPY_PRD" ]] \
+    || die "Execution requires CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD"
+  [[ "$ALLOW_RAW_PRD_DATA_IN_STG" == "true" ]] \
+    || die "Execution requires ALLOW_RAW_PRD_DATA_IN_STG=true"
+  [[ -n "$RAW_PRD_DATA_APPROVAL_REF" ]] \
+    || die "Execution requires RAW_PRD_DATA_APPROVAL_REF=<approved-ticket-or-ADR>"
+  [[ "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" == "true" ]] \
+    || die "Execution requires STG_OUTBOUND_INTEGRATIONS_ISOLATED=true"
+}
+
+validate_tools() {
+  local tools=(az awk base64 cat chmod cp gpg grep jq kubectl mkdir mv node pg_dump pg_restore psql rm sed shasum sort)
+  local tool
+  for tool in "${tools[@]}"; do
+    require_command "$tool"
+  done
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    print_help
+    return 0
+  fi
+  [[ $# -eq 0 ]] || die "Unknown argument: $1"
+
+  validate_configuration
+  validate_execution_gates
+  validate_tools
+  load_credentials
+  validate_endpoints
+
+  local prd_metadata stg_before_metadata
+  load_database_metadata prd_metadata "$PRD_DATABASE_URL" PRD
+  load_database_metadata stg_before_metadata "$STG_DATABASE_URL" STG
+  parse_prd_metadata "$prd_metadata"
+  parse_stg_before_metadata "$stg_before_metadata"
+  load_database_identity PRD_DATABASE_IDENTITY "$PRD_DATABASE_URL" PRD
+  load_database_identity STG_DATABASE_IDENTITY "$STG_DATABASE_URL" STG
+  [[ "$PRD_DATABASE_IDENTITY" != "$STG_DATABASE_IDENTITY" ]] \
+    || die "PRD and STG database identities unexpectedly match"
+  load_migration_history PRD_MIGRATION_HISTORY PRD_MIGRATION_FINGERPRINT \
+    "$PRD_DATABASE_URL" PRD
+  validate_stg_reset_capabilities
+  validate_client_and_capacity
+  validate_azure_storage_headroom
+  validate_kubernetes_target
+  validate_kubernetes_permissions
+  load_migrator_database_url
+  validate_migrator_target
+  load_argocd_state
+  load_argocd_project_state
+
+  local deployments_json
+  deployments_json="$(load_workload_state)"
+  PREFLIGHT_DEPLOYMENTS_JSON="$deployments_json"
+  validate_resume_workload_state "$deployments_json"
+  local deployment_count
+  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
+  print_preflight_summary "$deployment_count"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY_RUN=true: no dump was created and no external state was changed."
+    log "Re-run with the five documented execution gates after reviewing this plan."
+    return 0
+  fi
+
+  prepare_run_directory
+  set_run_phase prepared
+  acquire_refresh_lease
+  start_refresh_lease_renewal
+  prepare_deployment_receipt
+  encrypt_prd_dump
+  write_before_receipt
+  set_run_phase dump-verified
+
+  pause_argocd_policy
+  scale_stg_workloads_down
+  install_argocd_maintenance_fence \
+    || die "Could not install the app-scoped ArgoCD maintenance fence"
+
+  # Re-verify the pause and persistent deny window immediately before mutation.
+  assert_refresh_lease
+  assert_argocd_quiescent
+
+  reset_stg_owned_objects
+  restore_stg_database
+  local restored_metadata
+  load_database_metadata restored_metadata "$STG_DATABASE_URL" STG
+  validate_restored_snapshot "$restored_metadata"
+  validate_restored_migration_history
+  RESTORE_VERIFIED=true
+  set_run_phase restore-verified
+
+  remove_argocd_maintenance_fence \
+    || die "Could not remove the maintenance fence before the owned sync"
+  run_presync_hook
+  local migrated_metadata
+  load_database_metadata migrated_metadata "$STG_DATABASE_URL" STG
+  validate_migrated_target "$migrated_metadata"
+  restore_argocd_policy
+  wait_for_post_sync_health true
+
+  TERMINAL_SUCCESS=true
+  set_run_phase completed
+  write_after_receipt
+  log "PRD-to-STG database refresh completed successfully"
+  log "Receipts: $BEFORE_RECEIPT and $AFTER_RECEIPT"
+  log "Application-level validation is still required before STG is declared usable."
+  log "Verify the ArgoCD Application and migrator logs, backend behavior, outbound isolation, and one isolated synthetic STG request."
+  if [[ "$KEEP_ENCRYPTED_ARCHIVE" == "true" ]]; then
+    log "Encrypted archive retained at: $ARCHIVE_PATH"
+  else
+    log "Encrypted archive will be removed during cleanup"
+  fi
+}
+
+main "$@"

--- a/util/backup/refresh-stg-from-prd/argocd.sh
+++ b/util/backup/refresh-stg-from-prd/argocd.sh
@@ -454,6 +454,9 @@ run_presync_hook() {
   while true; do
     assert_refresh_lease
     if ! application_json="$(get_argocd_application)"; then
+      if (( SECONDS >= deadline )); then
+        die "Could not read the ArgoCD Application before the sync timeout"
+      fi
       log "Waiting for the ArgoCD Application resource to become readable"
       sleep "$ARGOCD_POLL_SECONDS"
       continue

--- a/util/backup/refresh-stg-from-prd/argocd.sh
+++ b/util/backup/refresh-stg-from-prd/argocd.sh
@@ -1,0 +1,594 @@
+# Sourced by refresh-stg-from-prd.sh; do not execute directly.
+# Contract: owns the app-scoped maintenance fence, automated-sync policy,
+# atomic Argo operation lifecycle, migrator evidence, and terminal health proof.
+# It reads immutable Argo/Kubernetes config and updates only Argo/migrator state
+# globals plus the current run evidence file through set_run_phase.
+
+get_argocd_application() {
+  kubectl_for_argocd get application.argoproj.io "$ARGOCD_APP" -o json
+}
+
+patch_argocd_application() {
+  local patch_payload="$1"
+  kubectl_for_argocd patch application.argoproj.io "$ARGOCD_APP" --type merge \
+    --patch "$patch_payload"
+}
+
+patch_argocd_application_json() {
+  local patch_payload="$1"
+  kubectl_for_argocd patch application.argoproj.io "$ARGOCD_APP" --type json \
+    --patch "$patch_payload"
+}
+
+patch_argocd_application_status_json() {
+  local patch_payload="$1"
+  kubectl_for_argocd patch application.argoproj.io "$ARGOCD_APP" --type json \
+    --subresource=status --patch "$patch_payload"
+}
+
+build_argocd_sync_patch() {
+  local initiator="$1"
+  local revision="$2"
+  local resource_version="$3"
+  jq -cn \
+    --arg initiator "$initiator" \
+    --arg revision "$revision" \
+    --arg resourceVersion "$resource_version" \
+    --arg uid "$EXPECTED_ARGOCD_APP_UID" '
+      [
+        {
+          op: "test",
+          path: "/metadata/resourceVersion",
+          value: $resourceVersion
+        },
+        {op: "test", path: "/metadata/uid", value: $uid},
+        {
+          op: "add",
+          path: "/operation",
+          value: {
+            initiatedBy: {username: $initiator},
+            sync: {
+              revision: $revision,
+              syncStrategy: {hook: {}}
+            }
+          }
+        }
+      ]
+    '
+}
+
+build_argocd_policy_patch() {
+  jq -cn --argjson automated "$1" \
+    '{spec: {syncPolicy: {automated: $automated}}}'
+}
+
+get_argocd_project() {
+  kubectl_for_argocd get appproject.argoproj.io "$EXPECTED_ARGOCD_PROJECT" -o json
+}
+
+patch_argocd_project_json() {
+  local patch_payload="$1"
+  kubectl_for_argocd patch appproject.argoproj.io "$EXPECTED_ARGOCD_PROJECT" \
+    --type json --patch "$patch_payload"
+}
+
+maintenance_sync_window() {
+  jq -cn --arg application "$ARGOCD_APP" '{
+    kind: "deny",
+    schedule: "* * * * *",
+    duration: "1h",
+    applications: [$application],
+    manualSync: false
+  }'
+}
+
+json_values_equal() {
+  jq -en --argjson actual "$1" --argjson expected "$2" \
+    '$actual == $expected' >/dev/null
+}
+
+load_argocd_state() {
+  local application_json
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP' using context '$ARGOCD_KUBE_CONTEXT'"
+
+  local operation_phase
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  if jq -e '.operation != null' >/dev/null <<<"$application_json"; then
+    die "ArgoCD Application '$ARGOCD_APP' already has a pending operation"
+  fi
+  [[ "$operation_phase" != "Running" && "$operation_phase" != "Terminating" ]] \
+    || die "ArgoCD application '$ARGOCD_APP' already has a running operation"
+  PINNED_ARGOCD_REVISION="$(jq -r '.status.sync.revision // ""' <<<"$application_json")"
+  [[ "$PINNED_ARGOCD_REVISION" =~ ^[0-9a-f]{40}$ ]] \
+    || die "ArgoCD Application does not expose an immutable comparison revision"
+
+  local current_automated_sync=false
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    current_automated_sync=true
+  fi
+
+  if [[ "$current_automated_sync" == "true" ]]; then
+    [[ -z "$RESUME_FAILED_RUN_ID" ]] \
+      || die "RESUME_FAILED_RUN_ID was provided but ArgoCD automated sync is enabled; refusing a stale resume"
+    ORIGINAL_AUTOMATED_JSON="$(jq -c '.spec.syncPolicy.automated' <<<"$application_json")"
+    ORIGINAL_AUTOMATED_SYNC=true
+    return 0
+  fi
+
+  [[ -n "$RESUME_FAILED_RUN_ID" ]] \
+    || die "ArgoCD automated sync is disabled before refresh; set RESUME_FAILED_RUN_ID only after validating the failed-run receipt and maintenance state"
+  load_failed_run_receipt
+}
+
+expected_fenced_sync_windows() {
+  local fence
+  fence="$(maintenance_sync_window)"
+  jq -cn --argjson original "$ORIGINAL_SYNC_WINDOWS_JSON" \
+    --argjson fence "$fence" '$original + [$fence]'
+}
+
+load_argocd_project_state() {
+  local project_json current_windows expected_windows
+  project_json="$(get_argocd_project)" \
+    || die "Could not read ArgoCD AppProject '$ARGOCD_NAMESPACE/$EXPECTED_ARGOCD_PROJECT'"
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$project_json")" == "$EXPECTED_ARGOCD_PROJECT_UID" ]] \
+    || die "ArgoCD AppProject '$EXPECTED_ARGOCD_PROJECT' has an unexpected UID"
+  current_windows="$(jq -c '.spec.syncWindows // []' <<<"$project_json")"
+
+  if [[ -n "$RESUME_FAILED_RUN_ID" ]]; then
+    expected_windows="$(expected_fenced_sync_windows)"
+    json_values_equal "$current_windows" "$expected_windows" \
+      || die "Resume requires the exact failed-run ArgoCD maintenance fence"
+    MAINTENANCE_FENCE_ACTIVE=true
+    return 0
+  fi
+
+  local fence
+  fence="$(maintenance_sync_window)"
+  jq -e --argjson fence "$fence" \
+    'all(.[]; . != $fence)' >/dev/null <<<"$current_windows" \
+    || die "ArgoCD AppProject already contains the refresh maintenance fence"
+  ORIGINAL_SYNC_WINDOWS_JSON="$current_windows"
+}
+
+set_argocd_project_sync_windows() {
+  local current_json="$1"
+  local windows_json="$2"
+  local resource_version patch_payload
+  resource_version="$(jq -r '.metadata.resourceVersion // ""' <<<"$current_json")"
+  [[ -n "$resource_version" ]] || return 1
+  patch_payload="$(
+    jq -cn \
+      --arg resourceVersion "$resource_version" \
+      --arg uid "$EXPECTED_ARGOCD_PROJECT_UID" \
+      --argjson windows "$windows_json" '
+        [
+          {op: "test", path: "/metadata/resourceVersion", value: $resourceVersion},
+          {op: "test", path: "/metadata/uid", value: $uid},
+          {op: "add", path: "/spec/syncWindows", value: $windows}
+        ]
+      '
+  )"
+  patch_argocd_project_json "$patch_payload" >/dev/null
+}
+
+install_argocd_maintenance_fence() {
+  local project_json current_windows expected_windows
+  expected_windows="$(expected_fenced_sync_windows)"
+  project_json="$(get_argocd_project)" || return 1
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$project_json")" == "$EXPECTED_ARGOCD_PROJECT_UID" ]] \
+    || return 1
+  current_windows="$(jq -c '.spec.syncWindows // []' <<<"$project_json")"
+  if ! json_values_equal "$current_windows" "$expected_windows"; then
+    json_values_equal "$current_windows" "$ORIGINAL_SYNC_WINDOWS_JSON" || return 1
+    set_argocd_project_sync_windows "$project_json" "$expected_windows" || return 1
+  fi
+  project_json="$(get_argocd_project)" || return 1
+  json_values_equal "$(jq -c '.spec.syncWindows // []' <<<"$project_json")" \
+    "$expected_windows" \
+    || return 1
+  MAINTENANCE_FENCE_ACTIVE=true
+  set_run_phase maintenance-fenced
+  log "Installed app-scoped ArgoCD deny window for '$ARGOCD_APP'"
+}
+
+remove_argocd_maintenance_fence() {
+  [[ "$MAINTENANCE_FENCE_ACTIVE" == "true" ]] || return 0
+  local project_json current_windows expected_windows
+  expected_windows="$(expected_fenced_sync_windows)"
+  project_json="$(get_argocd_project)" || return 1
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$project_json")" == "$EXPECTED_ARGOCD_PROJECT_UID" ]] \
+    || return 1
+  current_windows="$(jq -c '.spec.syncWindows // []' <<<"$project_json")"
+  json_values_equal "$current_windows" "$expected_windows" || return 1
+  set_argocd_project_sync_windows "$project_json" "$ORIGINAL_SYNC_WINDOWS_JSON" \
+    || return 1
+  project_json="$(get_argocd_project)" || return 1
+  json_values_equal "$(jq -c '.spec.syncWindows // []' <<<"$project_json")" \
+    "$ORIGINAL_SYNC_WINDOWS_JSON" \
+    || return 1
+  MAINTENANCE_FENCE_ACTIVE=false
+  set_run_phase maintenance-fence-removed
+  log "Removed the app-scoped ArgoCD deny window"
+}
+
+pause_argocd_policy() {
+  assert_refresh_lease
+  if [[ "$RESUMING_MAINTENANCE" == "true" ]]; then
+    log "ArgoCD automated sync is already disabled by failed run '$RESUME_FAILED_RUN_ID'"
+    ARGOCD_POLICY_PAUSED=true
+    set_run_phase argocd-paused
+    return 0
+  fi
+
+  set_run_phase pausing-argocd
+  log "Disabling automated sync/self-heal on ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP'"
+  patch_argocd_application '{"spec":{"syncPolicy":{"automated":null}}}' >/dev/null
+  ARGOCD_POLICY_PAUSED=true
+
+  local application_json
+  application_json="$(get_argocd_application)"
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    die "ArgoCD automated sync is still enabled after requesting manual policy"
+  fi
+  set_run_phase argocd-paused
+}
+
+assert_argocd_quiescent() {
+  local application_json operation_phase
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application during maintenance fencing"
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_APP_UID" ]] \
+    || die "ArgoCD Application identity changed during maintenance"
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  if jq -e '.operation != null' >/dev/null <<<"$application_json" ||
+    [[ "$operation_phase" == "Running" || "$operation_phase" == "Terminating" ]]; then
+    die "A competing ArgoCD operation appeared during the refresh Lease"
+  fi
+  if jq -e \
+    '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    die "ArgoCD automated sync was re-enabled during the refresh Lease"
+  fi
+}
+
+assert_argocd_maintenance_fence() {
+  local project_json expected_windows
+  expected_windows="$(expected_fenced_sync_windows)"
+  project_json="$(get_argocd_project)" \
+    || die "Could not read the ArgoCD maintenance fence"
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$project_json")" == "$EXPECTED_ARGOCD_PROJECT_UID" ]] \
+    || die "ArgoCD AppProject identity changed during maintenance"
+  json_values_equal "$(jq -c '.spec.syncWindows // []' <<<"$project_json")" \
+    "$expected_windows" \
+    || die "The app-scoped ArgoCD maintenance fence changed or disappeared"
+}
+
+start_migrator_evidence_watch() {
+  local existing_job_json
+  existing_job_json="$(
+    kubectl_for_workloads get job "$MIGRATOR_JOB_NAME" --ignore-not-found -o json
+  )" || die "Could not inspect the pre-existing migrator Job"
+  [[ -n "$existing_job_json" ]] || existing_job_json='{}'
+  PRE_SYNC_MIGRATOR_JOB_UID="$(jq -r '.metadata.uid // ""' <<<"$existing_job_json")"
+  rm -f -- "$MIGRATOR_EVIDENCE_FILE" "$MIGRATOR_EVIDENCE_FILE.tmp"
+
+  (
+    set +e
+    kubectl_for_workloads get pods -l "job-name=$MIGRATOR_JOB_NAME" \
+      --watch --output-watch-events -o json |
+      jq -c --unbuffered \
+        --arg jobName "$MIGRATOR_JOB_NAME" \
+        --arg staleJobUid "$PRE_SYNC_MIGRATOR_JOB_UID" '
+          select(.type == "ADDED" or .type == "MODIFIED") |
+          .object as $pod |
+          ([
+            $pod.metadata.ownerReferences[]? |
+            select(.kind == "Job" and .name == $jobName)
+          ][0] // null) as $owner |
+          select($owner != null and ($owner.uid // "") != "") |
+          select($owner.uid != $staleJobUid) |
+          ([
+            $pod.spec.containers[]? |
+            select(.name == "migrate") |
+            .image
+          ][0] // "") as $image |
+          ([
+            $pod.status.containerStatuses[]? |
+            select(.name == "migrate") |
+            .imageID
+          ][0] // "") as $imageId |
+          select($image != "" and $imageId != "") |
+          {
+            jobUid: $owner.uid,
+            podUid: $pod.metadata.uid,
+            image: $image,
+            imageId: $imageId
+          }
+        ' |
+      while IFS= read -r evidence; do
+        printf '%s\n' "$evidence" >"$MIGRATOR_EVIDENCE_FILE.tmp"
+        mv -- "$MIGRATOR_EVIDENCE_FILE.tmp" "$MIGRATOR_EVIDENCE_FILE"
+        break
+      done
+  ) &
+  MIGRATOR_EVIDENCE_WATCH_PID=$!
+}
+
+stop_migrator_evidence_watch() {
+  [[ -n "$MIGRATOR_EVIDENCE_WATCH_PID" ]] || return 0
+  kill "$MIGRATOR_EVIDENCE_WATCH_PID" 2>/dev/null || true
+  wait "$MIGRATOR_EVIDENCE_WATCH_PID" 2>/dev/null || true
+  MIGRATOR_EVIDENCE_WATCH_PID=""
+}
+
+load_migrator_evidence() {
+  [[ -s "$MIGRATOR_EVIDENCE_FILE" ]] \
+    || die "ArgoCD succeeded without evidence from a new migrator Pod"
+  OBSERVED_MIGRATOR_JOB_UID="$(jq -r '.jobUid // ""' "$MIGRATOR_EVIDENCE_FILE")"
+  OBSERVED_MIGRATOR_POD_UID="$(jq -r '.podUid // ""' "$MIGRATOR_EVIDENCE_FILE")"
+  OBSERVED_MIGRATOR_IMAGE="$(jq -r '.image // ""' "$MIGRATOR_EVIDENCE_FILE")"
+  OBSERVED_MIGRATOR_IMAGE_ID="$(jq -r '.imageId // ""' "$MIGRATOR_EVIDENCE_FILE")"
+  [[ -n "$OBSERVED_MIGRATOR_JOB_UID" &&
+    "$OBSERVED_MIGRATOR_JOB_UID" != "$PRE_SYNC_MIGRATOR_JOB_UID" ]] \
+    || die "Migrator evidence came from the pre-existing Job"
+  [[ -n "$OBSERVED_MIGRATOR_POD_UID" ]] \
+    || die "Migrator evidence does not contain a Pod UID"
+  [[ "$OBSERVED_MIGRATOR_IMAGE" == "$EXPECTED_MIGRATOR_IMAGE_REPOSITORY:"* ]] \
+    || die "Observed unexpected migrator image '$OBSERVED_MIGRATOR_IMAGE'"
+  local canonical_image_id="${OBSERVED_MIGRATOR_IMAGE_ID#docker-pullable://}"
+  local image_digest="${canonical_image_id#"$EXPECTED_MIGRATOR_IMAGE_REPOSITORY@sha256:"}"
+  [[ "$canonical_image_id" == "$EXPECTED_MIGRATOR_IMAGE_REPOSITORY@sha256:"* &&
+    "$image_digest" =~ ^[0-9a-f]{64}$ ]] \
+    || die "Migrator Pod did not expose an immutable image digest for the expected repository"
+  OBSERVED_MIGRATOR_IMAGE_ID="$canonical_image_id"
+  set_run_phase waiting-for-argocd
+  log "Observed new PreSync migrator Job/Pod and immutable image digest"
+}
+
+finish_migrator_evidence_watch() {
+  local deadline=$((SECONDS + MIGRATOR_EVIDENCE_TIMEOUT_SECONDS))
+  while true; do
+    [[ ! -s "$MIGRATOR_EVIDENCE_FILE" ]] || break
+    (( SECONDS < deadline )) || break
+    sleep 0.25
+  done
+  stop_migrator_evidence_watch
+  load_migrator_evidence
+}
+
+terminate_owned_argocd_operation() {
+  local deadline="${1:-$((SECONDS + CLEANUP_TIMEOUT_SECONDS))}"
+  local application_json active_initiator observed_initiator operation_phase
+  local termination_patch termination_requested=false
+  set_run_phase terminating-argocd
+  while true; do
+    if ! application_json="$(get_argocd_application)"; then
+      (( SECONDS < deadline )) || return 1
+      log "Waiting for ArgoCD to become readable while operation termination is unresolved"
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    fi
+    active_initiator="$(jq -r '.operation.initiatedBy.username // ""' <<<"$application_json")"
+    observed_initiator="$(jq -r '.status.operationState.operation.initiatedBy.username // ""' <<<"$application_json")"
+    operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+
+    if [[ -n "$active_initiator" && "$active_initiator" != "$ARGO_OPERATION_INITIATOR" ]]; then
+      log "A different ArgoCD operation is active; refusing to terminate it"
+      return 1
+    fi
+    if [[ "$observed_initiator" != "$ARGO_OPERATION_INITIATOR" ]]; then
+      if [[ "$active_initiator" == "$ARGO_OPERATION_INITIATOR" ]]; then
+        (( SECONDS < deadline )) || return 1
+        sleep "$ARGOCD_POLL_SECONDS"
+        continue
+      fi
+      log "Could not associate ArgoCD operation state with initiator '$ARGO_OPERATION_INITIATOR'"
+      return 1
+    fi
+
+    if [[ "$operation_phase" == "Succeeded" || "$operation_phase" == "Failed" ||
+      "$operation_phase" == "Error" ]] &&
+      [[ -z "$active_initiator" ]]; then
+      ARGO_OPERATION_ACCEPTED=false
+      log "Owned ArgoCD operation reached terminal phase '$operation_phase'"
+      return 0
+    fi
+
+    if [[ "$operation_phase" == "Running" && "$termination_requested" == "false" ]]; then
+      termination_patch="$(
+        jq -cn --arg initiator "$ARGO_OPERATION_INITIATOR" '
+          [
+            {op: "test", path: "/status/operationState/operation/initiatedBy/username", value: $initiator},
+            {op: "test", path: "/status/operationState/phase", value: "Running"},
+            {op: "replace", path: "/status/operationState/phase", value: "Terminating"}
+          ]
+        '
+      )"
+      patch_argocd_application_status_json "$termination_patch" >/dev/null \
+        || return 1
+      termination_requested=true
+      log "Requested termination of the owned ArgoCD operation"
+    fi
+    (( SECONDS < deadline )) || return 1
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+}
+
+run_presync_hook() {
+  local application_json operation_phase resource_version
+  assert_refresh_lease
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application immediately before sync"
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  if jq -e '.operation != null' >/dev/null <<<"$application_json" || \
+    [[ "$operation_phase" == "Running" || "$operation_phase" == "Terminating" ]]; then
+    die "ArgoCD Application '$ARGOCD_APP' acquired another operation before refresh sync"
+  fi
+
+  ARGO_OPERATION_INITIATOR="prd-to-stg-refresh-$RUN_ID"
+  local sync_patch
+  resource_version="$(jq -r '.metadata.resourceVersion // ""' <<<"$application_json")"
+  [[ -n "$resource_version" ]] \
+    || die "ArgoCD Application has no resourceVersion for atomic sync submission"
+  sync_patch="$(
+    build_argocd_sync_patch \
+      "$ARGO_OPERATION_INITIATOR" "$PINNED_ARGOCD_REVISION" "$resource_version"
+  )"
+
+  set_run_phase submitting-argocd
+  start_migrator_evidence_watch
+  log "Submitting a hook-based sync to ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP'"
+  if ! patch_argocd_application_json "$sync_patch" >/dev/null; then
+    die "Could not atomically submit the ArgoCD sync operation through the Kubernetes API"
+  fi
+
+  ARGO_OPERATION_ACCEPTED=true
+  WORKLOADS_SCALED=false
+  set_run_phase waiting-for-argocd
+
+  local deadline=$((SECONDS + ARGOCD_TIMEOUT_SECONDS))
+  while true; do
+    assert_refresh_lease
+    if ! application_json="$(get_argocd_application)"; then
+      log "Waiting for the ArgoCD Application resource to become readable"
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    fi
+
+    local observed_initiator
+    observed_initiator="$(jq -r '.status.operationState.operation.initiatedBy.username // ""' <<<"$application_json")"
+    if [[ "$observed_initiator" != "$ARGO_OPERATION_INITIATOR" ]]; then
+      if (( SECONDS >= deadline )); then
+        die "Submitted ArgoCD operation was not observed before the timeout"
+      fi
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    fi
+
+    operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+    case "$operation_phase" in
+      Succeeded)
+        ARGO_OPERATION_REVISION="$(jq -r '.status.operationState.syncResult.revision // ""' <<<"$application_json")"
+        [[ "$ARGO_OPERATION_REVISION" == "$PINNED_ARGOCD_REVISION" ]] \
+          || die "ArgoCD success revision does not match the preflight-pinned Git revision"
+        if ! jq -e '.operation == null' >/dev/null <<<"$application_json"; then
+          sleep "$ARGOCD_POLL_SECONDS"
+          continue
+        fi
+        finish_migrator_evidence_watch
+        ARGO_OPERATION_ACCEPTED=false
+        set_run_phase argocd-succeeded
+        log "ArgoCD sync succeeded at revision '$ARGO_OPERATION_REVISION'; the PreSync migration hook and Sync phase completed"
+        return 0
+        ;;
+      Failed|Error)
+        if ! jq -e '.operation == null' >/dev/null <<<"$application_json"; then
+          sleep "$ARGOCD_POLL_SECONDS"
+          continue
+        fi
+        ARGO_OPERATION_ACCEPTED=false
+        local operation_message
+        operation_message="$(jq -r '.status.operationState.message // "no operation message"' <<<"$application_json")"
+        set_run_phase argocd-failed
+        die "ArgoCD sync or PreSync migration hook failed in phase '$operation_phase': $operation_message"
+        ;;
+    esac
+
+    if (( SECONDS >= deadline )); then
+      log "ArgoCD operation exceeded $ARGOCD_TIMEOUT_SECONDS seconds; requesting termination and waiting for a terminal state"
+      terminate_owned_argocd_operation \
+        || die "Could not safely request termination of the owned ArgoCD operation"
+      die "ArgoCD sync exceeded $ARGOCD_TIMEOUT_SECONDS seconds and was terminated"
+    fi
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+}
+
+wait_for_post_sync_health() {
+  local require_restored_policy="${1:-false}"
+  local deadline=$((SECONDS + POST_SYNC_HEALTH_TIMEOUT_SECONDS))
+  local application_json deployments_json sync_status health_status sync_revision
+  local healthy_observations=0
+  set_run_phase waiting-for-health
+
+  while true; do
+    assert_refresh_lease
+    application_json="$(get_argocd_application)" \
+      || die "Could not read ArgoCD Application during post-sync health verification"
+    deployments_json="$(load_workload_state)"
+    assert_workload_set_matches_receipt
+
+    sync_status="$(jq -r '.status.sync.status // "Unknown"' <<<"$application_json")"
+    health_status="$(jq -r '.status.health.status // "Unknown"' <<<"$application_json")"
+    sync_revision="$(jq -r '.status.sync.revision // ""' <<<"$application_json")"
+
+    local policy_matches=true
+    if [[ "$require_restored_policy" == "true" ]] &&
+      ! jq -e --argjson expected "$ORIGINAL_AUTOMATED_JSON" \
+        '(.spec.syncPolicy.automated // null) == $expected' \
+        >/dev/null <<<"$application_json"; then
+      policy_matches=false
+    fi
+
+    if [[ "$policy_matches" == "true" &&
+      "$sync_status" == "Synced" && "$health_status" == "Healthy" &&
+      "$sync_revision" == "$ARGO_OPERATION_REVISION" ]] &&
+      jq -e '.operation == null' >/dev/null <<<"$application_json" &&
+      jq -e '
+        all(.items[];
+          (.status.observedGeneration // 0) >= (.metadata.generation // 0) and
+          (.status.readyReplicas // 0) == (.spec.replicas // 1) and
+          (.status.updatedReplicas // 0) == (.spec.replicas // 1) and
+          (.status.availableReplicas // 0) == (.spec.replicas // 1)
+        )
+      ' >/dev/null <<<"$deployments_json"; then
+      healthy_observations=$((healthy_observations + 1))
+      if (( healthy_observations >= 2 )); then
+        POST_SYNC_DEPLOYMENTS_JSON="$deployments_json"
+        set_run_phase healthy
+        log "ArgoCD is stably Synced/Healthy, the expected policy is active, and all bound Deployments are ready"
+        return 0
+      fi
+    else
+      healthy_observations=0
+    fi
+
+    if (( SECONDS >= deadline )); then
+      die "Timed out waiting for ArgoCD Synced/Healthy and ready bound Deployments"
+    fi
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+}
+
+restore_argocd_policy() {
+  assert_refresh_lease
+  set_run_phase restoring-argocd-policy
+  local policy_patch
+  policy_patch="$(build_argocd_policy_patch "$ORIGINAL_AUTOMATED_JSON")"
+  patch_argocd_application "$policy_patch" >/dev/null
+
+  local application_json
+  application_json="$(get_argocd_application)"
+  jq -e --argjson expected "$ORIGINAL_AUTOMATED_JSON" \
+    '(.spec.syncPolicy.automated // null) == $expected' \
+    >/dev/null <<<"$application_json" \
+    || die "Could not restore the exact original ArgoCD automated-sync policy"
+
+  local restored_automated=false
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    restored_automated=true
+  fi
+
+  [[ "$restored_automated" == "$ORIGINAL_AUTOMATED_SYNC" ]] \
+    || die "Could not restore the original ArgoCD automated-sync state"
+
+  ARGOCD_POLICY_PAUSED=false
+  WORKLOADS_SCALED=false
+  set_run_phase argocd-policy-restored
+  log "Restored the original ArgoCD sync policy"
+}

--- a/util/backup/refresh-stg-from-prd/database.sh
+++ b/util/backup/refresh-stg-from-prd/database.sh
@@ -440,6 +440,11 @@ WITH public_namespace AS (
         AND d.deptype IN ('i', 'e')
     )
 ), unsupported_objects AS (
+  SELECT c.oid
+  FROM pg_class c
+  WHERE c.relnamespace = (SELECT oid FROM public_namespace)
+    AND c.relkind = 'c'
+  UNION ALL
   SELECT coll.oid
   FROM pg_collation coll
   WHERE coll.collnamespace = (SELECT oid FROM public_namespace)

--- a/util/backup/refresh-stg-from-prd/database.sh
+++ b/util/backup/refresh-stg-from-prd/database.sh
@@ -1,0 +1,812 @@
+# Sourced by refresh-stg-from-prd.sh; do not execute directly.
+# Contract: reads validated configuration and run-state globals from the entrypoint,
+# uses log/die/validation helpers, and writes only the documented database/Azure
+# metadata globals plus the current run archive/catalog files.
+
+parse_database_url_field() {
+  local database_url="$1"
+  local field="$2"
+
+  KLICKER_DATABASE_URL_INPUT="$database_url" KLICKER_DATABASE_URL_FIELD="$field" \
+    node - <<'NODE'
+const input = process.env.KLICKER_DATABASE_URL_INPUT
+const field = process.env.KLICKER_DATABASE_URL_FIELD
+
+let parsed
+try {
+  parsed = new URL(input)
+} catch {
+  process.stderr.write('Invalid PostgreSQL connection URL\n')
+  process.exit(1)
+}
+
+if (!['postgres:', 'postgresql:'].includes(parsed.protocol)) {
+  process.stderr.write('Connection URL must use postgres:// or postgresql://\n')
+  process.exit(1)
+}
+
+if (field === 'host') {
+  process.stdout.write(parsed.hostname)
+} else if (field === 'port') {
+  process.stdout.write(parsed.port || '5432')
+} else if (field === 'username') {
+  process.stdout.write(decodeURIComponent(parsed.username))
+} else if (field === 'password') {
+  process.stdout.write(decodeURIComponent(parsed.password))
+} else if (field === 'database') {
+  const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
+  if (!database) {
+    process.stderr.write('Connection URL does not contain a database name\n')
+    process.exit(1)
+  }
+  process.stdout.write(database)
+} else if (field === 'libpq') {
+  parsed.searchParams.delete('schema')
+  parsed.searchParams.delete('pgbouncer')
+  process.stdout.write(parsed.toString())
+} else if (field === 'sslmode') {
+  process.stdout.write(parsed.searchParams.get('sslmode') || '')
+} else if (field === 'sslnegotiation') {
+  process.stdout.write(parsed.searchParams.get('sslnegotiation') || '')
+} else if (field === 'channel_binding') {
+  process.stdout.write(parsed.searchParams.get('channel_binding') || '')
+} else if (field === 'target_session_attrs') {
+  process.stdout.write(parsed.searchParams.get('target_session_attrs') || '')
+} else {
+  process.stderr.write(`Unknown URL field: ${field}\n`)
+  process.exit(1)
+}
+NODE
+}
+
+run_database_command() (
+  local database_url="$1"
+  shift
+
+  local host port username password database sslmode sslnegotiation
+  local channel_binding target_session_attrs
+  host="$(parse_database_url_field "$database_url" host)"
+  port="$(parse_database_url_field "$database_url" port)"
+  username="$(parse_database_url_field "$database_url" username)"
+  password="$(parse_database_url_field "$database_url" password)"
+  database="$(parse_database_url_field "$database_url" database)"
+  sslmode="$(parse_database_url_field "$database_url" sslmode)"
+  sslnegotiation="$(parse_database_url_field "$database_url" sslnegotiation)"
+  channel_binding="$(parse_database_url_field "$database_url" channel_binding)"
+  target_session_attrs="$(parse_database_url_field "$database_url" target_session_attrs)"
+
+  export PGCONNECT_TIMEOUT=15
+  export PGHOST="$host"
+  export PGPORT="$port"
+  export PGUSER="$username"
+  export PGPASSWORD="$password"
+  export PGDATABASE="$database"
+  [[ -z "$sslmode" ]] || export PGSSLMODE="$sslmode"
+  [[ -z "$sslnegotiation" ]] || export PGSSLNEGOTIATION="$sslnegotiation"
+  [[ -z "$channel_binding" ]] || export PGCHANNELBINDING="$channel_binding"
+  [[ -z "$target_session_attrs" ]] \
+    || export PGTARGETSESSIONATTRS="$target_session_attrs"
+
+  "$@"
+)
+
+load_infisical_secret() {
+  local output_variable="$1"
+  local secret_name="$2"
+  local environment="$3"
+  local project_id="$4"
+  local secret_value
+
+  if ! secret_value="$(
+    infisical secrets get "$secret_name" \
+      --domain="$INFISICAL_API_URL" \
+      --env="$environment" \
+      --path="$INFISICAL_SECRET_PATH" \
+      --projectId="$project_id" \
+      --plain \
+      --silent
+  )"; then
+    die "Could not load '$secret_name' from Infisical environment '$environment' at '$INFISICAL_API_URL'"
+  fi
+  [[ -n "$secret_value" ]] \
+    || die "Infisical returned an empty value for '$secret_name' in environment '$environment' at path '$INFISICAL_SECRET_PATH'"
+
+  printf -v "$output_variable" '%s' "$secret_value"
+}
+
+load_credentials() {
+  local needs_infisical=false
+  if [[ -z "$PRD_DATABASE_URL" || -z "$STG_DATABASE_URL" ]]; then
+    needs_infisical=true
+  fi
+  if [[ "$DRY_RUN" == "false" && -z "$BACKUP_ENCRYPTION_KEY" ]]; then
+    needs_infisical=true
+  fi
+  if [[ "$needs_infisical" == "false" ]]; then
+    return
+  fi
+
+  require_command infisical
+
+  if [[ -z "$PRD_DATABASE_URL" ]]; then
+    log "Loading the PRD direct database URL from Infisical environment '$PRD_INFISICAL_ENV'"
+    load_infisical_secret PRD_DATABASE_URL DIRECT_DATABASE_URL "$PRD_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+  if [[ -z "$STG_DATABASE_URL" ]]; then
+    log "Loading the STG direct database URL from Infisical environment '$STG_INFISICAL_ENV'"
+    load_infisical_secret STG_DATABASE_URL DIRECT_DATABASE_URL "$STG_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+  if [[ "$DRY_RUN" == "false" && -z "$BACKUP_ENCRYPTION_KEY" ]]; then
+    log "Loading the backup encryption key from Infisical environment '$PRD_INFISICAL_ENV'"
+    load_infisical_secret BACKUP_ENCRYPTION_KEY BACKUP_ENCRYPTION_KEY "$PRD_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+
+  [[ -n "$PRD_DATABASE_URL" ]] || die "PRD database URL is empty"
+  [[ -n "$STG_DATABASE_URL" ]] || die "STG database URL is empty"
+  if [[ "$DRY_RUN" == "false" ]]; then
+    [[ -n "$BACKUP_ENCRYPTION_KEY" ]] || die "Backup encryption key is empty"
+  fi
+}
+
+validate_database_tls() {
+  local label="$1"
+  local database_url="$2"
+  local sslmode
+  sslmode="$(parse_database_url_field "$database_url" sslmode)"
+  case "$sslmode" in
+    require|verify-ca|verify-full) ;;
+    *) die "$label database URL must set sslmode=require, verify-ca, or verify-full" ;;
+  esac
+}
+
+validate_endpoints() {
+  PRD_DATABASE_URL="$(parse_database_url_field "$PRD_DATABASE_URL" libpq)" \
+    || die "Could not normalize the PRD database URL"
+  STG_DATABASE_URL="$(parse_database_url_field "$STG_DATABASE_URL" libpq)" \
+    || die "Could not normalize the STG database URL"
+
+  PRD_DB_HOST="$(parse_database_url_field "$PRD_DATABASE_URL" host)"
+  PRD_DB_PORT="$(parse_database_url_field "$PRD_DATABASE_URL" port)"
+  PRD_DB_NAME="$(parse_database_url_field "$PRD_DATABASE_URL" database)"
+  STG_DB_HOST="$(parse_database_url_field "$STG_DATABASE_URL" host)"
+  STG_DB_PORT="$(parse_database_url_field "$STG_DATABASE_URL" port)"
+  STG_DB_NAME="$(parse_database_url_field "$STG_DATABASE_URL" database)"
+
+  [[ "$PRD_DB_HOST" == "$EXPECTED_PRD_DB_HOST" ]] \
+    || die "PRD host '$PRD_DB_HOST' does not equal expected host '$EXPECTED_PRD_DB_HOST'"
+  [[ "$STG_DB_HOST" == "$EXPECTED_STG_DB_HOST" ]] \
+    || die "STG host '$STG_DB_HOST' does not equal expected host '$EXPECTED_STG_DB_HOST'"
+  [[ "$PRD_DB_PORT" == "$EXPECTED_PRD_DB_PORT" ]] \
+    || die "PRD port '$PRD_DB_PORT' does not equal expected port '$EXPECTED_PRD_DB_PORT'"
+  [[ "$STG_DB_PORT" == "$EXPECTED_STG_DB_PORT" ]] \
+    || die "STG port '$STG_DB_PORT' does not equal expected port '$EXPECTED_STG_DB_PORT'"
+  [[ "$PRD_DB_NAME" == "$EXPECTED_PRD_DB_NAME" ]] \
+    || die "PRD database '$PRD_DB_NAME' does not equal expected database '$EXPECTED_PRD_DB_NAME'"
+  [[ "$STG_DB_NAME" == "$EXPECTED_STG_DB_NAME" ]] \
+    || die "STG database '$STG_DB_NAME' does not equal expected database '$EXPECTED_STG_DB_NAME'"
+  [[ "$PRD_DB_HOST" != "$STG_DB_HOST" ]] || die "PRD and STG resolve to the same configured host"
+  validate_database_tls PRD "$PRD_DATABASE_URL"
+  validate_database_tls STG "$STG_DATABASE_URL"
+}
+
+read_database_metadata() {
+  local database_url="$1"
+  local core_query core_metadata migration_metadata
+  core_query=$(cat <<'SQL'
+/* klicker_database_metadata_core */
+SELECT
+  current_database(),
+  current_setting('server_version_num')::bigint,
+  pg_database_size(current_database()),
+  (SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'),
+  CASE WHEN to_regclass('public."_prisma_migrations"') IS NULL THEN 0 ELSE 1 END,
+  (SELECT count(*) FROM pg_namespace WHERE nspname <> 'public' AND nspname <> 'information_schema' AND nspname !~ '^pg_'),
+  (SELECT count(*) FROM pg_largeobject_metadata);
+SQL
+)
+
+  core_metadata="$(
+    run_database_command "$database_url" \
+      psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$core_query"
+  )" || return 1
+
+  local database_name version_num size_bytes table_count
+  local migration_table_present extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count \
+    migration_table_present extra_schema_count large_object_count \
+    <<<"$core_metadata"
+  [[ "$migration_table_present" == "0" || "$migration_table_present" == "1" ]] \
+    || return 1
+
+  if [[ "$migration_table_present" == "1" ]]; then
+    local migration_query
+    migration_query=$(cat <<'SQL'
+/* klicker_database_metadata_migrations */
+SELECT
+  count(*) FILTER (WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL),
+  count(*) FILTER (WHERE finished_at IS NULL AND rolled_back_at IS NULL)
+FROM public."_prisma_migrations";
+SQL
+)
+    migration_metadata="$(
+      run_database_command "$database_url" \
+        psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$migration_query"
+    )" || return 1
+  else
+    migration_metadata='0|0'
+  fi
+
+  local applied_migrations failed_migrations
+  IFS='|' read -r applied_migrations failed_migrations <<<"$migration_metadata"
+  printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$database_name" "$version_num" "$size_bytes" "$table_count" \
+    "$applied_migrations" "$failed_migrations" "$extra_schema_count" \
+    "$large_object_count"
+}
+
+load_database_metadata() {
+  local output_variable="$1"
+  local database_url="$2"
+  local environment="$3"
+  local metadata
+
+  if ! metadata="$(read_database_metadata "$database_url")"; then
+    die "Could not read $environment database metadata"
+  fi
+  [[ -n "$metadata" ]] || die "$environment database metadata is empty"
+  printf -v "$output_variable" '%s' "$metadata"
+}
+
+read_database_identity() {
+  local database_url="$1"
+  local identity_query
+  identity_query=$(cat <<'SQL'
+/* klicker_database_identity */
+SELECT
+  current_database(),
+  (SELECT oid FROM pg_database WHERE datname = current_database()),
+  current_setting('server_version_num'),
+  coalesce(inet_server_addr()::text, ''),
+  coalesce(inet_server_port()::text, '');
+SQL
+)
+  run_database_command "$database_url" \
+    psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$identity_query"
+}
+
+load_database_identity() {
+  local output_variable="$1"
+  local database_url="$2"
+  local label="$3"
+  local identity
+  identity="$(read_database_identity "$database_url")" \
+    || die "Could not read $label database identity"
+  [[ "$identity" =~ ^[^|]+\|[0-9]+\|[0-9]+\|[^|]+\|[0-9]+$ ]] \
+    || die "$label database identity is incomplete or malformed"
+  printf -v "$output_variable" '%s' "$identity"
+}
+
+read_migration_history() {
+  local database_url="$1"
+  local migration_query
+  migration_query=$(cat <<'SQL'
+/* klicker_migration_history */
+SELECT migration_name, checksum
+FROM public."_prisma_migrations"
+WHERE finished_at IS NOT NULL
+  AND rolled_back_at IS NULL
+ORDER BY started_at, migration_name;
+SQL
+)
+  run_database_command "$database_url" \
+    psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$migration_query"
+}
+
+migration_history_fingerprint() {
+  local history="$1"
+  printf '%s' "$history" | shasum -a 256 | awk '{print $1}'
+}
+
+load_migration_history() {
+  local history_variable="$1"
+  local fingerprint_variable="$2"
+  local database_url="$3"
+  local label="$4"
+  local history fingerprint
+  history="$(read_migration_history "$database_url")" \
+    || die "Could not read $label Prisma migration history"
+  [[ -n "$history" ]] || die "$label Prisma migration history is empty"
+  fingerprint="$(migration_history_fingerprint "$history")"
+  [[ "$fingerprint" =~ ^[0-9a-fA-F]{64}$ ]] \
+    || die "Could not fingerprint $label Prisma migration history"
+  printf -v "$history_variable" '%s' "$history"
+  printf -v "$fingerprint_variable" '%s' "$fingerprint"
+}
+
+load_migrator_database_url() {
+  local encoded_url decoded_url
+  encoded_url="$(
+    kubectl_for_workloads get secret "$MIGRATOR_SECRET_NAME" \
+      -o "jsonpath={.data.$MIGRATOR_SECRET_KEY}"
+  )" || die "Could not read migrator Secret '$WORKLOAD_NAMESPACE/$MIGRATOR_SECRET_NAME' key '$MIGRATOR_SECRET_KEY'"
+  [[ -n "$encoded_url" ]] \
+    || die "Migrator Secret '$WORKLOAD_NAMESPACE/$MIGRATOR_SECRET_NAME' has no '$MIGRATOR_SECRET_KEY' value"
+  if decoded_url="$(printf '%s' "$encoded_url" | base64 --decode 2>/dev/null)"; then
+    MIGRATOR_DATABASE_URL="$decoded_url"
+  elif decoded_url="$(printf '%s' "$encoded_url" | base64 -D 2>/dev/null)"; then
+    MIGRATOR_DATABASE_URL="$decoded_url"
+  else
+    die "Could not decode migrator database URL"
+  fi
+  [[ -n "$MIGRATOR_DATABASE_URL" ]] || die "Migrator database URL is empty"
+  MIGRATOR_DATABASE_URL="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" libpq)" \
+    || die "Could not normalize migrator database URL"
+  export -n MIGRATOR_DATABASE_URL
+}
+
+validate_migrator_target() {
+  local migrator_host migrator_port migrator_database
+  migrator_host="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" host)"
+  migrator_port="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" port)"
+  migrator_database="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" database)"
+  validate_database_tls Migrator "$MIGRATOR_DATABASE_URL"
+
+  [[ "$migrator_host" == "$STG_DB_HOST" ]] \
+    || die "Migrator Secret host '$migrator_host' does not match STG restore host '$STG_DB_HOST'"
+  [[ "$migrator_port" == "$STG_DB_PORT" ]] \
+    || die "Migrator Secret port '$migrator_port' does not match STG restore port '$STG_DB_PORT'"
+  [[ "$migrator_database" == "$STG_DB_NAME" ]] \
+    || die "Migrator Secret database '$migrator_database' does not match STG restore database '$STG_DB_NAME'"
+
+  load_database_identity MIGRATOR_DATABASE_IDENTITY "$MIGRATOR_DATABASE_URL" Migrator
+  [[ "$MIGRATOR_DATABASE_IDENTITY" == "$STG_DATABASE_IDENTITY" ]] \
+    || die "Migrator Secret and STG restore URL do not reach the same database server identity"
+}
+
+parse_prd_metadata() {
+  local metadata="$1"
+  local database_name
+  IFS='|' read -r database_name PRD_VERSION_NUM PRD_SIZE_BYTES PRD_TABLE_COUNT \
+    PRD_APPLIED_MIGRATIONS PRD_FAILED_MIGRATIONS PRD_EXTRA_SCHEMA_COUNT \
+    PRD_LARGE_OBJECT_COUNT <<<"$metadata"
+
+  [[ "$database_name" == "$PRD_DB_NAME" ]] \
+    || die "PRD metadata returned unexpected database '$database_name'"
+  validate_positive_integer PRD_VERSION_NUM "$PRD_VERSION_NUM"
+  validate_positive_integer PRD_SIZE_BYTES "$PRD_SIZE_BYTES"
+  validate_positive_integer PRD_TABLE_COUNT "$PRD_TABLE_COUNT"
+  validate_positive_integer PRD_APPLIED_MIGRATIONS "$PRD_APPLIED_MIGRATIONS"
+  validate_positive_integer PRD_FAILED_MIGRATIONS "$PRD_FAILED_MIGRATIONS"
+  validate_positive_integer PRD_EXTRA_SCHEMA_COUNT "$PRD_EXTRA_SCHEMA_COUNT"
+  validate_positive_integer PRD_LARGE_OBJECT_COUNT "$PRD_LARGE_OBJECT_COUNT"
+  [[ "$PRD_FAILED_MIGRATIONS" == "0" ]] \
+    || die "PRD has $PRD_FAILED_MIGRATIONS unresolved Prisma migration(s); refusing to copy"
+  [[ "$PRD_EXTRA_SCHEMA_COUNT" == "0" ]] \
+    || die "PRD has $PRD_EXTRA_SCHEMA_COUNT non-public application schema(s); this refresh supports only the public schema"
+  [[ "$PRD_LARGE_OBJECT_COUNT" == "0" ]] \
+    || die "PRD has $PRD_LARGE_OBJECT_COUNT PostgreSQL large object(s); this refresh does not support large objects"
+}
+
+parse_stg_before_metadata() {
+  local metadata="$1"
+  local database_name
+  IFS='|' read -r database_name STG_BEFORE_VERSION_NUM STG_BEFORE_SIZE_BYTES \
+    STG_BEFORE_TABLE_COUNT STG_BEFORE_APPLIED_MIGRATIONS \
+    STG_BEFORE_FAILED_MIGRATIONS STG_EXTRA_SCHEMA_COUNT \
+    STG_LARGE_OBJECT_COUNT <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] \
+    || die "STG metadata returned unexpected database '$database_name'"
+  validate_positive_integer STG_BEFORE_VERSION_NUM "$STG_BEFORE_VERSION_NUM"
+  validate_positive_integer STG_BEFORE_SIZE_BYTES "$STG_BEFORE_SIZE_BYTES"
+  validate_positive_integer STG_BEFORE_TABLE_COUNT "$STG_BEFORE_TABLE_COUNT"
+  validate_positive_integer STG_BEFORE_APPLIED_MIGRATIONS "$STG_BEFORE_APPLIED_MIGRATIONS"
+  validate_positive_integer STG_BEFORE_FAILED_MIGRATIONS "$STG_BEFORE_FAILED_MIGRATIONS"
+  validate_positive_integer STG_EXTRA_SCHEMA_COUNT "$STG_EXTRA_SCHEMA_COUNT"
+  validate_positive_integer STG_LARGE_OBJECT_COUNT "$STG_LARGE_OBJECT_COUNT"
+  [[ "$STG_EXTRA_SCHEMA_COUNT" == "0" ]] \
+    || die "STG has $STG_EXTRA_SCHEMA_COUNT non-public application schema(s); refusing an incomplete replacement"
+  [[ "$STG_LARGE_OBJECT_COUNT" == "0" ]] \
+    || die "STG has $STG_LARGE_OBJECT_COUNT PostgreSQL large object(s); refusing an incomplete replacement"
+}
+
+read_stg_reset_capabilities() {
+  local query
+  query=$(cat <<'SQL'
+/* klicker_stg_reset_capabilities */
+WITH public_namespace AS (
+  SELECT oid, nspowner
+  FROM pg_namespace
+  WHERE nspname = 'public'
+), supported_objects AS (
+  SELECT c.relowner AS owner_oid
+  FROM pg_class c
+  WHERE c.relnamespace = (SELECT oid FROM public_namespace)
+    AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+  UNION ALL
+  SELECT p.proowner
+  FROM pg_proc p
+  WHERE p.pronamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT t.typowner
+  FROM pg_type t
+  WHERE t.typnamespace = (SELECT oid FROM public_namespace)
+    AND t.typrelid = 0
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_depend d
+      WHERE d.classid = 'pg_type'::regclass
+        AND d.objid = t.oid
+        AND d.deptype IN ('i', 'e')
+    )
+), unsupported_objects AS (
+  SELECT coll.oid
+  FROM pg_collation coll
+  WHERE coll.collnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT conv.oid
+  FROM pg_conversion conv
+  WHERE conv.connamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT op.oid
+  FROM pg_operator op
+  WHERE op.oprnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT opc.oid
+  FROM pg_opclass opc
+  WHERE opc.opcnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT opf.oid
+  FROM pg_opfamily opf
+  WHERE opf.opfnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT cfg.oid
+  FROM pg_ts_config cfg
+  WHERE cfg.cfgnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT dict.oid
+  FROM pg_ts_dict dict
+  WHERE dict.dictnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT ext.oid
+  FROM pg_extension ext
+  WHERE ext.extnamespace = (SELECT oid FROM public_namespace)
+)
+SELECT
+  current_database(),
+  current_user,
+  pg_get_userbyid((SELECT nspowner FROM public_namespace)),
+  has_schema_privilege(current_user, 'public', 'CREATE'),
+  (SELECT count(*) FROM supported_objects),
+  (SELECT count(*) FROM supported_objects WHERE NOT pg_has_role(current_user, owner_oid, 'USAGE')),
+  (SELECT count(*) FROM unsupported_objects),
+  (SELECT count(*) FROM pg_namespace WHERE nspname <> 'public' AND nspname <> 'information_schema' AND nspname !~ '^pg_'),
+  (SELECT count(*) FROM pg_largeobject_metadata);
+SQL
+)
+
+  run_database_command "$STG_DATABASE_URL" \
+    psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$query"
+}
+
+validate_stg_reset_capabilities() {
+  local metadata database_name extra_schema_count large_object_count
+  if ! metadata="$(read_stg_reset_capabilities)"; then
+    die "Could not validate STG object ownership for replacement"
+  fi
+
+  IFS='|' read -r database_name STG_CONNECTED_ROLE STG_PUBLIC_SCHEMA_OWNER \
+    STG_CAN_CREATE_IN_PUBLIC STG_SUPPORTED_OBJECT_COUNT \
+    STG_UNOWNED_OBJECT_COUNT STG_UNSUPPORTED_OBJECT_COUNT extra_schema_count \
+    large_object_count <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] \
+    || die "STG ownership metadata came from unexpected database '$database_name'"
+  [[ -n "$STG_CONNECTED_ROLE" && -n "$STG_PUBLIC_SCHEMA_OWNER" ]] \
+    || die "STG ownership metadata is incomplete"
+  [[ "$STG_CAN_CREATE_IN_PUBLIC" == "t" ]] \
+    || die "STG role '$STG_CONNECTED_ROLE' cannot create objects in the public schema"
+  validate_positive_integer STG_SUPPORTED_OBJECT_COUNT "$STG_SUPPORTED_OBJECT_COUNT"
+  validate_positive_integer STG_UNOWNED_OBJECT_COUNT "$STG_UNOWNED_OBJECT_COUNT"
+  validate_positive_integer STG_UNSUPPORTED_OBJECT_COUNT "$STG_UNSUPPORTED_OBJECT_COUNT"
+  validate_positive_integer stg_reset_extra_schema_count "$extra_schema_count"
+  validate_positive_integer stg_reset_large_object_count "$large_object_count"
+  [[ "$STG_UNOWNED_OBJECT_COUNT" == "0" ]] \
+    || die "STG contains $STG_UNOWNED_OBJECT_COUNT public object(s) that '$STG_CONNECTED_ROLE' cannot drop"
+  [[ "$STG_UNSUPPORTED_OBJECT_COUNT" == "0" ]] \
+    || die "STG contains $STG_UNSUPPORTED_OBJECT_COUNT unsupported public object(s); refusing an incomplete replacement"
+  [[ "$extra_schema_count" == "0" && "$large_object_count" == "0" ]] \
+    || die "STG replacement capability changed after metadata validation"
+}
+
+validate_client_and_capacity() {
+  local pg_dump_major pg_restore_major
+  pg_dump_major="$(pg_dump --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+  pg_restore_major="$(pg_restore --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+  validate_positive_integer pg_dump_major "$pg_dump_major"
+  validate_positive_integer pg_restore_major "$pg_restore_major"
+
+  local prd_major=$((PRD_VERSION_NUM / 10000))
+  local stg_major=$((STG_BEFORE_VERSION_NUM / 10000))
+  if (( pg_dump_major < prd_major )); then
+    die "pg_dump major $pg_dump_major cannot dump PRD PostgreSQL major $prd_major"
+  fi
+  if (( pg_restore_major < prd_major )); then
+    die "pg_restore major $pg_restore_major cannot restore a PRD PostgreSQL major $prd_major dump"
+  fi
+  if (( stg_major < prd_major )); then
+    die "STG PostgreSQL major $stg_major is older than PRD PostgreSQL major $prd_major"
+  fi
+
+  local stg_capacity_bytes=$((STG_STORAGE_GIB * 1024 * 1024 * 1024))
+  if (( PRD_SIZE_BYTES * 100 > stg_capacity_bytes * MAX_SOURCE_STORAGE_PERCENT )); then
+    die "PRD database size exceeds ${MAX_SOURCE_STORAGE_PERCENT}% of the configured ${STG_STORAGE_GIB} GiB STG storage capacity"
+  fi
+}
+
+read_azure_metric_point() {
+  local metrics_json="$1"
+  local metric_name="$2"
+  local aggregation="$3"
+  jq -r --arg metric "$metric_name" --arg aggregation "$aggregation" '
+    [
+      .value[] |
+      select(.name.value == $metric) |
+      .timeseries[].data[] |
+      select(.[$aggregation] != null) |
+      {value: (.[$aggregation] | floor), timeStamp}
+    ] |
+    last |
+    if . == null then empty else [.value, .timeStamp] | @tsv end
+  ' <<<"$metrics_json"
+}
+
+validate_azure_storage_headroom() {
+  local server_json metrics_json actual_storage_gib expected_resource_suffix
+  server_json="$(
+    az postgres flexible-server show \
+      --resource-group "$STG_AZURE_RESOURCE_GROUP" \
+      --name "$STG_AZURE_SERVER_NAME" \
+      --output json --only-show-errors
+  )" || die "Could not read the STG Azure PostgreSQL resource"
+
+  [[ "$(jq -r '.name // ""' <<<"$server_json")" == "$STG_AZURE_SERVER_NAME" ]] \
+    || die "Azure returned an unexpected STG PostgreSQL server name"
+  [[ "$(jq -r '.fullyQualifiedDomainName // ""' <<<"$server_json")" == "$STG_DB_HOST" ]] \
+    || die "Azure PostgreSQL resource does not match the validated STG database hostname"
+  STG_AZURE_RESOURCE_ID="$(jq -r '.id // ""' <<<"$server_json")"
+  expected_resource_suffix="/resourceGroups/$STG_AZURE_RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/flexibleServers/$STG_AZURE_SERVER_NAME"
+  [[ "$STG_AZURE_RESOURCE_ID" == *"$expected_resource_suffix" ]] \
+    || die "Azure returned an unexpected STG PostgreSQL resource ID"
+
+  actual_storage_gib="$(jq -r '.storage.storageSizeGb // ""' <<<"$server_json")"
+  [[ "$actual_storage_gib" =~ ^[0-9]+$ ]] \
+    || die "Azure STG storage capacity is missing or malformed"
+  [[ "$actual_storage_gib" == "$STG_STORAGE_GIB" ]] \
+    || die "Azure STG storage capacity is ${actual_storage_gib} GiB, not the expected ${STG_STORAGE_GIB} GiB"
+
+  metrics_json="$(
+    az monitor metrics list \
+      --resource "$STG_AZURE_RESOURCE_ID" \
+      --metrics storage_used storage_free txlogs_storage_used \
+      --interval PT5M --offset 2h --aggregation Maximum Minimum \
+      --output json --only-show-errors
+  )" || die "Could not read current STG Azure storage metrics"
+  jq -e '
+    . as $root |
+    ["storage_used", "storage_free", "txlogs_storage_used"] |
+    all(.[];
+      . as $name |
+      any($root.value[]; .name.value == $name and .unit == "Bytes")
+    )
+  ' >/dev/null <<<"$metrics_json" \
+    || die "Azure STG storage metrics are missing or do not use byte units"
+
+  local used_point free_point txlog_point used_time free_time txlog_time
+  used_point="$(read_azure_metric_point "$metrics_json" storage_used maximum)"
+  free_point="$(read_azure_metric_point "$metrics_json" storage_free minimum)"
+  txlog_point="$(read_azure_metric_point "$metrics_json" txlogs_storage_used maximum)"
+  IFS=$'\t' read -r STG_AZURE_STORAGE_USED_BYTES used_time <<<"$used_point"
+  IFS=$'\t' read -r STG_AZURE_STORAGE_FREE_BYTES free_time <<<"$free_point"
+  IFS=$'\t' read -r STG_AZURE_TXLOG_STORAGE_BYTES txlog_time <<<"$txlog_point"
+  validate_positive_integer STG_AZURE_STORAGE_USED_BYTES "$STG_AZURE_STORAGE_USED_BYTES"
+  validate_positive_integer STG_AZURE_STORAGE_FREE_BYTES "$STG_AZURE_STORAGE_FREE_BYTES"
+  validate_positive_integer STG_AZURE_TXLOG_STORAGE_BYTES "$STG_AZURE_TXLOG_STORAGE_BYTES"
+  [[ -n "$used_time" && "$used_time" == "$free_time" && "$used_time" == "$txlog_time" ]] \
+    || die "Azure STG storage metrics are missing or not aligned to one timestamp"
+  jq -en --arg timestamp "$used_time" '
+    ($timestamp | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $measured |
+    $measured <= now and (now - $measured) <= 1800
+  ' >/dev/null || die "Azure STG storage metrics are older than 30 minutes"
+  STG_AZURE_STORAGE_METRIC_TIME="$used_time"
+
+  if (( STG_AZURE_STORAGE_FREE_BYTES < PRD_SIZE_BYTES * MIN_STG_FREE_SPACE_MULTIPLIER )); then
+    die "Current STG free storage is less than ${MIN_STG_FREE_SPACE_MULTIPLIER}x the PRD database size required for restore, WAL, and migration headroom"
+  fi
+  log "Azure storage headroom: $STG_AZURE_STORAGE_FREE_BYTES bytes free, $STG_AZURE_STORAGE_USED_BYTES bytes used, $STG_AZURE_TXLOG_STORAGE_BYTES bytes transaction logs at $STG_AZURE_STORAGE_METRIC_TIME"
+}
+
+encrypt_prd_dump() {
+  log "Creating encrypted PRD custom-format dump"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! run_database_command "$PRD_DATABASE_URL" \
+    pg_dump --format=custom --no-owner --no-privileges \
+      | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+        --cipher-algo AES256 --symmetric --output "$ARCHIVE_PATH"; then
+    exec 3<&-
+    die "PRD dump or archive encryption failed"
+  fi
+  exec 3<&-
+
+  [[ -s "$ARCHIVE_PATH" ]] || die "Encrypted PRD archive is empty"
+
+  local checksum
+  checksum="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
+  [[ "$checksum" =~ ^[0-9a-fA-F]{64}$ ]] || die "Could not calculate archive checksum"
+  printf '%s  %s\n' "$checksum" "$(basename "$ARCHIVE_PATH")" >"$ARCHIVE_CHECKSUM_PATH"
+
+  log "Validating that the encrypted archive decrypts and has a readable pg_restore catalog"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+    --decrypt "$ARCHIVE_PATH" 2>/dev/null \
+      | {
+        pg_restore --list >"$ARCHIVE_CATALOG_PATH"
+        catalog_status=$?
+        cat >/dev/null
+        drain_status=$?
+        (( catalog_status == 0 && drain_status == 0 ))
+      }; then
+    exec 3<&-
+    die "Encrypted archive validation failed"
+  fi
+  exec 3<&-
+
+  local filtered_catalog="$ARCHIVE_CATALOG_PATH.filtered"
+  local public_schema_entries
+  public_schema_entries="$(
+    grep -Ec '^[0-9]+; [0-9]+ [0-9]+ (SCHEMA - public|(COMMENT|ACL|SECURITY LABEL) - SCHEMA public) ' \
+      "$ARCHIVE_CATALOG_PATH" || true
+  )"
+  (( public_schema_entries > 0 )) \
+    || die "PRD archive catalog does not contain the expected public schema entry"
+
+  awk '
+    /^[0-9]+; [0-9]+ [0-9]+ SCHEMA - public / ||
+    /^[0-9]+; [0-9]+ [0-9]+ (COMMENT|ACL|SECURITY LABEL) - SCHEMA public / {
+      print ";" $0
+      next
+    }
+    { print }
+  ' "$ARCHIVE_CATALOG_PATH" >"$filtered_catalog"
+  mv -- "$filtered_catalog" "$ARCHIVE_CATALOG_PATH"
+
+  if grep -Eq '^[0-9]+; [0-9]+ [0-9]+ (SCHEMA - public|(COMMENT|ACL|SECURITY LABEL) - SCHEMA public) ' \
+    "$ARCHIVE_CATALOG_PATH"; then
+    die "Could not exclude public schema ownership entries from the restore catalog"
+  fi
+}
+
+reset_stg_owned_objects() {
+  assert_refresh_lease
+  assert_argocd_maintenance_fence
+  assert_argocd_quiescent
+  assert_workload_set_matches_receipt
+  local current_target_identity
+  load_database_identity current_target_identity "$STG_DATABASE_URL" STG
+  [[ "$current_target_identity" == "$STG_DATABASE_IDENTITY" ]] \
+    || die "STG database identity changed immediately before destructive reset"
+  [[ "${current_target_identity%%|*}" == "$EXPECTED_STG_DB_NAME" ]] \
+    || die "STG current_database() changed immediately before destructive reset"
+  [[ "$MIGRATOR_DATABASE_IDENTITY" == "$current_target_identity" ]] \
+    || die "Migrator and restore target identities diverged before destructive reset"
+
+  TARGET_MUTATED=true
+  set_run_phase resetting-target
+  log "Removing STG objects owned by '$STG_CONNECTED_ROLE' while preserving schema 'public' owned by '$STG_PUBLIC_SCHEMA_OWNER'"
+  [[ -r "$SCRIPT_DIR/reset-stg-owned-objects.sql" ]] \
+    || die "STG reset SQL is missing or unreadable"
+  run_database_command "$STG_DATABASE_URL" \
+    psql -X -v ON_ERROR_STOP=1 \
+      -f "$SCRIPT_DIR/reset-stg-owned-objects.sql" >/dev/null \
+    || die "STG object reset failed"
+}
+
+restore_stg_database() {
+  assert_refresh_lease
+  assert_argocd_maintenance_fence
+  assert_argocd_quiescent
+  set_run_phase restoring-target
+  log "Restoring the encrypted PRD archive into STG"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+    --decrypt "$ARCHIVE_PATH" 2>/dev/null \
+      | run_database_command "$STG_DATABASE_URL" \
+        pg_restore --format=custom --exit-on-error --single-transaction \
+          --dbname="$STG_DB_NAME" --use-list="$ARCHIVE_CATALOG_PATH" \
+          --no-owner --no-privileges; then
+    exec 3<&-
+    die "STG pg_restore failed"
+  fi
+  exec 3<&-
+}
+
+validate_restored_snapshot() {
+  local metadata="$1"
+  local database_name version_num size_bytes table_count applied_migrations
+  local failed_migrations extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
+    failed_migrations extra_schema_count large_object_count <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] || die "Restored metadata came from an unexpected database"
+  validate_positive_integer restored_version_num "$version_num"
+  validate_positive_integer restored_size_bytes "$size_bytes"
+  validate_positive_integer restored_table_count "$table_count"
+  validate_positive_integer restored_applied_migrations "$applied_migrations"
+  validate_positive_integer restored_failed_migrations "$failed_migrations"
+  validate_positive_integer restored_extra_schema_count "$extra_schema_count"
+  validate_positive_integer restored_large_object_count "$large_object_count"
+  [[ "$table_count" == "$PRD_TABLE_COUNT" ]] \
+    || die "Restored table count $table_count does not match PRD snapshot count $PRD_TABLE_COUNT"
+  [[ "$applied_migrations" == "$PRD_APPLIED_MIGRATIONS" ]] \
+    || die "Restored migration count $applied_migrations does not match PRD snapshot count $PRD_APPLIED_MIGRATIONS"
+  [[ "$failed_migrations" == "0" ]] \
+    || die "Restored snapshot contains $failed_migrations unresolved Prisma migration(s)"
+  [[ "$extra_schema_count" == "0" && "$large_object_count" == "0" ]] \
+    || die "Restored snapshot contains unsupported schemas or large objects"
+
+  log "Logical restore matches the PRD table and migration metadata"
+}
+
+validate_restored_migration_history() {
+  local restored_history restored_fingerprint
+  load_migration_history restored_history restored_fingerprint \
+    "$STG_DATABASE_URL" restored-STG
+  [[ "$restored_history" == "$PRD_MIGRATION_HISTORY" ]] \
+    || die "Restored Prisma migration names or checksums do not exactly match the PRD snapshot"
+  [[ "$restored_fingerprint" == "$PRD_MIGRATION_FINGERPRINT" ]] \
+    || die "Restored Prisma migration fingerprint does not match the PRD snapshot"
+}
+
+validate_migrated_target() {
+  local metadata="$1"
+  local database_name version_num size_bytes table_count applied_migrations
+  local failed_migrations extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
+    failed_migrations extra_schema_count large_object_count <<<"$metadata"
+
+  local error=""
+  if [[ "$database_name" != "$STG_DB_NAME" ]]; then
+    error="Post-migration metadata came from unexpected database '$database_name'"
+  elif [[ ! "$version_num" =~ ^[0-9]+$ ||
+    ! "$size_bytes" =~ ^[0-9]+$ ||
+    ! "$table_count" =~ ^[0-9]+$ ||
+    ! "$applied_migrations" =~ ^[0-9]+$ ||
+    ! "$failed_migrations" =~ ^[0-9]+$ ||
+    ! "$extra_schema_count" =~ ^[0-9]+$ ||
+    ! "$large_object_count" =~ ^[0-9]+$ ]]; then
+    error="Post-migration database metadata is incomplete or malformed"
+  elif (( table_count == 0 )); then
+    error="Post-migration database contains no public tables"
+  elif (( applied_migrations < PRD_APPLIED_MIGRATIONS )); then
+    error="Post-migration applied count $applied_migrations is lower than PRD snapshot count $PRD_APPLIED_MIGRATIONS"
+  elif [[ "$failed_migrations" != "0" ]]; then
+    error="Post-migration database contains $failed_migrations unresolved Prisma migration(s)"
+  elif [[ "$extra_schema_count" != "0" || "$large_object_count" != "0" ]]; then
+    error="Post-migration database contains unsupported schemas or large objects"
+  fi
+
+  [[ -z "$error" ]] || die "$error"
+
+  local migrated_history
+  load_migration_history migrated_history MIGRATED_MIGRATION_FINGERPRINT \
+    "$STG_DATABASE_URL" migrated-STG
+  if [[ "$migrated_history" != "$PRD_MIGRATION_HISTORY" &&
+    "$migrated_history" != "$PRD_MIGRATION_HISTORY"$'\n'* ]]; then
+    die "Post-migration Prisma history does not preserve the exact PRD migration-name/checksum prefix"
+  fi
+
+  MIGRATED_METADATA="$metadata"
+  set_run_phase database-verified
+
+  log "Post-sync verification passed: $table_count tables, $applied_migrations applied migrations"
+}

--- a/util/backup/refresh-stg-from-prd/kubernetes.sh
+++ b/util/backup/refresh-stg-from-prd/kubernetes.sh
@@ -165,14 +165,19 @@ lease_is_available() {
   jq -e --arg holder "$LEASE_HOLDER_ID" '
     (.spec.holderIdentity // "") == "" or
     (.spec.holderIdentity // "") == $holder or
-    (((.spec.renewTime // .spec.acquireTime) |
-      sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) +
-      (.spec.leaseDurationSeconds // 0) < now)
+    (
+      (.spec.leaseDurationSeconds |
+        select(type == "number" and . > 0)) as $duration |
+      ((.spec.renewTime // .spec.acquireTime // "") |
+        sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601?) as $renewedAt |
+      $renewedAt != null and ($renewedAt + $duration < now)
+    )
   ' >/dev/null <<<"$lease_json"
 }
 
 build_refresh_lease() {
   local existing_json="${1:-}"
+  local phase="${2:-$RUN_PHASE}"
   local now
   now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   if [[ -z "$existing_json" ]]; then
@@ -182,7 +187,7 @@ build_refresh_lease() {
       --arg holder "$LEASE_HOLDER_ID" \
       --arg now "$now" \
       --arg runId "$RUN_ID" \
-      --arg phase "$RUN_PHASE" \
+      --arg phase "$phase" \
       --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
       --arg outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
       --argjson duration "$REFRESH_LEASE_DURATION_SECONDS" \
@@ -214,7 +219,7 @@ build_refresh_lease() {
     --arg holder "$LEASE_HOLDER_ID" \
     --arg now "$now" \
     --arg runId "$RUN_ID" \
-    --arg phase "$RUN_PHASE" \
+    --arg phase "$phase" \
     --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
     --arg outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
     --argjson duration "$REFRESH_LEASE_DURATION_SECONDS" '
@@ -259,21 +264,41 @@ acquire_refresh_lease() {
 }
 
 renew_refresh_lease_once() {
-  local existing_json lease_payload holder
+  local existing_json lease_payload holder phase
   existing_json="$(
     kubectl_for_argocd get lease.coordination.k8s.io "$REFRESH_LEASE_NAME" -o json
   )" || return 1
   holder="$(jq -r '.spec.holderIdentity // ""' <<<"$existing_json")"
   [[ "$holder" == "$LEASE_HOLDER_ID" ]] || return 1
-  lease_payload="$(build_refresh_lease "$existing_json")" || return 1
+  [[ -s "$RUN_PHASE_FILE" ]] || return 1
+  phase="$(<"$RUN_PHASE_FILE")"
+  [[ -n "$phase" ]] || return 1
+  lease_payload="$(build_refresh_lease "$existing_json" "$phase")" || return 1
   printf '%s' "$lease_payload" | kubectl_for_argocd replace -f - >/dev/null
 }
 
+renew_refresh_lease_with_retry() {
+  local attempt
+  for ((attempt = 1; attempt <= REFRESH_LEASE_RENEW_RETRY_ATTEMPTS; attempt++)); do
+    if renew_refresh_lease_once; then
+      return 0
+    fi
+    if (( attempt < REFRESH_LEASE_RENEW_RETRY_ATTEMPTS )); then
+      log "Refresh Lease renewal attempt $attempt failed; retrying"
+      sleep "$REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS"
+    fi
+  done
+  return 1
+}
+
 start_refresh_lease_renewal() {
+  local refresh_main_pid="$$"
   (
     while sleep "$REFRESH_LEASE_RENEW_INTERVAL_SECONDS"; do
-      if ! renew_refresh_lease_once; then
+      if ! renew_refresh_lease_with_retry; then
         printf '%s\n' 'Lease renewal failed' >"$LEASE_FAILURE_FILE"
+        log "Refresh Lease renewal failed after $REFRESH_LEASE_RENEW_RETRY_ATTEMPTS attempts; terminating the refresh"
+        kill -TERM "$refresh_main_pid" 2>/dev/null || true
         exit 1
       fi
     done
@@ -298,9 +323,13 @@ assert_refresh_lease() {
     .metadata.annotations["klicker.uzh.ch/refresh-run-id"] == $runId and
     .metadata.annotations["klicker.uzh.ch/raw-data-approval-ref"] == $approvalRef and
     .metadata.annotations["klicker.uzh.ch/outbound-integrations-isolated"] == $outboundIntegrationsIsolated and
-    (((.spec.renewTime // .spec.acquireTime) |
-      sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) +
-      (.spec.leaseDurationSeconds // 0) >= now)
+    (
+      (.spec.leaseDurationSeconds |
+        select(type == "number" and . > 0)) as $duration |
+      ((.spec.renewTime // .spec.acquireTime // "") |
+        sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601?) as $renewedAt |
+      $renewedAt != null and ($renewedAt + $duration >= now)
+    )
   ' >/dev/null <<<"$lease_json" \
     || die "Refresh Lease ownership was lost or expired; refusing further state changes"
 }

--- a/util/backup/refresh-stg-from-prd/kubernetes.sh
+++ b/util/backup/refresh-stg-from-prd/kubernetes.sh
@@ -1,0 +1,603 @@
+# Sourced by refresh-stg-from-prd.sh; do not execute directly.
+# Contract: owns Kubernetes target validation, workload selection/scaling, and
+# refresh-Lease lifecycle. It reads immutable identity/configuration globals and
+# updates Lease/workload state globals and run receipts through set_run_phase.
+
+kubectl_for_context() {
+  local context="$1"
+  shift
+  kubectl --request-timeout="$KUBECTL_REQUEST_TIMEOUT" --context "$context" "$@"
+}
+
+kubectl_for_workloads() {
+  kubectl_for_context "$KUBE_CONTEXT" -n "$WORKLOAD_NAMESPACE" "$@"
+}
+
+kubectl_for_argocd() {
+  kubectl_for_context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" "$@"
+}
+
+validate_kubernetes_context_identity() {
+  local label="$1"
+  local context="$2"
+  local config_json namespace_json
+  config_json="$(
+    kubectl_for_context "$context" config view --minify -o json
+  )" || die "Could not read $label Kubernetes context '$context'"
+
+  local tls_server_name
+  tls_server_name="$(jq -r '.clusters[0].cluster["tls-server-name"] // ""' <<<"$config_json")"
+  [[ "$tls_server_name" == "$EXPECTED_KUBE_TLS_SERVER_NAME" ]] \
+    || die "$label context '$context' TLS server name '$tls_server_name' does not match expected STG cluster '$EXPECTED_KUBE_TLS_SERVER_NAME'"
+
+  namespace_json="$(
+    kubectl_for_context "$context" get namespace kube-system -o json
+  )" || die "Could not read kube-system identity through $label context '$context'"
+  local kube_system_uid
+  kube_system_uid="$(jq -r '.metadata.uid // ""' <<<"$namespace_json")"
+  [[ "$kube_system_uid" == "$EXPECTED_KUBE_SYSTEM_UID" ]] \
+    || die "$label context '$context' points to unexpected cluster UID '$kube_system_uid'"
+}
+
+validate_kubernetes_target() {
+  validate_kubernetes_context_identity Workload "$KUBE_CONTEXT"
+  validate_kubernetes_context_identity ArgoCD "$ARGOCD_KUBE_CONTEXT"
+
+  local namespace_json
+  namespace_json="$(
+    kubectl_for_context "$KUBE_CONTEXT" get namespace "$WORKLOAD_NAMESPACE" -o json
+  )" || die "Could not read workload namespace '$WORKLOAD_NAMESPACE'"
+  local namespace_uid
+  namespace_uid="$(jq -r '.metadata.uid // ""' <<<"$namespace_json")"
+  [[ "$namespace_uid" == "$EXPECTED_WORKLOAD_NAMESPACE_UID" ]] \
+    || die "Workload namespace '$WORKLOAD_NAMESPACE' has unexpected UID '$namespace_uid'"
+
+  local application_json
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP'"
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_APP_UID" ]] \
+    || die "ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP' has an unexpected UID"
+  [[ "$(jq -r '.spec.project // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_PROJECT" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' uses an unexpected AppProject"
+  [[ "$(jq -r '.spec.destination.server // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_DESTINATION_SERVER" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' targets an unexpected cluster"
+  [[ "$(jq -r '.spec.destination.namespace // ""' <<<"$application_json")" == "$WORKLOAD_NAMESPACE" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' targets an unexpected namespace"
+  [[ "$(jq -r '.spec.source.repoURL // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_REPO_URL" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' uses an unexpected repository"
+  [[ "$(jq -r '.spec.source.targetRevision // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_TARGET_REVISION" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' uses an unexpected target revision"
+}
+
+require_kubernetes_permission() {
+  local context="$1"
+  local namespace="$2"
+  local verb="$3"
+  local resource="$4"
+  local subresource="${5:-}"
+  local args=(auth can-i "$verb" "$resource" --quiet)
+  [[ -z "$subresource" ]] || args+=(--subresource="$subresource")
+  kubectl_for_context "$context" -n "$namespace" "${args[@]}" \
+    || die "Kubernetes permission denied: $context namespace=$namespace verb=$verb resource=$resource${subresource:+/$subresource}"
+}
+
+validate_kubernetes_permissions() {
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" get applications.argoproj.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" patch applications.argoproj.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" patch applications.argoproj.io status
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" get appprojects.argoproj.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" patch appprojects.argoproj.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" get leases.coordination.k8s.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" create leases.coordination.k8s.io
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" "$ARGOCD_NAMESPACE" update leases.coordination.k8s.io
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" get secrets
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" list deployments.apps
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" patch deployments.apps scale
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" get jobs.batch
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" list pods
+  require_kubernetes_permission "$KUBE_CONTEXT" "$WORKLOAD_NAMESPACE" watch pods
+}
+
+load_workload_state() {
+  local deployments_json
+  deployments_json="$(
+    kubectl_for_workloads get deployments -l "$WORKLOAD_SELECTOR" -o json
+  )" || die "Could not list STG deployments in '$WORKLOAD_NAMESPACE' using context '$KUBE_CONTEXT'"
+
+  local deployment_count
+  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
+  validate_positive_integer deployment_count "$deployment_count"
+  (( deployment_count > 0 )) \
+    || die "No STG deployments matched selector '$WORKLOAD_SELECTOR'"
+  jq -e --arg namespace "$WORKLOAD_NAMESPACE" \
+    'all(.items[]; .metadata.namespace == $namespace)' \
+    >/dev/null <<<"$deployments_json" \
+    || die "Workload selector returned a Deployment outside '$WORKLOAD_NAMESPACE'"
+
+  printf '%s' "$deployments_json"
+}
+
+deployment_set_json() {
+  jq -c '[.items[] | {namespace: .metadata.namespace, name: .metadata.name}] | sort_by(.namespace, .name)'
+}
+
+assert_workload_set_unchanged() {
+  local current_json current_set expected_set
+  current_json="$(load_workload_state)"
+  current_set="$(deployment_set_json <<<"$current_json")"
+  expected_set="$(deployment_set_json <<<"$PREFLIGHT_DEPLOYMENTS_JSON")"
+  [[ "$current_set" == "$expected_set" ]] \
+    || die "Selected STG Deployment set changed after preflight"
+}
+
+validate_resume_workload_state() {
+  local deployments_json="$1"
+  [[ "$RESUMING_MAINTENANCE" == "true" ]] || return 0
+
+  local nonzero_replicas
+  nonzero_replicas="$(
+    jq '[.items[] | select((.spec.replicas // 1) != 0 or (.status.replicas // 0) != 0)] | length' \
+      <<<"$deployments_json"
+  )"
+  [[ "$nonzero_replicas" == "0" ]] \
+    || die "Cannot resume while any selected STG Deployment has desired or running replicas"
+
+  local failed_deployment_receipt="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID/deployments.tsv"
+  local receipt_deployments current_deployments
+  receipt_deployments="$(
+    jq -Rn \
+      '[inputs | select(length > 0) | split("\t") | {namespace: .[0], name: .[1]}] | sort_by(.namespace, .name)' \
+      <"$failed_deployment_receipt"
+  )"
+  current_deployments="$(
+    jq -c '[.items[] | {namespace: .metadata.namespace, name: .metadata.name}] | sort_by(.namespace, .name)' \
+      <<<"$deployments_json"
+  )"
+  [[ "$current_deployments" == "$(jq -c . <<<"$receipt_deployments")" ]] \
+    || die "Selected STG Deployments no longer match the failed-run receipt"
+
+  WORKLOADS_SCALED=true
+  log "Resuming fail-safe maintenance from run '$RESUME_FAILED_RUN_ID'; ArgoCD remains manual and all selected Deployments remain at zero"
+}
+
+lease_is_available() {
+  local lease_json="$1"
+  jq -e --arg holder "$LEASE_HOLDER_ID" '
+    (.spec.holderIdentity // "") == "" or
+    (.spec.holderIdentity // "") == $holder or
+    (((.spec.renewTime // .spec.acquireTime) |
+      sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) +
+      (.spec.leaseDurationSeconds // 0) < now)
+  ' >/dev/null <<<"$lease_json"
+}
+
+build_refresh_lease() {
+  local existing_json="${1:-}"
+  local now
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ -z "$existing_json" ]]; then
+    jq -n \
+      --arg name "$REFRESH_LEASE_NAME" \
+      --arg namespace "$ARGOCD_NAMESPACE" \
+      --arg holder "$LEASE_HOLDER_ID" \
+      --arg now "$now" \
+      --arg runId "$RUN_ID" \
+      --arg phase "$RUN_PHASE" \
+      --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+      --arg outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
+      --argjson duration "$REFRESH_LEASE_DURATION_SECONDS" \
+      '{
+        apiVersion: "coordination.k8s.io/v1",
+        kind: "Lease",
+        metadata: {
+          name: $name,
+          namespace: $namespace,
+          annotations: {
+            "klicker.uzh.ch/refresh-run-id": $runId,
+            "klicker.uzh.ch/refresh-phase": $phase,
+            "klicker.uzh.ch/raw-data-approval-ref": $approvalRef,
+            "klicker.uzh.ch/outbound-integrations-isolated": $outboundIntegrationsIsolated
+          }
+        },
+        spec: {
+          holderIdentity: $holder,
+          acquireTime: $now,
+          renewTime: $now,
+          leaseDurationSeconds: $duration,
+          leaseTransitions: 0
+        }
+      }'
+    return
+  fi
+
+  jq \
+    --arg holder "$LEASE_HOLDER_ID" \
+    --arg now "$now" \
+    --arg runId "$RUN_ID" \
+    --arg phase "$RUN_PHASE" \
+    --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+    --arg outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" \
+    --argjson duration "$REFRESH_LEASE_DURATION_SECONDS" '
+      (.spec.holderIdentity // "") as $previousHolder |
+      .metadata.annotations["klicker.uzh.ch/refresh-run-id"] = $runId |
+      .metadata.annotations["klicker.uzh.ch/refresh-phase"] = $phase |
+      .metadata.annotations["klicker.uzh.ch/raw-data-approval-ref"] = $approvalRef |
+      .metadata.annotations["klicker.uzh.ch/outbound-integrations-isolated"] = $outboundIntegrationsIsolated |
+      .spec.holderIdentity = $holder |
+      .spec.acquireTime = (if $previousHolder == $holder then (.spec.acquireTime // $now) else $now end) |
+      .spec.renewTime = $now |
+      .spec.leaseDurationSeconds = $duration |
+      .spec.leaseTransitions = (
+        if $previousHolder == $holder then (.spec.leaseTransitions // 0)
+        else ((.spec.leaseTransitions // 0) + 1)
+        end
+      )
+    ' <<<"$existing_json"
+}
+
+acquire_refresh_lease() {
+  local existing_json lease_payload
+  existing_json="$(
+    kubectl_for_argocd get lease.coordination.k8s.io "$REFRESH_LEASE_NAME" \
+      --ignore-not-found -o json
+  )" || die "Could not inspect refresh Lease '$ARGOCD_NAMESPACE/$REFRESH_LEASE_NAME'"
+
+  if [[ -z "$existing_json" ]]; then
+    lease_payload="$(build_refresh_lease)"
+    printf '%s' "$lease_payload" | kubectl_for_argocd create -f - >/dev/null \
+      || die "Could not acquire refresh Lease; another run may have started"
+  else
+    lease_is_available "$existing_json" \
+      || die "Refresh Lease '$ARGOCD_NAMESPACE/$REFRESH_LEASE_NAME' is held by another active run"
+    lease_payload="$(build_refresh_lease "$existing_json")"
+    printf '%s' "$lease_payload" | kubectl_for_argocd replace -f - >/dev/null \
+      || die "Could not atomically acquire refresh Lease; another run may have won the lease"
+  fi
+
+  LEASE_ACQUIRED=true
+  log "Acquired exclusive refresh Lease '$ARGOCD_NAMESPACE/$REFRESH_LEASE_NAME' as '$LEASE_HOLDER_ID'"
+}
+
+renew_refresh_lease_once() {
+  local existing_json lease_payload holder
+  existing_json="$(
+    kubectl_for_argocd get lease.coordination.k8s.io "$REFRESH_LEASE_NAME" -o json
+  )" || return 1
+  holder="$(jq -r '.spec.holderIdentity // ""' <<<"$existing_json")"
+  [[ "$holder" == "$LEASE_HOLDER_ID" ]] || return 1
+  lease_payload="$(build_refresh_lease "$existing_json")" || return 1
+  printf '%s' "$lease_payload" | kubectl_for_argocd replace -f - >/dev/null
+}
+
+start_refresh_lease_renewal() {
+  (
+    while sleep "$REFRESH_LEASE_RENEW_INTERVAL_SECONDS"; do
+      if ! renew_refresh_lease_once; then
+        printf '%s\n' 'Lease renewal failed' >"$LEASE_FAILURE_FILE"
+        exit 1
+      fi
+    done
+  ) &
+  LEASE_RENEWAL_PID=$!
+}
+
+assert_refresh_lease() {
+  [[ "$LEASE_ACQUIRED" == "true" ]] || die "Refresh Lease is not held"
+  [[ ! -e "$LEASE_FAILURE_FILE" ]] \
+    || die "Refresh Lease renewal failed; refusing further state changes"
+  local lease_json
+  lease_json="$(
+    kubectl_for_argocd get lease.coordination.k8s.io "$REFRESH_LEASE_NAME" -o json
+  )" || die "Could not read refresh Lease; refusing further state changes"
+  jq -e \
+    --arg holder "$LEASE_HOLDER_ID" \
+    --arg runId "$RUN_ID" \
+    --arg approvalRef "$RAW_PRD_DATA_APPROVAL_REF" \
+    --arg outboundIntegrationsIsolated "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" '
+    (.spec.holderIdentity // "") == $holder and
+    .metadata.annotations["klicker.uzh.ch/refresh-run-id"] == $runId and
+    .metadata.annotations["klicker.uzh.ch/raw-data-approval-ref"] == $approvalRef and
+    .metadata.annotations["klicker.uzh.ch/outbound-integrations-isolated"] == $outboundIntegrationsIsolated and
+    (((.spec.renewTime // .spec.acquireTime) |
+      sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) +
+      (.spec.leaseDurationSeconds // 0) >= now)
+  ' >/dev/null <<<"$lease_json" \
+    || die "Refresh Lease ownership was lost or expired; refusing further state changes"
+}
+
+stop_refresh_lease_renewal() {
+  [[ -n "$LEASE_RENEWAL_PID" ]] || return 0
+  kill "$LEASE_RENEWAL_PID" 2>/dev/null || true
+  wait "$LEASE_RENEWAL_PID" 2>/dev/null || true
+  LEASE_RENEWAL_PID=""
+}
+
+release_refresh_lease() {
+  stop_refresh_lease_renewal
+  [[ "$LEASE_ACQUIRED" == "true" ]] || return 0
+
+  local existing_json holder release_payload
+  existing_json="$(
+    kubectl_for_argocd get lease.coordination.k8s.io "$REFRESH_LEASE_NAME" -o json
+  )" || {
+    log "Could not read refresh Lease during cleanup; it will expire automatically"
+    return 0
+  }
+  holder="$(jq -r '.spec.holderIdentity // ""' <<<"$existing_json")"
+  if [[ "$holder" != "$LEASE_HOLDER_ID" ]]; then
+    log "Refresh Lease is no longer owned by this run; not releasing it"
+    LEASE_ACQUIRED=false
+    return 0
+  fi
+
+  release_payload="$(
+    jq \
+      --arg phase "$RUN_PHASE" \
+      --arg result "$(if [[ "$TERMINAL_SUCCESS" == "true" ]]; then printf success; else printf failed; fi)" \
+      --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+        .metadata.annotations["klicker.uzh.ch/refresh-phase"] = $phase |
+        .metadata.annotations["klicker.uzh.ch/refresh-result"] = $result |
+        .spec.holderIdentity = "" |
+        .spec.renewTime = $now |
+        .spec.leaseDurationSeconds = 1
+      ' <<<"$existing_json"
+  )"
+  if printf '%s' "$release_payload" | kubectl_for_argocd replace -f - >/dev/null; then
+    LEASE_ACQUIRED=false
+    log "Released refresh Lease '$ARGOCD_NAMESPACE/$REFRESH_LEASE_NAME'"
+  else
+    log "Could not release refresh Lease; it will expire automatically"
+  fi
+}
+
+assert_workload_set_matches_receipt() {
+  local deployments_json current_set receipt_set
+  deployments_json="$(load_workload_state)"
+  current_set="$(deployment_set_json <<<"$deployments_json")"
+  receipt_set="$(
+    deployment_receipt_json | jq -c 'map({namespace, name}) | sort_by(.namespace, .name)'
+  )"
+  [[ "$current_set" == "$receipt_set" ]] \
+    || die "Selected STG Deployment set no longer matches the bound run receipt"
+}
+
+restore_partially_scaled_workloads() {
+  local scaled_receipt="$1"
+  log "A pre-mutation scale operation failed; restoring already changed Deployments"
+  while IFS=$'\t' read -r namespace deployment replicas; do
+    [[ -n "$namespace" && -n "$deployment" && -n "$replicas" ]] || continue
+    if ! kubectl_for_workloads scale "deployment/$deployment" --replicas="$replicas" >/dev/null; then
+      log "Could not compensate $namespace/deployment/$deployment to $replicas replicas"
+    fi
+  done <"$scaled_receipt"
+}
+
+ensure_argocd_policy_paused_for_cleanup() {
+  local application_json
+  log "Ensuring ArgoCD automated sync is disabled for fail-safe cleanup"
+  if ! patch_argocd_application '{"spec":{"syncPolicy":{"automated":null}}}' \
+    >/dev/null; then
+    log "CRITICAL: Could not disable ArgoCD automated sync during cleanup"
+    return 1
+  fi
+  if ! application_json="$(get_argocd_application)"; then
+    log "CRITICAL: Could not verify ArgoCD policy during cleanup"
+    return 1
+  fi
+  if jq -e \
+    '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    log "CRITICAL: ArgoCD automated sync remains enabled during cleanup"
+    return 1
+  fi
+  ARGOCD_POLICY_PAUSED=true
+}
+
+restore_original_argocd_policy_for_cleanup() {
+  local policy_patch application_json
+  policy_patch="$(build_argocd_policy_patch "$ORIGINAL_AUTOMATED_JSON")"
+  if ! patch_argocd_application "$policy_patch" >/dev/null; then
+    log "Could not restore the original ArgoCD policy after a pre-mutation failure"
+    return 1
+  fi
+  if ! application_json="$(get_argocd_application)"; then
+    log "Could not verify the restored ArgoCD policy after a pre-mutation failure"
+    return 1
+  fi
+  if ! jq -e --argjson expected "$ORIGINAL_AUTOMATED_JSON" \
+    '(.spec.syncPolicy.automated // null) == $expected' \
+    >/dev/null <<<"$application_json"; then
+    log "The exact original ArgoCD policy was not restored after a pre-mutation failure"
+    return 1
+  fi
+  ARGOCD_POLICY_PAUSED=false
+  log "Restored the original ArgoCD policy after a pre-mutation failure"
+}
+
+restore_original_workloads_for_cleanup() {
+  [[ -n "$DEPLOYMENT_RECEIPT" && -s "$DEPLOYMENT_RECEIPT" ]] || {
+    log "No deployment receipt is available for pre-mutation compensation"
+    return 1
+  }
+
+  local failed=false
+  while IFS=$'\t' read -r namespace deployment replicas; do
+    [[ -n "$namespace" && -n "$deployment" && -n "$replicas" ]] || continue
+    if [[ "$namespace" != "$WORKLOAD_NAMESPACE" ]]; then
+      log "Refusing cleanup compensation for unexpected namespace '$namespace'"
+      failed=true
+      continue
+    fi
+    if ! kubectl_for_workloads scale "deployment/$deployment" \
+      --replicas="$replicas" >/dev/null; then
+      log "Could not restore $namespace/deployment/$deployment to $replicas replicas"
+      failed=true
+    fi
+  done <"$DEPLOYMENT_RECEIPT"
+
+  [[ "$failed" == "false" ]] || return 1
+  WORKLOADS_SCALED=false
+  log "Restored original Deployment replica targets after a pre-mutation failure"
+}
+
+force_selected_workloads_down_for_cleanup() {
+  [[ -n "$RUN_DIR" ]] || {
+    log "CRITICAL: No run directory is available for fail-safe workload shutdown"
+    return 1
+  }
+
+  local cleanup_receipt="$RUN_DIR/cleanup-deployments.tsv"
+  local deployments_json failed=false
+  : >"$cleanup_receipt"
+  if [[ -n "$DEPLOYMENT_RECEIPT" && -s "$DEPLOYMENT_RECEIPT" ]]; then
+    awk -F '\t' '{print $1 "\t" $2}' "$DEPLOYMENT_RECEIPT" \
+      >>"$cleanup_receipt"
+  fi
+  if deployments_json="$(
+    kubectl_for_workloads get deployments -l "$WORKLOAD_SELECTOR" -o json
+  )"; then
+    jq -r '.items[] | [.metadata.namespace, .metadata.name] | @tsv' \
+      <<<"$deployments_json" >>"$cleanup_receipt"
+  else
+    log "Could not enumerate current selected Deployments during cleanup"
+    failed=true
+  fi
+  sort -u "$cleanup_receipt" -o "$cleanup_receipt"
+
+  while IFS=$'\t' read -r namespace deployment; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    if [[ "$namespace" != "$WORKLOAD_NAMESPACE" ]]; then
+      log "Refusing cleanup shutdown for unexpected namespace '$namespace'"
+      failed=true
+      continue
+    fi
+    if ! kubectl_for_workloads scale "deployment/$deployment" \
+      --replicas=0 >/dev/null; then
+      log "CRITICAL: Could not scale $namespace/deployment/$deployment to zero during cleanup"
+      failed=true
+    fi
+  done <"$cleanup_receipt"
+
+  # Verify every name in the cleanup receipt directly. A receipt-bound
+  # Deployment may have lost the selector label after preflight; selector-only
+  # verification would then miss its still-running replicas.
+  local deployment_json
+  while IFS=$'\t' read -r namespace deployment; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    if [[ "$namespace" != "$WORKLOAD_NAMESPACE" ]]; then
+      failed=true
+      continue
+    fi
+    if ! deployment_json="$(
+      kubectl_for_workloads get "deployment/$deployment" -o json
+    )"; then
+      log "CRITICAL: Could not verify $namespace/deployment/$deployment during cleanup"
+      failed=true
+      continue
+    fi
+    if ! jq -e \
+      --arg namespace "$namespace" \
+      --arg deployment "$deployment" '
+        .metadata.namespace == $namespace and
+        .metadata.name == $deployment and
+        (.spec.replicas // 1) == 0 and
+        (.status.replicas // 0) == 0
+      ' >/dev/null <<<"$deployment_json"; then
+      log "CRITICAL: $namespace/deployment/$deployment has not reached zero desired and running replicas during cleanup"
+      failed=true
+    fi
+  done <"$cleanup_receipt"
+
+  [[ "$failed" == "false" ]] || return 1
+  WORKLOADS_SCALED=true
+  log "Verified all selected STG Deployments at zero replicas"
+}
+
+verify_no_active_argocd_operation_for_cleanup() {
+  local application_json operation_phase
+  application_json="$(get_argocd_application)" || return 1
+  [[ "$(jq -r '.metadata.uid // ""' <<<"$application_json")" == "$EXPECTED_ARGOCD_APP_UID" ]] \
+    || return 1
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  jq -e '.operation == null' >/dev/null <<<"$application_json" &&
+    [[ "$operation_phase" != "Running" && "$operation_phase" != "Terminating" ]]
+}
+
+establish_fail_safe_maintenance() {
+  local deadline=$((SECONDS + CLEANUP_TIMEOUT_SECONDS))
+  local fence_ok operation_ok policy_ok workloads_ok
+  set_run_phase cleanup-securing-maintenance
+
+  while true; do
+    fence_ok=false
+    operation_ok=false
+    policy_ok=false
+    workloads_ok=false
+
+    install_argocd_maintenance_fence && fence_ok=true
+    if [[ "$ARGO_OPERATION_ACCEPTED" == "true" ]]; then
+      terminate_owned_argocd_operation "$deadline" || true
+    fi
+    verify_no_active_argocd_operation_for_cleanup && operation_ok=true
+    ensure_argocd_policy_paused_for_cleanup && policy_ok=true
+    force_selected_workloads_down_for_cleanup && workloads_ok=true
+
+    if [[ "$fence_ok" == "true" && "$operation_ok" == "true" &&
+      "$policy_ok" == "true" && "$workloads_ok" == "true" ]]; then
+      return 0
+    fi
+    if (( SECONDS >= deadline )); then
+      log "CRITICAL: Timed out proving fail-safe maintenance invariants"
+      return 1
+    fi
+    log "Cleanup safety is not yet proven; retrying until the cleanup deadline"
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+}
+
+scale_stg_workloads_down() {
+  local deployments_json
+  local scaled_this_attempt="$RUN_DIR/scaled-this-attempt.tsv"
+  WORKLOADS_SCALED=false
+  : >"$scaled_this_attempt"
+  assert_refresh_lease
+  assert_workload_set_matches_receipt
+  set_run_phase stopping-workloads
+
+  while IFS=$'\t' read -r namespace deployment replicas; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    [[ "$namespace" == "$WORKLOAD_NAMESPACE" ]] \
+      || die "Deployment receipt contains disallowed namespace '$namespace'"
+    log "Scaling $namespace/deployment/$deployment from $replicas to 0"
+    if ! kubectl_for_workloads scale "deployment/$deployment" --replicas=0 >/dev/null; then
+      if [[ "$TARGET_MUTATED" != "true" ]]; then
+        restore_partially_scaled_workloads "$scaled_this_attempt"
+      fi
+      die "Could not scale $namespace/deployment/$deployment to zero"
+    fi
+    printf '%s\t%s\t%s\n' "$namespace" "$deployment" "$replicas" \
+      >>"$scaled_this_attempt"
+    printf '%s\t%s\t%s\t%s\n' \
+      "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$namespace" "$deployment" zero \
+      >>"$SCALE_OBSERVATION_RECEIPT"
+  done <"$DEPLOYMENT_RECEIPT"
+
+  local deadline=$((SECONDS + WORKLOAD_DRAIN_TIMEOUT_SECONDS))
+  while true; do
+    deployments_json="$(load_workload_state)"
+    local remaining_replicas
+    remaining_replicas="$(jq '[.items[] | (.status.replicas // 0)] | add // 0' <<<"$deployments_json")"
+    validate_positive_integer remaining_replicas "$remaining_replicas"
+    if (( remaining_replicas == 0 )); then
+      break
+    fi
+    if (( SECONDS >= deadline )); then
+      die "Timed out waiting for STG workloads to reach zero replicas"
+    fi
+    sleep 2
+  done
+
+  WORKLOADS_SCALED=true
+  set_run_phase workloads-stopped
+  log "All bound STG workloads are stopped"
+}

--- a/util/backup/reset-stg-owned-objects.sql
+++ b/util/backup/reset-stg-owned-objects.sql
@@ -1,0 +1,116 @@
+/* klicker_reset_owned_objects */
+SET lock_timeout = '30s';
+BEGIN;
+DO $reset$
+DECLARE
+  object_record record;
+  object_kind text;
+BEGIN
+  FOR object_record IN
+    SELECT
+      p.proname AS object_name,
+      p.prokind,
+      pg_get_function_identity_arguments(p.oid) AS identity_arguments
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND pg_has_role(current_user, p.proowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.prokind
+      WHEN 'p' THEN 'PROCEDURE'
+      WHEN 'a' THEN 'AGGREGATE'
+      ELSE 'FUNCTION'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I(%s) CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name,
+      object_record.identity_arguments
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name, c.relkind
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('v', 'm')
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.relkind
+      WHEN 'm' THEN 'MATERIALIZED VIEW'
+      ELSE 'VIEW'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name, c.relkind
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'f')
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.relkind
+      WHEN 'f' THEN 'FOREIGN TABLE'
+      ELSE 'TABLE'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'S'
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    EXECUTE format(
+      'DROP SEQUENCE IF EXISTS %I.%I CASCADE',
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT t.typname AS object_name, t.typtype
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND t.typrelid = 0
+      AND pg_has_role(current_user, t.typowner, 'USAGE')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        WHERE d.classid = 'pg_type'::regclass
+          AND d.objid = t.oid
+          AND d.deptype IN ('i', 'e')
+      )
+  LOOP
+    object_kind := CASE object_record.typtype
+      WHEN 'd' THEN 'DOMAIN'
+      ELSE 'TYPE'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+END
+$reset$;
+COMMIT;

--- a/util/backup/tests/refresh-stg-from-prd.test.sh
+++ b/util/backup/tests/refresh-stg-from-prd.test.sh
@@ -106,6 +106,7 @@ run_refresh() {
     FAKE_PSQL_CONNECT_FAIL="${FAKE_PSQL_CONNECT_FAIL:-false}" \
     FAKE_ARGO_SYNC_FAIL="${FAKE_ARGO_SYNC_FAIL:-false}" \
     FAKE_ARGO_TIMEOUT="${FAKE_ARGO_TIMEOUT:-false}" \
+    FAKE_ARGO_UNREADABLE_AFTER_SYNC="${FAKE_ARGO_UNREADABLE_AFTER_SYNC:-false}" \
     FAKE_CLUSTER_MISMATCH="${FAKE_CLUSTER_MISMATCH:-false}" \
     FAKE_RBAC_DENY="${FAKE_RBAC_DENY:-false}" \
     FAKE_MIGRATOR_MISMATCH="${FAKE_MIGRATOR_MISMATCH:-false}" \
@@ -116,6 +117,11 @@ run_refresh() {
     FAKE_HEALTH_FAIL="${FAKE_HEALTH_FAIL:-false}" \
     FAKE_STORAGE_LOW="${FAKE_STORAGE_LOW:-false}" \
     FAKE_LEASE_LOSS="${FAKE_LEASE_LOSS:-false}" \
+    FAKE_LEASE_RENEW_FAIL="${FAKE_LEASE_RENEW_FAIL:-false}" \
+    FAKE_LEASE_RENEW_FAIL_COUNT="${FAKE_LEASE_RENEW_FAIL_COUNT:-0}" \
+    FAKE_LEASE_RENEW_FAIL_PHASE="${FAKE_LEASE_RENEW_FAIL_PHASE:-}" \
+    FAKE_SLOW_RESTORE="${FAKE_SLOW_RESTORE:-false}" \
+    FAKE_STG_UNSUPPORTED_OBJECT_COUNT="${FAKE_STG_UNSUPPORTED_OBJECT_COUNT:-0}" \
     FAKE_COMPETING_SYNC="${FAKE_COMPETING_SYNC:-false}" \
     FAKE_CAS_RACE="${FAKE_CAS_RACE:-false}" \
     FAKE_CLEANUP_FENCE_FAIL="${FAKE_CLEANUP_FENCE_FAIL:-false}" \
@@ -138,12 +144,15 @@ run_refresh() {
     BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY_OVERRIDE-synthetic-test-key}" \
     ARGOCD_TIMEOUT_SECONDS=2 \
     ARGOCD_POLL_SECONDS=1 \
+    KUBECTL_REQUEST_TIMEOUT=1s \
     WORKLOAD_DRAIN_TIMEOUT_SECONDS=2 \
     POST_SYNC_HEALTH_TIMEOUT_SECONDS=2 \
     CLEANUP_TIMEOUT_SECONDS=2 \
     MIGRATOR_EVIDENCE_TIMEOUT_SECONDS=1 \
-    REFRESH_LEASE_DURATION_SECONDS=61 \
-    REFRESH_LEASE_RENEW_INTERVAL_SECONDS=20 \
+    REFRESH_LEASE_DURATION_SECONDS="${REFRESH_LEASE_DURATION_SECONDS_OVERRIDE:-61}" \
+    REFRESH_LEASE_RENEW_INTERVAL_SECONDS="${REFRESH_LEASE_RENEW_INTERVAL_SECONDS_OVERRIDE:-20}" \
+    REFRESH_LEASE_RENEW_RETRY_ATTEMPTS="${REFRESH_LEASE_RENEW_RETRY_ATTEMPTS_OVERRIDE:-3}" \
+    REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS="${REFRESH_LEASE_RENEW_RETRY_DELAY_SECONDS_OVERRIDE:-0}" \
     "$SCRIPT_UNDER_TEST" "$@" >"$OUTPUT_FILE" 2>&1
 }
 
@@ -387,6 +396,38 @@ test_active_lease() {
   fi
 }
 
+test_malformed_lease_fails_closed() {
+  new_case malformed-lease
+  jq -n --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+    {
+      metadata: {name: "app-klicker-prd-to-stg-refresh", resourceVersion: "7"},
+      spec: {
+        holderIdentity: "another-refresh",
+        acquireTime: $now,
+        renewTime: $now,
+        leaseDurationSeconds: 0
+      }
+    }
+  ' >"$FAKE_LEASE_FILE"
+  if ! run_live && assert_contains "$OUTPUT_FILE" 'held by another active run' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'a malformed active Lease cannot be treated as expired'
+  else
+    fail 'a malformed active Lease cannot be treated as expired'
+  fi
+}
+
+test_unsupported_composite_type() {
+  new_case unsupported-composite
+  if ! FAKE_STG_UNSUPPORTED_OBJECT_COUNT=1 run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'unsupported public object' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'unsupported public objects are rejected before maintenance mode'
+  else
+    fail 'unsupported public objects are rejected before maintenance mode'
+  fi
+}
+
 test_storage_headroom() {
   new_case storage-headroom
   if ! FAKE_STORAGE_LOW=true run_refresh &&
@@ -409,6 +450,38 @@ test_lease_loss() {
     pass 'Lease loss stops mutation and compensates pre-mutation state'
   else
     fail 'Lease loss stops mutation and compensates pre-mutation state'
+  fi
+}
+
+test_transient_lease_renewal_failure() {
+  new_case transient-lease-renewal
+  local REFRESH_LEASE_DURATION_SECONDS_OVERRIDE=10
+  local REFRESH_LEASE_RENEW_INTERVAL_SECONDS_OVERRIDE=1
+  if FAKE_LEASE_RENEW_FAIL_COUNT=1 \
+    FAKE_LEASE_RENEW_FAIL_PHASE=restoring-target \
+    FAKE_SLOW_RESTORE=true run_live &&
+    assert_contains "$OUTPUT_FILE" 'Lease renewal attempt 1 failed; retrying' &&
+    assert_contains "$FAKE_LOG" 'kubectl lease write phase=restoring-target'; then
+    pass 'Lease renewal retries a transient conflict and publishes the current phase'
+  else
+    fail 'Lease renewal retries a transient conflict and publishes the current phase'
+  fi
+}
+
+test_permanent_lease_renewal_failure() {
+  new_case permanent-lease-renewal
+  local REFRESH_LEASE_DURATION_SECONDS_OVERRIDE=10
+  local REFRESH_LEASE_RENEW_INTERVAL_SECONDS_OVERRIDE=1
+  if ! FAKE_LEASE_RENEW_FAIL=true \
+    FAKE_LEASE_RENEW_FAIL_PHASE=restoring-target \
+    FAKE_SLOW_RESTORE=true run_live &&
+    assert_contains "$OUTPUT_FILE" 'Lease renewal failed after 3 attempts' &&
+    assert_contains "$OUTPUT_FILE" "failed during phase 'restoring-target'" &&
+    assert_fail_safe_failure &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app sync hook'; then
+    pass 'repeated Lease renewal failure interrupts restore and enters fail-safe cleanup'
+  else
+    fail 'repeated Lease renewal failure interrupts restore and enters fail-safe cleanup'
   fi
 }
 
@@ -640,6 +713,19 @@ test_argocd_timeout() {
   fi
 }
 
+test_argocd_unreadable_timeout() {
+  new_case argocd-unreadable-timeout
+  if ! FAKE_ARGO_UNREADABLE_AFTER_SYNC=true run_live &&
+    assert_contains "$OUTPUT_FILE" \
+      'Could not read the ArgoCD Application before the sync timeout' &&
+    jq -e '.cleanupIncomplete == true' \
+      "$REFRESH_DIR/test-run/state.json" >/dev/null; then
+    pass 'an unreadable ArgoCD Application exits through the bounded fail-safe path'
+  else
+    fail 'an unreadable ArgoCD Application exits through the bounded fail-safe path'
+  fi
+}
+
 test_health_failure() {
   new_case health-failure
   if ! FAKE_HEALTH_FAIL=true run_live && assert_fail_safe_failure &&
@@ -716,8 +802,12 @@ test_cluster_guard
 test_rbac_guard
 test_migrator_guard
 test_active_lease
+test_malformed_lease_fails_closed
+test_unsupported_composite_type
 test_storage_headroom
 test_lease_loss
+test_transient_lease_renewal_failure
+test_permanent_lease_renewal_failure
 test_competing_sync
 test_infisical
 test_success
@@ -734,6 +824,7 @@ test_post_sync_metadata_failure
 test_policy_restore_failure
 test_migration_divergence
 test_argocd_timeout
+test_argocd_unreadable_timeout
 test_health_failure
 test_post_policy_operation
 test_resume

--- a/util/backup/tests/refresh-stg-from-prd.test.sh
+++ b/util/backup/tests/refresh-stg-from-prd.test.sh
@@ -1,0 +1,744 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_SOURCE" ]]; do
+  SOURCE_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ "$SCRIPT_SOURCE" == /* ]] || SCRIPT_SOURCE="$SOURCE_DIR/$SCRIPT_SOURCE"
+done
+TEST_SCRIPT="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)/$(basename "$SCRIPT_SOURCE")"
+SCRIPT_UNDER_TEST="$(cd "$(dirname "$TEST_SCRIPT")/.." && pwd)/refresh-stg-from-prd.sh"
+
+# shellcheck source=refresh-stg-from-prd/fakes.sh
+source "$(cd "$(dirname "$TEST_SCRIPT")" && pwd)/refresh-stg-from-prd/fakes.sh"
+
+if [[ "$(basename "$0")" != "$(basename "$TEST_SCRIPT")" ]]; then
+  dispatch_fake_tool "$@"
+  exit
+fi
+
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/refresh-stg-from-prd-test.XXXXXX")"
+cleanup_test_tmp() {
+  if [[ "${KEEP_TEST_TMP:-false}" == true ]]; then
+    printf 'retained test artifacts: %s\n' "$TEST_TMP" >&2
+  else
+    rm -rf -- "$TEST_TMP"
+  fi
+}
+trap cleanup_test_tmp EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+pass() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'ok %s - %s\n' "$TEST_COUNT" "$1"
+}
+
+fail() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'not ok %s - %s\n' "$TEST_COUNT" "$1" >&2
+  sed -n '1,160p' "$OUTPUT_FILE" >&2
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1"
+}
+
+assert_not_contains() {
+  ! grep -Fq -- "$2" "$1"
+}
+
+assert_before() {
+  local first_line second_line
+  first_line="$(grep -nF -- "$2" "$1" | head -1 | cut -d: -f1)"
+  second_line="$(grep -nF -- "$3" "$1" | head -1 | cut -d: -f1)"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]]
+}
+
+new_case() {
+  CASE_DIR="$TEST_TMP/$1"
+  FAKE_BIN="$CASE_DIR/bin"
+  FAKE_LOG="$CASE_DIR/fake.log"
+  FAKE_STATE_DIR="$CASE_DIR/state"
+  FAKE_ARGO_POLICY_FILE="$FAKE_STATE_DIR/argocd-policy"
+  FAKE_PROJECT_FILE="$FAKE_STATE_DIR/argocd-project.json"
+  FAKE_OPERATION_FILE="$FAKE_STATE_DIR/argocd-operation"
+  FAKE_SYNCED_FILE="$FAKE_STATE_DIR/synced"
+  FAKE_TERMINATED_FILE="$FAKE_STATE_DIR/terminated"
+  FAKE_LEASE_FILE="$FAKE_STATE_DIR/lease.json"
+  FAKE_LEASE_READS_FILE="$FAKE_STATE_DIR/lease-reads"
+  FAKE_RESTORED_FILE="$FAKE_STATE_DIR/restored"
+  OUTPUT_FILE="$CASE_DIR/output.log"
+  REFRESH_DIR="$CASE_DIR/refreshes"
+  mkdir -p "$FAKE_BIN" "$FAKE_STATE_DIR"
+  : >"$FAKE_LOG"
+  printf '%s' automated >"$FAKE_ARGO_POLICY_FILE"
+  printf '%s\n' '{"metadata":{"uid":"6faae3ef-2736-45ee-a2d5-8fd4cfd41b16","resourceVersion":"7"},"spec":{"syncWindows":[]}}' \
+    >"$FAKE_PROJECT_FILE"
+  local tool
+  for tool in az gpg infisical kubectl pg_dump pg_restore psql; do
+    ln -s "$TEST_SCRIPT" "$FAKE_BIN/$tool"
+  done
+}
+
+run_refresh() {
+  local prd_url stg_url
+  prd_url="${PRD_DATABASE_URL_OVERRIDE-$(prd_database_url)}"
+  stg_url="${STG_DATABASE_URL_OVERRIDE-$(stg_database_url)}"
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_LOG="$FAKE_LOG" \
+    FAKE_STATE_DIR="$FAKE_STATE_DIR" \
+    FAKE_ARGO_POLICY_FILE="$FAKE_ARGO_POLICY_FILE" \
+    FAKE_PROJECT_FILE="$FAKE_PROJECT_FILE" \
+    FAKE_OPERATION_FILE="$FAKE_OPERATION_FILE" \
+    FAKE_SYNCED_FILE="$FAKE_SYNCED_FILE" \
+    FAKE_TERMINATED_FILE="$FAKE_TERMINATED_FILE" \
+    FAKE_LEASE_FILE="$FAKE_LEASE_FILE" \
+    FAKE_RESTORED_FILE="$FAKE_RESTORED_FILE" \
+    FAKE_PG_RESTORE_FAIL="${FAKE_PG_RESTORE_FAIL:-false}" \
+    FAKE_PSQL_CONNECT_FAIL="${FAKE_PSQL_CONNECT_FAIL:-false}" \
+    FAKE_ARGO_SYNC_FAIL="${FAKE_ARGO_SYNC_FAIL:-false}" \
+    FAKE_ARGO_TIMEOUT="${FAKE_ARGO_TIMEOUT:-false}" \
+    FAKE_CLUSTER_MISMATCH="${FAKE_CLUSTER_MISMATCH:-false}" \
+    FAKE_RBAC_DENY="${FAKE_RBAC_DENY:-false}" \
+    FAKE_MIGRATOR_MISMATCH="${FAKE_MIGRATOR_MISMATCH:-false}" \
+    FAKE_PARTIAL_SCALE_FAIL="${FAKE_PARTIAL_SCALE_FAIL:-false}" \
+    FAKE_POST_SYNC_METADATA_FAIL="${FAKE_POST_SYNC_METADATA_FAIL:-false}" \
+    FAKE_POLICY_RESTORE_FAIL="${FAKE_POLICY_RESTORE_FAIL:-false}" \
+    FAKE_MIGRATION_DIVERGENCE="${FAKE_MIGRATION_DIVERGENCE:-false}" \
+    FAKE_HEALTH_FAIL="${FAKE_HEALTH_FAIL:-false}" \
+    FAKE_STORAGE_LOW="${FAKE_STORAGE_LOW:-false}" \
+    FAKE_LEASE_LOSS="${FAKE_LEASE_LOSS:-false}" \
+    FAKE_COMPETING_SYNC="${FAKE_COMPETING_SYNC:-false}" \
+    FAKE_CAS_RACE="${FAKE_CAS_RACE:-false}" \
+    FAKE_CLEANUP_FENCE_FAIL="${FAKE_CLEANUP_FENCE_FAIL:-false}" \
+    FAKE_CLEANUP_SCALE_FAIL="${FAKE_CLEANUP_SCALE_FAIL:-false}" \
+    FAKE_POST_MUTATION_WORKLOAD_DRIFT="${FAKE_POST_MUTATION_WORKLOAD_DRIFT:-false}" \
+    FAKE_STALE_MIGRATOR_EVIDENCE="${FAKE_STALE_MIGRATOR_EVIDENCE:-false}" \
+    FAKE_WRONG_MIGRATOR_DIGEST="${FAKE_WRONG_MIGRATOR_DIGEST:-false}" \
+    FAKE_POST_POLICY_OPERATION="${FAKE_POST_POLICY_OPERATION:-false}" \
+    FAKE_LEASE_READS_FILE="$FAKE_LEASE_READS_FILE" \
+    REFRESH_ROOT_DIR="$REFRESH_DIR" \
+    RUN_ID="${RUN_ID_OVERRIDE:-test-run}" \
+    RESUME_FAILED_RUN_ID="${RESUME_FAILED_RUN_ID_OVERRIDE:-}" \
+    DRY_RUN="${DRY_RUN:-true}" \
+    CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}" \
+    ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}" \
+    RAW_PRD_DATA_APPROVAL_REF="${RAW_PRD_DATA_APPROVAL_REF-}" \
+    STG_OUTBOUND_INTEGRATIONS_ISOLATED="${STG_OUTBOUND_INTEGRATIONS_ISOLATED:-false}" \
+    PRD_DATABASE_URL="$prd_url" \
+    STG_DATABASE_URL="$stg_url" \
+    BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY_OVERRIDE-synthetic-test-key}" \
+    ARGOCD_TIMEOUT_SECONDS=2 \
+    ARGOCD_POLL_SECONDS=1 \
+    WORKLOAD_DRAIN_TIMEOUT_SECONDS=2 \
+    POST_SYNC_HEALTH_TIMEOUT_SECONDS=2 \
+    CLEANUP_TIMEOUT_SECONDS=2 \
+    MIGRATOR_EVIDENCE_TIMEOUT_SECONDS=1 \
+    REFRESH_LEASE_DURATION_SECONDS=61 \
+    REFRESH_LEASE_RENEW_INTERVAL_SECONDS=20 \
+    "$SCRIPT_UNDER_TEST" "$@" >"$OUTPUT_FILE" 2>&1
+}
+
+write_failed_run_receipt() {
+  local failed_run_id="$1" failed_run_dir="$REFRESH_DIR/$1"
+  local fingerprint deployments
+  mkdir -p "$failed_run_dir"
+  fingerprint="$(migration_history | shasum -a 256 | awk '{print $1}')"
+  deployments='[{"namespace":"stg-klicker","name":"backend","replicas":1},{"namespace":"stg-klicker","name":"worker","replicas":2}]'
+  jq -n \
+    --arg runId "$failed_run_id" \
+    --arg fingerprint "$fingerprint" \
+    --argjson deployments "$deployments" '
+      {
+        runId: $runId,
+        source: {
+          host: "db-server-prd-apps.postgres.database.azure.com",
+          port: "6432",
+          database: "klicker-prod-prd",
+          migrationFingerprint: $fingerprint
+        },
+        targetBefore: {
+          host: "db-server-stg-apps.postgres.database.azure.com",
+          port: "6432",
+          database: "klicker-qa-stg"
+        },
+        kubernetes: {
+          kubeSystemUid: "207f1b0e-5ad7-4de6-94d1-2b4564a41fe7",
+          workloadNamespace: "stg-klicker",
+          workloadNamespaceUid: "ae9b8ae9-d3df-4078-820d-1ef69d4cf816",
+          argocdApplicationUid: "9f936f7f-58ff-4a72-8c75-eb969ac3bd6f",
+          argocdProject: "stg-apps-klicker",
+          argocdProjectUid: "6faae3ef-2736-45ee-a2d5-8fd4cfd41b16"
+        },
+        argocdRevision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        deployments: $deployments,
+        argocdAutomatedPolicy: {
+          prune: true,
+          selfHeal: true,
+          allowEmpty: false
+        },
+        argocdProjectOriginalSyncWindows: []
+      }
+    ' >"$failed_run_dir/before.json"
+  printf '%s\t%s\t%s\n' stg-klicker backend 1 >"$failed_run_dir/deployments.tsv"
+  printf '%s\t%s\t%s\n' stg-klicker worker 2 >>"$failed_run_dir/deployments.tsv"
+  jq '.spec.syncWindows = [{
+    kind: "deny",
+    schedule: "* * * * *",
+    duration: "1h",
+    applications: ["app-klicker"],
+    manualSync: false
+  }]' "$FAKE_PROJECT_FILE" >"$FAKE_PROJECT_FILE.tmp"
+  mv -- "$FAKE_PROJECT_FILE.tmp" "$FAKE_PROJECT_FILE"
+}
+
+run_live() {
+  DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    RAW_PRD_DATA_APPROVAL_REF=TEST-APPROVAL-REF \
+    STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+    run_refresh
+}
+
+test_help() {
+  new_case help
+  if "$SCRIPT_UNDER_TEST" --help >"$OUTPUT_FILE" 2>&1 &&
+    assert_contains "$OUTPUT_FILE" 'Execution requires all five explicit gates' &&
+    assert_contains "$OUTPUT_FILE" 'checked-in target constants'; then
+    pass 'help is available without external tools'
+  else
+    fail 'help is available without external tools'
+  fi
+}
+
+test_dry_run() {
+  new_case dry-run
+  if BACKUP_ENCRYPTION_KEY_OVERRIDE= run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'DRY_RUN=true' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl lease write' &&
+    [[ ! -e "$REFRESH_DIR" ]]; then
+    pass 'dry run performs only read-only preflight checks'
+  else
+    fail 'dry run performs only read-only preflight checks'
+  fi
+}
+
+test_confirmation_gate() {
+  new_case confirmation
+  if ! DRY_RUN=false run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'CONFIRM_PRD_TO_STG_REFRESH' &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'execution refuses to start without destructive confirmation'
+  else
+    fail 'execution refuses to start without destructive confirmation'
+  fi
+}
+
+test_raw_data_approval_gate() {
+  new_case raw-data-approval
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'RAW_PRD_DATA_APPROVAL_REF' &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'execution requires a recorded raw-data approval reference'
+  else
+    fail 'execution requires a recorded raw-data approval reference'
+  fi
+}
+
+test_raw_data_approval_format() {
+  new_case raw-data-approval-format
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    RAW_PRD_DATA_APPROVAL_REF='not approval prose' \
+    STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'must be a 1-200 character ticket' &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'raw-data approval evidence is bounded and identifier-shaped'
+  else
+    fail 'raw-data approval evidence is bounded and identifier-shaped'
+  fi
+}
+
+test_outbound_isolation_gate() {
+  new_case outbound-isolation
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    RAW_PRD_DATA_APPROVAL_REF=TEST-APPROVAL-REF \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'STG_OUTBOUND_INTEGRATIONS_ISOLATED=true' &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'execution requires explicit outbound-integration isolation'
+  else
+    fail 'execution requires explicit outbound-integration isolation'
+  fi
+}
+
+test_wrong_database() {
+  new_case wrong-database
+  local STG_DATABASE_URL_OVERRIDE
+  STG_DATABASE_URL_OVERRIDE="$(stg_database_url wrong-database)"
+  if ! run_refresh && assert_contains "$OUTPUT_FILE" "does not equal expected database" &&
+    assert_not_contains "$FAKE_LOG" 'psql reset target'; then
+    pass 'correct STG host with a wrong database name fails closed'
+  else
+    fail 'correct STG host with a wrong database name fails closed'
+  fi
+}
+
+test_target_contract_ignores_ambient_overrides() {
+  new_case immutable-target-contract
+  if EXPECTED_PRD_DB_HOST=untrusted.invalid \
+    EXPECTED_STG_DB_NAME=wrong-database \
+    ARGOCD_APP=wrong-application \
+    WORKLOAD_NAMESPACE=wrong-namespace \
+    EXPECTED_KUBE_SYSTEM_UID=wrong-cluster \
+    EXPECTED_ARGOCD_REPO_URL=https://example.invalid/wrong.git \
+    run_live &&
+    assert_contains "$OUTPUT_FILE" \
+      'Source: db-server-prd-apps.postgres.database.azure.com/klicker-prod-prd' &&
+    assert_contains "$OUTPUT_FILE" \
+      'Target: db-server-stg-apps.postgres.database.azure.com/klicker-qa-stg' &&
+    assert_contains "$OUTPUT_FILE" 'ArgoCD Application: argo/app-klicker'; then
+    pass 'ambient variables cannot redefine the checked-in target contract'
+  else
+    fail 'ambient variables cannot redefine the checked-in target contract'
+  fi
+}
+
+test_tls_guard() {
+  new_case tls-guard
+  local STG_DATABASE_URL_OVERRIDE
+  STG_DATABASE_URL_OVERRIDE="$(stg_database_url | sed 's/?sslmode=require&schema=public//')"
+  if ! run_refresh && assert_contains "$OUTPUT_FILE" 'must set sslmode='; then
+    pass 'database URLs without an approved TLS mode fail closed'
+  else
+    fail 'database URLs without an approved TLS mode fail closed'
+  fi
+}
+
+test_cluster_guard() {
+  new_case cluster-guard
+  if ! FAKE_CLUSTER_MISMATCH=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'does not match expected STG cluster' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'mutable context alias cannot bypass immutable cluster identity'
+  else
+    fail 'mutable context alias cannot bypass immutable cluster identity'
+  fi
+}
+
+test_rbac_guard() {
+  new_case rbac-guard
+  if ! FAKE_RBAC_DENY=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Kubernetes permission denied' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'missing write RBAC fails before the dump'
+  else
+    fail 'missing write RBAC fails before the dump'
+  fi
+}
+
+test_migrator_guard() {
+  new_case migrator-guard
+  if ! FAKE_MIGRATOR_MISMATCH=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Migrator Secret database' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'migrator Secret must target the exact restore database'
+  else
+    fail 'migrator Secret must target the exact restore database'
+  fi
+}
+
+test_active_lease() {
+  new_case active-lease
+  jq -n --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+    {
+      metadata: {name: "app-klicker-prd-to-stg-refresh", resourceVersion: "7"},
+      spec: {
+        holderIdentity: "another-refresh",
+        acquireTime: $now,
+        renewTime: $now,
+        leaseDurationSeconds: 120
+      }
+    }
+  ' >"$FAKE_LEASE_FILE"
+  if ! run_live && assert_contains "$OUTPUT_FILE" 'held by another active run' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'an active refresh Lease fences concurrent runs'
+  else
+    fail 'an active refresh Lease fences concurrent runs'
+  fi
+}
+
+test_storage_headroom() {
+  new_case storage-headroom
+  if ! FAKE_STORAGE_LOW=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'free storage is less than' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'fresh Azure storage metrics must provide restore and WAL headroom'
+  else
+    fail 'fresh Azure storage metrics must provide restore and WAL headroom'
+  fi
+}
+
+test_lease_loss() {
+  new_case lease-loss
+  if ! FAKE_LEASE_LOSS=true run_live &&
+    assert_contains "$OUTPUT_FILE" 'Lease ownership was lost' &&
+    [[ "$(deployment_replicas backend 1)" == 1 ]] &&
+    [[ "$(deployment_replicas worker 2)" == 2 ]] &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == automated ]] &&
+    assert_not_contains "$FAKE_LOG" 'psql reset target'; then
+    pass 'Lease loss stops mutation and compensates pre-mutation state'
+  else
+    fail 'Lease loss stops mutation and compensates pre-mutation state'
+  fi
+}
+
+test_competing_sync() {
+  new_case competing-sync
+  if ! FAKE_COMPETING_SYNC=true run_live &&
+    assert_contains "$OUTPUT_FILE" 'competing ArgoCD operation appeared' &&
+    [[ "$(deployment_replicas backend 1)" == 1 ]] &&
+    [[ "$(deployment_replicas worker 2)" == 2 ]] &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == automated ]] &&
+    assert_not_contains "$FAKE_LOG" 'psql reset target'; then
+    pass 'a competing manual sync is rejected before database mutation'
+  else
+    fail 'a competing manual sync is rejected before database mutation'
+  fi
+}
+
+test_infisical() {
+  new_case infisical
+  if PRD_DATABASE_URL_OVERRIDE= STG_DATABASE_URL_OVERRIDE= \
+    BACKUP_ENCRYPTION_KEY_OVERRIDE= run_live &&
+    assert_contains "$FAKE_LOG" 'DIRECT_DATABASE_URL from prd' &&
+    assert_contains "$FAKE_LOG" 'DIRECT_DATABASE_URL from stg' &&
+    assert_contains "$FAKE_LOG" 'BACKUP_ENCRYPTION_KEY from prd'; then
+    pass 'credentials load from the self-hosted Infisical project'
+  else
+    fail 'credentials load from the self-hosted Infisical project'
+  fi
+}
+
+test_success() {
+  new_case success
+  if run_live && [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == automated ]] &&
+    [[ -f "$REFRESH_DIR/test-run/after.json" ]] &&
+    [[ ! -e "$REFRESH_DIR/test-run/prd.dump.gpg" ]] &&
+    jq -e '.terminalSuccess == true and
+      .argocd.originalPolicyRestored == true and
+      .argocd.health == "Healthy" and
+      (.argocd.migratorImageId | test("@sha256:[0-9a-f]{64}$")) and
+      .argocd.migratorJobUid == "synthetic-new-job-uid" and
+      .argocd.migratorPodUid == "synthetic-migrator-pod-uid" and
+      (.argocd.revision | length) == 40' \
+      "$REFRESH_DIR/test-run/after.json" >/dev/null &&
+    jq -s -e 'all(.[];
+      .governance.rawPrdDataApprovalRef == "TEST-APPROVAL-REF" and
+      .governance.stgOutboundIntegrationsIsolated == true)' \
+      "$REFRESH_DIR/test-run/state.json" \
+      "$REFRESH_DIR/test-run/before.json" \
+      "$REFRESH_DIR/test-run/after.json" >/dev/null &&
+    jq -e '
+      .metadata.annotations["klicker.uzh.ch/raw-data-approval-ref"] ==
+        "TEST-APPROVAL-REF" and
+      .metadata.annotations["klicker.uzh.ch/outbound-integrations-isolated"] ==
+        "true"' "$FAKE_LEASE_FILE" >/dev/null &&
+    [[ "$(jq -c '.spec.syncWindows' "$FAKE_PROJECT_FILE")" == '[]' ]] &&
+    assert_before "$FAKE_LOG" 'pg_dump source' 'kubectl app policy manual' &&
+    assert_before "$FAKE_LOG" 'psql reset target' 'pg_restore target' &&
+    assert_before "$FAKE_LOG" 'pg_restore target' 'kubectl app sync hook' &&
+    assert_contains "$OUTPUT_FILE" 'refresh completed successfully' &&
+    assert_contains "$OUTPUT_FILE" \
+      'Application-level validation is still required before STG is declared usable'; then
+    pass 'successful refresh reaches health and writes a terminal receipt'
+  else
+    fail 'successful refresh reaches health and writes a terminal receipt'
+  fi
+}
+
+test_atomic_sync_submission_race() {
+  new_case sync-cas-race
+  if ! FAKE_CAS_RACE=true run_live &&
+    assert_contains "$OUTPUT_FILE" 'Could not atomically submit' &&
+    [[ ! -e "$REFRESH_DIR/test-run/after.json" ]] &&
+    jq -e '.maintenanceFenceActive == true and .cleanupIncomplete == false' \
+      "$REFRESH_DIR/test-run/state.json" >/dev/null; then
+    pass 'Argo sync submission fails closed on a resource-version race'
+  else
+    fail 'Argo sync submission fails closed on a resource-version race'
+  fi
+}
+
+test_stale_migrator_evidence() {
+  new_case stale-migrator
+  if ! FAKE_STALE_MIGRATOR_EVIDENCE=true run_live &&
+    assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'without evidence from a new migrator Pod'; then
+    pass 'a retained migrator Job cannot satisfy this run evidence'
+  else
+    fail 'a retained migrator Job cannot satisfy this run evidence'
+  fi
+}
+
+test_wrong_migrator_digest() {
+  new_case wrong-migrator-digest
+  if ! FAKE_WRONG_MIGRATOR_DIGEST=true run_live &&
+    assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'immutable image digest'; then
+    pass 'migrator evidence requires the executed immutable image digest'
+  else
+    fail 'migrator evidence requires the executed immutable image digest'
+  fi
+}
+
+test_partial_scale_failure() {
+  new_case partial-scale
+  if ! FAKE_PARTIAL_SCALE_FAIL=true run_live &&
+    [[ "$(deployment_replicas backend 1)" == 1 ]] &&
+    [[ "$(deployment_replicas worker 2)" == 2 ]] &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == automated ]] &&
+    assert_not_contains "$FAKE_LOG" 'psql reset target'; then
+    pass 'partial pre-mutation scaling is compensated'
+  else
+    fail 'partial pre-mutation scaling is compensated'
+  fi
+}
+
+assert_fail_safe_failure() {
+  [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == manual ]] &&
+    [[ "$(deployment_replicas backend 1)" == 0 ]] &&
+    [[ "$(deployment_replicas worker 2)" == 0 ]] &&
+    [[ ! -e "$REFRESH_DIR/test-run/after.json" ]] &&
+    assert_contains "$OUTPUT_FILE" 'Verified fail-safe maintenance'
+}
+
+test_restore_failure() {
+  new_case restore-failure
+  if ! FAKE_PG_RESTORE_FAIL=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'STG pg_restore failed' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app sync hook'; then
+    pass 'restore failure leaves STG in fail-safe maintenance'
+  else
+    fail 'restore failure leaves STG in fail-safe maintenance'
+  fi
+}
+
+test_argocd_failure() {
+  new_case argocd-failure
+  if ! FAKE_ARGO_SYNC_FAIL=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'PreSync migration hook failed'; then
+    pass 'migration-hook failure forces every selected workload to zero'
+  else
+    fail 'migration-hook failure forces every selected workload to zero'
+  fi
+}
+
+test_cleanup_fence_api_failure() {
+  new_case cleanup-fence-failure
+  if ! FAKE_ARGO_SYNC_FAIL=true FAKE_CLEANUP_FENCE_FAIL=true run_live &&
+    jq -e '.cleanupIncomplete == true and .phase == "cleanup-incomplete"' \
+      "$REFRESH_DIR/test-run/state.json" >/dev/null &&
+    [[ "$(jq -r '.spec.holderIdentity' "$FAKE_LEASE_FILE")" == \
+      prd-to-stg-refresh-test-run ]] &&
+    assert_contains "$OUTPUT_FILE" 'STG safety could not be fully proven' &&
+    assert_not_contains "$OUTPUT_FILE" 'Verified fail-safe maintenance:'; then
+    pass 'cleanup records incomplete state when the maintenance fence API fails'
+  else
+    fail 'cleanup records incomplete state when the maintenance fence API fails'
+  fi
+}
+
+test_cleanup_scale_api_failure() {
+  new_case cleanup-scale-failure
+  if ! FAKE_ARGO_SYNC_FAIL=true FAKE_CLEANUP_SCALE_FAIL=true run_live &&
+    jq -e '.cleanupIncomplete == true and .maintenanceFenceActive == true' \
+      "$REFRESH_DIR/test-run/state.json" >/dev/null &&
+    [[ "$(jq -r '.spec.holderIdentity' "$FAKE_LEASE_FILE")" == \
+      prd-to-stg-refresh-test-run ]] &&
+    assert_contains "$OUTPUT_FILE" 'STG safety could not be fully proven'; then
+    pass 'cleanup records incomplete state when workload shutdown cannot be proven'
+  else
+    fail 'cleanup records incomplete state when workload shutdown cannot be proven'
+  fi
+}
+
+test_post_mutation_workload_drift() {
+  new_case cleanup-workload-drift
+  if ! FAKE_ARGO_SYNC_FAIL=true FAKE_POST_MUTATION_WORKLOAD_DRIFT=true run_live &&
+    jq -e '.cleanupIncomplete == true and .phase == "cleanup-incomplete"' \
+      "$REFRESH_DIR/test-run/state.json" >/dev/null &&
+    [[ "$(jq -r '.spec.holderIdentity' "$FAKE_LEASE_FILE")" == \
+      prd-to-stg-refresh-test-run ]] &&
+    assert_contains "$OUTPUT_FILE" 'backend has not reached zero desired and running replicas' &&
+    assert_contains "$OUTPUT_FILE" 'STG safety could not be fully proven' &&
+    assert_not_contains "$OUTPUT_FILE" 'Verified fail-safe maintenance:'; then
+    pass 'cleanup verifies receipt-bound workloads after selector-label drift'
+  else
+    fail 'cleanup verifies receipt-bound workloads after selector-label drift'
+  fi
+}
+
+test_post_sync_metadata_failure() {
+  new_case metadata-failure
+  if ! FAKE_POST_SYNC_METADATA_FAIL=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'Could not read STG database metadata'; then
+    pass 'post-sync metadata failure cannot leave workloads running'
+  else
+    fail 'post-sync metadata failure cannot leave workloads running'
+  fi
+}
+
+test_policy_restore_failure() {
+  new_case policy-failure
+  if ! FAKE_POLICY_RESTORE_FAIL=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'entering fail-safe cleanup'; then
+    pass 'policy-restore failure cannot create a terminal receipt'
+  else
+    fail 'policy-restore failure cannot create a terminal receipt'
+  fi
+}
+
+test_migration_divergence() {
+  new_case migration-divergence
+  if ! FAKE_MIGRATION_DIVERGENCE=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'does not preserve the exact PRD migration-name/checksum prefix'; then
+    pass 'equal-count or extended divergent migration history is rejected'
+  else
+    fail 'equal-count or extended divergent migration history is rejected'
+  fi
+}
+
+test_argocd_timeout() {
+  new_case argocd-timeout
+  if ! FAKE_ARGO_TIMEOUT=true run_live && assert_fail_safe_failure &&
+    assert_contains "$FAKE_LOG" 'kubectl app operation terminated' &&
+    assert_contains "$OUTPUT_FILE" 'reached terminal phase' &&
+    assert_contains "$OUTPUT_FILE" 'was terminated'; then
+    pass 'Argo timeout terminates and drains the owned operation before return'
+  else
+    fail 'Argo timeout terminates and drains the owned operation before return'
+  fi
+}
+
+test_health_failure() {
+  new_case health-failure
+  if ! FAKE_HEALTH_FAIL=true run_live && assert_fail_safe_failure &&
+    assert_contains "$OUTPUT_FILE" 'Timed out waiting for ArgoCD Synced/Healthy'; then
+    pass 'post-sync health failure returns STG to fail-safe maintenance'
+  else
+    fail 'post-sync health failure returns STG to fail-safe maintenance'
+  fi
+}
+
+test_post_policy_operation() {
+  new_case post-policy-operation
+  if ! FAKE_POST_POLICY_OPERATION=true run_live &&
+    [[ ! -e "$REFRESH_DIR/test-run/after.json" ]] &&
+    assert_contains "$OUTPUT_FILE" 'Timed out waiting for ArgoCD Synced/Healthy'; then
+    pass 'terminal receipt is withheld when policy restoration starts another operation'
+  else
+    fail 'terminal receipt is withheld when policy restoration starts another operation'
+  fi
+}
+
+test_resume() {
+  new_case resume
+  write_failed_run_receipt previous-failure
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+  printf '%s' 0 >"$FAKE_STATE_DIR/backend.replicas"
+  printf '%s' 0 >"$FAKE_STATE_DIR/worker.replicas"
+  local RESUME_FAILED_RUN_ID_OVERRIDE=previous-failure
+  local RUN_ID_OVERRIDE=resume-run
+  if run_live && [[ -f "$REFRESH_DIR/resume-run/after.json" ]] &&
+    jq -e '.resumedFromRunId == "previous-failure"' \
+      "$REFRESH_DIR/resume-run/before.json" >/dev/null &&
+    assert_contains "$OUTPUT_FILE" 'Resuming fail-safe maintenance'; then
+    pass 'receipt-bound resume restores and verifies the target'
+  else
+    fail 'receipt-bound resume restores and verifies the target'
+  fi
+}
+
+test_resume_rejects_running() {
+  new_case resume-running
+  write_failed_run_receipt previous-failure
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+  local RESUME_FAILED_RUN_ID_OVERRIDE=previous-failure
+  if ! run_refresh && assert_contains "$OUTPUT_FILE" 'Cannot resume while any selected' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'resume refuses any running selected workload'
+  else
+    fail 'resume refuses any running selected workload'
+  fi
+}
+
+test_prd_connection_failure() {
+  new_case prd-connection
+  if ! FAKE_PSQL_CONNECT_FAIL=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Could not read PRD database metadata' &&
+    assert_not_contains "$OUTPUT_FILE" "unexpected database ''"; then
+    pass 'PRD connection errors fail without misleading metadata'
+  else
+    fail 'PRD connection errors fail without misleading metadata'
+  fi
+}
+
+test_help
+test_dry_run
+test_confirmation_gate
+test_raw_data_approval_gate
+test_raw_data_approval_format
+test_outbound_isolation_gate
+test_wrong_database
+test_target_contract_ignores_ambient_overrides
+test_tls_guard
+test_cluster_guard
+test_rbac_guard
+test_migrator_guard
+test_active_lease
+test_storage_headroom
+test_lease_loss
+test_competing_sync
+test_infisical
+test_success
+test_atomic_sync_submission_race
+test_stale_migrator_evidence
+test_wrong_migrator_digest
+test_partial_scale_failure
+test_restore_failure
+test_argocd_failure
+test_cleanup_fence_api_failure
+test_cleanup_scale_api_failure
+test_post_mutation_workload_drift
+test_post_sync_metadata_failure
+test_policy_restore_failure
+test_migration_divergence
+test_argocd_timeout
+test_health_failure
+test_post_policy_operation
+test_resume
+test_resume_rejects_running
+test_prd_connection_failure
+
+printf '1..%s\n' "$TEST_COUNT"
+(( FAIL_COUNT == 0 ))

--- a/util/backup/tests/refresh-stg-from-prd/fakes.sh
+++ b/util/backup/tests/refresh-stg-from-prd/fakes.sh
@@ -1,0 +1,571 @@
+# Sourced by refresh-stg-from-prd.test.sh and its fake-tool symlinks.
+# Contract: provides deterministic URL fixtures and fake external command
+# implementations. It reads only FAKE_* state paths supplied by the harness.
+
+prd_database_url() {
+  printf '%s://%s:%s@%s:%s/%s?sslmode=require&schema=public' \
+    postgresql prd-user synthetic \
+    db-server-prd-apps.postgres.database.azure.com 6432 klicker-prod-prd
+}
+
+stg_database_url() {
+  local database="${1:-klicker-qa-stg}"
+  local user="${2:-stg-user}"
+  printf '%s://%s:%s@%s:%s/%s?sslmode=require&schema=public' \
+    postgresql "$user" synthetic \
+    db-server-stg-apps.postgres.database.azure.com 6432 "$database"
+}
+
+migration_history() {
+  printf '%s\n%s' \
+    '20260101000000_initial|checksum-initial' \
+    '20260202000000_feature|checksum-feature'
+}
+
+fake_log() {
+  printf '%s\n' "$*" >>"$FAKE_LOG"
+}
+
+fake_infisical() {
+  [[ " $* " == *" --domain=https://inf.prd.df-app.ch/api "* ]] || return 2
+  [[ " $* " == *" --projectId=d071be96-5136-4f23-a6cb-e0c7f9b9a6c8 "* ]] \
+    || return 2
+
+  local secret_name="${3:-}" environment="" argument
+  for argument in "$@"; do
+    [[ "$argument" == --env=* ]] && environment="${argument#--env=}"
+  done
+  fake_log "infisical get $secret_name from $environment via self-hosted project"
+  case "$secret_name:$environment" in
+    DIRECT_DATABASE_URL:prd) prd_database_url ;;
+    DIRECT_DATABASE_URL:stg) stg_database_url ;;
+    BACKUP_ENCRYPTION_KEY:prd) printf '%s' synthetic-test-key ;;
+    *) return 2 ;;
+  esac
+}
+
+fake_az() {
+  if [[ " $* " == *" postgres flexible-server show "* ]]; then
+    jq -cn '{
+      id: "/subscriptions/synthetic/resourceGroups/DF_Klicker_RG/providers/Microsoft.DBforPostgreSQL/flexibleServers/db-server-stg-apps",
+      name: "db-server-stg-apps",
+      fullyQualifiedDomainName: "db-server-stg-apps.postgres.database.azure.com",
+      storage: {storageSizeGb: 32}
+    }'
+  elif [[ " $* " == *" monitor metrics list "* ]]; then
+    local free_bytes=21474836480
+    [[ "${FAKE_STORAGE_LOW:-false}" != true ]] || free_bytes=1048576
+    local measured_at
+    measured_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    jq -cn \
+      --arg measuredAt "$measured_at" \
+      --argjson free "$free_bytes" '{value: [
+        {
+          name: {value: "storage_used"},
+          unit: "Bytes",
+          timeseries: [{data: [{maximum: 10737418240, timeStamp: $measuredAt}]}]
+        },
+        {
+          name: {value: "storage_free"},
+          unit: "Bytes",
+          timeseries: [{data: [{maximum: $free, minimum: $free, timeStamp: $measuredAt}]}]
+        },
+        {
+          name: {value: "txlogs_storage_used"},
+          unit: "Bytes",
+          timeseries: [{data: [{maximum: 1073741824, timeStamp: $measuredAt}]}]
+        }
+      ]}'
+  else
+    return 2
+  fi
+}
+
+deployment_replicas() {
+  local name="$1"
+  local default_replicas="$2"
+  local file="$FAKE_STATE_DIR/$name.replicas"
+  if [[ -f "$file" ]]; then
+    printf '%s' "$(<"$file")"
+  else
+    printf '%s' "$default_replicas"
+  fi
+}
+
+fake_deployments_json() {
+  local backend worker backend_ready worker_ready
+  backend="$(deployment_replicas backend 1)"
+  worker="$(deployment_replicas worker 2)"
+  backend_ready="$backend"
+  worker_ready="$worker"
+  if [[ "${FAKE_HEALTH_FAIL:-false}" == "true" && -f "$FAKE_SYNCED_FILE" ]]; then
+    backend_ready=0
+  fi
+  local deployments_json
+  deployments_json="$(jq -cn \
+    --argjson backend "$backend" --argjson worker "$worker" \
+    --argjson backendReady "$backend_ready" --argjson workerReady "$worker_ready" '
+      {items: [
+        {
+          metadata: {namespace: "stg-klicker", name: "backend", generation: 1},
+          spec: {replicas: $backend},
+          status: {
+            replicas: $backendReady,
+            readyReplicas: $backendReady,
+            updatedReplicas: $backendReady,
+            availableReplicas: $backendReady,
+            observedGeneration: 1
+          }
+        },
+        {
+          metadata: {namespace: "stg-klicker", name: "worker", generation: 1},
+          spec: {replicas: $worker},
+          status: {
+            replicas: $workerReady,
+            readyReplicas: $workerReady,
+            updatedReplicas: $workerReady,
+            availableReplicas: $workerReady,
+            observedGeneration: 1
+          }
+        }
+      ]}
+    ')"
+  if [[ "${FAKE_POST_MUTATION_WORKLOAD_DRIFT:-false}" == true &&
+    -f "$FAKE_SYNCED_FILE" ]]; then
+    jq -c '.items |= map(select(.metadata.name != "backend"))' \
+      <<<"$deployments_json"
+  else
+    printf '%s\n' "$deployments_json"
+  fi
+}
+
+fake_deployment_json() {
+  local name="$1" default_replicas desired running
+  case "$name" in
+    backend) default_replicas=1 ;;
+    worker) default_replicas=2 ;;
+    *) return 1 ;;
+  esac
+  desired="$(deployment_replicas "$name" "$default_replicas")"
+  running="$desired"
+  if [[ "${FAKE_POST_MUTATION_WORKLOAD_DRIFT:-false}" == true &&
+    -f "$FAKE_SYNCED_FILE" && "$name" == backend ]]; then
+    running=1
+  fi
+  jq -cn \
+    --arg name "$name" \
+    --argjson desired "$desired" \
+    --argjson running "$running" '{
+      metadata: {namespace: "stg-klicker", name: $name, generation: 1},
+      spec: {replicas: $desired},
+      status: {
+        replicas: $running,
+        readyReplicas: $running,
+        updatedReplicas: $running,
+        availableReplicas: $running,
+        observedGeneration: 1
+      }
+    }'
+}
+
+fake_argocd_application_json() {
+  local policy automated initiator="" phase="Succeeded" message="success"
+  local active_operation='null' sync_revision health_status="Healthy"
+  policy="$(<"$FAKE_ARGO_POLICY_FILE")"
+  automated='null'
+  if [[ "$policy" == automated ]]; then
+    automated='{"prune":true,"selfHeal":true,"allowEmpty":false}'
+  fi
+  [[ ! -f "$FAKE_OPERATION_FILE" ]] || initiator="$(<"$FAKE_OPERATION_FILE")"
+  sync_revision='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+  if [[ -z "$initiator" && "${FAKE_COMPETING_SYNC:-false}" == true &&
+    "$policy" == manual ]]; then
+    initiator=another-operator
+    phase=Running
+    message="synthetic competing operation"
+    active_operation="$(
+      jq -cn --arg initiator "$initiator" \
+        '{initiatedBy:{username:$initiator},sync:{syncStrategy:{hook:{}}}}'
+    )"
+  fi
+
+  if [[ "${FAKE_POST_POLICY_OPERATION:-false}" == true &&
+    "$policy" == automated && -f "$FAKE_SYNCED_FILE" ]]; then
+    initiator=post-policy-operator
+    phase=Running
+    message="synthetic operation after policy restoration"
+    active_operation="$(
+      jq -cn --arg initiator "$initiator" \
+        '{initiatedBy:{username:$initiator},sync:{syncStrategy:{hook:{}}}}'
+    )"
+  fi
+
+  if [[ -n "$initiator" ]]; then
+    if [[ "${FAKE_ARGO_TIMEOUT:-false}" == "true" && ! -f "$FAKE_TERMINATED_FILE" ]]; then
+      phase="Running"
+      message="synthetic long-running operation"
+      active_operation="$(
+        jq -cn --arg initiator "$initiator" \
+          '{initiatedBy:{username:$initiator},sync:{syncStrategy:{hook:{}}}}'
+      )"
+    elif [[ "${FAKE_ARGO_SYNC_FAIL:-false}" == "true" || -f "$FAKE_TERMINATED_FILE" ]]; then
+      phase="Failed"
+      message="synthetic migration failure"
+    fi
+  fi
+  [[ "${FAKE_HEALTH_FAIL:-false}" != "true" || -z "$initiator" ]] \
+    || health_status="Degraded"
+
+  jq -cn \
+    --argjson automated "$automated" \
+    --argjson operation "$active_operation" \
+    --arg initiator "$initiator" \
+    --arg phase "$phase" \
+    --arg message "$message" \
+    --arg revision "$sync_revision" \
+    --arg health "$health_status" '
+      {
+        metadata: {
+          uid: "9f936f7f-58ff-4a72-8c75-eb969ac3bd6f",
+          resourceVersion: "42"
+        },
+        spec: {
+          project: "stg-apps-klicker",
+          destination: {
+            server: "https://kubernetes.default.svc",
+            namespace: "stg-klicker"
+          },
+          source: {
+            repoURL: "https://github.com/uzh-bf/klicker-uzh.git",
+            targetRevision: "v3"
+          },
+          syncPolicy: {automated: $automated}
+        },
+        operation: $operation,
+        status: {
+          sync: {status: "Synced", revision: $revision},
+          health: {status: $health},
+          operationState: {
+            phase: $phase,
+            message: $message,
+            operation: {
+              initiatedBy: {username: $initiator},
+              sync: {syncStrategy: {hook: {}}}
+            },
+            syncResult: {revision: $revision}
+          }
+        }
+      }
+    '
+}
+
+extract_patch_payload() {
+  local expect=false argument
+  for argument in "$@"; do
+    if [[ "$expect" == true ]]; then
+      printf '%s' "$argument"
+      return
+    fi
+    [[ "$argument" == --patch ]] && expect=true
+  done
+  return 2
+}
+
+fake_kubectl() {
+  if [[ " $* " == *" config view --minify -o json "* ]]; then
+    local server_name=stg-apps-vhziuhfl.hcp.switzerlandnorth.azmk8s.io
+    [[ "${FAKE_CLUSTER_MISMATCH:-false}" != true ]] || server_name=wrong.example.test
+    jq -cn --arg name "$server_name" \
+      '{clusters:[{cluster:{"tls-server-name":$name,server:"https://127.0.0.1:6443"}}]}'
+  elif [[ " $* " == *" get namespace kube-system "* ]]; then
+    printf '%s\n' '{"metadata":{"uid":"207f1b0e-5ad7-4de6-94d1-2b4564a41fe7"}}'
+  elif [[ " $* " == *" get namespace stg-klicker "* ]]; then
+    printf '%s\n' '{"metadata":{"uid":"ae9b8ae9-d3df-4078-820d-1ef69d4cf816"}}'
+  elif [[ " $* " == *" auth can-i "* ]]; then
+    [[ "${FAKE_RBAC_DENY:-false}" != true ]] || return 1
+  elif [[ " $* " == *" get application.argoproj.io "* ]]; then
+    fake_argocd_application_json
+  elif [[ " $* " == *" get appproject.argoproj.io "* ]]; then
+    cat "$FAKE_PROJECT_FILE"
+  elif [[ " $* " == *" patch appproject.argoproj.io "* ]]; then
+    local patch_payload
+    patch_payload="$(extract_patch_payload "$@")"
+    local expected_resource_version current_resource_version windows
+    expected_resource_version="$(jq -r '.[0].value // ""' <<<"$patch_payload")"
+    current_resource_version="$(jq -r '.metadata.resourceVersion // ""' "$FAKE_PROJECT_FILE")"
+    [[ "$expected_resource_version" == "$current_resource_version" ]] || return 1
+    windows="$(jq -c '.[2].value' <<<"$patch_payload")"
+    if [[ "${FAKE_CLEANUP_FENCE_FAIL:-false}" == true &&
+      -f "$FAKE_SYNCED_FILE" && "$windows" != '[]' ]]; then
+      return 1
+    fi
+    jq --argjson windows "$windows" \
+      '.metadata.resourceVersion = ((.metadata.resourceVersion | tonumber) + 1 | tostring) |
+       .spec.syncWindows = $windows' \
+      "$FAKE_PROJECT_FILE" >"$FAKE_PROJECT_FILE.tmp"
+    mv -- "$FAKE_PROJECT_FILE.tmp" "$FAKE_PROJECT_FILE"
+    fake_log "kubectl appproject sync windows $(jq -c '.spec.syncWindows' "$FAKE_PROJECT_FILE")"
+  elif [[ " $* " == *" patch application.argoproj.io "* ]]; then
+    local patch_payload
+    patch_payload="$(extract_patch_payload "$@")"
+    if jq -e 'type == "array"' >/dev/null <<<"$patch_payload"; then
+      if [[ " $* " == *" --subresource=status "* ]]; then
+        : >"$FAKE_TERMINATED_FILE"
+        fake_log 'kubectl app operation terminated'
+      else
+        [[ "${FAKE_CAS_RACE:-false}" != true ]] || return 1
+        [[ "$(jq -r '.[0].value // ""' <<<"$patch_payload")" == 42 ]] || return 2
+        [[ "$(jq -r '.[2].value.sync.revision // ""' <<<"$patch_payload")" == \
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]] || return 2
+        jq -r '.[2].value.initiatedBy.username' <<<"$patch_payload" \
+          >"$FAKE_OPERATION_FILE"
+        : >"$FAKE_SYNCED_FILE"
+        printf '%s' 1 >"$FAKE_STATE_DIR/backend.replicas"
+        printf '%s' 2 >"$FAKE_STATE_DIR/worker.replicas"
+        fake_log 'kubectl app sync hook atomic'
+      fi
+    elif jq -e '.operation.sync != null' >/dev/null <<<"$patch_payload"; then
+      return 2
+    elif jq -e '.spec.syncPolicy | has("automated")' >/dev/null \
+      <<<"$patch_payload"; then
+      local automated
+      automated="$(jq -c '.spec.syncPolicy.automated' <<<"$patch_payload")"
+      if [[ "$automated" == null ]]; then
+        printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+        fake_log 'kubectl app policy manual'
+      else
+        if [[ "${FAKE_POLICY_RESTORE_FAIL:-false}" == true && -f "$FAKE_SYNCED_FILE" ]]; then
+          return 1
+        fi
+        printf '%s' automated >"$FAKE_ARGO_POLICY_FILE"
+        fake_log "kubectl app policy automated $automated"
+      fi
+    else
+      return 2
+    fi
+  elif [[ " $* " == *" get secret "* ]]; then
+    local database=klicker-qa-stg
+    [[ "${FAKE_MIGRATOR_MISMATCH:-false}" != true ]] || database=wrong-stg
+    stg_database_url "$database" migrator-user | base64 | tr -d '\n'
+  elif [[ " $* " == *" get deployments "* ]]; then
+    fake_deployments_json
+  elif [[ " $* " == *" get deployment/"* ]]; then
+    local argument deployment_name=""
+    for argument in "$@"; do
+      [[ "$argument" == deployment/* ]] && deployment_name="${argument#deployment/}"
+    done
+    [[ -n "$deployment_name" ]] || return 2
+    fake_deployment_json "$deployment_name"
+  elif [[ " $* " == *" scale deployment/"* ]]; then
+    local argument name="" replicas=""
+    for argument in "$@"; do
+      [[ "$argument" == deployment/* ]] && name="${argument#deployment/}"
+      [[ "$argument" == --replicas=* ]] && replicas="${argument#--replicas=}"
+    done
+    [[ -n "$name" && -n "$replicas" ]] || return 2
+    if [[ "${FAKE_CLEANUP_SCALE_FAIL:-false}" == true &&
+      -f "$FAKE_SYNCED_FILE" && "$replicas" == 0 ]]; then
+      return 1
+    fi
+    if [[ "${FAKE_PARTIAL_SCALE_FAIL:-false}" == true && "$name" == worker && "$replicas" == 0 ]]; then
+      return 1
+    fi
+    printf '%s' "$replicas" >"$FAKE_STATE_DIR/$name.replicas"
+    fake_log "kubectl scale $name=$replicas"
+  elif [[ " $* " == *" get pods "*" --watch "* ]]; then
+    local attempt
+    for attempt in {1..100}; do
+      [[ ! -f "$FAKE_SYNCED_FILE" ]] || break
+      sleep 0.02
+    done
+    [[ -f "$FAKE_SYNCED_FILE" ]] || return 0
+    local evidence_job_uid=synthetic-new-job-uid
+    local evidence_image_id=ghcr.io/uzh-bf/klicker-uzh/backend-docker-migrator-arm@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    [[ "${FAKE_STALE_MIGRATOR_EVIDENCE:-false}" != true ]] \
+      || evidence_job_uid=synthetic-stale-job-uid
+    [[ "${FAKE_WRONG_MIGRATOR_DIGEST:-false}" != true ]] \
+      || evidence_image_id=ghcr.io/uzh-bf/klicker-uzh/backend-docker-migrator-arm@sha256:not-a-digest
+    jq -cn --arg jobUid "$evidence_job_uid" --arg imageId "$evidence_image_id" '{
+      type: "MODIFIED",
+      object: {
+        metadata: {
+          uid: "synthetic-migrator-pod-uid",
+          ownerReferences: [{kind: "Job", name: "app-klicker-klicker-uzh-v2-migrate", uid: $jobUid}]
+        },
+        spec: {containers: [{name: "migrate", image: "ghcr.io/uzh-bf/klicker-uzh/backend-docker-migrator-arm:v3"}]},
+        status: {containerStatuses: [{name: "migrate", imageID: $imageId}]}
+      }
+    }'
+  elif [[ " $* " == *" get job "* ]]; then
+    if [[ ! -f "$FAKE_SYNCED_FILE" ]]; then
+      [[ "${FAKE_STALE_MIGRATOR_EVIDENCE:-false}" == true ]] || return 0
+      printf '%s\n' '{"metadata":{"uid":"synthetic-stale-job-uid"}}'
+      return 0
+    fi
+    printf '%s\n' '{"metadata":{"uid":"synthetic-new-job-uid"}}'
+  elif [[ " $* " == *" get lease.coordination.k8s.io "* ]]; then
+    if [[ -f "$FAKE_LEASE_FILE" ]]; then
+      local lease_reads=0
+      [[ ! -f "$FAKE_LEASE_READS_FILE" ]] \
+        || lease_reads="$(<"$FAKE_LEASE_READS_FILE")"
+      lease_reads=$((lease_reads + 1))
+      printf '%s' "$lease_reads" >"$FAKE_LEASE_READS_FILE"
+      if [[ "${FAKE_LEASE_LOSS:-false}" == true && "$lease_reads" -ge 4 ]]; then
+        jq '.spec.holderIdentity = "another-refresh"' "$FAKE_LEASE_FILE"
+      else
+        cat "$FAKE_LEASE_FILE"
+      fi
+    fi
+  elif [[ " $* " == *" create -f - "* || " $* " == *" replace -f - "* ]]; then
+    cat >"$FAKE_LEASE_FILE"
+    fake_log 'kubectl lease write'
+  else
+    return 2
+  fi
+}
+
+fake_pg_dump() {
+  if [[ "${1:-}" == --version ]]; then
+    printf '%s\n' 'pg_dump (PostgreSQL) 17.4'
+    return
+  fi
+  [[ "${PGHOST:-}" == db-server-prd-apps.postgres.database.azure.com ]] || return 2
+  [[ "${PGPORT:-}" == 6432 && "${PGDATABASE:-}" == klicker-prod-prd ]] || return 2
+  fake_log 'pg_dump source'
+  printf '%s\n' 'synthetic custom archive'
+}
+
+fake_gpg() {
+  if [[ " $* " == *" --decrypt "* ]]; then
+    fake_log 'gpg decrypt'
+    cat "${*: -1}"
+    return
+  fi
+  local output="" expect=false argument
+  for argument in "$@"; do
+    if [[ "$expect" == true ]]; then
+      output="$argument"
+      expect=false
+    elif [[ "$argument" == --output ]]; then
+      expect=true
+    fi
+  done
+  [[ -n "$output" ]] || return 2
+  fake_log 'gpg encrypt'
+  cat >"$output"
+}
+
+fake_pg_restore() {
+  if [[ "${1:-}" == --version ]]; then
+    printf '%s\n' 'pg_restore (PostgreSQL) 17.4'
+    return
+  fi
+  if [[ " $* " == *" --list "* ]]; then
+    cat >/dev/null
+    printf '%s\n' \
+      '; synthetic archive catalog' \
+      '5; 2615 2200 SCHEMA - public prd-user' \
+      '100; 0 0 COMMENT - SCHEMA public prd-user' \
+      '200; 1259 12345 TABLE public Example prd-user'
+    fake_log 'pg_restore list'
+    return
+  fi
+  [[ "${PGHOST:-}" == db-server-stg-apps.postgres.database.azure.com ]] || return 2
+  [[ "${PGPORT:-}" == 6432 && "${PGDATABASE:-}" == klicker-qa-stg ]] || return 2
+  [[ " $* " == *" --dbname=klicker-qa-stg "* ]] || return 2
+  cat >/dev/null
+  [[ "${FAKE_PG_RESTORE_FAIL:-false}" != true ]] || return 1
+  : >"$FAKE_RESTORED_FILE"
+  fake_log 'pg_restore target database=klicker-qa-stg'
+}
+
+fake_psql() {
+  if [[ "${FAKE_PSQL_CONNECT_FAIL:-false}" == true &&
+    "${PGHOST:-}" == db-server-prd-apps.postgres.database.azure.com ]]; then
+    printf '%s\n' 'psql: error: synthetic connection failure' >&2
+    return 2
+  fi
+  [[ "${PGPORT:-}" == 6432 ]] || return 2
+
+  if [[ " $* " == *" klicker_database_identity "* ]]; then
+    if [[ "${PGDATABASE:-}" == klicker-prod-prd ]]; then
+      printf '%s\n' 'klicker-prod-prd|101|170000|10.0.0.1|6432'
+    elif [[ "${PGDATABASE:-}" == klicker-qa-stg ]]; then
+      printf '%s\n' 'klicker-qa-stg|202|170000|10.0.0.2|6432'
+    else
+      printf '%s|999|170000|10.0.0.2|6432\n' "${PGDATABASE:-}"
+    fi
+    return
+  fi
+
+  if [[ " $* " == *" klicker_migration_history "* ]]; then
+    if [[ "${PGDATABASE:-}" == klicker-prod-prd || ! -f "$FAKE_SYNCED_FILE" ]]; then
+      migration_history
+    elif [[ "${FAKE_MIGRATION_DIVERGENCE:-false}" == true ]]; then
+      printf '%s\n%s\n%s' \
+        '20260101000000_initial|checksum-initial' \
+        '20260202000000_feature|different-checksum' \
+        '20260303000000_new|checksum-new'
+    else
+      migration_history
+      printf '\n%s' '20260303000000_new|checksum-new'
+    fi
+    return
+  fi
+
+  if [[ " $* " == *" klicker_stg_reset_capabilities "* ]]; then
+    printf '%s\n' 'klicker-qa-stg|stg-user|azure_pg_admin|t|253|0|0|0|0'
+    return
+  fi
+  if [[ " $* " == *"reset-stg-owned-objects.sql "* ]]; then
+    fake_log 'psql reset target'
+    return
+  fi
+
+  if [[ "${PGDATABASE:-}" == klicker-prod-prd ]]; then
+    if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+      printf '%s\n' 'klicker-prod-prd|170000|1048576|200|1|0|0'
+    elif [[ " $* " == *" klicker_database_metadata_migrations "* ]]; then
+      printf '%s\n' '2|0'
+    else
+      return 2
+    fi
+    return
+  fi
+  [[ "${PGDATABASE:-}" == klicker-qa-stg ]] || return 2
+  if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+    if [[ "${FAKE_POST_SYNC_METADATA_FAIL:-false}" == true && -f "$FAKE_SYNCED_FILE" ]]; then
+      return 2
+    elif [[ -f "$FAKE_SYNCED_FILE" ]]; then
+      printf '%s\n' 'klicker-qa-stg|170000|1100000|205|1|0|0'
+    elif [[ -f "$FAKE_RESTORED_FILE" ]]; then
+      printf '%s\n' 'klicker-qa-stg|170000|1048576|200|1|0|0'
+    else
+      printf '%s\n' 'klicker-qa-stg|170000|524288|190|1|0|0'
+    fi
+  elif [[ " $* " == *" klicker_database_metadata_migrations "* ]]; then
+    if [[ -f "$FAKE_SYNCED_FILE" ]]; then
+      printf '%s\n' '3|0'
+    elif [[ -f "$FAKE_RESTORED_FILE" ]]; then
+      printf '%s\n' '2|0'
+    else
+      printf '%s\n' '1|0'
+    fi
+  else
+    return 2
+  fi
+}
+
+dispatch_fake_tool() {
+  case "$(basename "$0")" in
+    az) fake_az "$@" ;;
+    gpg) fake_gpg "$@" ;;
+    infisical) fake_infisical "$@" ;;
+    kubectl) fake_kubectl "$@" ;;
+    pg_dump) fake_pg_dump "$@" ;;
+    pg_restore) fake_pg_restore "$@" ;;
+    psql) fake_psql "$@" ;;
+    *) return 2 ;;
+  esac
+}

--- a/util/backup/tests/refresh-stg-from-prd/fakes.sh
+++ b/util/backup/tests/refresh-stg-from-prd/fakes.sh
@@ -285,6 +285,10 @@ fake_kubectl() {
   elif [[ " $* " == *" auth can-i "* ]]; then
     [[ "${FAKE_RBAC_DENY:-false}" != true ]] || return 1
   elif [[ " $* " == *" get application.argoproj.io "* ]]; then
+    if [[ "${FAKE_ARGO_UNREADABLE_AFTER_SYNC:-false}" == true &&
+      -f "$FAKE_SYNCED_FILE" ]]; then
+      return 1
+    fi
     fake_argocd_application_json
   elif [[ " $* " == *" get appproject.argoproj.io "* ]]; then
     cat "$FAKE_PROJECT_FILE"
@@ -418,8 +422,26 @@ fake_kubectl() {
       fi
     fi
   elif [[ " $* " == *" create -f - "* || " $* " == *" replace -f - "* ]]; then
-    cat >"$FAKE_LEASE_FILE"
-    fake_log 'kubectl lease write'
+    local lease_payload lease_phase
+    lease_payload="$(cat)"
+    lease_phase="$(jq -r '.metadata.annotations["klicker.uzh.ch/refresh-phase"] // ""' \
+      <<<"$lease_payload")"
+    if [[ " $* " == *" replace -f - "* ]]; then
+      local failed_renewals_file="$FAKE_STATE_DIR/failed-lease-renewals"
+      local failed_renewals=0 requested_failures
+      [[ ! -f "$failed_renewals_file" ]] \
+        || failed_renewals="$(<"$failed_renewals_file")"
+      requested_failures="${FAKE_LEASE_RENEW_FAIL_COUNT:-0}"
+      local failure_phase="${FAKE_LEASE_RENEW_FAIL_PHASE:-}"
+      if [[ ( -z "$failure_phase" || "$lease_phase" == "$failure_phase" ) &&
+        ( "${FAKE_LEASE_RENEW_FAIL:-false}" == true ||
+          "$failed_renewals" -lt "$requested_failures" ) ]]; then
+        printf '%s' "$((failed_renewals + 1))" >"$failed_renewals_file"
+        return 1
+      fi
+    fi
+    printf '%s' "$lease_payload" >"$FAKE_LEASE_FILE"
+    fake_log "kubectl lease write phase=$lease_phase"
   else
     return 2
   fi
@@ -475,6 +497,9 @@ fake_pg_restore() {
   [[ "${PGPORT:-}" == 6432 && "${PGDATABASE:-}" == klicker-qa-stg ]] || return 2
   [[ " $* " == *" --dbname=klicker-qa-stg "* ]] || return 2
   cat >/dev/null
+  if [[ "${FAKE_SLOW_RESTORE:-false}" == true ]]; then
+    sleep 3
+  fi
   [[ "${FAKE_PG_RESTORE_FAIL:-false}" != true ]] || return 1
   : >"$FAKE_RESTORED_FILE"
   fake_log 'pg_restore target database=klicker-qa-stg'
@@ -515,7 +540,8 @@ fake_psql() {
   fi
 
   if [[ " $* " == *" klicker_stg_reset_capabilities "* ]]; then
-    printf '%s\n' 'klicker-qa-stg|stg-user|azure_pg_admin|t|253|0|0|0|0'
+    printf 'klicker-qa-stg|stg-user|azure_pg_admin|t|253|0|%s|0|0\n' \
+      "${FAKE_STG_UNSUPPORTED_OBJECT_COUNT:-0}"
     return
   fi
   if [[ " $* " == *"reset-stg-owned-objects.sql "* ]]; then

--- a/util/backup/tests/reset-stg-owned-objects.integration.sh
+++ b/util/backup/tests/reset-stg-owned-objects.integration.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESET_SQL="$(cd "$SCRIPT_DIR/.." && pwd)/reset-stg-owned-objects.sql"
+CONTAINER_NAME="klicker-refresh-reset-test-${RANDOM}-$$"
+POSTGRES_IMAGE="${POSTGRES_TEST_IMAGE:-postgres:17-alpine}"
+
+skip() {
+  printf '1..1\n'
+  printf 'ok 1 - owner-safe reset SQL integration # SKIP %s\n' "$1"
+  exit 0
+}
+
+command -v docker >/dev/null 2>&1 || skip 'docker is unavailable'
+docker info >/dev/null 2>&1 || skip 'docker daemon is unavailable'
+docker image inspect "$POSTGRES_IMAGE" >/dev/null 2>&1 \
+  || skip "$POSTGRES_IMAGE is not available locally (test does not pull images)"
+[[ -r "$RESET_SQL" ]] || {
+  printf 'not ok 1 - reset SQL is unreadable\n' >&2
+  exit 1
+}
+
+cleanup() {
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run --rm -d \
+  --name "$CONTAINER_NAME" \
+  -e POSTGRES_PASSWORD=synthetic-integration-password \
+  "$POSTGRES_IMAGE" >/dev/null
+
+ready=false
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER_NAME" pg_isready -U postgres >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+[[ "$ready" == true ]] || {
+  printf 'not ok 1 - disposable PostgreSQL did not become ready\n' >&2
+  exit 1
+}
+
+docker exec -i "$CONTAINER_NAME" psql -X -v ON_ERROR_STOP=1 \
+  -U postgres -d postgres >/dev/null <<'SQL'
+ALTER SCHEMA public OWNER TO postgres;
+CREATE ROLE refresh_app LOGIN;
+CREATE ROLE schema_observer;
+GRANT USAGE, CREATE ON SCHEMA public TO refresh_app;
+GRANT USAGE ON SCHEMA public TO schema_observer;
+CREATE TABLE public.admin_sentinel (id integer PRIMARY KEY);
+SET ROLE refresh_app;
+CREATE TYPE public.refresh_state AS ENUM ('ready', 'done');
+CREATE SEQUENCE public.refresh_sequence;
+CREATE TABLE public.refresh_table (
+  id integer DEFAULT nextval('public.refresh_sequence'),
+  state public.refresh_state NOT NULL
+);
+CREATE VIEW public.refresh_view AS SELECT id FROM public.refresh_table;
+CREATE MATERIALIZED VIEW public.refresh_materialized AS
+  SELECT count(*) AS row_count FROM public.refresh_table;
+CREATE FUNCTION public.refresh_function(value integer)
+RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT value + 1';
+RESET ROLE;
+SQL
+
+docker exec -i "$CONTAINER_NAME" psql -X -v ON_ERROR_STOP=1 \
+  -U refresh_app -d postgres -f - <"$RESET_SQL" >/dev/null
+
+result="$(
+  docker exec -i "$CONTAINER_NAME" psql -X -v ON_ERROR_STOP=1 \
+    -U postgres -d postgres -At -F '|' <<'SQL'
+SELECT
+  pg_get_userbyid((SELECT nspowner FROM pg_namespace WHERE nspname = 'public')),
+  has_schema_privilege('schema_observer', 'public', 'USAGE'),
+  to_regclass('public.admin_sentinel') IS NOT NULL,
+  (
+    SELECT count(*)
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND pg_get_userbyid(c.relowner) = 'refresh_app'
+  ),
+  (
+    SELECT count(*)
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND pg_get_userbyid(p.proowner) = 'refresh_app'
+  ),
+  (
+    SELECT count(*)
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND pg_get_userbyid(t.typowner) = 'refresh_app'
+      AND t.typrelid = 0
+  );
+SQL
+)"
+
+printf '1..1\n'
+if [[ "$result" == 'postgres|t|t|0|0|0' ]]; then
+  printf 'ok 1 - reset removes app-owned objects and preserves schema owner, grants, and admin objects\n'
+else
+  printf 'not ok 1 - unexpected post-reset state: %s\n' "$result" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What this changes

Adds an operator-run workflow that replaces the exact Klicker STG PostgreSQL
database with an encrypted logical copy of PRD and then runs the existing
ArgoCD `PreSync` migration hook. The workflow is read-only by default and fails
closed around database, Kubernetes, ArgoCD, storage, migration, workload, and
governance identity checks.

This revision also reconciles the useful requirements from superseded stacked
PR #5472: a recorded raw-data approval reference, an explicit outbound-
integration isolation acknowledgement, checked-in target identities, and a
documented application smoke-test boundary. It retains this PR's stronger fresh
Azure capacity metrics, modular implementation, and failure fencing.

## How it works

- Pins the Infisical locations, PRD/STG database endpoints, Azure server,
  Kubernetes and ArgoCD identities, Git source, workload selector, migrator,
  and Lease as checked-in constants that ambient variables cannot redefine.
- Requires five live-execution gates: `DRY_RUN=false`, destructive
  confirmation, raw-data acknowledgement, a bounded approval reference, and an
  explicit STG outbound-integration isolation acknowledgement.
- Validates database endpoint/TLS/live identity, ordered Prisma migration
  history, PostgreSQL version, reset capability, and fresh Azure storage/WAL
  headroom before creating a dump.
- Acquires an exclusive five-minute Kubernetes Lease and renews it every 30
  seconds with bounded retries. A repeated renewal failure interrupts the main
  process and enters the signal-aware fail-safe cleanup path. Lease parsing
  treats malformed timestamps or non-positive durations as unavailable.
- Streams `pg_dump` directly into an AES-256 GPG archive; no plaintext dump is
  written. The encrypted archive and `pg_restore` catalog are validated before
  any STG mutation.
- Binds the exact Argo Application/AppProject/cluster/namespace identities and
  Deployment set, disables automated sync, stops workloads, and installs an
  app-scoped AppProject deny window during reset/restore.
- Preserves Azure's `public` schema and grants while transactionally deleting
  only application-owned supported objects. Unsupported standalone composite
  types are rejected during read-only preflight.
- Restores through an explicit target database, submits the pinned Argo sync
  through a resource-version compare-and-swap, and proves migration execution
  with a new Job UID, Pod UID, and immutable migrator image digest.
- Bounds an unreadable Argo Application by the existing sync deadline instead
  of waiting indefinitely.
- Restores the exact original Argo policy only after migration/database proof,
  then requires two stable `Synced`/`Healthy` observations and ready bound
  Deployments before writing the terminal receipt.
- On post-mutation failure, reinstalls the deny window, drains the owned
  operation, disables automated sync, and verifies every receipt-bound and
  currently selected Deployment at zero desired and running replicas. If any
  invariant cannot be proven, it records `cleanupIncomplete: true` and retains
  the Lease until expiry.
- Supports receipt-bound recovery with a fresh dump; partial archives are never
  reused.

## Branch coverage

- Base: `v3` at `5ffc6a6d2`
- Head: `820aec33d`
- Scope: 2 commits, 13 files, 5,261 insertions, 2 deletions
- Includes the operator entrypoint, focused database/Kubernetes/Argo modules,
  owner-safe reset SQL, fake-tool and disposable-PostgreSQL tests, runbook/wiki
  guidance, and archived implementation/readiness plans.
- The latest rebase is patch-identical for both feature commits (`git
  range-diff`); its only new base commit is a non-overlapping STG deployment
  promotion.
- The initial feature history was intentionally squashed so obsolete synthetic
  credential-shaped URL literals are no longer present in the PR history.

## Review focus

- Fail-closed target binding and source-read-only behavior.
- Azure-owned `public` schema preservation and application-object reset
  coverage.
- Lease renewal/expiry/signal semantics and long-running restore interruption.
- AppProject deny-window lifecycle and atomic Argo operation submission.
- New migrator Job/Pod/image-digest evidence and exact migration-history checks.
- Failure cleanup when labels, workloads, policies, operations, or APIs drift.
- Privacy boundary: raw PRD data is intentionally copied to STG only after all
  explicit operator gates and environmental governance checks.

## Verification

Exact published head/local working tree:

- `bash -n` over the entrypoint, all sourced modules, and both test scripts —
  passed
- `bash util/backup/tests/refresh-stg-from-prd.test.sh` — 41/41 passed
- `bash util/backup/tests/reset-stg-owned-objects.integration.sh` — clean TAP
  skip because the Docker daemon is unavailable locally
- `pnpm run check:all` — passed directly and through the commit hook
- `pnpm run build` — passed again after the latest rebase, 23/23 tasks (existing
  repository warnings only)
- `git range-diff` across the latest rebase — both feature commits are
  patch-identical
- `git diff --check` and targeted Prettier checks — passed
- Staged data-hygiene audit — no credential-bearing database URL, email-like
  data, bulk/data artifact path, tracked dump, real personal data, or secret
  value committed
- Local `shellcheck` and `gitleaks` are unavailable; exact-head GitHub checks
  are the required authority

Intentionally not run:

- A destructive PRD-to-STG refresh from this PR head. The workflow was exercised
  through deterministic fake-tool failures instead of mutating live data again.
- The disposable PostgreSQL reset integration, because Docker is unavailable on
  this host.
- UI/browser E2E checks; no UI behavior changed.

## Security and privacy

- PRD is source-read-only: the workflow uses metadata queries and `pg_dump`
  only.
- Raw PRD personal data enters STG by design and requires all five execution
  gates. The runbook additionally requires approved access, outbound-
  integration isolation, and retention/deletion controls.
- Dumps are encrypted at rest, never written as plaintext, deleted by default,
  and stored with metadata receipts only below gitignored
  `util/backup/dumps/`.
- A successful terminal receipt proves database/control-plane invariants, not
  cross-service application behavior. The operator must still inspect Argo and
  migrator logs, confirm outbound isolation, verify backend behavior, and run
  one isolated synthetic STG request.

## Blocking before merge

- Keep this PR in draft until all checks on exact head `820aec33d` are green.
- Complete the repository's manual final AI review for this exact head.
- Obtain human review/approval of the destructive workflow and environment-
  governance contract.
- Run the disposable reset integration on a Docker-capable host if CI does not
  provide equivalent PostgreSQL coverage.

## Blocking before production use

- Confirm the STG data-classification, restricted-access, outbound-integration,
  backup/PITR retention, and local-archive deletion prerequisites.
- Perform the live refresh only as an explicit monitored operator action; this
  PR does not schedule or automatically execute it.
- Complete the documented application-level smoke checks after a successful
  control-plane receipt.

## Follow-up

- PR #5472 is closed and superseded by this reconciled implementation; it must
  not be merged separately.
