### PR TITLE
fix(backup): harden PRD-to-STG refresh

### DIFF
--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -2,7 +2,7 @@
 type: Data Layer
 title: Data & Migrations
 description: Split Prisma schema, the migrate→sync→build ritual, seeding paths, typed Json fields, and schema-level gotchas.
-timestamp: '2026-08-04'
+timestamp: '2026-08-21'
 tags:
   - backend
   - prisma
@@ -50,6 +50,62 @@ The Python twin (`apps/analytics/prisma/schema/py.prisma`) uses `prisma-client-p
 - **Bootstrap and rollback:** the tag coupling means a release tag with no matching migrator image renders an unpullable hook image, which fails the sync after `activeDeadlineSeconds`. No migrator image exists for any tag cut before this feature landed, so `migrator.enabled` stays `false` on prd until the env tags reach the first release whose CI built it — and rolling prd back to a pre-hook tag means setting it back to `false`. Stg is unaffected: its floating `v3` tag is rebuilt on every merge.
 
 Where `migrate deploy` is invoked in deployment is now the PreSync hook above (see [CI & Deployment → Deployment migrations](./ci-and-deployment.md#deployment-migrations)). Rationale and rejected alternatives: [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md).
+
+### Refreshing STG from PRD
+
+The operator-run
+[`util/backup/refresh-stg-from-prd.sh`](../util/backup/refresh-stg-from-prd.sh)
+replaces the disposable Klicker STG PostgreSQL database with a consistent
+logical PRD dump. It does not copy Redis, Blob Storage, Hatchet state, or other
+components. The dump is not sanitized, so the workflow requires an explicit
+acknowledgement that STG may contain raw PRD data and assumes STG integrations
+and access controls are appropriate for it.
+
+The script is read-only by default. During an approved execution it validates
+the fixed PRD/STG hosts and database metadata, creates and verifies an encrypted
+custom-format dump, disables ArgoCD automated sync, and scales the
+`app-klicker` Deployments to zero. Azure's administration role owns `public`,
+while the Klicker application role owns its contents. The refresh therefore
+preserves the schema and its grants, removes only application-owned objects in
+one transaction, and filters schema creation/ownership entries from the restore
+catalog. Preflight rejects unowned or unsupported objects, non-public
+application schemas, and PostgreSQL large objects before maintenance mode. A
+hook-based sync submitted directly through the self-hosted ArgoCD `Application`
+custom resource then reapplies the existing `PreSync` hook; this is intentional
+because ArgoCD runs hooks on a requested sync even if the rendered manifests are
+unchanged. The script identifies and waits for its exact operation rather than
+accepting a stale successful status. The successful sync applies forward
+migrations from the STG migrator image and restores desired replicas. This path
+uses `kubectl` and Kubernetes RBAC (`get`/`patch` on the `Application`); it does
+not require the local `argocd` CLI.
+
+PostgreSQL client commands go through
+`util/backup/refresh-stg-from-prd.sh:run_database_command`, which validates and
+decomposes each URL into libpq connection variables. Do not put a full URI in
+`PGDATABASE`: libpq treats that environment value as the database name and can
+fall back to the local Unix socket. The wrapper keeps the URL out of process
+arguments while preserving the remote host, credentials, and supported SSL
+settings. `pg_restore` is the exception for database selection: it does not use
+`PGDATABASE` unless direct-to-database mode is selected, so the script also
+passes the already-validated, non-secret STG database name through `--dbname`.
+
+This command and resource selection are config-derived and fake-tested; the
+implementation workflow does not execute a real environment refresh.
+
+The source schema must not be newer than the STG release. Prisma migrations are
+forward-only: copying a newer PRD database into an older STG release is not a
+downgrade strategy. On any failure after workloads stop, automated sync remains
+disabled and Deployments remain at zero for inspection. A normal subsequent run
+refuses to adopt that unfinished state. When reset completed but restore did
+not, the operator must not trigger an ArgoCD sync against the incomplete
+database. `RESUME_FAILED_RUN_ID` enables a receipt-bound retry only while ArgoCD
+is still manual, the exact recorded Deployment set remains stopped, the receipt
+matches the current endpoints and prior automated policy, and no successful
+after receipt exists. The retry creates a fresh encrypted dump and restores the
+saved policy only after restore verification and the hook-based sync succeed.
+The complete operator procedure, confirmation gates, prerequisites, receipts,
+and recovery behavior
+are documented in the [backup README](../util/backup/README.md#refresh-the-stg-database-from-prd).
 
 ### Recovering a failed migration hook
 

--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -62,22 +62,30 @@ acknowledgement that STG may contain raw PRD data and assumes STG integrations
 and access controls are appropriate for it.
 
 The script is read-only by default. During an approved execution it validates
-the fixed PRD/STG hosts and database metadata, creates and verifies an encrypted
-custom-format dump, disables ArgoCD automated sync, and scales the
-`app-klicker` Deployments to zero. Azure's administration role owns `public`,
-while the Klicker application role owns its contents. The refresh therefore
-preserves the schema and its grants, removes only application-owned objects in
-one transaction, and filters schema creation/ownership entries from the restore
-catalog. Preflight rejects unowned or unsupported objects, non-public
-application schemas, and PostgreSQL large objects before maintenance mode. A
-hook-based sync submitted directly through the self-hosted ArgoCD `Application`
-custom resource then reapplies the existing `PreSync` hook; this is intentional
-because ArgoCD runs hooks on a requested sync even if the rendered manifests are
-unchanged. The script identifies and waits for its exact operation rather than
-accepting a stale successful status. The successful sync applies forward
-migrations from the STG migrator image and restores desired replicas. This path
-uses `kubectl` and Kubernetes RBAC (`get`/`patch` on the `Application`); it does
-not require the local `argocd` CLI.
+the fixed PRD/STG hosts and database names, TLS mode, current free-storage
+evidence, Kubernetes cluster identities, the exact Application destination
+namespace, write RBAC, and an exclusive refresh Lease before creating and
+verifying an encrypted custom-format dump. It disables ArgoCD automated sync
+and scales the `app-klicker` Deployments to zero. Azure's administration role
+owns `public`, while the Klicker application role owns its contents. The
+refresh therefore preserves the schema and its grants, removes only
+application-owned objects in one transaction, and filters schema
+creation/ownership entries from the restore catalog. Preflight rejects
+unowned or unsupported objects, non-public application schemas, and PostgreSQL
+large objects before maintenance mode.
+
+A hook-based sync submitted directly through the self-hosted ArgoCD
+`Application` custom resource then reapplies the existing `PreSync` hook; this
+is intentional because ArgoCD runs hooks on a requested sync even if the
+rendered manifests are unchanged. The script identifies and waits for its
+exact operation rather than accepting a stale successful status. If the
+operation times out, the script terminates it and waits for a terminal state
+before recovering workloads. The successful sync applies forward migrations
+from the STG migrator image, proves that the migrator Secret and validated STG
+URL resolve to the same database identity, compares ordered migration names
+and checksums, restores desired replicas, and writes the terminal receipt only
+after policy restoration. This path uses `kubectl` and Kubernetes RBAC; it
+does not require the local `argocd` CLI.
 
 PostgreSQL client commands go through
 `util/backup/refresh-stg-from-prd.sh:run_database_command`, which validates and
@@ -90,7 +98,13 @@ settings. `pg_restore` is the exception for database selection: it does not use
 passes the already-validated, non-secret STG database name through `--dbname`.
 
 This command and resource selection are config-derived and fake-tested; the
-implementation workflow does not execute a real environment refresh.
+implementation workflow does not execute a real environment refresh. The
+execution gate also requires an approval reference for raw PRD data,
+`STG_OUTBOUND_INTEGRATIONS_ISOLATED=true`, and current `STG_FREE_STORAGE_GIB`
+evidence. After a successful run, the operator must separately verify the
+ArgoCD Application, migrator Job logs, backend health, and an isolated
+synthetic STG request; the script does not provide live application or
+cross-service proof.
 
 The source schema must not be newer than the STG release. Prisma migrations are
 forward-only: copying a newer PRD database into an older STG release is not a
@@ -111,7 +125,9 @@ are documented in the [backup README](../util/backup/README.md#refresh-the-stg-d
 
 A failed hook blocks **every** sync to that environment, by design. Recovery order:
 
-Nothing alerts on hook failure — detection is whoever is watching ArgoCD, so a blocked environment stays blocked silently until someone looks.
+The refresh receipt and failure log are the durable run-scoped evidence. There
+is still no external alerting for a failed hook; detection remains whoever is
+watching ArgoCD. Operators must collect the failed Job logs before recovery.
 
 1. **Get the logs first.** Find the Job with `kubectl get jobs -n <ns> -l app.kubernetes.io/component=migrate` (it is named `<helm-release>-klicker-uzh-v2-migrate` unless the release name already contains the chart name), then `kubectl logs job/<name> -n <ns>` — the failed Job is kept (`hook-delete-policy: BeforeHookCreation,HookSucceeded`, no TTL), but the next sync deletes it. Treat the output as potentially containing row data from backfill migrations; scrub before pasting it anywhere.
 2. **Classify the failure.** Image pull (`ImagePullBackOff` → the rendered tag has no migrator image, see bootstrap above); connection error (DB unreachable — `backoffLimit: 1` gives little retry, so a failover during the hook simply needs a re-sync); or a SQL error inside a migration.

--- a/project/2026-08-21-pr5465-fixes-plan.md
+++ b/project/2026-08-21-pr5465-fixes-plan.md
@@ -1,0 +1,106 @@
+# PR #5465 follow-up fixes
+
+## Problem
+
+PR #5465's guarded PRD-to-STG refresh has confirmed target-identity, Kubernetes
+fencing, timeout, cleanup, migration-compatibility, and data-boundary gaps.
+This follow-up is a dependent change against Patrick's branch
+`feat/prd-to-stg-database-refresh` at head
+`300f1b5eae3baee22036b5d75748e0c95cb11cf7`.
+
+## Decision
+
+Keep the existing operator-run workflow and fake-tool seam, but make every
+destructive boundary fail closed. Use explicit database and cluster identity
+configuration, an exact workload namespace, a Kubernetes Lease for run
+ownership, bounded operation cancellation, receipt-preserving cleanup, and
+credential-suppressed migrator-target checks. Replace aggregate migration
+counts with ordered migration name/checksum comparison. Require explicit raw
+data approval, outbound-isolation acknowledgement, and current free-capacity
+evidence for execution.
+
+## Authority
+
+- Granted: edit the dependent branch, commit local changes, push the branch,
+  create a dependent GitHub PR targeting Patrick's branch, and assign that PR
+  to Patrick (`jabbadizzleCode`).
+- Withheld: live Infisical, PostgreSQL, Kubernetes, ArgoCD, deployment, and
+  production-data access; merging, closing, or deleting any PR or branch.
+
+## Terminal
+
+The branch is pushed with a non-draft dependent PR targeting
+`feat/prd-to-stg-database-refresh`, assigned to Patrick, with repository-native
+checks run and the exact PR URL read back. The PR remains unmerged.
+
+## Plan route
+
+The configured native planner route was unavailable in this session. The main
+session owns this bounded implementation plan and will run the required local
+verification and final read-only review before publication.
+
+## Delegation map
+
+| workstream | owner | acceptance boundary |
+| --- | --- | --- |
+| Shell workflow and security-sensitive seams | main | `bash -n`, ShellCheck, focused fake tests, diff review |
+| Documentation and plan contract | main | Prettier/check-format and source-to-doc consistency |
+| Live proof | withheld | explicitly not run; record as manual follow-up |
+
+## Slices
+
+### 1. Fail-closed configuration and target selection
+
+- `Do:` bind expected PRD/STG database names; require approved TLS; require
+  current free-capacity evidence and raw-data/isolation approval; default and
+  assert `argocd`; derive and pin the Argo destination namespace; validate
+  stable Kubernetes namespace UIDs for both contexts; check write RBAC; scope
+  workload discovery to the exact namespace and print the selected set; include
+  resource identity in the preflight binding and re-check the target database
+  identity immediately before reset.
+- `Test obligation:` extend the fake harness for wrong database, namespace,
+  cluster UID, workload namespace, TLS, approval, capacity, and RBAC failures.
+- `Check:` focused fake suite plus shell syntax and ShellCheck.
+- `Commit:` `fix(backup): bind refresh targets and cluster identity`.
+
+### 2. Exclusive maintenance and failure state machine
+
+- `Do:` acquire an environment-scoped Kubernetes Lease before the dump; release
+  only when the process exits; terminate and drain a timed-out owned Argo
+  operation; preserve the first Deployment receipt; retry scale-down on cleanup;
+  move the terminal receipt after policy restoration. Live application health
+  and cross-service checks remain an operator follow-up because this branch has
+  no live-environment authority.
+- `Test obligation:` add fake lease ownership, timeout termination, partial
+  scale, metadata-read failure, and policy-restore ordering cases.
+- `Check:` focused fake suite and static control-flow review.
+- `Commit:` `fix(backup): fence maintenance and preserve recovery state`.
+
+### 3. Migrator target and migration-history proof
+
+- `Do:` read the migrator Secret without logging its value; compare target
+  database/server identity through both credential paths; capture ordered
+  Prisma migration names and checksums; require the restored snapshot to equal
+  PRD and the post-hook history to extend it as a prefix.
+- `Test obligation:` add fake Secret and identity mismatch cases plus equal-count
+  divergent-history rejection.
+- `Check:` focused fake suite and source inspection; no real Secret or database.
+- `Commit:` `fix(backup): verify migrator target and migration history`.
+
+### 4. Durable documentation and wiki contract
+
+- `Do:` update the operator README, Data & Migrations wiki page, and archived
+  plan; remove stale interface claims and document all required identity, lease,
+  capacity, approval, and post-sync checks.
+- `Check:` Prettier, wiki validation, focused source-to-doc grep, and final diff
+  scope review.
+- `Commit:` `docs(backup): document guarded refresh prerequisites`.
+
+## Finish gate
+
+- Run the focused 26-test suite, `bash -n`, ShellCheck, `git diff --check`,
+  diff-scoped gitleaks, and applicable Markdown/wiki formatting checks.
+- Run one integrated read-only final review over the exact committed range.
+- Compute substantive branch size against Patrick's branch for the PR body.
+- Publish only after the dependent branch and PR read back with Patrick as
+  assignee; do not merge or execute the refresh.

--- a/project/2026-08-21-pr5465-fixes-plan.md
+++ b/project/2026-08-21-pr5465-fixes-plan.md
@@ -96,6 +96,19 @@ verification and final read-only review before publication.
   scope review.
 - `Commit:` `docs(backup): document guarded refresh prerequisites`.
 
+## Progress
+
+- [x] Confirmed Patrick's exact parent head and isolated the dependent branch.
+- [x] Implemented database, TLS, cluster, namespace, RBAC, Lease, timeout,
+  migrator-target, workload-set, cleanup, and migration-history guards.
+- [x] Focused fake suite passes all 26 tests; `bash -n`, ShellCheck, Prettier,
+  repository build, and commit hooks pass.
+- [x] Updated the operator README, Data & Migrations page, and archived plan.
+- [ ] Native planner, slice-reviewer, simplifier, and final-reviewer routes were
+  unavailable; the main session owns the documented read-only review fallback.
+- [ ] Push the dependent branch, create the PR against Patrick's branch, and
+  assign Patrick for review.
+
 ## Finish gate
 
 - Run the focused 26-test suite, `bash -n`, ShellCheck, `git diff --check`,

--- a/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
+++ b/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
@@ -1,0 +1,105 @@
+# PRD-to-STG database refresh
+
+## Goal
+
+Provide one operator-run script that replaces the Klicker STG PostgreSQL data
+with a consistent logical dump of PRD, then triggers the existing ArgoCD sync so
+the STG `PreSync` migrator applies every migration required by the currently
+deployed STG release before workloads resume.
+
+## Non-goals
+
+- Preserve or back up the previous STG data; the user explicitly declared it
+  disposable.
+- Copy Redis, Blob Storage, Hatchet state, or any external integration.
+- Sanitize PRD data. The script instead requires an explicit raw-data approval
+  gate and keeps the dump encrypted at rest.
+- Change Prisma schema, GraphQL, application UI, gamification behavior, or
+  deployment manifests.
+- Run against PRD as a mutation target.
+
+## Domain and layer footprint
+
+- Source: the Klicker PRD PostgreSQL database, read only.
+- Target: the Klicker STG PostgreSQL database, fully replaced.
+- Infrastructure: `util/backup`, the `app-klicker` ArgoCD application, and STG
+  Deployments selected by `app.kubernetes.io/instance=app-klicker`.
+- Migrations: the existing
+  `deploy/charts/klicker-uzh-v3/templates/job-migrate.yaml` ArgoCD `PreSync`
+  hook. The script does not duplicate `prisma migrate deploy` logic.
+- Documentation: `util/backup/README.md` for the operator procedure and
+  `docs/data-and-migrations.md` for the durable deployment contract.
+
+No application authorization surface is added. Execution authority comes from
+Infisical read access to both environments, STG Kubernetes access, and
+Kubernetes RBAC to read and patch the self-hosted ArgoCD `Application`.
+
+## Safety contract
+
+- `DRY_RUN` defaults to `true`. Mutations require `DRY_RUN=false`.
+- Execution additionally requires the exact destructive confirmation and a
+  separate acknowledgement that raw PRD data is allowed in STG.
+- PRD and STG connection hosts are fail-closed against their expected Azure
+  Flexible Server hostnames and must differ.
+- The dump is streamed directly into a GPG-encrypted custom archive; no
+  plaintext dump is written to disk or passed as a process argument.
+- The encrypted archive is listed with `pg_restore` before STG is touched.
+- ArgoCD automated sync/self-heal is disabled before scaling workloads down.
+- The target `public` schema is dropped only after all STG workloads report zero
+  replicas.
+- `pg_restore` uses `--exit-on-error` and `--single-transaction`; restore errors
+  cannot be converted into success.
+- A hook-based `Application.operation.sync` submitted through Kubernetes runs
+  the existing `PreSync` hook. A failed hook prevents the Sync phase, leaving
+  workloads stopped.
+- Automated sync policy is restored only after post-sync database verification.
+- Receipts contain aggregate metadata and archive hashes only, never row data or
+  connection strings. Reusing a run ID is refused.
+
+## Async and external-state impact
+
+All STG workloads in the release, including Hatchet workers and response APIs,
+are stopped during replacement. PRD remains online and is only read by
+`pg_dump`. The resulting STG database contains raw production data, so this
+workflow is permitted only when STG is approved for that data classification.
+
+## Verification
+
+- Shell syntax (`bash -n`) and ShellCheck when available.
+- A self-contained fake-tool test proves dry-run immutability, host and approval
+  guards, phase ordering, encrypted-archive verification, fail-closed restore,
+  direct Kubernetes sync submission, exact-operation polling, policy
+  restoration, and receipt generation.
+- Helm render verifies the hook remains enabled for STG and uses the expected
+  migrator image/secret.
+- The implementation agent does not execute the real PRD/STG refresh; operator
+  runs are used separately to validate the guarded workflow and feed failures
+  back into the fake-tool regression suite.
+
+## Slices
+
+1. Add the plan and safety contract.
+2. Implement `util/backup/refresh-stg-from-prd.sh`.
+3. Add the fake-tool shell test.
+4. Document prerequisites, execution, failure behavior, and limitations.
+5. Run focused formatting/static tests and inspect the final diff.
+6. Replace the ArgoCD API-server CLI dependency with direct Kubernetes
+   `Application` operations for the self-hosted installation.
+7. Route all credential reads through the production self-hosted Infisical
+   endpoint and script-specific project, and cover that boundary with a
+   regression test.
+8. Decompose database URLs into libpq connection variables so PostgreSQL tools
+   connect remotely without exposing credentials in process arguments.
+
+## Progress
+
+- [x] Repository, deployment hook, and legacy backup scripts inspected.
+- [x] Safety and operational design fixed.
+- [x] Script implemented.
+- [x] Tests implemented and passing.
+- [x] Documentation updated and verified.
+- [x] Direct Kubernetes sync implemented and verified.
+- [x] Self-hosted Infisical credential loading for project
+      `d071be96-5136-4f23-a6cb-e0c7f9b9a6c8` implemented and verified.
+- [x] Secure libpq connection handoff and immediate connection-error propagation
+      implemented and verified.

--- a/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
+++ b/project/plans_archive/PLAN-prd-to-stg-database-refresh.md
@@ -45,14 +45,16 @@ Kubernetes RBAC to read and patch the self-hosted ArgoCD `Application`.
   plaintext dump is written to disk or passed as a process argument.
 - The encrypted archive is listed with `pg_restore` before STG is touched.
 - ArgoCD automated sync/self-heal is disabled before scaling workloads down.
-- The target `public` schema is dropped only after all STG workloads report zero
-  replicas.
+- Application-owned objects in the target `public` schema are removed only
+  after all STG workloads report zero replicas; the Azure-owned `public` schema
+  and its grants are preserved.
 - `pg_restore` uses `--exit-on-error` and `--single-transaction`; restore errors
   cannot be converted into success.
 - A hook-based `Application.operation.sync` submitted through Kubernetes runs
   the existing `PreSync` hook. A failed hook prevents the Sync phase, leaving
   workloads stopped.
-- Automated sync policy is restored only after post-sync database verification.
+- Automated sync policy is restored only after post-sync database verification,
+  migrator-target identity verification, and ordered migration-history checks.
 - Receipts contain aggregate metadata and archive hashes only, never row data or
   connection strings. Reusing a run ID is refused.
 
@@ -66,7 +68,8 @@ workflow is permitted only when STG is approved for that data classification.
 ## Verification
 
 - Shell syntax (`bash -n`) and ShellCheck when available.
-- A self-contained fake-tool test proves dry-run immutability, host and approval
+- A self-contained fake-tool test proves dry-run immutability, host/database and
+  cluster-identity guards, Lease ownership, timeout termination, approval,
   guards, phase ordering, encrypted-archive verification, fail-closed restore,
   direct Kubernetes sync submission, exact-operation polling, policy
   restoration, and receipt generation.

--- a/util/backup/README.md
+++ b/util/backup/README.md
@@ -2,6 +2,138 @@
 
 Production-ready backup and restore scripts for PostgreSQL databases and Redis data across development, staging, and production environments.
 
+## Refresh the STG database from PRD
+
+[`refresh-stg-from-prd.sh`](./refresh-stg-from-prd.sh) replaces the Klicker STG
+PostgreSQL database with a transactionally consistent logical dump of PRD. It
+then submits a hook-based sync directly to the self-hosted `app-klicker` ArgoCD
+`Application` resource, which runs the existing STG `PreSync` migration hook
+before restoring the desired Deployment replicas. The local `argocd` CLI is not
+required.
+
+This is a **database-only** operation. It does not copy Redis, Hatchet state,
+Azure Blob Storage, or other services, and it does not preserve the previous STG
+database. It also does not sanitize the dump: after a successful run, raw PRD
+data—including personal data—is present in STG. Run it only when STG is approved
+for that data classification and its outbound integrations are safely isolated.
+
+### Prerequisites
+
+- Private-network access to both Azure PostgreSQL Flexible Servers.
+- `infisical` access to `DIRECT_DATABASE_URL` in the `prd` and `stg`
+  environments and `BACKUP_ENCRYPTION_KEY` in `prd` on the self-hosted
+  `https://inf.prd.df-app.ch/api` instance, project
+  `d071be96-5136-4f23-a6cb-e0c7f9b9a6c8`. The secrets default to path `/`;
+  override `INFISICAL_SECRET_PATH` if they are stored in a folder.
+- A working `aks-stg-apps` kubectl context with permission to list and scale the
+  release Deployments.
+- Kubernetes access to the ArgoCD control-plane cluster, with `get` and `patch`
+  permission for `applications.argoproj.io/app-klicker` in the `argocd`
+  namespace. This defaults to the same `aks-stg-apps` context; set
+  `ARGOCD_KUBE_CONTEXT` and `ARGOCD_NAMESPACE` if ArgoCD runs elsewhere.
+- PostgreSQL client tools (`pg_dump`, `pg_restore`, and `psql`) version 17 or
+  newer, plus `gpg`, `jq`, Node.js, and standard Unix utilities.
+- A STG release whose database schema is the same as or newer than PRD. The hook
+  can migrate forward; it cannot downgrade a newer PRD schema for an older app.
+
+Run the read-only preflight first from the repository root:
+
+```bash
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The preflight validates the exact source and target hostnames, PostgreSQL client
+compatibility, source size against STG capacity, Prisma migration health,
+STG object ownership, ArgoCD state, and the set of STG Deployments. The database
+must use only the `public` application schema and must not contain PostgreSQL
+large objects. It creates no dump and changes no external state.
+
+After reviewing that output, execute the refresh with all three gates:
+
+```bash
+DRY_RUN=false \
+CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+ALLOW_RAW_PRD_DATA_IN_STG=true \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The script streams `pg_dump` directly into an AES-256 GPG archive; it never
+writes a plaintext dump. Before changing STG it validates the archive, disables
+ArgoCD automated sync/self-heal, and scales every Deployment in the Klicker
+release to zero. Azure owns the `public` schema, so the script preserves the
+schema and its grants, transactionally removes only objects owned by the STG
+application role, and excludes `public` schema creation/ownership entries from
+the restore catalog. It restores with an explicit
+`pg_restore --dbname=<STG-database> --exit-on-error --single-transaction`,
+verifies aggregate table and migration counts, and patches
+`Application.operation.sync` with ArgoCD's hook sync strategy. It then waits
+for the operation carrying this run's unique initiator to reach `Succeeded`. A
+successful sync runs the PreSync migrator and restores the Git-declared replica
+counts; a failed hook fails the operation.
+
+The database URLs are validated and decomposed into libpq's `PGHOST`, `PGPORT`,
+`PGUSER`, `PGPASSWORD`, `PGDATABASE`, and supported SSL environment variables.
+The URLs are never placed in process arguments, and `PGDATABASE` receives only
+the database name rather than the full URI. PostgreSQL's `pg_restore` does not
+use `PGDATABASE` to select direct-to-database mode, so the non-secret database
+name is also supplied explicitly with `--dbname`; the host, username, and
+password remain environment-only.
+
+For a self-hosted ArgoCD control plane in another Kubernetes context, run both
+the preflight and execution with the overrides, for example:
+
+```bash
+ARGOCD_KUBE_CONTEXT=aks-platform \
+ARGOCD_NAMESPACE=argocd \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The Infisical endpoint defaults to the production self-hosted instance. If the
+CLI is authenticated against another host, log in to this instance before the
+preflight:
+
+```bash
+infisical login --domain=https://inf.prd.df-app.ch/api
+```
+
+Metadata-only receipts are written below
+`util/backup/dumps/prd-to-stg-refresh/<run-id>/`, which is gitignored. The
+encrypted archive is deleted after the run unless
+`KEEP_ENCRYPTED_ARCHIVE=true` is explicitly set.
+
+If anything fails after maintenance mode starts, the script deliberately leaves
+automated sync disabled and the selected Deployments at zero. Do not simply
+restart them. If the restore was not verified, do **not** submit an ArgoCD hook
+sync against the incomplete database. Inspect the failed run's metadata-only
+`before.json` and `deployments.tsv`, then validate the guarded resume in
+read-only mode with a fresh default `RUN_ID`:
+
+```bash
+RESUME_FAILED_RUN_ID=<failed-run-id> \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The resume is accepted only when the failed run has no `after.json`, its source
+and target match the current fixed endpoints, its saved policy was automated,
+ArgoCD is still manual with no active operation, and the exact recorded
+Deployment set remains at zero desired and running replicas. After reviewing
+that preflight, rerun with the same failed-run ID and the three execution gates:
+
+```bash
+RESUME_FAILED_RUN_ID=<failed-run-id> \
+DRY_RUN=false \
+CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+ALLOW_RAW_PRD_DATA_IN_STG=true \
+./util/backup/refresh-stg-from-prd.sh
+```
+
+The resume creates and validates a fresh encrypted PRD dump under a new run ID;
+it never reuses a partial archive. It resets any remaining application-owned
+STG objects, restores the snapshot, runs the PreSync hook, and only then
+restores the exact automated-sync policy saved by the failed run. A normal
+refresh still refuses to adopt an unfinished manual Argo state, and a failed
+run never mutates PRD.
+
 **Main Interface:** Use `dump.sh` and `restore.sh` for all operations - these unified wrappers provide consistent commands for both database and Redis operations.
 
 ## Prerequisites

--- a/util/backup/README.md
+++ b/util/backup/README.md
@@ -26,15 +26,28 @@ for that data classification and its outbound integrations are safely isolated.
   `d071be96-5136-4f23-a6cb-e0c7f9b9a6c8`. The secrets default to path `/`;
   override `INFISICAL_SECRET_PATH` if they are stored in a folder.
 - A working `aks-stg-apps` kubectl context with permission to list and scale the
-  release Deployments.
+  release Deployments. Set `EXPECTED_STG_CLUSTER_UID` to the stable UID of the
+  intended cluster; the script rejects a repointed context.
 - Kubernetes access to the ArgoCD control-plane cluster, with `get` and `patch`
   permission for `applications.argoproj.io/app-klicker` in the `argocd`
   namespace. This defaults to the same `aks-stg-apps` context; set
-  `ARGOCD_KUBE_CONTEXT` and `ARGOCD_NAMESPACE` if ArgoCD runs elsewhere.
+  `ARGOCD_KUBE_CONTEXT` and `ARGOCD_NAMESPACE` if ArgoCD runs elsewhere, and
+  set `EXPECTED_ARGOCD_CLUSTER_UID` to that cluster's stable UID.
+- The ArgoCD Application destination namespace must be the intended STG
+  workload namespace. Set `WORKLOAD_NAMESPACE` to bind it explicitly; the
+  script refuses a mismatch and never lists Deployments cluster-wide.
+- The operator must be able to create, read, patch, and delete the refresh
+  Lease, patch the ArgoCD Application, update Deployment scale, and read the
+  migrator Secret. These write checks run before the dump.
 - PostgreSQL client tools (`pg_dump`, `pg_restore`, and `psql`) version 17 or
   newer, plus `gpg`, `jq`, Node.js, and standard Unix utilities.
+- Both database URLs must use at least `sslmode=require`, must name the exact
+  expected databases (`EXPECTED_PRD_DB_NAME` and `EXPECTED_STG_DB_NAME`), and
+  must point to the expected hosts.
 - A STG release whose database schema is the same as or newer than PRD. The hook
   can migrate forward; it cannot downgrade a newer PRD schema for an older app.
+- Current free STG storage evidence in `STG_FREE_STORAGE_GIB`, with enough
+  headroom for the dump, restore, WAL, temporary indexes, and migrations.
 
 Run the read-only preflight first from the repository root:
 
@@ -42,18 +55,26 @@ Run the read-only preflight first from the repository root:
 ./util/backup/refresh-stg-from-prd.sh
 ```
 
-The preflight validates the exact source and target hostnames, PostgreSQL client
-compatibility, source size against STG capacity, Prisma migration health,
-STG object ownership, ArgoCD state, and the set of STG Deployments. The database
-must use only the `public` application schema and must not contain PostgreSQL
-large objects. It creates no dump and changes no external state.
+The preflight validates the exact source and target hostnames and database
+names, TLS mode, PostgreSQL client compatibility, supplied free-storage
+evidence, Prisma migration names and checksums, STG object ownership, the
+ArgoCD and workload cluster identities, write RBAC, the migrator Secret's
+database identity, and the exact set of STG Deployments. The database must use
+only the `public` application schema and must not contain PostgreSQL large
+objects. It creates no dump and changes no external state.
 
-After reviewing that output, execute the refresh with all three gates:
+After reviewing that output, execute the refresh with the required execution
+gates:
 
 ```bash
 DRY_RUN=false \
 CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
 ALLOW_RAW_PRD_DATA_IN_STG=true \
+RAW_PRD_DATA_APPROVAL_REF=<approved-ticket-or-ADR> \
+STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+STG_FREE_STORAGE_GIB=<current-free-gib> \
+EXPECTED_STG_CLUSTER_UID=<stg-cluster-uid> \
+EXPECTED_ARGOCD_CLUSTER_UID=<argocd-cluster-uid> \
 ./util/backup/refresh-stg-from-prd.sh
 ```
 
@@ -65,11 +86,13 @@ schema and its grants, transactionally removes only objects owned by the STG
 application role, and excludes `public` schema creation/ownership entries from
 the restore catalog. It restores with an explicit
 `pg_restore --dbname=<STG-database> --exit-on-error --single-transaction`,
-verifies aggregate table and migration counts, and patches
+verifies table metadata and ordered migration names/checksums, and patches
 `Application.operation.sync` with ArgoCD's hook sync strategy. It then waits
 for the operation carrying this run's unique initiator to reach `Succeeded`. A
-successful sync runs the PreSync migrator and restores the Git-declared replica
-counts; a failed hook fails the operation.
+successful sync runs the PreSync migrator, proves that its Secret still points
+to the restored database, verifies post-hook migration history, and restores
+the Git-declared replica counts. A failed hook fails the operation. A timed-out
+operation is terminated and drained before workloads are recovered.
 
 The database URLs are validated and decomposed into libpq's `PGHOST`, `PGPORT`,
 `PGUSER`, `PGPASSWORD`, `PGDATABASE`, and supported SSL environment variables.
@@ -113,17 +136,29 @@ RESUME_FAILED_RUN_ID=<failed-run-id> \
 ./util/backup/refresh-stg-from-prd.sh
 ```
 
+If the operator process crashes while it holds the refresh Lease, first verify
+that no refresh process is still active. Then remove only the exact configured
+Lease (`REFRESH_LEASE_NAMESPACE` and `REFRESH_LEASE_NAME`) before retrying; do
+not delete a Lease held by another run. Preserve the failed run's receipt and
+logs for diagnosis before removing the stale ownership record.
+
 The resume is accepted only when the failed run has no `after.json`, its source
 and target match the current fixed endpoints, its saved policy was automated,
 ArgoCD is still manual with no active operation, and the exact recorded
 Deployment set remains at zero desired and running replicas. After reviewing
-that preflight, rerun with the same failed-run ID and the three execution gates:
+that preflight, rerun with the same failed-run ID and the required execution
+gates:
 
 ```bash
 RESUME_FAILED_RUN_ID=<failed-run-id> \
 DRY_RUN=false \
 CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
 ALLOW_RAW_PRD_DATA_IN_STG=true \
+RAW_PRD_DATA_APPROVAL_REF=<approved-ticket-or-ADR> \
+STG_OUTBOUND_INTEGRATIONS_ISOLATED=true \
+STG_FREE_STORAGE_GIB=<current-free-gib> \
+EXPECTED_STG_CLUSTER_UID=<stg-cluster-uid> \
+EXPECTED_ARGOCD_CLUSTER_UID=<argocd-cluster-uid> \
 ./util/backup/refresh-stg-from-prd.sh
 ```
 
@@ -134,7 +169,10 @@ restores the exact automated-sync policy saved by the failed run. A normal
 refresh still refuses to adopt an unfinished manual Argo state, and a failed
 run never mutates PRD.
 
-**Main Interface:** Use `dump.sh` and `restore.sh` for all operations - these unified wrappers provide consistent commands for both database and Redis operations.
+After a successful run, the operator still must check the ArgoCD Application,
+migrator Job logs, backend health, and an isolated synthetic STG request before
+declaring the environment usable. The script records control-plane evidence but
+does not claim live application health or cross-service proof.
 
 ## Prerequisites
 

--- a/util/backup/refresh-stg-from-prd.sh
+++ b/util/backup/refresh-stg-from-prd.sh
@@ -1,0 +1,1408 @@
+#!/usr/bin/env bash
+
+# Replace the Klicker STG PostgreSQL database with a logical copy of PRD, then
+# run the existing ArgoCD PreSync migration hook by submitting a sync operation
+# directly to the self-hosted ArgoCD Application custom resource.
+#
+# Safety defaults:
+# - DRY_RUN=true performs read-only validation only.
+# - Execution requires two explicit acknowledgement variables.
+# - The PRD dump is encrypted while streaming; no plaintext dump is written.
+# - STG workloads stay stopped and ArgoCD auto-sync stays disabled on failure.
+
+set -Eeuo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DRY_RUN="${DRY_RUN:-true}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RESUME_FAILED_RUN_ID="${RESUME_FAILED_RUN_ID:-}"
+REFRESH_ROOT_DIR="${REFRESH_ROOT_DIR:-$SCRIPT_DIR/dumps/prd-to-stg-refresh}"
+KEEP_ENCRYPTED_ARCHIVE="${KEEP_ENCRYPTED_ARCHIVE:-false}"
+
+PRD_INFISICAL_ENV="${PRD_INFISICAL_ENV:-prd}"
+STG_INFISICAL_ENV="${STG_INFISICAL_ENV:-stg}"
+INFISICAL_API_URL="${INFISICAL_API_URL:-https://inf.prd.df-app.ch/api}"
+INFISICAL_PROJECT_ID="${INFISICAL_PROJECT_ID:-d071be96-5136-4f23-a6cb-e0c7f9b9a6c8}"
+INFISICAL_SECRET_PATH="${INFISICAL_SECRET_PATH:-/}"
+
+EXPECTED_PRD_DB_HOST="${EXPECTED_PRD_DB_HOST:-db-server-prd-apps.postgres.database.azure.com}"
+EXPECTED_STG_DB_HOST="${EXPECTED_STG_DB_HOST:-db-server-stg-apps.postgres.database.azure.com}"
+STG_STORAGE_GIB="${STG_STORAGE_GIB:-32}"
+MAX_SOURCE_STORAGE_PERCENT="${MAX_SOURCE_STORAGE_PERCENT:-75}"
+
+KUBE_CONTEXT="${KUBE_CONTEXT:-aks-stg-apps}"
+ARGOCD_KUBE_CONTEXT="${ARGOCD_KUBE_CONTEXT:-$KUBE_CONTEXT}"
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argo}"
+ARGOCD_APP="${ARGOCD_APP:-app-klicker}"
+ARGOCD_TIMEOUT_SECONDS="${ARGOCD_TIMEOUT_SECONDS:-1200}"
+ARGOCD_POLL_SECONDS="${ARGOCD_POLL_SECONDS:-2}"
+WORKLOAD_SELECTOR="${WORKLOAD_SELECTOR:-app.kubernetes.io/instance=app-klicker}"
+WORKLOAD_DRAIN_TIMEOUT_SECONDS="${WORKLOAD_DRAIN_TIMEOUT_SECONDS:-300}"
+
+CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}"
+ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}"
+
+PRD_DATABASE_URL="${PRD_DATABASE_URL:-}"
+STG_DATABASE_URL="${STG_DATABASE_URL:-}"
+BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
+
+RUN_DIR=""
+ARCHIVE_PATH=""
+ARCHIVE_CHECKSUM_PATH=""
+ARCHIVE_CATALOG_PATH=""
+BEFORE_RECEIPT=""
+AFTER_RECEIPT=""
+DEPLOYMENT_RECEIPT=""
+
+ARGOCD_POLICY_PAUSED=false
+WORKLOADS_SCALED=false
+TARGET_MUTATED=false
+RESTORE_VERIFIED=false
+RESUMING_MAINTENANCE=false
+
+ORIGINAL_AUTOMATED_SYNC=false
+ORIGINAL_AUTOMATED_JSON="null"
+
+PRD_DB_HOST=""
+PRD_DB_NAME=""
+STG_DB_HOST=""
+STG_DB_NAME=""
+
+PRD_VERSION_NUM=""
+PRD_SIZE_BYTES=""
+PRD_TABLE_COUNT=""
+PRD_APPLIED_MIGRATIONS=""
+PRD_FAILED_MIGRATIONS=""
+PRD_EXTRA_SCHEMA_COUNT=""
+PRD_LARGE_OBJECT_COUNT=""
+
+STG_BEFORE_VERSION_NUM=""
+STG_BEFORE_SIZE_BYTES=""
+STG_BEFORE_TABLE_COUNT=""
+STG_BEFORE_APPLIED_MIGRATIONS=""
+STG_BEFORE_FAILED_MIGRATIONS=""
+STG_EXTRA_SCHEMA_COUNT=""
+STG_LARGE_OBJECT_COUNT=""
+
+STG_CONNECTED_ROLE=""
+STG_PUBLIC_SCHEMA_OWNER=""
+STG_CAN_CREATE_IN_PUBLIC=""
+STG_SUPPORTED_OBJECT_COUNT=""
+STG_UNOWNED_OBJECT_COUNT=""
+STG_UNSUPPORTED_OBJECT_COUNT=""
+
+print_help() {
+  cat <<'EOF'
+Usage: util/backup/refresh-stg-from-prd.sh
+
+Copies the Klicker PRD PostgreSQL database to STG, then runs the existing
+ArgoCD PreSync migration hook by patching the self-hosted app-klicker
+Application resource through the Kubernetes API. The argocd CLI is not
+required.
+
+The script is read-only by default:
+
+  ./util/backup/refresh-stg-from-prd.sh
+
+Execution requires all three explicit gates:
+
+  DRY_RUN=false \
+  CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+  ALLOW_RAW_PRD_DATA_IN_STG=true \
+  ./util/backup/refresh-stg-from-prd.sh
+
+Credentials are loaded from Infisical by default:
+
+  prd: DIRECT_DATABASE_URL + BACKUP_ENCRYPTION_KEY
+  stg: DIRECT_DATABASE_URL
+
+For CI or controlled testing, provide PRD_DATABASE_URL, STG_DATABASE_URL, and
+BACKUP_ENCRYPTION_KEY as environment variables instead. Never pass connection
+URLs as command-line arguments.
+
+Important configuration variables:
+
+  KUBE_CONTEXT                       STG workload context; default: aks-stg-apps
+  ARGOCD_KUBE_CONTEXT                ArgoCD control-plane context; defaults to KUBE_CONTEXT
+  ARGOCD_NAMESPACE                   Application namespace; default: argocd
+  ARGOCD_APP                         default: app-klicker
+  INFISICAL_API_URL                  default: https://inf.prd.df-app.ch/api
+  INFISICAL_PROJECT_ID               default: d071be96-5136-4f23-a6cb-e0c7f9b9a6c8
+  INFISICAL_SECRET_PATH              default: /
+  WORKLOAD_SELECTOR                   default: app.kubernetes.io/instance=app-klicker
+  EXPECTED_PRD_DB_HOST                fail-closed PRD hostname
+  EXPECTED_STG_DB_HOST                fail-closed STG hostname
+  STG_STORAGE_GIB                     default: 32
+  MAX_SOURCE_STORAGE_PERCENT          default: 75
+  RUN_ID                              unique receipt identifier
+  RESUME_FAILED_RUN_ID                failed run receipt to resume while STG is stopped
+  KEEP_ENCRYPTED_ARCHIVE              default: false
+
+Failure after workload shutdown intentionally leaves ArgoCD auto-sync disabled
+and STG workloads stopped. If reset completed but restore did not, do not submit
+an ArgoCD sync. Re-run with RESUME_FAILED_RUN_ID=<failed-run-id>, a fresh RUN_ID,
+and the three execution gates after inspecting the retained receipt.
+EOF
+}
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >&2
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+validate_boolean() {
+  local name="$1"
+  local value="$2"
+
+  case "$value" in
+    true|false) ;;
+    *) die "$name must be exactly 'true' or 'false' (received '$value')" ;;
+  esac
+}
+
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  [[ "$value" =~ ^[0-9]+$ ]] || die "$name must be a non-negative integer"
+}
+
+validate_run_id() {
+  [[ "$RUN_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] \
+    || die "RUN_ID must be 1-128 characters and contain only letters, numbers, dots, underscores, or hyphens"
+}
+
+validate_resume_failed_run_id() {
+  [[ -z "$RESUME_FAILED_RUN_ID" ]] && return 0
+  [[ "$RESUME_FAILED_RUN_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] \
+    || die "RESUME_FAILED_RUN_ID must be 1-128 characters and contain only letters, numbers, dots, underscores, or hyphens"
+  [[ "$RESUME_FAILED_RUN_ID" != "$RUN_ID" ]] \
+    || die "RESUME_FAILED_RUN_ID must differ from the new RUN_ID"
+}
+
+get_argocd_application() {
+  kubectl --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
+    get application.argoproj.io "$ARGOCD_APP" -o json
+}
+
+patch_argocd_application() {
+  local patch_payload="$1"
+  kubectl --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
+    patch application.argoproj.io "$ARGOCD_APP" --type merge \
+    --patch "$patch_payload"
+}
+
+build_argocd_sync_patch() {
+  local initiator="$1"
+  jq -cn --arg initiator "$initiator" \
+    '{
+      operation: {
+        initiatedBy: {username: $initiator},
+        sync: {syncStrategy: {hook: {}}}
+      }
+    }'
+}
+
+build_argocd_policy_patch() {
+  jq -cn --argjson automated "$1" \
+    '{spec: {syncPolicy: {automated: $automated}}}'
+}
+
+cleanup() {
+  local exit_code=$?
+
+  unset PRD_DATABASE_URL STG_DATABASE_URL BACKUP_ENCRYPTION_KEY
+
+  if [[ "$KEEP_ENCRYPTED_ARCHIVE" != "true" ]]; then
+    if [[ -n "$ARCHIVE_PATH" && -f "$ARCHIVE_PATH" ]]; then
+      rm -f -- "$ARCHIVE_PATH"
+    fi
+    if [[ -n "$ARCHIVE_CHECKSUM_PATH" && -f "$ARCHIVE_CHECKSUM_PATH" ]]; then
+      rm -f -- "$ARCHIVE_CHECKSUM_PATH"
+    fi
+    if [[ -n "$ARCHIVE_CATALOG_PATH" && -f "$ARCHIVE_CATALOG_PATH" ]]; then
+      rm -f -- "$ARCHIVE_CATALOG_PATH"
+    fi
+  fi
+
+  if [[ $exit_code -ne 0 && "$ARGOCD_POLICY_PAUSED" == "true" ]]; then
+    log "ArgoCD application: $ARGOCD_APP (automated sync disabled)"
+    if [[ "$WORKLOADS_SCALED" == "true" ]]; then
+      log "STG remains in fail-safe maintenance mode."
+      log "Deployments matching '$WORKLOAD_SELECTOR' remain scaled to zero."
+    else
+      log "Deployment state is not guaranteed to be zero; verify it before database recovery."
+    fi
+    if [[ "$TARGET_MUTATED" == "true" ]]; then
+      log "The STG database was modified; inspect restore and migration state before recovery."
+    fi
+    if [[ "$RESTORE_VERIFIED" != "true" ]]; then
+      local resumable_run_id=""
+      if [[ -n "$BEFORE_RECEIPT" && -s "$BEFORE_RECEIPT" ]]; then
+        resumable_run_id="$RUN_ID"
+      elif [[ -n "$RESUME_FAILED_RUN_ID" ]]; then
+        resumable_run_id="$RESUME_FAILED_RUN_ID"
+      fi
+      log "Do not submit an ArgoCD sync: a complete restored database has not been verified."
+      if [[ -n "$resumable_run_id" ]]; then
+        log "Retry the refresh with RESUME_FAILED_RUN_ID=$resumable_run_id, a fresh RUN_ID, and the three execution gates."
+      else
+        log "No resumable before receipt exists; inspect STG and restore it before re-enabling workloads."
+      fi
+    else
+      local recovery_sync_patch recovery_policy_patch
+      recovery_sync_patch="$(build_argocd_sync_patch "prd-to-stg-recovery-$RUN_ID")"
+      recovery_policy_patch="$(build_argocd_policy_patch "$ORIGINAL_AUTOMATED_JSON")"
+      log "After confirming the restored snapshot is intact, retry the hook sync: kubectl --context $ARGOCD_KUBE_CONTEXT -n $ARGOCD_NAMESPACE patch application.argoproj.io $ARGOCD_APP --type merge --patch '$recovery_sync_patch'"
+      log "Then restore the prior policy: kubectl --context $ARGOCD_KUBE_CONTEXT -n $ARGOCD_NAMESPACE patch application.argoproj.io $ARGOCD_APP --type merge --patch '$recovery_policy_patch'"
+    fi
+  fi
+
+  return "$exit_code"
+}
+
+trap cleanup EXIT
+
+parse_database_url_field() {
+  local database_url="$1"
+  local field="$2"
+
+  KLICKER_DATABASE_URL_INPUT="$database_url" KLICKER_DATABASE_URL_FIELD="$field" \
+    node - <<'NODE'
+const input = process.env.KLICKER_DATABASE_URL_INPUT
+const field = process.env.KLICKER_DATABASE_URL_FIELD
+
+let parsed
+try {
+  parsed = new URL(input)
+} catch {
+  process.stderr.write('Invalid PostgreSQL connection URL\n')
+  process.exit(1)
+}
+
+if (!['postgres:', 'postgresql:'].includes(parsed.protocol)) {
+  process.stderr.write('Connection URL must use postgres:// or postgresql://\n')
+  process.exit(1)
+}
+
+if (field === 'host') {
+  process.stdout.write(parsed.hostname)
+} else if (field === 'port') {
+  process.stdout.write(parsed.port || '5432')
+} else if (field === 'username') {
+  process.stdout.write(decodeURIComponent(parsed.username))
+} else if (field === 'password') {
+  process.stdout.write(decodeURIComponent(parsed.password))
+} else if (field === 'database') {
+  const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
+  if (!database) {
+    process.stderr.write('Connection URL does not contain a database name\n')
+    process.exit(1)
+  }
+  process.stdout.write(database)
+} else if (field === 'libpq') {
+  parsed.searchParams.delete('schema')
+  parsed.searchParams.delete('pgbouncer')
+  process.stdout.write(parsed.toString())
+} else if (field === 'sslmode') {
+  process.stdout.write(parsed.searchParams.get('sslmode') || '')
+} else if (field === 'sslnegotiation') {
+  process.stdout.write(parsed.searchParams.get('sslnegotiation') || '')
+} else if (field === 'channel_binding') {
+  process.stdout.write(parsed.searchParams.get('channel_binding') || '')
+} else if (field === 'target_session_attrs') {
+  process.stdout.write(parsed.searchParams.get('target_session_attrs') || '')
+} else {
+  process.stderr.write(`Unknown URL field: ${field}\n`)
+  process.exit(1)
+}
+NODE
+}
+
+run_database_command() (
+  local database_url="$1"
+  shift
+
+  local host port username password database sslmode sslnegotiation
+  local channel_binding target_session_attrs
+  host="$(parse_database_url_field "$database_url" host)"
+  port="$(parse_database_url_field "$database_url" port)"
+  username="$(parse_database_url_field "$database_url" username)"
+  password="$(parse_database_url_field "$database_url" password)"
+  database="$(parse_database_url_field "$database_url" database)"
+  sslmode="$(parse_database_url_field "$database_url" sslmode)"
+  sslnegotiation="$(parse_database_url_field "$database_url" sslnegotiation)"
+  channel_binding="$(parse_database_url_field "$database_url" channel_binding)"
+  target_session_attrs="$(parse_database_url_field "$database_url" target_session_attrs)"
+
+  export PGCONNECT_TIMEOUT=15
+  export PGHOST="$host"
+  export PGPORT="$port"
+  export PGUSER="$username"
+  export PGPASSWORD="$password"
+  export PGDATABASE="$database"
+  [[ -z "$sslmode" ]] || export PGSSLMODE="$sslmode"
+  [[ -z "$sslnegotiation" ]] || export PGSSLNEGOTIATION="$sslnegotiation"
+  [[ -z "$channel_binding" ]] || export PGCHANNELBINDING="$channel_binding"
+  [[ -z "$target_session_attrs" ]] \
+    || export PGTARGETSESSIONATTRS="$target_session_attrs"
+
+  "$@"
+)
+
+load_infisical_secret() {
+  local output_variable="$1"
+  local secret_name="$2"
+  local environment="$3"
+  local project_id="$4"
+  local secret_value
+
+  if ! secret_value="$(
+    infisical secrets get "$secret_name" \
+      --domain="$INFISICAL_API_URL" \
+      --env="$environment" \
+      --path="$INFISICAL_SECRET_PATH" \
+      --projectId="$project_id" \
+      --plain \
+      --silent
+  )"; then
+    die "Could not load '$secret_name' from Infisical environment '$environment' at '$INFISICAL_API_URL'"
+  fi
+  [[ -n "$secret_value" ]] \
+    || die "Infisical returned an empty value for '$secret_name' in environment '$environment' at path '$INFISICAL_SECRET_PATH'"
+
+  printf -v "$output_variable" '%s' "$secret_value"
+}
+
+load_credentials() {
+  local needs_infisical=false
+  if [[ -z "$PRD_DATABASE_URL" || -z "$STG_DATABASE_URL" ]]; then
+    needs_infisical=true
+  fi
+  if [[ "$DRY_RUN" == "false" && -z "$BACKUP_ENCRYPTION_KEY" ]]; then
+    needs_infisical=true
+  fi
+  if [[ "$needs_infisical" == "false" ]]; then
+    return
+  fi
+
+  require_command infisical
+
+  if [[ -z "$PRD_DATABASE_URL" ]]; then
+    log "Loading the PRD direct database URL from Infisical environment '$PRD_INFISICAL_ENV'"
+    load_infisical_secret PRD_DATABASE_URL DIRECT_DATABASE_URL "$PRD_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+  if [[ -z "$STG_DATABASE_URL" ]]; then
+    log "Loading the STG direct database URL from Infisical environment '$STG_INFISICAL_ENV'"
+    load_infisical_secret STG_DATABASE_URL DIRECT_DATABASE_URL "$STG_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+  if [[ "$DRY_RUN" == "false" && -z "$BACKUP_ENCRYPTION_KEY" ]]; then
+    log "Loading the backup encryption key from Infisical environment '$PRD_INFISICAL_ENV'"
+    load_infisical_secret BACKUP_ENCRYPTION_KEY BACKUP_ENCRYPTION_KEY "$PRD_INFISICAL_ENV" "$INFISICAL_PROJECT_ID"
+  fi
+
+  [[ -n "$PRD_DATABASE_URL" ]] || die "PRD database URL is empty"
+  [[ -n "$STG_DATABASE_URL" ]] || die "STG database URL is empty"
+  if [[ "$DRY_RUN" == "false" ]]; then
+    [[ -n "$BACKUP_ENCRYPTION_KEY" ]] || die "Backup encryption key is empty"
+  fi
+}
+
+validate_endpoints() {
+  PRD_DATABASE_URL="$(parse_database_url_field "$PRD_DATABASE_URL" libpq)" \
+    || die "Could not normalize the PRD database URL"
+  STG_DATABASE_URL="$(parse_database_url_field "$STG_DATABASE_URL" libpq)" \
+    || die "Could not normalize the STG database URL"
+
+  PRD_DB_HOST="$(parse_database_url_field "$PRD_DATABASE_URL" host)"
+  PRD_DB_NAME="$(parse_database_url_field "$PRD_DATABASE_URL" database)"
+  STG_DB_HOST="$(parse_database_url_field "$STG_DATABASE_URL" host)"
+  STG_DB_NAME="$(parse_database_url_field "$STG_DATABASE_URL" database)"
+
+  [[ "$PRD_DB_HOST" == "$EXPECTED_PRD_DB_HOST" ]] \
+    || die "PRD host '$PRD_DB_HOST' does not equal expected host '$EXPECTED_PRD_DB_HOST'"
+  [[ "$STG_DB_HOST" == "$EXPECTED_STG_DB_HOST" ]] \
+    || die "STG host '$STG_DB_HOST' does not equal expected host '$EXPECTED_STG_DB_HOST'"
+  [[ "$PRD_DB_HOST" != "$STG_DB_HOST" ]] || die "PRD and STG resolve to the same configured host"
+}
+
+read_database_metadata() {
+  local database_url="$1"
+  local core_query core_metadata migration_metadata
+  core_query=$(cat <<'SQL'
+/* klicker_database_metadata_core */
+SELECT
+  current_database(),
+  current_setting('server_version_num')::bigint,
+  pg_database_size(current_database()),
+  (SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'),
+  CASE WHEN to_regclass('public."_prisma_migrations"') IS NULL THEN 0 ELSE 1 END,
+  (SELECT count(*) FROM pg_namespace WHERE nspname <> 'public' AND nspname <> 'information_schema' AND nspname !~ '^pg_'),
+  (SELECT count(*) FROM pg_largeobject_metadata);
+SQL
+)
+
+  core_metadata="$(
+    run_database_command "$database_url" \
+      psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$core_query"
+  )" || return 1
+
+  local database_name version_num size_bytes table_count
+  local migration_table_present extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count \
+    migration_table_present extra_schema_count large_object_count \
+    <<<"$core_metadata"
+  [[ "$migration_table_present" == "0" || "$migration_table_present" == "1" ]] \
+    || return 1
+
+  if [[ "$migration_table_present" == "1" ]]; then
+    local migration_query
+    migration_query=$(cat <<'SQL'
+/* klicker_database_metadata_migrations */
+SELECT
+  count(*) FILTER (WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL),
+  count(*) FILTER (WHERE finished_at IS NULL AND rolled_back_at IS NULL)
+FROM public."_prisma_migrations";
+SQL
+)
+    migration_metadata="$(
+      run_database_command "$database_url" \
+        psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$migration_query"
+    )" || return 1
+  else
+    migration_metadata='0|0'
+  fi
+
+  local applied_migrations failed_migrations
+  IFS='|' read -r applied_migrations failed_migrations <<<"$migration_metadata"
+  printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$database_name" "$version_num" "$size_bytes" "$table_count" \
+    "$applied_migrations" "$failed_migrations" "$extra_schema_count" \
+    "$large_object_count"
+}
+
+load_database_metadata() {
+  local output_variable="$1"
+  local database_url="$2"
+  local environment="$3"
+  local metadata
+
+  if ! metadata="$(read_database_metadata "$database_url")"; then
+    die "Could not read $environment database metadata"
+  fi
+  [[ -n "$metadata" ]] || die "$environment database metadata is empty"
+  printf -v "$output_variable" '%s' "$metadata"
+}
+
+parse_prd_metadata() {
+  local metadata="$1"
+  local database_name
+  IFS='|' read -r database_name PRD_VERSION_NUM PRD_SIZE_BYTES PRD_TABLE_COUNT \
+    PRD_APPLIED_MIGRATIONS PRD_FAILED_MIGRATIONS PRD_EXTRA_SCHEMA_COUNT \
+    PRD_LARGE_OBJECT_COUNT <<<"$metadata"
+
+  [[ "$database_name" == "$PRD_DB_NAME" ]] \
+    || die "PRD metadata returned unexpected database '$database_name'"
+  validate_positive_integer PRD_VERSION_NUM "$PRD_VERSION_NUM"
+  validate_positive_integer PRD_SIZE_BYTES "$PRD_SIZE_BYTES"
+  validate_positive_integer PRD_TABLE_COUNT "$PRD_TABLE_COUNT"
+  validate_positive_integer PRD_APPLIED_MIGRATIONS "$PRD_APPLIED_MIGRATIONS"
+  validate_positive_integer PRD_FAILED_MIGRATIONS "$PRD_FAILED_MIGRATIONS"
+  validate_positive_integer PRD_EXTRA_SCHEMA_COUNT "$PRD_EXTRA_SCHEMA_COUNT"
+  validate_positive_integer PRD_LARGE_OBJECT_COUNT "$PRD_LARGE_OBJECT_COUNT"
+  [[ "$PRD_FAILED_MIGRATIONS" == "0" ]] \
+    || die "PRD has $PRD_FAILED_MIGRATIONS unresolved Prisma migration(s); refusing to copy"
+  [[ "$PRD_EXTRA_SCHEMA_COUNT" == "0" ]] \
+    || die "PRD has $PRD_EXTRA_SCHEMA_COUNT non-public application schema(s); this refresh supports only the public schema"
+  [[ "$PRD_LARGE_OBJECT_COUNT" == "0" ]] \
+    || die "PRD has $PRD_LARGE_OBJECT_COUNT PostgreSQL large object(s); this refresh does not support large objects"
+}
+
+parse_stg_before_metadata() {
+  local metadata="$1"
+  local database_name
+  IFS='|' read -r database_name STG_BEFORE_VERSION_NUM STG_BEFORE_SIZE_BYTES \
+    STG_BEFORE_TABLE_COUNT STG_BEFORE_APPLIED_MIGRATIONS \
+    STG_BEFORE_FAILED_MIGRATIONS STG_EXTRA_SCHEMA_COUNT \
+    STG_LARGE_OBJECT_COUNT <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] \
+    || die "STG metadata returned unexpected database '$database_name'"
+  validate_positive_integer STG_BEFORE_VERSION_NUM "$STG_BEFORE_VERSION_NUM"
+  validate_positive_integer STG_BEFORE_SIZE_BYTES "$STG_BEFORE_SIZE_BYTES"
+  validate_positive_integer STG_BEFORE_TABLE_COUNT "$STG_BEFORE_TABLE_COUNT"
+  validate_positive_integer STG_BEFORE_APPLIED_MIGRATIONS "$STG_BEFORE_APPLIED_MIGRATIONS"
+  validate_positive_integer STG_BEFORE_FAILED_MIGRATIONS "$STG_BEFORE_FAILED_MIGRATIONS"
+  validate_positive_integer STG_EXTRA_SCHEMA_COUNT "$STG_EXTRA_SCHEMA_COUNT"
+  validate_positive_integer STG_LARGE_OBJECT_COUNT "$STG_LARGE_OBJECT_COUNT"
+  [[ "$STG_EXTRA_SCHEMA_COUNT" == "0" ]] \
+    || die "STG has $STG_EXTRA_SCHEMA_COUNT non-public application schema(s); refusing an incomplete replacement"
+  [[ "$STG_LARGE_OBJECT_COUNT" == "0" ]] \
+    || die "STG has $STG_LARGE_OBJECT_COUNT PostgreSQL large object(s); refusing an incomplete replacement"
+}
+
+read_stg_reset_capabilities() {
+  local query
+  query=$(cat <<'SQL'
+/* klicker_stg_reset_capabilities */
+WITH public_namespace AS (
+  SELECT oid, nspowner
+  FROM pg_namespace
+  WHERE nspname = 'public'
+), supported_objects AS (
+  SELECT c.relowner AS owner_oid
+  FROM pg_class c
+  WHERE c.relnamespace = (SELECT oid FROM public_namespace)
+    AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+  UNION ALL
+  SELECT p.proowner
+  FROM pg_proc p
+  WHERE p.pronamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT t.typowner
+  FROM pg_type t
+  WHERE t.typnamespace = (SELECT oid FROM public_namespace)
+    AND t.typrelid = 0
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_depend d
+      WHERE d.classid = 'pg_type'::regclass
+        AND d.objid = t.oid
+        AND d.deptype IN ('i', 'e')
+    )
+), unsupported_objects AS (
+  SELECT coll.oid
+  FROM pg_collation coll
+  WHERE coll.collnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT conv.oid
+  FROM pg_conversion conv
+  WHERE conv.connamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT op.oid
+  FROM pg_operator op
+  WHERE op.oprnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT opc.oid
+  FROM pg_opclass opc
+  WHERE opc.opcnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT opf.oid
+  FROM pg_opfamily opf
+  WHERE opf.opfnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT cfg.oid
+  FROM pg_ts_config cfg
+  WHERE cfg.cfgnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT dict.oid
+  FROM pg_ts_dict dict
+  WHERE dict.dictnamespace = (SELECT oid FROM public_namespace)
+  UNION ALL
+  SELECT ext.oid
+  FROM pg_extension ext
+  WHERE ext.extnamespace = (SELECT oid FROM public_namespace)
+)
+SELECT
+  current_database(),
+  current_user,
+  pg_get_userbyid((SELECT nspowner FROM public_namespace)),
+  has_schema_privilege(current_user, 'public', 'CREATE'),
+  (SELECT count(*) FROM supported_objects),
+  (SELECT count(*) FROM supported_objects WHERE NOT pg_has_role(current_user, owner_oid, 'USAGE')),
+  (SELECT count(*) FROM unsupported_objects),
+  (SELECT count(*) FROM pg_namespace WHERE nspname <> 'public' AND nspname <> 'information_schema' AND nspname !~ '^pg_'),
+  (SELECT count(*) FROM pg_largeobject_metadata);
+SQL
+)
+
+  run_database_command "$STG_DATABASE_URL" \
+    psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$query"
+}
+
+validate_stg_reset_capabilities() {
+  local metadata database_name extra_schema_count large_object_count
+  if ! metadata="$(read_stg_reset_capabilities)"; then
+    die "Could not validate STG object ownership for replacement"
+  fi
+
+  IFS='|' read -r database_name STG_CONNECTED_ROLE STG_PUBLIC_SCHEMA_OWNER \
+    STG_CAN_CREATE_IN_PUBLIC STG_SUPPORTED_OBJECT_COUNT \
+    STG_UNOWNED_OBJECT_COUNT STG_UNSUPPORTED_OBJECT_COUNT extra_schema_count \
+    large_object_count <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] \
+    || die "STG ownership metadata came from unexpected database '$database_name'"
+  [[ -n "$STG_CONNECTED_ROLE" && -n "$STG_PUBLIC_SCHEMA_OWNER" ]] \
+    || die "STG ownership metadata is incomplete"
+  [[ "$STG_CAN_CREATE_IN_PUBLIC" == "t" ]] \
+    || die "STG role '$STG_CONNECTED_ROLE' cannot create objects in the public schema"
+  validate_positive_integer STG_SUPPORTED_OBJECT_COUNT "$STG_SUPPORTED_OBJECT_COUNT"
+  validate_positive_integer STG_UNOWNED_OBJECT_COUNT "$STG_UNOWNED_OBJECT_COUNT"
+  validate_positive_integer STG_UNSUPPORTED_OBJECT_COUNT "$STG_UNSUPPORTED_OBJECT_COUNT"
+  validate_positive_integer stg_reset_extra_schema_count "$extra_schema_count"
+  validate_positive_integer stg_reset_large_object_count "$large_object_count"
+  [[ "$STG_UNOWNED_OBJECT_COUNT" == "0" ]] \
+    || die "STG contains $STG_UNOWNED_OBJECT_COUNT public object(s) that '$STG_CONNECTED_ROLE' cannot drop"
+  [[ "$STG_UNSUPPORTED_OBJECT_COUNT" == "0" ]] \
+    || die "STG contains $STG_UNSUPPORTED_OBJECT_COUNT unsupported public object(s); refusing an incomplete replacement"
+  [[ "$extra_schema_count" == "0" && "$large_object_count" == "0" ]] \
+    || die "STG replacement capability changed after metadata validation"
+}
+
+validate_client_and_capacity() {
+  local pg_dump_major pg_restore_major
+  pg_dump_major="$(pg_dump --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+  pg_restore_major="$(pg_restore --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+  validate_positive_integer pg_dump_major "$pg_dump_major"
+  validate_positive_integer pg_restore_major "$pg_restore_major"
+
+  local prd_major=$((PRD_VERSION_NUM / 10000))
+  local stg_major=$((STG_BEFORE_VERSION_NUM / 10000))
+  if (( pg_dump_major < prd_major )); then
+    die "pg_dump major $pg_dump_major cannot dump PRD PostgreSQL major $prd_major"
+  fi
+  if (( pg_restore_major < prd_major )); then
+    die "pg_restore major $pg_restore_major cannot restore a PRD PostgreSQL major $prd_major dump"
+  fi
+  if (( stg_major < prd_major )); then
+    die "STG PostgreSQL major $stg_major is older than PRD PostgreSQL major $prd_major"
+  fi
+
+  local stg_capacity_bytes=$((STG_STORAGE_GIB * 1024 * 1024 * 1024))
+  if (( PRD_SIZE_BYTES * 100 > stg_capacity_bytes * MAX_SOURCE_STORAGE_PERCENT )); then
+    die "PRD database size exceeds ${MAX_SOURCE_STORAGE_PERCENT}% of the configured ${STG_STORAGE_GIB} GiB STG storage capacity"
+  fi
+}
+
+load_failed_run_receipt() {
+  local failed_run_dir="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID"
+  local failed_before_receipt="$failed_run_dir/before.json"
+  local failed_after_receipt="$failed_run_dir/after.json"
+  local failed_deployment_receipt="$failed_run_dir/deployments.tsv"
+
+  [[ -s "$failed_before_receipt" ]] \
+    || die "Resume receipt does not exist or is empty: $failed_before_receipt"
+  [[ ! -e "$failed_after_receipt" ]] \
+    || die "Run '$RESUME_FAILED_RUN_ID' has an after receipt and cannot be resumed"
+  [[ -s "$failed_deployment_receipt" ]] \
+    || die "Resume deployment receipt does not exist or is empty: $failed_deployment_receipt"
+
+  jq -e \
+    --arg runId "$RESUME_FAILED_RUN_ID" \
+    --arg sourceHost "$PRD_DB_HOST" \
+    --arg sourceDatabase "$PRD_DB_NAME" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    '
+      .runId == $runId and
+      .source.host == $sourceHost and
+      .source.database == $sourceDatabase and
+      .targetBefore.host == $targetHost and
+      .targetBefore.database == $targetDatabase and
+      (.argocdAutomatedPolicy | type) == "object" and
+      ((.argocdAutomatedPolicy.enabled // true) != false)
+    ' "$failed_before_receipt" >/dev/null \
+    || die "Resume receipt does not match the current source, target, or prior automated-sync state"
+
+  ORIGINAL_AUTOMATED_JSON="$(jq -c '.argocdAutomatedPolicy' "$failed_before_receipt")"
+  ORIGINAL_AUTOMATED_SYNC=true
+  RESUMING_MAINTENANCE=true
+  ARGOCD_POLICY_PAUSED=true
+}
+
+load_argocd_state() {
+  local application_json
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP' using context '$ARGOCD_KUBE_CONTEXT'"
+
+  local operation_phase
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  if jq -e '.operation != null' >/dev/null <<<"$application_json"; then
+    die "ArgoCD Application '$ARGOCD_APP' already has a pending operation"
+  fi
+  [[ "$operation_phase" != "Running" && "$operation_phase" != "Terminating" ]] \
+    || die "ArgoCD application '$ARGOCD_APP' already has a running operation"
+
+  local current_automated_sync=false
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    current_automated_sync=true
+  fi
+
+  if [[ "$current_automated_sync" == "true" ]]; then
+    [[ -z "$RESUME_FAILED_RUN_ID" ]] \
+      || die "RESUME_FAILED_RUN_ID was provided but ArgoCD automated sync is enabled; refusing a stale resume"
+    ORIGINAL_AUTOMATED_JSON="$(jq -c '.spec.syncPolicy.automated' <<<"$application_json")"
+    ORIGINAL_AUTOMATED_SYNC=true
+    return 0
+  fi
+
+  [[ -n "$RESUME_FAILED_RUN_ID" ]] \
+    || die "ArgoCD automated sync is disabled before refresh; set RESUME_FAILED_RUN_ID only after validating the failed-run receipt and maintenance state"
+  load_failed_run_receipt
+}
+
+load_workload_state() {
+  local deployments_json
+  deployments_json="$(kubectl --context "$KUBE_CONTEXT" get deployments -A \
+    -l "$WORKLOAD_SELECTOR" -o json)" \
+    || die "Could not list STG deployments using context '$KUBE_CONTEXT'"
+
+  local deployment_count
+  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
+  validate_positive_integer deployment_count "$deployment_count"
+  (( deployment_count > 0 )) \
+    || die "No STG deployments matched selector '$WORKLOAD_SELECTOR'"
+
+  printf '%s' "$deployments_json"
+}
+
+validate_resume_workload_state() {
+  local deployments_json="$1"
+  [[ "$RESUMING_MAINTENANCE" == "true" ]] || return 0
+
+  local nonzero_replicas
+  nonzero_replicas="$(
+    jq '[.items[] | select((.spec.replicas // 1) != 0 or (.status.replicas // 0) != 0)] | length' \
+      <<<"$deployments_json"
+  )"
+  [[ "$nonzero_replicas" == "0" ]] \
+    || die "Cannot resume while any selected STG Deployment has desired or running replicas"
+
+  local failed_deployment_receipt="$REFRESH_ROOT_DIR/$RESUME_FAILED_RUN_ID/deployments.tsv"
+  local receipt_deployments current_deployments
+  receipt_deployments="$(
+    jq -Rn \
+      '[inputs | select(length > 0) | split("\t") | {namespace: .[0], name: .[1]}] | sort_by(.namespace, .name)' \
+      <"$failed_deployment_receipt"
+  )"
+  current_deployments="$(
+    jq -c '[.items[] | {namespace: .metadata.namespace, name: .metadata.name}] | sort_by(.namespace, .name)' \
+      <<<"$deployments_json"
+  )"
+  [[ "$current_deployments" == "$(jq -c . <<<"$receipt_deployments")" ]] \
+    || die "Selected STG Deployments no longer match the failed-run receipt"
+
+  WORKLOADS_SCALED=true
+  log "Resuming fail-safe maintenance from run '$RESUME_FAILED_RUN_ID'; ArgoCD remains manual and all selected Deployments remain at zero"
+}
+
+print_preflight_summary() {
+  local deployment_count="$1"
+  log "Preflight complete"
+  log "Source: $PRD_DB_HOST/$PRD_DB_NAME (PostgreSQL $((PRD_VERSION_NUM / 10000)), $PRD_SIZE_BYTES bytes, $PRD_TABLE_COUNT tables)"
+  log "Target: $STG_DB_HOST/$STG_DB_NAME (PostgreSQL $((STG_BEFORE_VERSION_NUM / 10000)), current size $STG_BEFORE_SIZE_BYTES bytes)"
+  log "ArgoCD Application: $ARGOCD_NAMESPACE/$ARGOCD_APP via context $ARGOCD_KUBE_CONTEXT"
+  log "STG deployments to stop: $deployment_count"
+  log "STG reset: remove $STG_SUPPORTED_OBJECT_COUNT objects owned by $STG_CONNECTED_ROLE; preserve public schema owned by $STG_PUBLIC_SCHEMA_OWNER"
+  log "Raw PRD data, including personal data, will be present in STG after execution."
+}
+
+prepare_run_directory() {
+  RUN_DIR="$REFRESH_ROOT_DIR/$RUN_ID"
+  ARCHIVE_PATH="$RUN_DIR/prd.dump.gpg"
+  ARCHIVE_CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
+  ARCHIVE_CATALOG_PATH="$RUN_DIR/prd.dump.list"
+  BEFORE_RECEIPT="$RUN_DIR/before.json"
+  AFTER_RECEIPT="$RUN_DIR/after.json"
+  DEPLOYMENT_RECEIPT="$RUN_DIR/deployments.tsv"
+
+  [[ ! -e "$RUN_DIR" ]] || die "Run directory already exists; choose a new RUN_ID: $RUN_DIR"
+  mkdir -p "$RUN_DIR"
+  chmod 700 "$RUN_DIR"
+}
+
+encrypt_prd_dump() {
+  log "Creating encrypted PRD custom-format dump"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! run_database_command "$PRD_DATABASE_URL" \
+    pg_dump --format=custom --no-owner --no-privileges \
+      | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+        --cipher-algo AES256 --symmetric --output "$ARCHIVE_PATH"; then
+    exec 3<&-
+    die "PRD dump or archive encryption failed"
+  fi
+  exec 3<&-
+
+  [[ -s "$ARCHIVE_PATH" ]] || die "Encrypted PRD archive is empty"
+
+  local checksum
+  checksum="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
+  [[ "$checksum" =~ ^[0-9a-fA-F]{64}$ ]] || die "Could not calculate archive checksum"
+  printf '%s  %s\n' "$checksum" "$(basename "$ARCHIVE_PATH")" >"$ARCHIVE_CHECKSUM_PATH"
+
+  log "Validating that the encrypted archive decrypts and has a readable pg_restore catalog"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+    --decrypt "$ARCHIVE_PATH" 2>/dev/null \
+      | {
+        pg_restore --list >"$ARCHIVE_CATALOG_PATH"
+        catalog_status=$?
+        cat >/dev/null
+        drain_status=$?
+        (( catalog_status == 0 && drain_status == 0 ))
+      }; then
+    exec 3<&-
+    die "Encrypted archive validation failed"
+  fi
+  exec 3<&-
+
+  local filtered_catalog="$ARCHIVE_CATALOG_PATH.filtered"
+  local public_schema_entries
+  public_schema_entries="$(
+    grep -Ec '^[0-9]+; [0-9]+ [0-9]+ (SCHEMA - public|(COMMENT|ACL|SECURITY LABEL) - SCHEMA public) ' \
+      "$ARCHIVE_CATALOG_PATH" || true
+  )"
+  (( public_schema_entries > 0 )) \
+    || die "PRD archive catalog does not contain the expected public schema entry"
+
+  awk '
+    /^[0-9]+; [0-9]+ [0-9]+ SCHEMA - public / ||
+    /^[0-9]+; [0-9]+ [0-9]+ (COMMENT|ACL|SECURITY LABEL) - SCHEMA public / {
+      print ";" $0
+      next
+    }
+    { print }
+  ' "$ARCHIVE_CATALOG_PATH" >"$filtered_catalog"
+  mv -- "$filtered_catalog" "$ARCHIVE_CATALOG_PATH"
+
+  if grep -Eq '^[0-9]+; [0-9]+ [0-9]+ (SCHEMA - public|(COMMENT|ACL|SECURITY LABEL) - SCHEMA public) ' \
+    "$ARCHIVE_CATALOG_PATH"; then
+    die "Could not exclude public schema ownership entries from the restore catalog"
+  fi
+}
+
+write_before_receipt() {
+  local archive_checksum
+  archive_checksum="$(awk '{print $1}' "$ARCHIVE_CHECKSUM_PATH")"
+
+  jq -n \
+    --arg runId "$RUN_ID" \
+    --arg resumedFromRunId "$RESUME_FAILED_RUN_ID" \
+    --arg createdAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg sourceHost "$PRD_DB_HOST" \
+    --arg sourceDatabase "$PRD_DB_NAME" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    --arg archiveSha256 "$archive_checksum" \
+    --argjson sourceSizeBytes "$PRD_SIZE_BYTES" \
+    --argjson sourceTableCount "$PRD_TABLE_COUNT" \
+    --argjson sourceAppliedMigrations "$PRD_APPLIED_MIGRATIONS" \
+    --argjson targetBeforeSizeBytes "$STG_BEFORE_SIZE_BYTES" \
+    --argjson targetBeforeTableCount "$STG_BEFORE_TABLE_COUNT" \
+    --argjson targetBeforeAppliedMigrations "$STG_BEFORE_APPLIED_MIGRATIONS" \
+    --argjson argocdAutomatedPolicy "$ORIGINAL_AUTOMATED_JSON" \
+    '{
+      runId: $runId,
+      resumedFromRunId: (if $resumedFromRunId == "" then null else $resumedFromRunId end),
+      createdAt: $createdAt,
+      source: {
+        host: $sourceHost,
+        database: $sourceDatabase,
+        sizeBytes: $sourceSizeBytes,
+        tableCount: $sourceTableCount,
+        appliedMigrations: $sourceAppliedMigrations
+      },
+      targetBefore: {
+        host: $targetHost,
+        database: $targetDatabase,
+        sizeBytes: $targetBeforeSizeBytes,
+        tableCount: $targetBeforeTableCount,
+        appliedMigrations: $targetBeforeAppliedMigrations
+      },
+      archiveSha256: $archiveSha256,
+      argocdAutomatedPolicy: $argocdAutomatedPolicy
+    }' >"$BEFORE_RECEIPT"
+}
+
+pause_argocd_policy() {
+  if [[ "$RESUMING_MAINTENANCE" == "true" ]]; then
+    log "ArgoCD automated sync is already disabled by failed run '$RESUME_FAILED_RUN_ID'"
+    ARGOCD_POLICY_PAUSED=true
+    return 0
+  fi
+
+  log "Disabling automated sync/self-heal on ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP'"
+  patch_argocd_application '{"spec":{"syncPolicy":{"automated":null}}}' >/dev/null
+  ARGOCD_POLICY_PAUSED=true
+
+  local application_json
+  application_json="$(get_argocd_application)"
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    die "ArgoCD automated sync is still enabled after requesting manual policy"
+  fi
+}
+
+scale_stg_workloads_down() {
+  local deployments_json
+  WORKLOADS_SCALED=false
+  deployments_json="$(load_workload_state)"
+  jq -r '.items[] | [.metadata.namespace, .metadata.name, (.spec.replicas // 1)] | @tsv' \
+    <<<"$deployments_json" >"$DEPLOYMENT_RECEIPT"
+
+  while IFS=$'\t' read -r namespace deployment replicas; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    log "Scaling $namespace/deployment/$deployment from $replicas to 0"
+    kubectl --context "$KUBE_CONTEXT" -n "$namespace" \
+      scale "deployment/$deployment" --replicas=0 >/dev/null
+  done <"$DEPLOYMENT_RECEIPT"
+
+  local deadline=$((SECONDS + WORKLOAD_DRAIN_TIMEOUT_SECONDS))
+  while true; do
+    deployments_json="$(load_workload_state)"
+    local remaining_replicas
+    remaining_replicas="$(jq '[.items[] | (.status.replicas // 0)] | add // 0' <<<"$deployments_json")"
+    validate_positive_integer remaining_replicas "$remaining_replicas"
+    if (( remaining_replicas == 0 )); then
+      break
+    fi
+    if (( SECONDS >= deadline )); then
+      die "Timed out waiting for STG workloads to reach zero replicas"
+    fi
+    sleep 2
+  done
+
+  WORKLOADS_SCALED=true
+  log "All selected STG workloads are stopped"
+}
+
+reset_stg_owned_objects() {
+  local reset_sql
+  reset_sql=$(cat <<'SQL'
+/* klicker_reset_owned_objects */
+SET lock_timeout = '30s';
+BEGIN;
+DO $reset$
+DECLARE
+  object_record record;
+  object_kind text;
+BEGIN
+  FOR object_record IN
+    SELECT
+      p.proname AS object_name,
+      p.prokind,
+      pg_get_function_identity_arguments(p.oid) AS identity_arguments
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND pg_has_role(current_user, p.proowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.prokind
+      WHEN 'p' THEN 'PROCEDURE'
+      WHEN 'a' THEN 'AGGREGATE'
+      ELSE 'FUNCTION'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I(%s) CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name,
+      object_record.identity_arguments
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name, c.relkind
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('v', 'm')
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.relkind
+      WHEN 'm' THEN 'MATERIALIZED VIEW'
+      ELSE 'VIEW'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name, c.relkind
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'f')
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    object_kind := CASE object_record.relkind
+      WHEN 'f' THEN 'FOREIGN TABLE'
+      ELSE 'TABLE'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT c.relname AS object_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'S'
+      AND pg_has_role(current_user, c.relowner, 'USAGE')
+  LOOP
+    EXECUTE format(
+      'DROP SEQUENCE IF EXISTS %I.%I CASCADE',
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT t.typname AS object_name, t.typtype
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND t.typrelid = 0
+      AND pg_has_role(current_user, t.typowner, 'USAGE')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        WHERE d.classid = 'pg_type'::regclass
+          AND d.objid = t.oid
+          AND d.deptype IN ('i', 'e')
+      )
+  LOOP
+    object_kind := CASE object_record.typtype
+      WHEN 'd' THEN 'DOMAIN'
+      ELSE 'TYPE'
+    END;
+    EXECUTE format(
+      'DROP %s IF EXISTS %I.%I CASCADE',
+      object_kind,
+      'public',
+      object_record.object_name
+    );
+  END LOOP;
+END
+$reset$;
+COMMIT;
+SQL
+)
+
+  log "Removing STG objects owned by '$STG_CONNECTED_ROLE' while preserving schema 'public' owned by '$STG_PUBLIC_SCHEMA_OWNER'"
+  run_database_command "$STG_DATABASE_URL" \
+    psql -X -v ON_ERROR_STOP=1 -c "$reset_sql" >/dev/null
+  TARGET_MUTATED=true
+}
+
+restore_stg_database() {
+  log "Restoring the encrypted PRD archive into STG"
+  exec 3<<<"$BACKUP_ENCRYPTION_KEY"
+  if ! gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+    --decrypt "$ARCHIVE_PATH" 2>/dev/null \
+      | run_database_command "$STG_DATABASE_URL" \
+        pg_restore --format=custom --exit-on-error --single-transaction \
+          --dbname="$STG_DB_NAME" --use-list="$ARCHIVE_CATALOG_PATH" \
+          --no-owner --no-privileges; then
+    exec 3<&-
+    die "STG pg_restore failed"
+  fi
+  exec 3<&-
+}
+
+validate_restored_snapshot() {
+  local metadata="$1"
+  local database_name version_num size_bytes table_count applied_migrations
+  local failed_migrations extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
+    failed_migrations extra_schema_count large_object_count <<<"$metadata"
+
+  [[ "$database_name" == "$STG_DB_NAME" ]] || die "Restored metadata came from an unexpected database"
+  validate_positive_integer restored_version_num "$version_num"
+  validate_positive_integer restored_size_bytes "$size_bytes"
+  validate_positive_integer restored_table_count "$table_count"
+  validate_positive_integer restored_applied_migrations "$applied_migrations"
+  validate_positive_integer restored_failed_migrations "$failed_migrations"
+  validate_positive_integer restored_extra_schema_count "$extra_schema_count"
+  validate_positive_integer restored_large_object_count "$large_object_count"
+  [[ "$table_count" == "$PRD_TABLE_COUNT" ]] \
+    || die "Restored table count $table_count does not match PRD snapshot count $PRD_TABLE_COUNT"
+  [[ "$applied_migrations" == "$PRD_APPLIED_MIGRATIONS" ]] \
+    || die "Restored migration count $applied_migrations does not match PRD snapshot count $PRD_APPLIED_MIGRATIONS"
+  [[ "$failed_migrations" == "0" ]] \
+    || die "Restored snapshot contains $failed_migrations unresolved Prisma migration(s)"
+  [[ "$extra_schema_count" == "0" && "$large_object_count" == "0" ]] \
+    || die "Restored snapshot contains unsupported schemas or large objects"
+
+  log "Logical restore matches the PRD table and migration metadata"
+}
+
+run_presync_hook() {
+  local application_json operation_phase
+  application_json="$(get_argocd_application)" \
+    || die "Could not read ArgoCD Application immediately before sync"
+  operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+  if jq -e '.operation != null' >/dev/null <<<"$application_json" || \
+    [[ "$operation_phase" == "Running" || "$operation_phase" == "Terminating" ]]; then
+    die "ArgoCD Application '$ARGOCD_APP' acquired another operation before refresh sync"
+  fi
+
+  local initiator="prd-to-stg-refresh-$RUN_ID"
+  local sync_patch
+  sync_patch="$(build_argocd_sync_patch "$initiator")"
+
+  log "Submitting a hook-based sync to ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP'"
+  if ! patch_argocd_application "$sync_patch" >/dev/null; then
+    die "Could not submit the ArgoCD sync operation through the Kubernetes API"
+  fi
+
+  # Once the operation is accepted, Deployment replica state is no longer
+  # guaranteed to be zero: a successful PreSync allows the main Sync phase.
+  WORKLOADS_SCALED=false
+
+  local deadline=$((SECONDS + ARGOCD_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    if ! application_json="$(get_argocd_application)"; then
+      log "Waiting for the ArgoCD Application resource to become readable"
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    fi
+
+    local observed_initiator
+    observed_initiator="$(jq -r '.status.operationState.operation.initiatedBy.username // ""' <<<"$application_json")"
+    if [[ "$observed_initiator" != "$initiator" ]]; then
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    fi
+
+    operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+    case "$operation_phase" in
+      Succeeded)
+        log "ArgoCD sync succeeded; the PreSync migration hook and Sync phase completed"
+        return 0
+        ;;
+      Failed|Error)
+        local operation_message
+        operation_message="$(jq -r '.status.operationState.message // "no operation message"' <<<"$application_json")"
+        log "ArgoCD operation ended in phase '$operation_phase': $operation_message"
+        log "Forcing the selected STG Deployments back to zero"
+        scale_stg_workloads_down
+        die "ArgoCD sync or PreSync migration hook failed"
+        ;;
+    esac
+
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+
+  log "Timed out waiting for the submitted ArgoCD operation; forcing STG Deployments back to zero"
+  scale_stg_workloads_down
+  die "ArgoCD sync did not complete within $ARGOCD_TIMEOUT_SECONDS seconds"
+}
+
+scale_stg_workloads_down_after_verification_failure() {
+  log "Post-sync verification failed; returning STG workloads to zero replicas"
+  scale_stg_workloads_down
+}
+
+validate_migrated_target() {
+  local metadata="$1"
+  local database_name version_num size_bytes table_count applied_migrations
+  local failed_migrations extra_schema_count large_object_count
+  IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
+    failed_migrations extra_schema_count large_object_count <<<"$metadata"
+
+  local error=""
+  if [[ "$database_name" != "$STG_DB_NAME" ]]; then
+    error="Post-migration metadata came from unexpected database '$database_name'"
+  elif [[ ! "$version_num" =~ ^[0-9]+$ ||
+    ! "$size_bytes" =~ ^[0-9]+$ ||
+    ! "$table_count" =~ ^[0-9]+$ ||
+    ! "$applied_migrations" =~ ^[0-9]+$ ||
+    ! "$failed_migrations" =~ ^[0-9]+$ ||
+    ! "$extra_schema_count" =~ ^[0-9]+$ ||
+    ! "$large_object_count" =~ ^[0-9]+$ ]]; then
+    error="Post-migration database metadata is incomplete or malformed"
+  elif (( table_count == 0 )); then
+    error="Post-migration database contains no public tables"
+  elif (( applied_migrations < PRD_APPLIED_MIGRATIONS )); then
+    error="Post-migration applied count $applied_migrations is lower than PRD snapshot count $PRD_APPLIED_MIGRATIONS"
+  elif [[ "$failed_migrations" != "0" ]]; then
+    error="Post-migration database contains $failed_migrations unresolved Prisma migration(s)"
+  elif [[ "$extra_schema_count" != "0" || "$large_object_count" != "0" ]]; then
+    error="Post-migration database contains unsupported schemas or large objects"
+  fi
+
+  if [[ -n "$error" ]]; then
+    scale_stg_workloads_down_after_verification_failure
+    die "$error"
+  fi
+
+  jq -n \
+    --arg runId "$RUN_ID" \
+    --arg completedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg targetHost "$STG_DB_HOST" \
+    --arg targetDatabase "$STG_DB_NAME" \
+    --argjson targetSizeBytes "$size_bytes" \
+    --argjson targetTableCount "$table_count" \
+    --argjson targetAppliedMigrations "$applied_migrations" \
+    '{
+      runId: $runId,
+      completedAt: $completedAt,
+      targetAfter: {
+        host: $targetHost,
+        database: $targetDatabase,
+        sizeBytes: $targetSizeBytes,
+        tableCount: $targetTableCount,
+        appliedMigrations: $targetAppliedMigrations,
+        unresolvedMigrations: 0
+      }
+    }' >"$AFTER_RECEIPT"
+
+  log "Post-sync verification passed: $table_count tables, $applied_migrations applied migrations"
+}
+
+restore_argocd_policy() {
+  local policy_patch
+  policy_patch="$(build_argocd_policy_patch "$ORIGINAL_AUTOMATED_JSON")"
+  patch_argocd_application "$policy_patch" >/dev/null
+
+  local application_json
+  application_json="$(get_argocd_application)"
+  jq -e --argjson expected "$ORIGINAL_AUTOMATED_JSON" \
+    '(.spec.syncPolicy.automated // null) == $expected' \
+    >/dev/null <<<"$application_json" \
+    || die "Could not restore the exact original ArgoCD automated-sync policy"
+
+  local restored_automated=false
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$application_json"; then
+    restored_automated=true
+  fi
+
+  [[ "$restored_automated" == "$ORIGINAL_AUTOMATED_SYNC" ]] \
+    || die "Could not restore the original ArgoCD automated-sync state"
+
+  ARGOCD_POLICY_PAUSED=false
+  WORKLOADS_SCALED=false
+  log "Restored the original ArgoCD sync policy"
+}
+
+validate_configuration() {
+  validate_boolean DRY_RUN "$DRY_RUN"
+  validate_boolean KEEP_ENCRYPTED_ARCHIVE "$KEEP_ENCRYPTED_ARCHIVE"
+  validate_boolean ALLOW_RAW_PRD_DATA_IN_STG "$ALLOW_RAW_PRD_DATA_IN_STG"
+  validate_positive_integer STG_STORAGE_GIB "$STG_STORAGE_GIB"
+  validate_positive_integer MAX_SOURCE_STORAGE_PERCENT "$MAX_SOURCE_STORAGE_PERCENT"
+  validate_positive_integer ARGOCD_TIMEOUT_SECONDS "$ARGOCD_TIMEOUT_SECONDS"
+  validate_positive_integer ARGOCD_POLL_SECONDS "$ARGOCD_POLL_SECONDS"
+  validate_positive_integer WORKLOAD_DRAIN_TIMEOUT_SECONDS "$WORKLOAD_DRAIN_TIMEOUT_SECONDS"
+  validate_run_id
+  validate_resume_failed_run_id
+  (( STG_STORAGE_GIB > 0 )) || die "STG_STORAGE_GIB must be greater than zero"
+  (( ARGOCD_POLL_SECONDS > 0 )) || die "ARGOCD_POLL_SECONDS must be greater than zero"
+  (( MAX_SOURCE_STORAGE_PERCENT > 0 && MAX_SOURCE_STORAGE_PERCENT <= 95 )) \
+    || die "MAX_SOURCE_STORAGE_PERCENT must be between 1 and 95"
+}
+
+validate_execution_gates() {
+  [[ "$DRY_RUN" == "false" ]] || return 0
+
+  [[ "$CONFIRM_PRD_TO_STG_REFRESH" == "ERASE_STG_AND_COPY_PRD" ]] \
+    || die "Execution requires CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD"
+  [[ "$ALLOW_RAW_PRD_DATA_IN_STG" == "true" ]] \
+    || die "Execution requires ALLOW_RAW_PRD_DATA_IN_STG=true"
+}
+
+validate_tools() {
+  local tools=(awk cat gpg grep jq kubectl mv node pg_dump pg_restore psql sed shasum)
+  local tool
+  for tool in "${tools[@]}"; do
+    require_command "$tool"
+  done
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    print_help
+    return 0
+  fi
+  [[ $# -eq 0 ]] || die "Unknown argument: $1"
+
+  validate_configuration
+  validate_execution_gates
+  validate_tools
+  load_credentials
+  validate_endpoints
+
+  local prd_metadata stg_before_metadata
+  load_database_metadata prd_metadata "$PRD_DATABASE_URL" PRD
+  load_database_metadata stg_before_metadata "$STG_DATABASE_URL" STG
+  parse_prd_metadata "$prd_metadata"
+  parse_stg_before_metadata "$stg_before_metadata"
+  validate_stg_reset_capabilities
+  validate_client_and_capacity
+  load_argocd_state
+
+  local deployments_json
+  deployments_json="$(load_workload_state)"
+  validate_resume_workload_state "$deployments_json"
+  local deployment_count
+  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
+  print_preflight_summary "$deployment_count"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY_RUN=true: no dump was created and no external state was changed."
+    log "Re-run with the three documented execution gates after reviewing this plan."
+    return 0
+  fi
+
+  prepare_run_directory
+  encrypt_prd_dump
+  write_before_receipt
+
+  pause_argocd_policy
+  scale_stg_workloads_down
+
+  # Re-verify the pause immediately before the first destructive database action.
+  local paused_application_json
+  paused_application_json="$(get_argocd_application)"
+  if jq -e '.spec.syncPolicy.automated != null and (.spec.syncPolicy.automated.enabled // true) != false' \
+    >/dev/null <<<"$paused_application_json"; then
+    die "ArgoCD automated sync was re-enabled before database replacement"
+  fi
+
+  reset_stg_owned_objects
+  restore_stg_database
+  local restored_metadata
+  load_database_metadata restored_metadata "$STG_DATABASE_URL" STG
+  validate_restored_snapshot "$restored_metadata"
+  RESTORE_VERIFIED=true
+
+  run_presync_hook
+  local migrated_metadata
+  load_database_metadata migrated_metadata "$STG_DATABASE_URL" STG
+  validate_migrated_target "$migrated_metadata"
+  restore_argocd_policy
+
+  log "PRD-to-STG database refresh completed successfully"
+  log "Receipts: $BEFORE_RECEIPT and $AFTER_RECEIPT"
+  if [[ "$KEEP_ENCRYPTED_ARCHIVE" == "true" ]]; then
+    log "Encrypted archive retained at: $ARCHIVE_PATH"
+  else
+    log "Encrypted archive will be removed during cleanup"
+  fi
+}
+
+main "$@"

--- a/util/backup/refresh-stg-from-prd.sh
+++ b/util/backup/refresh-stg-from-prd.sh
@@ -14,7 +14,6 @@ set -Eeuo pipefail
 umask 077
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 DRY_RUN="${DRY_RUN:-true}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
@@ -30,20 +29,35 @@ INFISICAL_SECRET_PATH="${INFISICAL_SECRET_PATH:-/}"
 
 EXPECTED_PRD_DB_HOST="${EXPECTED_PRD_DB_HOST:-db-server-prd-apps.postgres.database.azure.com}"
 EXPECTED_STG_DB_HOST="${EXPECTED_STG_DB_HOST:-db-server-stg-apps.postgres.database.azure.com}"
-STG_STORAGE_GIB="${STG_STORAGE_GIB:-32}"
+EXPECTED_PRD_DB_NAME="${EXPECTED_PRD_DB_NAME:-klicker}"
+EXPECTED_STG_DB_NAME="${EXPECTED_STG_DB_NAME:-klicker}"
+REQUIRED_DB_SSLMODE="${REQUIRED_DB_SSLMODE:-require}"
+STG_FREE_STORAGE_GIB="${STG_FREE_STORAGE_GIB:-}"
 MAX_SOURCE_STORAGE_PERCENT="${MAX_SOURCE_STORAGE_PERCENT:-75}"
 
 KUBE_CONTEXT="${KUBE_CONTEXT:-aks-stg-apps}"
 ARGOCD_KUBE_CONTEXT="${ARGOCD_KUBE_CONTEXT:-$KUBE_CONTEXT}"
-ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argo}"
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
 ARGOCD_APP="${ARGOCD_APP:-app-klicker}"
+WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-}"
+EXPECTED_STG_CLUSTER_UID="${EXPECTED_STG_CLUSTER_UID:-}"
+EXPECTED_ARGOCD_CLUSTER_UID="${EXPECTED_ARGOCD_CLUSTER_UID:-$EXPECTED_STG_CLUSTER_UID}"
+KUBECTL_REQUEST_TIMEOUT="${KUBECTL_REQUEST_TIMEOUT:-30s}"
+REFRESH_LEASE_NAME="${REFRESH_LEASE_NAME:-${ARGOCD_APP}-prd-to-stg-refresh}"
+REFRESH_LEASE_NAMESPACE="${REFRESH_LEASE_NAMESPACE:-$ARGOCD_NAMESPACE}"
+REFRESH_LEASE_DURATION_SECONDS="${REFRESH_LEASE_DURATION_SECONDS:-7200}"
+MIGRATOR_SECRET_NAME="${MIGRATOR_SECRET_NAME:-${ARGOCD_APP}-secret-backend-graphql}"
+MIGRATOR_SECRET_KEY="${MIGRATOR_SECRET_KEY:-DATABASE_URL}"
 ARGOCD_TIMEOUT_SECONDS="${ARGOCD_TIMEOUT_SECONDS:-1200}"
+ARGOCD_TERMINATION_TIMEOUT_SECONDS="${ARGOCD_TERMINATION_TIMEOUT_SECONDS:-120}"
 ARGOCD_POLL_SECONDS="${ARGOCD_POLL_SECONDS:-2}"
 WORKLOAD_SELECTOR="${WORKLOAD_SELECTOR:-app.kubernetes.io/instance=app-klicker}"
 WORKLOAD_DRAIN_TIMEOUT_SECONDS="${WORKLOAD_DRAIN_TIMEOUT_SECONDS:-300}"
 
 CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}"
 ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}"
+RAW_PRD_DATA_APPROVAL_REF="${RAW_PRD_DATA_APPROVAL_REF:-}"
+STG_OUTBOUND_INTEGRATIONS_ISOLATED="${STG_OUTBOUND_INTEGRATIONS_ISOLATED:-false}"
 
 PRD_DATABASE_URL="${PRD_DATABASE_URL:-}"
 STG_DATABASE_URL="${STG_DATABASE_URL:-}"
@@ -62,6 +76,7 @@ WORKLOADS_SCALED=false
 TARGET_MUTATED=false
 RESTORE_VERIFIED=false
 RESUMING_MAINTENANCE=false
+REFRESH_LEASE_HELD=false
 
 ORIGINAL_AUTOMATED_SYNC=false
 ORIGINAL_AUTOMATED_JSON="null"
@@ -93,6 +108,12 @@ STG_CAN_CREATE_IN_PUBLIC=""
 STG_SUPPORTED_OBJECT_COUNT=""
 STG_UNOWNED_OBJECT_COUNT=""
 STG_UNSUPPORTED_OBJECT_COUNT=""
+WORKLOAD_SET_HASH=""
+PRD_MIGRATION_HISTORY=""
+MIGRATOR_DATABASE_URL=""
+MIGRATED_SIZE_BYTES=""
+MIGRATED_TABLE_COUNT=""
+MIGRATED_APPLIED_MIGRATIONS=""
 
 print_help() {
   cat <<'EOF'
@@ -129,17 +150,31 @@ Important configuration variables:
   ARGOCD_KUBE_CONTEXT                ArgoCD control-plane context; defaults to KUBE_CONTEXT
   ARGOCD_NAMESPACE                   Application namespace; default: argocd
   ARGOCD_APP                         default: app-klicker
+  WORKLOAD_NAMESPACE                 exact STG workload namespace; otherwise derived from the Application
+  EXPECTED_STG_CLUSTER_UID           expected stable UID for the STG workload cluster
+  EXPECTED_ARGOCD_CLUSTER_UID        expected stable UID for the ArgoCD cluster; defaults to STG UID
+  KUBECTL_REQUEST_TIMEOUT             per-request Kubernetes API timeout; default: 30s
+  REFRESH_LEASE_NAME                 exclusive maintenance Lease name
+  REFRESH_LEASE_NAMESPACE            namespace for the maintenance Lease; default: argocd
+  MIGRATOR_SECRET_NAME               Secret containing the PreSync DATABASE_URL
+  MIGRATOR_SECRET_KEY                Secret key containing the PreSync DATABASE_URL
+  ARGOCD_TERMINATION_TIMEOUT_SECONDS timeout for draining a timed-out operation
   INFISICAL_API_URL                  default: https://inf.prd.df-app.ch/api
   INFISICAL_PROJECT_ID               default: d071be96-5136-4f23-a6cb-e0c7f9b9a6c8
   INFISICAL_SECRET_PATH              default: /
   WORKLOAD_SELECTOR                   default: app.kubernetes.io/instance=app-klicker
   EXPECTED_PRD_DB_HOST                fail-closed PRD hostname
   EXPECTED_STG_DB_HOST                fail-closed STG hostname
-  STG_STORAGE_GIB                     default: 32
+  EXPECTED_PRD_DB_NAME                fail-closed PRD database name
+  EXPECTED_STG_DB_NAME                fail-closed STG database name
+  REQUIRED_DB_SSLMODE                 minimum PostgreSQL SSL mode; default: require
+  STG_FREE_STORAGE_GIB                current free STG storage evidence; required for execution
   MAX_SOURCE_STORAGE_PERCENT          default: 75
   RUN_ID                              unique receipt identifier
   RESUME_FAILED_RUN_ID                failed run receipt to resume while STG is stopped
   KEEP_ENCRYPTED_ARCHIVE              default: false
+  RAW_PRD_DATA_APPROVAL_REF           ticket/ADR reference approving raw PRD data in STG
+  STG_OUTBOUND_INTEGRATIONS_ISOLATED  must be true for execution
 
 Failure after workload shutdown intentionally leaves ArgoCD auto-sync disabled
 and STG workloads stopped. If reset completed but restore did not, do not submit
@@ -191,14 +226,18 @@ validate_resume_failed_run_id() {
     || die "RESUME_FAILED_RUN_ID must differ from the new RUN_ID"
 }
 
+kubectl_safe() {
+  kubectl --request-timeout="$KUBECTL_REQUEST_TIMEOUT" "$@"
+}
+
 get_argocd_application() {
-  kubectl --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
+  kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
     get application.argoproj.io "$ARGOCD_APP" -o json
 }
 
 patch_argocd_application() {
   local patch_payload="$1"
-  kubectl --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
+  kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$ARGOCD_NAMESPACE" \
     patch application.argoproj.io "$ARGOCD_APP" --type merge \
     --patch "$patch_payload"
 }
@@ -219,10 +258,69 @@ build_argocd_policy_patch() {
     '{spec: {syncPolicy: {automated: $automated}}}'
 }
 
+refresh_lease_holder() {
+  printf 'prd-to-stg-refresh-%s' "$RUN_ID"
+}
+
+acquire_refresh_lease() {
+  local holder_identity lease_manifest
+  holder_identity="$(refresh_lease_holder)"
+  lease_manifest="$(jq -cn \
+    --arg name "$REFRESH_LEASE_NAME" \
+    --arg holderIdentity "$holder_identity" \
+    --argjson duration "$REFRESH_LEASE_DURATION_SECONDS" \
+    '{
+      apiVersion: "coordination.k8s.io/v1",
+      kind: "Lease",
+      metadata: {name: $name},
+      spec: {
+        holderIdentity: $holderIdentity,
+        leaseDurationSeconds: $duration
+      }
+    }')"
+
+  kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$REFRESH_LEASE_NAMESPACE" \
+    create -f - <<<"$lease_manifest" >/dev/null \
+    || die "Refresh Lease '$REFRESH_LEASE_NAMESPACE/$REFRESH_LEASE_NAME' is already held or cannot be created"
+  REFRESH_LEASE_HELD=true
+  log "Acquired refresh Lease '$REFRESH_LEASE_NAMESPACE/$REFRESH_LEASE_NAME'"
+}
+
+renew_refresh_lease() {
+  [[ "$REFRESH_LEASE_HELD" == "true" ]] || return 0
+  local holder_identity renew_time current_holder
+  holder_identity="$(refresh_lease_holder)"
+  renew_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  current_holder="$(kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$REFRESH_LEASE_NAMESPACE" \
+    get lease "$REFRESH_LEASE_NAME" -o jsonpath='{.spec.holderIdentity}')" \
+    || die "Could not read refresh Lease ownership"
+  [[ "$current_holder" == "$holder_identity" ]] \
+    || die "Refresh Lease ownership changed during run"
+  kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$REFRESH_LEASE_NAMESPACE" \
+    patch lease "$REFRESH_LEASE_NAME" --type merge \
+    --patch "$(jq -cn --arg renewTime "$renew_time" '{spec: {renewTime: $renewTime}}')" \
+    >/dev/null \
+    || die "Could not renew refresh Lease"
+}
+
+release_refresh_lease() {
+  [[ "$REFRESH_LEASE_HELD" == "true" ]] || return 0
+  local holder_identity current_holder
+  holder_identity="$(refresh_lease_holder)"
+  current_holder="$(kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$REFRESH_LEASE_NAMESPACE" \
+    get lease "$REFRESH_LEASE_NAME" -o jsonpath='{.spec.holderIdentity}' 2>/dev/null)" || true
+  if [[ "$current_holder" == "$holder_identity" ]]; then
+    kubectl_safe --context "$ARGOCD_KUBE_CONTEXT" -n "$REFRESH_LEASE_NAMESPACE" \
+      delete lease "$REFRESH_LEASE_NAME" --wait=false >/dev/null || return 1
+    log "Released refresh Lease '$REFRESH_LEASE_NAMESPACE/$REFRESH_LEASE_NAME'"
+  fi
+  REFRESH_LEASE_HELD=false
+}
+
 cleanup() {
   local exit_code=$?
 
-  unset PRD_DATABASE_URL STG_DATABASE_URL BACKUP_ENCRYPTION_KEY
+  unset PRD_DATABASE_URL STG_DATABASE_URL BACKUP_ENCRYPTION_KEY MIGRATOR_DATABASE_URL
 
   if [[ "$KEEP_ENCRYPTED_ARCHIVE" != "true" ]]; then
     if [[ -n "$ARCHIVE_PATH" && -f "$ARCHIVE_PATH" ]]; then
@@ -237,6 +335,9 @@ cleanup() {
   fi
 
   if [[ $exit_code -ne 0 && "$ARGOCD_POLICY_PAUSED" == "true" ]]; then
+    if [[ "$WORKLOADS_SCALED" != "true" ]]; then
+      best_effort_scale_stg_workloads_down || log "WARNING: fail-safe workload scale-down could not be confirmed"
+    fi
     log "ArgoCD application: $ARGOCD_APP (automated sync disabled)"
     if [[ "$WORKLOADS_SCALED" == "true" ]]; then
       log "STG remains in fail-safe maintenance mode."
@@ -267,6 +368,10 @@ cleanup() {
       log "After confirming the restored snapshot is intact, retry the hook sync: kubectl --context $ARGOCD_KUBE_CONTEXT -n $ARGOCD_NAMESPACE patch application.argoproj.io $ARGOCD_APP --type merge --patch '$recovery_sync_patch'"
       log "Then restore the prior policy: kubectl --context $ARGOCD_KUBE_CONTEXT -n $ARGOCD_NAMESPACE patch application.argoproj.io $ARGOCD_APP --type merge --patch '$recovery_policy_patch'"
     fi
+  fi
+
+  if [[ "$REFRESH_LEASE_HELD" == "true" ]]; then
+    release_refresh_lease || log "WARNING: could not release refresh Lease '$REFRESH_LEASE_NAMESPACE/$REFRESH_LEASE_NAME'; remove it only after confirming this run is no longer active"
   fi
 
   return "$exit_code"
@@ -352,6 +457,7 @@ run_database_command() (
   export PGUSER="$username"
   export PGPASSWORD="$password"
   export PGDATABASE="$database"
+  unset PGSSLMODE PGSSLNEGOTIATION PGCHANNELBINDING PGTARGETSESSIONATTRS
   [[ -z "$sslmode" ]] || export PGSSLMODE="$sslmode"
   [[ -z "$sslnegotiation" ]] || export PGSSLNEGOTIATION="$sslnegotiation"
   [[ -z "$channel_binding" ]] || export PGCHANNELBINDING="$channel_binding"
@@ -434,7 +540,34 @@ validate_endpoints() {
     || die "PRD host '$PRD_DB_HOST' does not equal expected host '$EXPECTED_PRD_DB_HOST'"
   [[ "$STG_DB_HOST" == "$EXPECTED_STG_DB_HOST" ]] \
     || die "STG host '$STG_DB_HOST' does not equal expected host '$EXPECTED_STG_DB_HOST'"
+  [[ "$PRD_DB_NAME" == "$EXPECTED_PRD_DB_NAME" ]] \
+    || die "PRD database '$PRD_DB_NAME' does not equal expected database '$EXPECTED_PRD_DB_NAME'"
+  [[ "$STG_DB_NAME" == "$EXPECTED_STG_DB_NAME" ]] \
+    || die "STG database '$STG_DB_NAME' does not equal expected database '$EXPECTED_STG_DB_NAME'"
   [[ "$PRD_DB_HOST" != "$STG_DB_HOST" ]] || die "PRD and STG resolve to the same configured host"
+
+  local prd_sslmode stg_sslmode
+  prd_sslmode="$(parse_database_url_field "$PRD_DATABASE_URL" sslmode)"
+  stg_sslmode="$(parse_database_url_field "$STG_DATABASE_URL" sslmode)"
+  case "$REQUIRED_DB_SSLMODE" in
+    require)
+      case "$prd_sslmode:$stg_sslmode" in
+        require:require|require:verify-ca|require:verify-full|verify-ca:require|verify-ca:verify-ca|verify-ca:verify-full|verify-full:require|verify-full:verify-ca|verify-full:verify-full) ;;
+        *) die "PRD and STG URLs must use at least sslmode=require" ;;
+      esac
+      ;;
+    verify-ca)
+      [[ "$prd_sslmode" == "verify-ca" || "$prd_sslmode" == "verify-full" ]] \
+        || die "PRD URL must use at least sslmode=verify-ca"
+      [[ "$stg_sslmode" == "verify-ca" || "$stg_sslmode" == "verify-full" ]] \
+        || die "STG URL must use at least sslmode=verify-ca"
+      ;;
+    verify-full)
+      [[ "$prd_sslmode" == "verify-full" ]] || die "PRD URL must use sslmode=verify-full"
+      [[ "$stg_sslmode" == "verify-full" ]] || die "STG URL must use sslmode=verify-full"
+      ;;
+    *) die "REQUIRED_DB_SSLMODE must be require, verify-ca, or verify-full" ;;
+  esac
 }
 
 read_database_metadata() {
@@ -503,6 +636,70 @@ load_database_metadata() {
   fi
   [[ -n "$metadata" ]] || die "$environment database metadata is empty"
   printf -v "$output_variable" '%s' "$metadata"
+}
+
+read_database_identity() {
+  local database_url="$1"
+  local identity_query
+  identity_query=$(cat <<'SQL'
+/* klicker_database_identity */
+SELECT current_database(), COALESCE(inet_server_addr()::text, ''), inet_server_port();
+SQL
+)
+
+  run_database_command "$database_url" \
+    psql -X -v ON_ERROR_STOP=1 -At -F '|' -c "$identity_query"
+}
+
+load_database_identity() {
+  local output_variable="$1"
+  local database_url="$2"
+  local environment="$3"
+  local identity
+
+  if ! identity="$(read_database_identity "$database_url")"; then
+    die "Could not read $environment database identity"
+  fi
+  [[ -n "$identity" ]] || die "$environment database identity is empty"
+  printf -v "$output_variable" '%s' "$identity"
+}
+
+read_migration_history() {
+  local database_url="$1"
+  local migration_history_query
+  migration_history_query=$(cat <<'SQL'
+/* klicker_database_migration_history */
+SELECT CASE
+  WHEN to_regclass('public."_prisma_migrations"') IS NULL THEN ''
+  ELSE COALESCE(
+    (
+      SELECT string_agg(
+        migration_name || '|' || COALESCE(checksum, ''), E'\n'
+        ORDER BY finished_at, migration_name
+      )
+      FROM public."_prisma_migrations"
+      WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL
+    ),
+    ''
+  )
+END;
+SQL
+)
+
+  run_database_command "$database_url" \
+    psql -X -v ON_ERROR_STOP=1 -At -c "$migration_history_query"
+}
+
+load_migration_history() {
+  local output_variable="$1"
+  local database_url="$2"
+  local environment="$3"
+  local migration_history
+
+  if ! migration_history="$(read_migration_history "$database_url")"; then
+    die "Could not read $environment migration history"
+  fi
+  printf -v "$output_variable" '%s' "$migration_history"
 }
 
 parse_prd_metadata() {
@@ -680,9 +877,14 @@ validate_client_and_capacity() {
     die "STG PostgreSQL major $stg_major is older than PRD PostgreSQL major $prd_major"
   fi
 
-  local stg_capacity_bytes=$((STG_STORAGE_GIB * 1024 * 1024 * 1024))
-  if (( PRD_SIZE_BYTES * 100 > stg_capacity_bytes * MAX_SOURCE_STORAGE_PERCENT )); then
-    die "PRD database size exceeds ${MAX_SOURCE_STORAGE_PERCENT}% of the configured ${STG_STORAGE_GIB} GiB STG storage capacity"
+  if [[ -z "$STG_FREE_STORAGE_GIB" ]]; then
+    log "STG_FREE_STORAGE_GIB is not supplied; capacity is checked only for read-only preflight"
+    return
+  fi
+
+  local stg_free_capacity_bytes=$((STG_FREE_STORAGE_GIB * 1024 * 1024 * 1024))
+  if (( PRD_SIZE_BYTES * 100 > stg_free_capacity_bytes * MAX_SOURCE_STORAGE_PERCENT )); then
+    die "PRD database size exceeds ${MAX_SOURCE_STORAGE_PERCENT}% of the supplied ${STG_FREE_STORAGE_GIB} GiB STG free-storage evidence"
   fi
 }
 
@@ -727,6 +929,15 @@ load_argocd_state() {
   application_json="$(get_argocd_application)" \
     || die "Could not read ArgoCD Application '$ARGOCD_NAMESPACE/$ARGOCD_APP' using context '$ARGOCD_KUBE_CONTEXT'"
 
+  local application_namespace
+  application_namespace="$(jq -r '.spec.destination.namespace // empty' <<<"$application_json")"
+  [[ -n "$application_namespace" ]] \
+    || die "ArgoCD Application '$ARGOCD_APP' has no destination namespace"
+  if [[ -n "$WORKLOAD_NAMESPACE" && "$WORKLOAD_NAMESPACE" != "$application_namespace" ]]; then
+    die "WORKLOAD_NAMESPACE '$WORKLOAD_NAMESPACE' does not match ArgoCD destination namespace '$application_namespace'"
+  fi
+  WORKLOAD_NAMESPACE="$application_namespace"
+
   local operation_phase
   operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
   if jq -e '.operation != null' >/dev/null <<<"$application_json"; then
@@ -754,9 +965,102 @@ load_argocd_state() {
   load_failed_run_receipt
 }
 
+read_cluster_namespace_uid() {
+  local context="$1"
+  kubectl_safe --context "$context" get namespace kube-system \
+    -o jsonpath='{.metadata.uid}'
+}
+
+validate_cluster_identity() {
+  local stg_cluster_uid argocd_cluster_uid
+  stg_cluster_uid="$(read_cluster_namespace_uid "$KUBE_CONTEXT")" \
+    || die "Could not read kube-system namespace identity from STG context '$KUBE_CONTEXT'"
+  argocd_cluster_uid="$(read_cluster_namespace_uid "$ARGOCD_KUBE_CONTEXT")" \
+    || die "Could not read kube-system namespace identity from ArgoCD context '$ARGOCD_KUBE_CONTEXT'"
+  [[ -n "$stg_cluster_uid" && "$stg_cluster_uid" == "$EXPECTED_STG_CLUSTER_UID" ]] \
+    || die "STG Kubernetes context '$KUBE_CONTEXT' does not match expected cluster identity"
+  [[ -n "$argocd_cluster_uid" && "$argocd_cluster_uid" == "$EXPECTED_ARGOCD_CLUSTER_UID" ]] \
+    || die "ArgoCD Kubernetes context '$ARGOCD_KUBE_CONTEXT' does not match expected cluster identity"
+}
+
+require_kubernetes_permission() {
+  local context="$1"
+  shift
+  local result
+  result="$(kubectl_safe --context "$context" auth can-i "$@")" \
+    || die "Could not verify Kubernetes permission for '$*' in context '$context'"
+  [[ "$result" == "yes" ]] \
+    || die "Kubernetes permission denied for '$*' in context '$context'"
+}
+
+validate_kubernetes_permissions() {
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    get application.argoproj.io "$ARGOCD_APP" -n "$ARGOCD_NAMESPACE"
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    patch application.argoproj.io "$ARGOCD_APP" -n "$ARGOCD_NAMESPACE"
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    get lease "$REFRESH_LEASE_NAME" -n "$REFRESH_LEASE_NAMESPACE"
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    patch lease "$REFRESH_LEASE_NAME" -n "$REFRESH_LEASE_NAMESPACE"
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    create leases -n "$REFRESH_LEASE_NAMESPACE"
+  require_kubernetes_permission "$ARGOCD_KUBE_CONTEXT" \
+    delete lease "$REFRESH_LEASE_NAME" -n "$REFRESH_LEASE_NAMESPACE"
+  require_kubernetes_permission "$KUBE_CONTEXT" \
+    get deployments -n "$WORKLOAD_NAMESPACE"
+  require_kubernetes_permission "$KUBE_CONTEXT" \
+    update deployments/scale -n "$WORKLOAD_NAMESPACE"
+  require_kubernetes_permission "$KUBE_CONTEXT" \
+    get secret "$MIGRATOR_SECRET_NAME" -n "$WORKLOAD_NAMESPACE"
+}
+
+load_migrator_database_url() {
+  local encoded_url
+  encoded_url="$(kubectl_safe --context "$KUBE_CONTEXT" -n "$WORKLOAD_NAMESPACE" \
+    get secret "$MIGRATOR_SECRET_NAME" \
+    -o "jsonpath={.data.$MIGRATOR_SECRET_KEY}")" \
+    || die "Could not read the migrator Secret '$WORKLOAD_NAMESPACE/$MIGRATOR_SECRET_NAME'"
+  [[ -n "$encoded_url" ]] \
+    || die "Migrator Secret '$WORKLOAD_NAMESPACE/$MIGRATOR_SECRET_NAME' has no '$MIGRATOR_SECRET_KEY' value"
+  if ! MIGRATOR_DATABASE_URL="$(
+    printf '%s' "$encoded_url" | base64 --decode 2>/dev/null ||
+      printf '%s' "$encoded_url" | base64 -D
+  )"; then
+    die "Could not decode the migrator database URL from Secret '$WORKLOAD_NAMESPACE/$MIGRATOR_SECRET_NAME'"
+  fi
+  [[ -n "$MIGRATOR_DATABASE_URL" ]] \
+    || die "Migrator database URL is empty"
+}
+
+validate_migrator_secret_target() {
+  load_migrator_database_url
+
+  local migrator_host migrator_port migrator_database migrator_sslmode
+  migrator_host="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" host)"
+  migrator_port="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" port)"
+  migrator_database="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" database)"
+  migrator_sslmode="$(parse_database_url_field "$MIGRATOR_DATABASE_URL" sslmode)"
+  [[ "$migrator_host" == "$STG_DB_HOST" ]] \
+    || die "Migrator Secret points to host '$migrator_host', not the validated STG host '$STG_DB_HOST'"
+  [[ "$migrator_port" == "$(parse_database_url_field "$STG_DATABASE_URL" port)" ]] \
+    || die "Migrator Secret points to port '$migrator_port', not the validated STG port"
+  [[ "$migrator_database" == "$STG_DB_NAME" ]] \
+    || die "Migrator Secret points to database '$migrator_database', not '$STG_DB_NAME'"
+  case "$REQUIRED_DB_SSLMODE:$migrator_sslmode" in
+    require:require|require:verify-ca|require:verify-full|verify-ca:verify-ca|verify-ca:verify-full|verify-full:verify-full) ;;
+    *) die "Migrator Secret database URL does not meet sslmode=$REQUIRED_DB_SSLMODE" ;;
+  esac
+
+  local stg_identity migrator_identity
+  load_database_identity stg_identity "$STG_DATABASE_URL" STG
+  load_database_identity migrator_identity "$MIGRATOR_DATABASE_URL" migrator
+  [[ "$stg_identity" == "$migrator_identity" ]] \
+    || die "Migrator Secret and STG database URLs resolve to different database identities"
+}
+
 load_workload_state() {
   local deployments_json
-  deployments_json="$(kubectl --context "$KUBE_CONTEXT" get deployments -A \
+  deployments_json="$(kubectl_safe --context "$KUBE_CONTEXT" -n "$WORKLOAD_NAMESPACE" get deployments \
     -l "$WORKLOAD_SELECTOR" -o json)" \
     || die "Could not list STG deployments using context '$KUBE_CONTEXT'"
 
@@ -767,6 +1071,33 @@ load_workload_state() {
     || die "No STG deployments matched selector '$WORKLOAD_SELECTOR'"
 
   printf '%s' "$deployments_json"
+}
+
+workload_set_hash() {
+  jq -c '[.items[] | {namespace: .metadata.namespace, name: .metadata.name, uid: (.metadata.uid // "")}] | sort_by(.namespace, .name, .uid)' \
+    | shasum -a 256 | awk '{print $1}'
+}
+
+validate_stg_database_identity() {
+  local stg_identity stg_database
+  load_database_identity stg_identity "$STG_DATABASE_URL" STG
+  stg_database="$(printf '%s' "$stg_identity" | cut -d'|' -f1)"
+  [[ "$stg_database" == "$STG_DB_NAME" ]] \
+    || die "STG database identity '$stg_database' does not match expected database '$STG_DB_NAME'"
+}
+
+record_preflight_workload_set() {
+  local deployments_json="$1"
+  WORKLOAD_SET_HASH="$(workload_set_hash <<<"$deployments_json")"
+}
+
+validate_preflight_workload_set() {
+  local deployments_json="$1"
+  [[ -n "$WORKLOAD_SET_HASH" ]] || return 0
+  local current_hash
+  current_hash="$(workload_set_hash <<<"$deployments_json")"
+  [[ "$current_hash" == "$WORKLOAD_SET_HASH" ]] \
+    || die "Selected STG Deployments changed after preflight; refusing mutation"
 }
 
 validate_resume_workload_state() {
@@ -800,12 +1131,18 @@ validate_resume_workload_state() {
 }
 
 print_preflight_summary() {
-  local deployment_count="$1"
+  local deployments_json="$1"
+  local deployment_count
+  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
   log "Preflight complete"
   log "Source: $PRD_DB_HOST/$PRD_DB_NAME (PostgreSQL $((PRD_VERSION_NUM / 10000)), $PRD_SIZE_BYTES bytes, $PRD_TABLE_COUNT tables)"
   log "Target: $STG_DB_HOST/$STG_DB_NAME (PostgreSQL $((STG_BEFORE_VERSION_NUM / 10000)), current size $STG_BEFORE_SIZE_BYTES bytes)"
   log "ArgoCD Application: $ARGOCD_NAMESPACE/$ARGOCD_APP via context $ARGOCD_KUBE_CONTEXT"
   log "STG deployments to stop: $deployment_count"
+  while IFS=$'\t' read -r namespace deployment; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    log "  - $namespace/$deployment"
+  done < <(jq -r '.items[] | [.metadata.namespace, .metadata.name] | @tsv' <<<"$deployments_json")
   log "STG reset: remove $STG_SUPPORTED_OBJECT_COUNT objects owned by $STG_CONNECTED_ROLE; preserve public schema owned by $STG_PUBLIC_SCHEMA_OWNER"
   log "Raw PRD data, including personal data, will be present in STG after execution."
 }
@@ -950,15 +1287,24 @@ scale_stg_workloads_down() {
   local deployments_json
   WORKLOADS_SCALED=false
   deployments_json="$(load_workload_state)"
-  jq -r '.items[] | [.metadata.namespace, .metadata.name, (.spec.replicas // 1)] | @tsv' \
-    <<<"$deployments_json" >"$DEPLOYMENT_RECEIPT"
+  validate_preflight_workload_set "$deployments_json"
+  if [[ ! -s "$DEPLOYMENT_RECEIPT" ]]; then
+    jq -r '.items[] | [.metadata.namespace, .metadata.name, (.spec.replicas // 1)] | @tsv' \
+      <<<"$deployments_json" >"$DEPLOYMENT_RECEIPT"
+  fi
 
+  local scale_failed=false
   while IFS=$'\t' read -r namespace deployment replicas; do
     [[ -n "$namespace" && -n "$deployment" ]] || continue
     log "Scaling $namespace/deployment/$deployment from $replicas to 0"
-    kubectl --context "$KUBE_CONTEXT" -n "$namespace" \
-      scale "deployment/$deployment" --replicas=0 >/dev/null
+    if ! kubectl_safe --context "$KUBE_CONTEXT" -n "$namespace" \
+      scale "deployment/$deployment" --replicas=0 >/dev/null; then
+      scale_failed=true
+    fi
   done <"$DEPLOYMENT_RECEIPT"
+
+  [[ "$scale_failed" == "false" ]] \
+    || return 1
 
   local deadline=$((SECONDS + WORKLOAD_DRAIN_TIMEOUT_SECONDS))
   while true; do
@@ -977,6 +1323,21 @@ scale_stg_workloads_down() {
 
   WORKLOADS_SCALED=true
   log "All selected STG workloads are stopped"
+}
+
+best_effort_scale_stg_workloads_down() {
+  local deployments_json
+  deployments_json="$(kubectl_safe --context "$KUBE_CONTEXT" -n "$WORKLOAD_NAMESPACE" \
+    get deployments -l "$WORKLOAD_SELECTOR" -o json 2>/dev/null)" || return 1
+  local scale_failed=false
+  while IFS=$'\t' read -r namespace deployment; do
+    [[ -n "$namespace" && -n "$deployment" ]] || continue
+    if ! kubectl_safe --context "$KUBE_CONTEXT" -n "$namespace" \
+      scale "deployment/$deployment" --replicas=0 >/dev/null; then
+      scale_failed=true
+    fi
+  done < <(jq -r '.items[] | [.metadata.namespace, .metadata.name] | @tsv' <<<"$deployments_json")
+  [[ "$scale_failed" == "false" ]]
 }
 
 reset_stg_owned_objects() {
@@ -1146,7 +1507,34 @@ validate_restored_snapshot() {
   [[ "$extra_schema_count" == "0" && "$large_object_count" == "0" ]] \
     || die "Restored snapshot contains unsupported schemas or large objects"
 
+  local restored_migration_history
+  load_migration_history restored_migration_history "$STG_DATABASE_URL" STG
+  [[ "$restored_migration_history" == "$PRD_MIGRATION_HISTORY" ]] \
+    || die "Restored migration names and checksums do not exactly match the PRD snapshot"
+
   log "Logical restore matches the PRD table and migration metadata"
+}
+
+terminate_argocd_operation() {
+  log "Terminating the timed-out ArgoCD operation before recovery"
+  patch_argocd_application '{"operation":null}' >/dev/null \
+    || return 1
+
+  local deadline=$((SECONDS + ARGOCD_TERMINATION_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    local application_json operation_phase
+    application_json="$(get_argocd_application)" || {
+      sleep "$ARGOCD_POLL_SECONDS"
+      continue
+    }
+    operation_phase="$(jq -r '.status.operationState.phase // "Unknown"' <<<"$application_json")"
+    if ! jq -e '.operation != null' >/dev/null <<<"$application_json" && \
+      [[ "$operation_phase" != "Running" && "$operation_phase" != "Terminating" ]]; then
+      return 0
+    fi
+    sleep "$ARGOCD_POLL_SECONDS"
+  done
+  return 1
 }
 
 run_presync_hook() {
@@ -1206,6 +1594,10 @@ run_presync_hook() {
     sleep "$ARGOCD_POLL_SECONDS"
   done
 
+  if ! terminate_argocd_operation; then
+    die "Timed out waiting for the submitted ArgoCD operation and could not confirm its termination"
+  fi
+  renew_refresh_lease
   log "Timed out waiting for the submitted ArgoCD operation; forcing STG Deployments back to zero"
   scale_stg_workloads_down
   die "ArgoCD sync did not complete within $ARGOCD_TIMEOUT_SECONDS seconds"
@@ -1222,8 +1614,13 @@ validate_migrated_target() {
   local failed_migrations extra_schema_count large_object_count
   IFS='|' read -r database_name version_num size_bytes table_count applied_migrations \
     failed_migrations extra_schema_count large_object_count <<<"$metadata"
+  MIGRATED_SIZE_BYTES="$size_bytes"
+  MIGRATED_TABLE_COUNT="$table_count"
+  MIGRATED_APPLIED_MIGRATIONS="$applied_migrations"
 
   local error=""
+  local migrated_migration_history
+  load_migration_history migrated_migration_history "$STG_DATABASE_URL" STG
   if [[ "$database_name" != "$STG_DB_NAME" ]]; then
     error="Post-migration metadata came from unexpected database '$database_name'"
   elif [[ ! "$version_num" =~ ^[0-9]+$ ||
@@ -1240,6 +1637,10 @@ validate_migrated_target() {
     error="Post-migration applied count $applied_migrations is lower than PRD snapshot count $PRD_APPLIED_MIGRATIONS"
   elif [[ "$failed_migrations" != "0" ]]; then
     error="Post-migration database contains $failed_migrations unresolved Prisma migration(s)"
+  elif [[ -n "$PRD_MIGRATION_HISTORY" &&
+    "$migrated_migration_history" != "$PRD_MIGRATION_HISTORY" &&
+    "$migrated_migration_history" != "$PRD_MIGRATION_HISTORY"$'\n'* ]]; then
+    error="Post-migration migration names and checksums do not extend the PRD history"
   elif [[ "$extra_schema_count" != "0" || "$large_object_count" != "0" ]]; then
     error="Post-migration database contains unsupported schemas or large objects"
   fi
@@ -1249,14 +1650,18 @@ validate_migrated_target() {
     die "$error"
   fi
 
+  log "Post-sync verification passed: $table_count tables, $applied_migrations applied migrations"
+}
+
+write_after_receipt() {
   jq -n \
     --arg runId "$RUN_ID" \
     --arg completedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
     --arg targetHost "$STG_DB_HOST" \
     --arg targetDatabase "$STG_DB_NAME" \
-    --argjson targetSizeBytes "$size_bytes" \
-    --argjson targetTableCount "$table_count" \
-    --argjson targetAppliedMigrations "$applied_migrations" \
+    --argjson targetSizeBytes "$MIGRATED_SIZE_BYTES" \
+    --argjson targetTableCount "$MIGRATED_TABLE_COUNT" \
+    --argjson targetAppliedMigrations "$MIGRATED_APPLIED_MIGRATIONS" \
     '{
       runId: $runId,
       completedAt: $completedAt,
@@ -1269,13 +1674,12 @@ validate_migrated_target() {
         unresolvedMigrations: 0
       }
     }' >"$AFTER_RECEIPT"
-
-  log "Post-sync verification passed: $table_count tables, $applied_migrations applied migrations"
 }
 
 restore_argocd_policy() {
   local policy_patch
   policy_patch="$(build_argocd_policy_patch "$ORIGINAL_AUTOMATED_JSON")"
+  renew_refresh_lease
   patch_argocd_application "$policy_patch" >/dev/null
 
   local application_json
@@ -1303,14 +1707,23 @@ validate_configuration() {
   validate_boolean DRY_RUN "$DRY_RUN"
   validate_boolean KEEP_ENCRYPTED_ARCHIVE "$KEEP_ENCRYPTED_ARCHIVE"
   validate_boolean ALLOW_RAW_PRD_DATA_IN_STG "$ALLOW_RAW_PRD_DATA_IN_STG"
-  validate_positive_integer STG_STORAGE_GIB "$STG_STORAGE_GIB"
+  validate_boolean STG_OUTBOUND_INTEGRATIONS_ISOLATED "$STG_OUTBOUND_INTEGRATIONS_ISOLATED"
   validate_positive_integer MAX_SOURCE_STORAGE_PERCENT "$MAX_SOURCE_STORAGE_PERCENT"
+  if [[ -n "$STG_FREE_STORAGE_GIB" ]]; then
+    validate_positive_integer STG_FREE_STORAGE_GIB "$STG_FREE_STORAGE_GIB"
+  fi
+  validate_positive_integer REFRESH_LEASE_DURATION_SECONDS "$REFRESH_LEASE_DURATION_SECONDS"
   validate_positive_integer ARGOCD_TIMEOUT_SECONDS "$ARGOCD_TIMEOUT_SECONDS"
+  validate_positive_integer ARGOCD_TERMINATION_TIMEOUT_SECONDS "$ARGOCD_TERMINATION_TIMEOUT_SECONDS"
   validate_positive_integer ARGOCD_POLL_SECONDS "$ARGOCD_POLL_SECONDS"
   validate_positive_integer WORKLOAD_DRAIN_TIMEOUT_SECONDS "$WORKLOAD_DRAIN_TIMEOUT_SECONDS"
+  [[ -n "$EXPECTED_STG_CLUSTER_UID" ]] \
+    || die "EXPECTED_STG_CLUSTER_UID is required for Kubernetes target binding"
+  [[ -n "$EXPECTED_ARGOCD_CLUSTER_UID" ]] \
+    || die "EXPECTED_ARGOCD_CLUSTER_UID is required for Kubernetes target binding"
   validate_run_id
   validate_resume_failed_run_id
-  (( STG_STORAGE_GIB > 0 )) || die "STG_STORAGE_GIB must be greater than zero"
+  (( REFRESH_LEASE_DURATION_SECONDS > 0 )) || die "REFRESH_LEASE_DURATION_SECONDS must be greater than zero"
   (( ARGOCD_POLL_SECONDS > 0 )) || die "ARGOCD_POLL_SECONDS must be greater than zero"
   (( MAX_SOURCE_STORAGE_PERCENT > 0 && MAX_SOURCE_STORAGE_PERCENT <= 95 )) \
     || die "MAX_SOURCE_STORAGE_PERCENT must be between 1 and 95"
@@ -1323,10 +1736,16 @@ validate_execution_gates() {
     || die "Execution requires CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD"
   [[ "$ALLOW_RAW_PRD_DATA_IN_STG" == "true" ]] \
     || die "Execution requires ALLOW_RAW_PRD_DATA_IN_STG=true"
+  [[ -n "$RAW_PRD_DATA_APPROVAL_REF" ]] \
+    || die "Execution requires RAW_PRD_DATA_APPROVAL_REF=<approved ticket or ADR reference>"
+  [[ "$STG_OUTBOUND_INTEGRATIONS_ISOLATED" == "true" ]] \
+    || die "Execution requires STG_OUTBOUND_INTEGRATIONS_ISOLATED=true"
+  [[ -n "$STG_FREE_STORAGE_GIB" ]] \
+    || die "Execution requires STG_FREE_STORAGE_GIB=<current free storage evidence>"
 }
 
 validate_tools() {
-  local tools=(awk cat gpg grep jq kubectl mv node pg_dump pg_restore psql sed shasum)
+  local tools=(awk base64 cat cut gpg grep jq kubectl mv node pg_dump pg_restore psql sed shasum)
   local tool
   for tool in "${tools[@]}"; do
     require_command "$tool"
@@ -1351,16 +1770,19 @@ main() {
   load_database_metadata stg_before_metadata "$STG_DATABASE_URL" STG
   parse_prd_metadata "$prd_metadata"
   parse_stg_before_metadata "$stg_before_metadata"
+  load_migration_history PRD_MIGRATION_HISTORY "$PRD_DATABASE_URL" PRD
   validate_stg_reset_capabilities
   validate_client_and_capacity
+  validate_cluster_identity
   load_argocd_state
+  validate_kubernetes_permissions
+  validate_migrator_secret_target
 
   local deployments_json
   deployments_json="$(load_workload_state)"
   validate_resume_workload_state "$deployments_json"
-  local deployment_count
-  deployment_count="$(jq '.items | length' <<<"$deployments_json")"
-  print_preflight_summary "$deployment_count"
+  record_preflight_workload_set "$deployments_json"
+  print_preflight_summary "$deployments_json"
 
   if [[ "$DRY_RUN" == "true" ]]; then
     log "DRY_RUN=true: no dump was created and no external state was changed."
@@ -1368,11 +1790,15 @@ main() {
     return 0
   fi
 
+  acquire_refresh_lease
   prepare_run_directory
   encrypt_prd_dump
+  renew_refresh_lease
   write_before_receipt
 
   pause_argocd_policy
+  renew_refresh_lease
+  validate_preflight_workload_set "$(load_workload_state)"
   scale_stg_workloads_down
 
   # Re-verify the pause immediately before the first destructive database action.
@@ -1383,6 +1809,8 @@ main() {
     die "ArgoCD automated sync was re-enabled before database replacement"
   fi
 
+  renew_refresh_lease
+  validate_stg_database_identity
   reset_stg_owned_objects
   restore_stg_database
   local restored_metadata
@@ -1390,11 +1818,20 @@ main() {
   validate_restored_snapshot "$restored_metadata"
   RESTORE_VERIFIED=true
 
+  renew_refresh_lease
   run_presync_hook
   local migrated_metadata
-  load_database_metadata migrated_metadata "$STG_DATABASE_URL" STG
+  if ! migrated_metadata="$(read_database_metadata "$STG_DATABASE_URL")"; then
+    scale_stg_workloads_down
+    die "Could not read STG database metadata after the migration hook"
+  fi
+  [[ -n "$migrated_metadata" ]] || {
+    scale_stg_workloads_down
+    die "STG database metadata after the migration hook is empty"
+  }
   validate_migrated_target "$migrated_metadata"
   restore_argocd_policy
+  write_after_receipt
 
   log "PRD-to-STG database refresh completed successfully"
   log "Receipts: $BEFORE_RECEIPT and $AFTER_RECEIPT"

--- a/util/backup/tests/refresh-stg-from-prd.test.sh
+++ b/util/backup/tests/refresh-stg-from-prd.test.sh
@@ -32,10 +32,10 @@ fake_infisical() {
   fake_log "infisical get $secret_name from $environment via self-hosted project"
   case "$secret_name:$environment" in
     DIRECT_DATABASE_URL:prd)
-      printf '%s\n' 'postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public'
+      printf '%s\n' 'postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require'
       ;;
     DIRECT_DATABASE_URL:stg)
-      printf '%s\n' 'postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public'
+      printf '%s\n' 'postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require'
       ;;
     BACKUP_ENCRYPTION_KEY:prd)
       printf '%s\n' 'synthetic-test-key'
@@ -61,6 +61,10 @@ fake_argocd_application_json() {
   if [[ -n "$initiator" ]]; then
     local phase="Succeeded"
     local message="successfully synced (all tasks run)"
+    if [[ "${FAKE_ARGO_OPERATION_RUNNING:-false}" == "true" ]]; then
+      phase="Running"
+      message="synthetic operation still running"
+    fi
     if [[ "${FAKE_ARGO_SYNC_FAIL:-false}" == "true" ]]; then
       phase="Failed"
       message="synthetic migration failure"
@@ -72,7 +76,10 @@ fake_argocd_application_json() {
       --arg phase "$phase" \
       --arg message "$message" \
       '{
-        spec: {syncPolicy: {automated: $automated}},
+        spec: {
+          destination: {namespace: "stg-klicker"},
+          syncPolicy: {automated: $automated}
+        },
         status: {
           operationState: {
             phase: $phase,
@@ -90,7 +97,10 @@ fake_argocd_application_json() {
     jq -cn \
       --argjson automated "$automated" \
       '{
-        spec: {syncPolicy: {automated: $automated}},
+        spec: {
+          destination: {namespace: "stg-klicker"},
+          syncPolicy: {automated: $automated}
+        },
         status: {
           operationState: {
             phase: "Succeeded",
@@ -102,7 +112,50 @@ fake_argocd_application_json() {
 }
 
 fake_kubectl() {
-  if [[ " $* " == *" get application.argoproj.io "* ]]; then
+  if [[ " $* " == *" auth can-i "* ]]; then
+    if [[ "${FAKE_KUBE_CAN_I:-allow}" == "deny" ]]; then
+      printf '%s\n' no
+    else
+      printf '%s\n' yes
+    fi
+  elif [[ " $* " == *" get namespace kube-system "* ]]; then
+    printf '%s' synthetic-cluster-uid
+  elif [[ " $* " == *" get secret "* ]]; then
+    printf '%s' "${FAKE_MIGRATOR_URL:-postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require}" | base64
+  elif [[ " $* " == *" create -f - "* ]]; then
+    local lease_payload
+    lease_payload="$(cat)"
+    [[ ! -e "$FAKE_LEASE_FILE" ]] || return 1
+    printf '%s' "$lease_payload" >"$FAKE_LEASE_FILE"
+    fake_log 'kubectl lease create'
+  elif [[ " $* " == *" get lease "* ]]; then
+    [[ -f "$FAKE_LEASE_FILE" ]] || return 1
+    if [[ " $* " == *" jsonpath={.spec.holderIdentity} "* ]]; then
+      jq -r '.spec.holderIdentity' "$FAKE_LEASE_FILE"
+    else
+      cat "$FAKE_LEASE_FILE"
+    fi
+  elif [[ " $* " == *" patch lease "* ]]; then
+    [[ -f "$FAKE_LEASE_FILE" ]] || return 1
+    local patch_payload=""
+    local expect_patch=false
+    local argument
+    for argument in "$@"; do
+      if [[ "$expect_patch" == "true" ]]; then
+        patch_payload="$argument"
+        break
+      elif [[ "$argument" == "--patch" ]]; then
+        expect_patch=true
+      fi
+    done
+    jq -s '.[0] * .[1]' "$FAKE_LEASE_FILE" <(printf '%s' "$patch_payload") \
+      >"$FAKE_LEASE_FILE.tmp"
+    mv -- "$FAKE_LEASE_FILE.tmp" "$FAKE_LEASE_FILE"
+    fake_log 'kubectl lease renew'
+  elif [[ " $* " == *" delete lease "* ]]; then
+    rm -f -- "$FAKE_LEASE_FILE"
+    fake_log 'kubectl lease delete'
+  elif [[ " $* " == *" get application.argoproj.io "* ]]; then
     fake_argocd_application_json
   elif [[ " $* " == *" patch application.argoproj.io "* ]]; then
     local patch_payload=""
@@ -118,7 +171,10 @@ fake_kubectl() {
     done
     [[ -n "$patch_payload" ]] || return 2
 
-    if jq -e '.operation.sync != null' <<<"$patch_payload" >/dev/null; then
+    if jq -e 'has("operation") and .operation == null' <<<"$patch_payload" >/dev/null; then
+      rm -f -- "$FAKE_ARGO_OPERATION_INITIATOR_FILE"
+      fake_log 'kubectl app operation terminate'
+    elif jq -e '.operation.sync != null' <<<"$patch_payload" >/dev/null; then
       jq -r '.operation.initiatedBy.username' <<<"$patch_payload" \
         >"$FAKE_ARGO_OPERATION_INITIATOR_FILE"
       fake_log 'kubectl app sync hook'
@@ -161,6 +217,7 @@ fake_pg_dump() {
   [[ "${PGPORT:-}" == '5432' ]] || return 2
   [[ "${PGUSER:-}" == 'prd-user' ]] || return 2
   [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+  [[ "${PGSSLMODE:-}" == 'require' ]] || return 2
   fake_log 'pg_dump source'
   printf '%s\n' 'synthetic custom archive'
 }
@@ -223,6 +280,7 @@ fake_pg_restore() {
   [[ "${PGPORT:-}" == '5432' ]] || return 2
   [[ "${PGUSER:-}" == 'stg-user' ]] || return 2
   [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+  [[ "${PGSSLMODE:-}" == 'require' ]] || return 2
   local restore_database=""
   local restore_list=""
   local expect_database=false
@@ -291,11 +349,16 @@ fake_psql() {
   fi
 
   [[ "${PGDATABASE:-}" == 'klicker' ]] || return 2
+  [[ "${PGSSLMODE:-}" == 'require' ]] || return 2
   if [[ "${PGHOST:-}" == 'db-server-prd-apps.postgres.database.azure.com' ]]; then
     [[ "${PGUSER:-}" == 'prd-user' ]] || return 2
     [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
     fake_log 'psql metadata source'
-    if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+    if [[ " $* " == *" klicker_database_identity "* ]]; then
+      printf '%s\n' 'klicker|10.0.0.5|5432'
+    elif [[ " $* " == *" klicker_database_migration_history "* ]]; then
+      printf '%s\n' '001_init|checksum-a'
+    elif [[ " $* " == *" klicker_database_metadata_core "* ]]; then
       printf '%s\n' 'klicker|170000|1048576|200|1|0|0'
     elif [[ " $* " == *" klicker_database_metadata_migrations "* ]]; then
       printf '%s\n' '180|0'
@@ -312,7 +375,17 @@ fake_psql() {
   fake_log 'psql metadata target'
   local count=0
   [[ -f "$FAKE_STG_METADATA_COUNTER" ]] && count="$(<"$FAKE_STG_METADATA_COUNTER")"
-  if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+  if [[ " $* " == *" klicker_database_identity "* ]]; then
+    printf '%s\n' 'klicker|10.0.0.5|5432'
+  elif [[ " $* " == *" klicker_database_migration_history "* ]]; then
+    if [[ "${FAKE_MIGRATION_HISTORY_MODE:-prefix}" == "divergent" ]] && (( count >= 3 )); then
+      printf '%s\n' '999_wrong|checksum-z'
+    elif (( count >= 3 )); then
+      printf '%s\n' $'001_init|checksum-a\n002_forward|checksum-b'
+    else
+      printf '%s\n' '001_init|checksum-a'
+    fi
+  elif [[ " $* " == *" klicker_database_metadata_core "* ]]; then
     count=$((count + 1))
     printf '%s' "$count" >"$FAKE_STG_METADATA_COUNTER"
     if [[ "${FAKE_STG_EMPTY_BEFORE:-false}" == "true" && "$count" == "1" ]]; then
@@ -407,6 +480,7 @@ new_case() {
   FAKE_LOG="$CASE_DIR/fake.log"
   FAKE_ARGO_POLICY_FILE="$CASE_DIR/argocd-policy"
   FAKE_ARGO_OPERATION_INITIATOR_FILE="$CASE_DIR/argocd-operation-initiator"
+  FAKE_LEASE_FILE="$CASE_DIR/refresh-lease.json"
   FAKE_WORKLOADS_SCALED_FILE="$CASE_DIR/workloads-scaled"
   FAKE_STG_METADATA_COUNTER="$CASE_DIR/stg-metadata-counter"
   FAKE_STG_RESTORED_FILE="$CASE_DIR/stg-restored"
@@ -427,12 +501,17 @@ run_refresh() {
     FAKE_LOG="$FAKE_LOG" \
     FAKE_ARGO_POLICY_FILE="$FAKE_ARGO_POLICY_FILE" \
     FAKE_ARGO_OPERATION_INITIATOR_FILE="$FAKE_ARGO_OPERATION_INITIATOR_FILE" \
+    FAKE_LEASE_FILE="$FAKE_LEASE_FILE" \
     FAKE_WORKLOADS_SCALED_FILE="$FAKE_WORKLOADS_SCALED_FILE" \
     FAKE_STG_METADATA_COUNTER="$FAKE_STG_METADATA_COUNTER" \
     FAKE_STG_RESTORED_FILE="$FAKE_STG_RESTORED_FILE" \
     FAKE_PG_RESTORE_FAIL="${FAKE_PG_RESTORE_FAIL:-false}" \
     FAKE_PSQL_CONNECT_FAIL="${FAKE_PSQL_CONNECT_FAIL:-false}" \
     FAKE_ARGO_SYNC_FAIL="${FAKE_ARGO_SYNC_FAIL:-false}" \
+    FAKE_ARGO_OPERATION_RUNNING="${FAKE_ARGO_OPERATION_RUNNING:-false}" \
+    FAKE_MIGRATOR_URL="${FAKE_MIGRATOR_URL:-postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require}" \
+    FAKE_MIGRATION_HISTORY_MODE="${FAKE_MIGRATION_HISTORY_MODE:-prefix}" \
+    FAKE_KUBE_CAN_I="${FAKE_KUBE_CAN_I:-allow}" \
     FAKE_CATALOG_READS_PREFIX_ONLY="${FAKE_CATALOG_READS_PREFIX_ONLY:-false}" \
     FAKE_PUBLIC_SCHEMA_NOT_OWNED="${FAKE_PUBLIC_SCHEMA_NOT_OWNED:-false}" \
     FAKE_STG_EMPTY_BEFORE="${FAKE_STG_EMPTY_BEFORE:-false}" \
@@ -442,10 +521,17 @@ run_refresh() {
     DRY_RUN="${DRY_RUN:-true}" \
     CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}" \
     ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}" \
-    PRD_DATABASE_URL="${PRD_DATABASE_URL_OVERRIDE-postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public}" \
-    STG_DATABASE_URL="${STG_DATABASE_URL_OVERRIDE-postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public}" \
+    RAW_PRD_DATA_APPROVAL_REF="${RAW_PRD_DATA_APPROVAL_REF-TEST-APPROVAL}" \
+    STG_OUTBOUND_INTEGRATIONS_ISOLATED="${STG_OUTBOUND_INTEGRATIONS_ISOLATED:-true}" \
+    STG_FREE_STORAGE_GIB="${STG_FREE_STORAGE_GIB:-64}" \
+    EXPECTED_STG_CLUSTER_UID="${EXPECTED_STG_CLUSTER_UID:-synthetic-cluster-uid}" \
+    EXPECTED_ARGOCD_CLUSTER_UID="${EXPECTED_ARGOCD_CLUSTER_UID:-synthetic-cluster-uid}" \
+    WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-}" \
+    ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}" \
+    PRD_DATABASE_URL="${PRD_DATABASE_URL_OVERRIDE-postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require}" \
+    STG_DATABASE_URL="${STG_DATABASE_URL_OVERRIDE-postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public&sslmode=require}" \
     BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY_OVERRIDE-synthetic-test-key}" \
-    "$SCRIPT_UNDER_TEST" "$@" >"$OUTPUT_FILE" 2>&1
+    "$SCRIPT_UNDER_TEST" >"$OUTPUT_FILE" 2>&1
 }
 
 write_failed_run_receipt() {
@@ -494,7 +580,7 @@ test_help() {
 
 test_dry_run() {
   new_case dry-run
-  if BACKUP_ENCRYPTION_KEY_OVERRIDE= run_refresh &&
+  if BACKUP_ENCRYPTION_KEY_OVERRIDE='' run_refresh &&
     assert_contains "$OUTPUT_FILE" 'DRY_RUN=true' &&
     assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
     assert_not_contains "$FAKE_LOG" 'gpg encrypt' &&
@@ -526,8 +612,10 @@ test_host_guard() {
   if ! env \
     PATH="$FAKE_BIN:$PATH" \
     FAKE_LOG="$FAKE_LOG" \
-    PRD_DATABASE_URL='postgresql://prd-user:synthetic@unexpected.example.com/klicker' \
-    STG_DATABASE_URL='postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker' \
+    EXPECTED_STG_CLUSTER_UID=synthetic-cluster-uid \
+    EXPECTED_ARGOCD_CLUSTER_UID=synthetic-cluster-uid \
+    PRD_DATABASE_URL='postgresql://prd-user:synthetic@unexpected.example.com/klicker?sslmode=require' \
+    STG_DATABASE_URL='postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?sslmode=require' \
     BACKUP_ENCRYPTION_KEY='synthetic-test-key' \
     "$SCRIPT_UNDER_TEST" >"$OUTPUT_FILE" 2>&1 &&
     assert_contains "$OUTPUT_FILE" "does not equal expected host" &&
@@ -535,6 +623,104 @@ test_host_guard() {
     pass 'unexpected database host fails closed before connections'
   else
     fail 'unexpected database host fails closed before connections'
+  fi
+}
+
+test_database_name_guard() {
+  new_case database-name-guard
+  if ! env \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_LOG="$FAKE_LOG" \
+    EXPECTED_STG_CLUSTER_UID=synthetic-cluster-uid \
+    EXPECTED_ARGOCD_CLUSTER_UID=synthetic-cluster-uid \
+    PRD_DATABASE_URL='postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/not-klicker?sslmode=require' \
+    STG_DATABASE_URL='postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?sslmode=require' \
+    BACKUP_ENCRYPTION_KEY='synthetic-test-key' \
+    "$SCRIPT_UNDER_TEST" >"$OUTPUT_FILE" 2>&1 &&
+    assert_contains "$OUTPUT_FILE" "does not equal expected database" &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'unexpected database name fails closed before connections'
+  else
+    fail 'unexpected database name fails closed before connections'
+  fi
+}
+
+test_cluster_identity_guard() {
+  new_case cluster-identity-guard
+  if ! EXPECTED_STG_CLUSTER_UID=wrong-cluster run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'does not match expected cluster identity' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl lease create' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'unexpected Kubernetes cluster identity fails closed before mutation'
+  else
+    fail 'unexpected Kubernetes cluster identity fails closed before mutation'
+  fi
+}
+
+test_workload_namespace_guard() {
+  new_case workload-namespace-guard
+  if ! WORKLOAD_NAMESPACE=unexpected-namespace run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'does not match ArgoCD destination namespace' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl lease create' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'unexpected workload namespace fails closed before mutation'
+  else
+    fail 'unexpected workload namespace fails closed before mutation'
+  fi
+}
+
+test_migrator_target_guard() {
+  new_case migrator-target-guard
+  if ! FAKE_MIGRATOR_URL='postgresql://stg-user:synthetic@other-stg.postgres.database.azure.com/klicker?sslmode=require' run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Migrator Secret points to host' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl lease create' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'migrator Secret target must match the validated STG target'
+  else
+    fail 'migrator Secret target must match the validated STG target'
+  fi
+}
+
+test_existing_refresh_lease_guard() {
+  new_case existing-refresh-lease
+  jq -n --arg holder 'other-refresh' '{spec: {holderIdentity: $holder}}' >"$FAKE_LEASE_FILE"
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Refresh Lease' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'an existing refresh Lease blocks a competing execution'
+  else
+    fail 'an existing refresh Lease blocks a competing execution'
+  fi
+}
+
+test_write_rbac_guard() {
+  new_case write-rbac-guard
+  if ! FAKE_KUBE_CAN_I=deny run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Kubernetes permission denied' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl lease create' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'missing Kubernetes write permission fails during preflight'
+  else
+    fail 'missing Kubernetes write permission fails during preflight'
+  fi
+}
+
+test_raw_data_approval_guard() {
+  new_case raw-data-approval-guard
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    RAW_PRD_DATA_APPROVAL_REF='' \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'RAW_PRD_DATA_APPROVAL_REF' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source'; then
+    pass 'raw production-data execution requires an approval reference'
+  else
+    fail 'raw production-data execution requires an approval reference'
   fi
 }
 
@@ -551,9 +737,9 @@ test_run_id_guard() {
 
 test_self_hosted_infisical_credentials() {
   new_case self-hosted-infisical
-  if PRD_DATABASE_URL_OVERRIDE= \
-    STG_DATABASE_URL_OVERRIDE= \
-    BACKUP_ENCRYPTION_KEY_OVERRIDE= \
+  if PRD_DATABASE_URL_OVERRIDE='' \
+    STG_DATABASE_URL_OVERRIDE='' \
+    BACKUP_ENCRYPTION_KEY_OVERRIDE='' \
     DRY_RUN=false \
     CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
     ALLOW_RAW_PRD_DATA_IN_STG=true \
@@ -757,6 +943,39 @@ test_migration_failure() {
   fi
 }
 
+test_timeout_terminates_operation() {
+  new_case timeout-terminates-operation
+  if ! DRY_RUN=false \
+    ARGOCD_TIMEOUT_SECONDS=1 \
+    ARGOCD_POLL_SECONDS=1 \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_ARGO_OPERATION_RUNNING=true \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'did not complete within 1 seconds' &&
+    assert_contains "$FAKE_LOG" 'kubectl app operation terminate' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app policy automated'; then
+    pass 'a timed-out ArgoCD operation is terminated before recovery'
+  else
+    fail 'a timed-out ArgoCD operation is terminated before recovery'
+  fi
+}
+
+test_migration_history_guard() {
+  new_case migration-history-guard
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_MIGRATION_HISTORY_MODE=divergent \
+    run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'do not extend the PRD history' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app policy automated'; then
+    pass 'divergent migration history fails closed after the hook'
+  else
+    fail 'divergent migration history fails closed after the hook'
+  fi
+}
+
 test_replay_lock() {
   new_case replay-lock
   if DRY_RUN=false \
@@ -778,6 +997,13 @@ test_help
 test_dry_run
 test_confirmation_gate
 test_host_guard
+test_database_name_guard
+test_cluster_identity_guard
+test_workload_namespace_guard
+test_migrator_target_guard
+test_existing_refresh_lease_guard
+test_write_rbac_guard
+test_raw_data_approval_guard
 test_run_id_guard
 test_self_hosted_infisical_credentials
 test_prd_connection_failure
@@ -790,6 +1016,8 @@ test_catalog_validation_drains_decrypted_archive
 test_public_schema_owner_is_not_required
 test_restore_failure
 test_migration_failure
+test_timeout_terminates_operation
+test_migration_history_guard
 test_replay_lock
 
 printf '1..%s\n' "$TEST_COUNT"

--- a/util/backup/tests/refresh-stg-from-prd.test.sh
+++ b/util/backup/tests/refresh-stg-from-prd.test.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_SOURCE" ]]; do
+  SOURCE_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ "$SCRIPT_SOURCE" == /* ]] || SCRIPT_SOURCE="$SOURCE_DIR/$SCRIPT_SOURCE"
+done
+TEST_SCRIPT="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)/$(basename "$SCRIPT_SOURCE")"
+SCRIPT_UNDER_TEST="$(cd "$(dirname "$TEST_SCRIPT")/.." && pwd)/refresh-stg-from-prd.sh"
+
+fake_log() {
+  printf '%s\n' "$*" >>"$FAKE_LOG"
+}
+
+fake_infisical() {
+  [[ " $* " == *" --domain=https://inf.prd.df-app.ch/api "* ]] || return 0
+  [[ " $* " == *" --projectId=d071be96-5136-4f23-a6cb-e0c7f9b9a6c8 "* ]] \
+    || return 0
+
+  local secret_name="${3:-}"
+  local environment=""
+  local argument
+  for argument in "$@"; do
+    if [[ "$argument" == --env=* ]]; then
+      environment="${argument#--env=}"
+    fi
+  done
+
+  fake_log "infisical get $secret_name from $environment via self-hosted project"
+  case "$secret_name:$environment" in
+    DIRECT_DATABASE_URL:prd)
+      printf '%s\n' 'postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public'
+      ;;
+    DIRECT_DATABASE_URL:stg)
+      printf '%s\n' 'postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public'
+      ;;
+    BACKUP_ENCRYPTION_KEY:prd)
+      printf '%s\n' 'synthetic-test-key'
+      ;;
+    *) return 2 ;;
+  esac
+}
+
+fake_argocd_application_json() {
+  local policy="manual"
+  [[ -f "$FAKE_ARGO_POLICY_FILE" ]] && policy="$(<"$FAKE_ARGO_POLICY_FILE")"
+
+  local automated='null'
+  if [[ "$policy" == "automated" ]]; then
+    automated='{"prune":true,"selfHeal":true,"allowEmpty":false}'
+  fi
+
+  local initiator=""
+  if [[ -f "$FAKE_ARGO_OPERATION_INITIATOR_FILE" ]]; then
+    initiator="$(<"$FAKE_ARGO_OPERATION_INITIATOR_FILE")"
+  fi
+
+  if [[ -n "$initiator" ]]; then
+    local phase="Succeeded"
+    local message="successfully synced (all tasks run)"
+    if [[ "${FAKE_ARGO_SYNC_FAIL:-false}" == "true" ]]; then
+      phase="Failed"
+      message="synthetic migration failure"
+    fi
+
+    jq -cn \
+      --argjson automated "$automated" \
+      --arg initiator "$initiator" \
+      --arg phase "$phase" \
+      --arg message "$message" \
+      '{
+        spec: {syncPolicy: {automated: $automated}},
+        status: {
+          operationState: {
+            phase: $phase,
+            startedAt: "2026-08-21T09:00:00Z",
+            finishedAt: "2026-08-21T09:00:01Z",
+            message: $message,
+            operation: {
+              initiatedBy: {username: $initiator},
+              sync: {syncStrategy: {hook: {}}}
+            }
+          }
+        }
+      }'
+  else
+    jq -cn \
+      --argjson automated "$automated" \
+      '{
+        spec: {syncPolicy: {automated: $automated}},
+        status: {
+          operationState: {
+            phase: "Succeeded",
+            startedAt: "2026-08-20T09:00:00Z"
+          }
+        }
+      }'
+  fi
+}
+
+fake_kubectl() {
+  if [[ " $* " == *" get application.argoproj.io "* ]]; then
+    fake_argocd_application_json
+  elif [[ " $* " == *" patch application.argoproj.io "* ]]; then
+    local patch_payload=""
+    local expect_patch=false
+    local argument
+    for argument in "$@"; do
+      if [[ "$expect_patch" == "true" ]]; then
+        patch_payload="$argument"
+        break
+      elif [[ "$argument" == "--patch" ]]; then
+        expect_patch=true
+      fi
+    done
+    [[ -n "$patch_payload" ]] || return 2
+
+    if jq -e '.operation.sync != null' <<<"$patch_payload" >/dev/null; then
+      jq -r '.operation.initiatedBy.username' <<<"$patch_payload" \
+        >"$FAKE_ARGO_OPERATION_INITIATOR_FILE"
+      fake_log 'kubectl app sync hook'
+    elif jq -e '.spec.syncPolicy | has("automated")' <<<"$patch_payload" \
+      >/dev/null; then
+      local automated
+      automated="$(jq -c '.spec.syncPolicy.automated' <<<"$patch_payload")"
+      if [[ "$automated" == "null" ]]; then
+        printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+        fake_log 'kubectl app policy manual'
+      else
+        printf '%s' automated >"$FAKE_ARGO_POLICY_FILE"
+        fake_log "kubectl app policy automated $automated"
+      fi
+    else
+      return 2
+    fi
+  elif [[ " $* " == *" get deployments "* ]]; then
+    local replicas=1
+    [[ -f "$FAKE_WORKLOADS_SCALED_FILE" ]] && replicas=0
+    printf '{"items":[{"metadata":{"namespace":"stg-klicker","name":"backend"},"spec":{"replicas":%s},"status":{"replicas":%s}}]}\n' \
+      "$replicas" "$replicas"
+  elif [[ " $* " == *" scale deployment/"* ]]; then
+    fake_log "kubectl scale $*"
+    : >"$FAKE_WORKLOADS_SCALED_FILE"
+  else
+    return 2
+  fi
+}
+
+fake_pg_dump() {
+  if [[ "${1:-}" == "--version" ]]; then
+    printf '%s\n' 'pg_dump (PostgreSQL) 17.4'
+    return
+  fi
+
+  [[ "${PGHOST:-}" == 'db-server-prd-apps.postgres.database.azure.com' ]] \
+    || return 2
+  [[ "${PGDATABASE:-}" == 'klicker' ]] || return 2
+  [[ "${PGPORT:-}" == '5432' ]] || return 2
+  [[ "${PGUSER:-}" == 'prd-user' ]] || return 2
+  [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+  fake_log 'pg_dump source'
+  printf '%s\n' 'synthetic custom archive'
+}
+
+fake_gpg() {
+  if [[ " $* " == *" --decrypt "* ]]; then
+    local archive="${*: -1}"
+    fake_log 'gpg decrypt'
+    if [[ "${FAKE_CATALOG_READS_PREFIX_ONLY:-false}" == "true" ]]; then
+      local index
+      for ((index = 0; index < 20000; index++)); do
+        printf '%064d\n' "$index"
+      done
+      return
+    fi
+    cat "$archive"
+    return
+  fi
+
+  local output=""
+  local expect_output=false
+  local argument
+  for argument in "$@"; do
+    if [[ "$expect_output" == "true" ]]; then
+      output="$argument"
+      expect_output=false
+    elif [[ "$argument" == "--output" ]]; then
+      expect_output=true
+    fi
+  done
+  [[ -n "$output" ]] || return 2
+  fake_log 'gpg encrypt'
+  cat >"$output"
+}
+
+fake_pg_restore() {
+  if [[ "${1:-}" == "--version" ]]; then
+    printf '%s\n' 'pg_restore (PostgreSQL) 17.4'
+    return
+  fi
+
+  if [[ " $* " == *" --list "* ]]; then
+    fake_log 'pg_restore list'
+    if [[ "${FAKE_CATALOG_READS_PREFIX_ONLY:-false}" == "true" ]]; then
+      IFS= read -r _ || true
+    else
+      cat >/dev/null
+    fi
+    printf '%s\n' \
+      '; synthetic archive catalog' \
+      '5; 2615 2200 SCHEMA - public prd-user' \
+      '100; 0 0 COMMENT - SCHEMA public prd-user' \
+      '200; 1259 12345 TABLE public Example prd-user'
+    return
+  fi
+
+  [[ "${PGHOST:-}" == 'db-server-stg-apps.postgres.database.azure.com' ]] \
+    || return 2
+  [[ "${PGDATABASE:-}" == 'klicker' ]] || return 2
+  [[ "${PGPORT:-}" == '5432' ]] || return 2
+  [[ "${PGUSER:-}" == 'stg-user' ]] || return 2
+  [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+  local restore_database=""
+  local restore_list=""
+  local expect_database=false
+  local argument
+  for argument in "$@"; do
+    if [[ "$expect_database" == "true" ]]; then
+      restore_database="$argument"
+      expect_database=false
+    elif [[ "$argument" == "--dbname" || "$argument" == "-d" ]]; then
+      expect_database=true
+    elif [[ "$argument" == --dbname=* ]]; then
+      restore_database="${argument#--dbname=}"
+    elif [[ "$argument" == -d* && "$argument" != "-d" ]]; then
+      restore_database="${argument#-d}"
+    elif [[ "$argument" == --use-list=* ]]; then
+      restore_list="${argument#--use-list=}"
+    fi
+  done
+  if [[ -z "$restore_database" ]]; then
+    printf '%s\n' 'pg_restore: error: one of -d/--dbname and -f/--file must be specified' >&2
+    return 1
+  fi
+  [[ "$restore_database" == 'klicker' ]] || return 2
+  [[ -n "$restore_list" && -f "$restore_list" ]] || return 2
+  ! grep -Eq '^[0-9]+; [0-9]+ [0-9]+ (SCHEMA - public|COMMENT - SCHEMA public) ' \
+    "$restore_list" || return 2
+  fake_log "pg_restore target database=$restore_database"
+  cat >/dev/null
+  [[ "${FAKE_PG_RESTORE_FAIL:-false}" != "true" ]] || return 1
+  : >"$FAKE_STG_RESTORED_FILE"
+}
+
+fake_psql() {
+  if [[ "${FAKE_PSQL_CONNECT_FAIL:-false}" == "true" &&
+    "${PGHOST:-}" == 'db-server-prd-apps.postgres.database.azure.com' ]]; then
+    printf '%s\n' 'psql: error: synthetic connection failure' >&2
+    return 2
+  fi
+
+  if [[ " $* " == *" DROP SCHEMA IF EXISTS public CASCADE; "* ]]; then
+    if [[ "${FAKE_PUBLIC_SCHEMA_NOT_OWNED:-false}" == "true" ]]; then
+      printf '%s\n' 'ERROR: must be owner of schema public' >&2
+      return 2
+    fi
+    [[ "${PGHOST:-}" == 'db-server-stg-apps.postgres.database.azure.com' ]] \
+      || return 2
+    fake_log 'psql reset target'
+    return
+  fi
+
+  if [[ " $* " == *" klicker_stg_reset_capabilities "* ]]; then
+    local supported_objects=253
+    if [[ "${FAKE_STG_EMPTY_BEFORE:-false}" == "true" &&
+      ! -f "$FAKE_STG_RESTORED_FILE" ]]; then
+      supported_objects=0
+    fi
+    printf 'klicker|stg-user|azure_pg_admin|t|%s|0|0|0|0\n' "$supported_objects"
+    return
+  fi
+
+  if [[ " $* " == *" klicker_reset_owned_objects "* ]]; then
+    [[ "${PGHOST:-}" == 'db-server-stg-apps.postgres.database.azure.com' ]] \
+      || return 2
+    fake_log 'psql reset target'
+    return
+  fi
+
+  [[ "${PGDATABASE:-}" == 'klicker' ]] || return 2
+  if [[ "${PGHOST:-}" == 'db-server-prd-apps.postgres.database.azure.com' ]]; then
+    [[ "${PGUSER:-}" == 'prd-user' ]] || return 2
+    [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+    fake_log 'psql metadata source'
+    if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+      printf '%s\n' 'klicker|170000|1048576|200|1|0|0'
+    elif [[ " $* " == *" klicker_database_metadata_migrations "* ]]; then
+      printf '%s\n' '180|0'
+    else
+      return 2
+    fi
+    return
+  fi
+
+  [[ "${PGHOST:-}" == 'db-server-stg-apps.postgres.database.azure.com' ]] \
+    || return 2
+  [[ "${PGUSER:-}" == 'stg-user' ]] || return 2
+  [[ "${PGPASSWORD:-}" == 'synthetic' ]] || return 2
+  fake_log 'psql metadata target'
+  local count=0
+  [[ -f "$FAKE_STG_METADATA_COUNTER" ]] && count="$(<"$FAKE_STG_METADATA_COUNTER")"
+  if [[ " $* " == *" klicker_database_metadata_core "* ]]; then
+    count=$((count + 1))
+    printf '%s' "$count" >"$FAKE_STG_METADATA_COUNTER"
+    if [[ "${FAKE_STG_EMPTY_BEFORE:-false}" == "true" && "$count" == "1" ]]; then
+      printf '%s\n' 'klicker|170000|8192|0|0|0|0'
+    else
+      case "$count" in
+        1) printf '%s\n' 'klicker|170000|524288|190|1|0|0' ;;
+        2) printf '%s\n' 'klicker|170000|1048576|200|1|0|0' ;;
+        *) printf '%s\n' 'klicker|170000|1100000|205|1|0|0' ;;
+      esac
+    fi
+  elif [[ " $* " == *" klicker_database_metadata_migrations "* ]]; then
+    case "$count" in
+      1) printf '%s\n' '175|0' ;;
+      2) printf '%s\n' '180|0' ;;
+      *) printf '%s\n' '185|0' ;;
+    esac
+  else
+    return 2
+  fi
+}
+
+dispatch_fake_tool() {
+  case "$(basename "$0")" in
+    gpg) fake_gpg "$@" ;;
+    infisical) fake_infisical "$@" ;;
+    kubectl) fake_kubectl "$@" ;;
+    pg_dump) fake_pg_dump "$@" ;;
+    pg_restore) fake_pg_restore "$@" ;;
+    psql) fake_psql "$@" ;;
+    *) return 2 ;;
+  esac
+}
+
+if [[ "$(basename "$0")" != "$(basename "$TEST_SCRIPT")" ]]; then
+  dispatch_fake_tool "$@"
+  exit
+fi
+
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/refresh-stg-from-prd-test.XXXXXX")"
+cleanup_test_tmp() {
+  if [[ "${KEEP_TEST_TMP:-false}" == "true" ]]; then
+    printf 'retained test artifacts: %s\n' "$TEST_TMP" >&2
+  else
+    rm -rf -- "$TEST_TMP"
+  fi
+}
+trap cleanup_test_tmp EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+pass() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'ok %s - %s\n' "$TEST_COUNT" "$1"
+}
+
+fail() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'not ok %s - %s\n' "$TEST_COUNT" "$1" >&2
+}
+
+assert_contains() {
+  local file="$1"
+  local text="$2"
+  grep -Fq -- "$text" "$file"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local text="$2"
+  ! grep -Fq -- "$text" "$file"
+}
+
+assert_before() {
+  local file="$1"
+  local first="$2"
+  local second="$3"
+  local first_line second_line
+  first_line="$(grep -nF -- "$first" "$file" | head -1 | cut -d: -f1)"
+  second_line="$(grep -nF -- "$second" "$file" | head -1 | cut -d: -f1)"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]]
+}
+
+new_case() {
+  local name="$1"
+  CASE_DIR="$TEST_TMP/$name"
+  FAKE_BIN="$CASE_DIR/bin"
+  FAKE_LOG="$CASE_DIR/fake.log"
+  FAKE_ARGO_POLICY_FILE="$CASE_DIR/argocd-policy"
+  FAKE_ARGO_OPERATION_INITIATOR_FILE="$CASE_DIR/argocd-operation-initiator"
+  FAKE_WORKLOADS_SCALED_FILE="$CASE_DIR/workloads-scaled"
+  FAKE_STG_METADATA_COUNTER="$CASE_DIR/stg-metadata-counter"
+  FAKE_STG_RESTORED_FILE="$CASE_DIR/stg-restored"
+  OUTPUT_FILE="$CASE_DIR/output.log"
+  REFRESH_DIR="$CASE_DIR/refreshes"
+  mkdir -p "$FAKE_BIN"
+  : >"$FAKE_LOG"
+  printf '%s' automated >"$FAKE_ARGO_POLICY_FILE"
+  local tool
+  for tool in gpg infisical kubectl pg_dump pg_restore psql; do
+    ln -s "$TEST_SCRIPT" "$FAKE_BIN/$tool"
+  done
+}
+
+run_refresh() {
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_LOG="$FAKE_LOG" \
+    FAKE_ARGO_POLICY_FILE="$FAKE_ARGO_POLICY_FILE" \
+    FAKE_ARGO_OPERATION_INITIATOR_FILE="$FAKE_ARGO_OPERATION_INITIATOR_FILE" \
+    FAKE_WORKLOADS_SCALED_FILE="$FAKE_WORKLOADS_SCALED_FILE" \
+    FAKE_STG_METADATA_COUNTER="$FAKE_STG_METADATA_COUNTER" \
+    FAKE_STG_RESTORED_FILE="$FAKE_STG_RESTORED_FILE" \
+    FAKE_PG_RESTORE_FAIL="${FAKE_PG_RESTORE_FAIL:-false}" \
+    FAKE_PSQL_CONNECT_FAIL="${FAKE_PSQL_CONNECT_FAIL:-false}" \
+    FAKE_ARGO_SYNC_FAIL="${FAKE_ARGO_SYNC_FAIL:-false}" \
+    FAKE_CATALOG_READS_PREFIX_ONLY="${FAKE_CATALOG_READS_PREFIX_ONLY:-false}" \
+    FAKE_PUBLIC_SCHEMA_NOT_OWNED="${FAKE_PUBLIC_SCHEMA_NOT_OWNED:-false}" \
+    FAKE_STG_EMPTY_BEFORE="${FAKE_STG_EMPTY_BEFORE:-false}" \
+    REFRESH_ROOT_DIR="$REFRESH_DIR" \
+    RUN_ID="${RUN_ID_OVERRIDE:-test-run}" \
+    RESUME_FAILED_RUN_ID="${RESUME_FAILED_RUN_ID_OVERRIDE:-}" \
+    DRY_RUN="${DRY_RUN:-true}" \
+    CONFIRM_PRD_TO_STG_REFRESH="${CONFIRM_PRD_TO_STG_REFRESH:-}" \
+    ALLOW_RAW_PRD_DATA_IN_STG="${ALLOW_RAW_PRD_DATA_IN_STG:-false}" \
+    PRD_DATABASE_URL="${PRD_DATABASE_URL_OVERRIDE-postgresql://prd-user:synthetic@db-server-prd-apps.postgres.database.azure.com/klicker?schema=public}" \
+    STG_DATABASE_URL="${STG_DATABASE_URL_OVERRIDE-postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker?schema=public}" \
+    BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY_OVERRIDE-synthetic-test-key}" \
+    "$SCRIPT_UNDER_TEST" "$@" >"$OUTPUT_FILE" 2>&1
+}
+
+write_failed_run_receipt() {
+  local failed_run_id="$1"
+  local failed_run_dir="$REFRESH_DIR/$failed_run_id"
+  mkdir -p "$failed_run_dir"
+  jq -n \
+    --arg runId "$failed_run_id" \
+    '{
+      runId: $runId,
+      createdAt: "2026-08-21T11:28:45Z",
+      source: {
+        host: "db-server-prd-apps.postgres.database.azure.com",
+        database: "klicker",
+        sizeBytes: 1048576,
+        tableCount: 200,
+        appliedMigrations: 180
+      },
+      targetBefore: {
+        host: "db-server-stg-apps.postgres.database.azure.com",
+        database: "klicker",
+        sizeBytes: 524288,
+        tableCount: 190,
+        appliedMigrations: 175
+      },
+      archiveSha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      argocdAutomatedPolicy: {
+        prune: true,
+        selfHeal: true,
+        allowEmpty: false
+      }
+    }' >"$failed_run_dir/before.json"
+  printf '%s\t%s\t%s\n' 'stg-klicker' 'backend' '1' \
+    >"$failed_run_dir/deployments.tsv"
+}
+
+test_help() {
+  new_case help
+  if "$SCRIPT_UNDER_TEST" --help >"$OUTPUT_FILE" 2>&1 &&
+    assert_contains "$OUTPUT_FILE" 'DRY_RUN=false'; then
+    pass 'help is available without external tools'
+  else
+    fail 'help is available without external tools'
+  fi
+}
+
+test_dry_run() {
+  new_case dry-run
+  if BACKUP_ENCRYPTION_KEY_OVERRIDE= run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'DRY_RUN=true' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    assert_not_contains "$FAKE_LOG" 'gpg encrypt' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app policy' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app sync' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale' &&
+    [[ ! -e "$REFRESH_DIR" ]]; then
+    pass 'dry run performs only read-only preflight checks'
+  else
+    fail 'dry run performs only read-only preflight checks'
+  fi
+}
+
+test_confirmation_gate() {
+  new_case confirmation
+  if ! DRY_RUN=false run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app policy' &&
+    assert_not_contains "$FAKE_LOG" 'psql metadata'; then
+    pass 'execution refuses to start without destructive confirmation'
+  else
+    fail 'execution refuses to start without destructive confirmation'
+  fi
+}
+
+test_host_guard() {
+  new_case host-guard
+  if ! env \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_LOG="$FAKE_LOG" \
+    PRD_DATABASE_URL='postgresql://prd-user:synthetic@unexpected.example.com/klicker' \
+    STG_DATABASE_URL='postgresql://stg-user:synthetic@db-server-stg-apps.postgres.database.azure.com/klicker' \
+    BACKUP_ENCRYPTION_KEY='synthetic-test-key' \
+    "$SCRIPT_UNDER_TEST" >"$OUTPUT_FILE" 2>&1 &&
+    assert_contains "$OUTPUT_FILE" "does not equal expected host" &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'unexpected database host fails closed before connections'
+  else
+    fail 'unexpected database host fails closed before connections'
+  fi
+}
+
+test_run_id_guard() {
+  new_case run-id-guard
+  if ! RUN_ID_OVERRIDE='../escape' run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'RUN_ID must be 1-128 characters' &&
+    [[ ! -s "$FAKE_LOG" ]]; then
+    pass 'run IDs cannot escape the gitignored receipt directory'
+  else
+    fail 'run IDs cannot escape the gitignored receipt directory'
+  fi
+}
+
+test_self_hosted_infisical_credentials() {
+  new_case self-hosted-infisical
+  if PRD_DATABASE_URL_OVERRIDE= \
+    STG_DATABASE_URL_OVERRIDE= \
+    BACKUP_ENCRYPTION_KEY_OVERRIDE= \
+    DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    run_refresh &&
+    assert_contains "$FAKE_LOG" 'infisical get DIRECT_DATABASE_URL from prd via self-hosted project' &&
+    assert_contains "$FAKE_LOG" 'infisical get DIRECT_DATABASE_URL from stg via self-hosted project' &&
+    assert_contains "$FAKE_LOG" 'infisical get BACKUP_ENCRYPTION_KEY from prd via self-hosted project'; then
+    pass 'credentials are loaded from the self-hosted Infisical project'
+  else
+    fail 'credentials are loaded from the self-hosted Infisical project'
+  fi
+}
+
+test_prd_connection_failure() {
+  new_case prd-connection-failure
+  if ! FAKE_PSQL_CONNECT_FAIL=true run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Could not read PRD database metadata' &&
+    assert_not_contains "$OUTPUT_FILE" "PRD metadata returned unexpected database ''"; then
+    pass 'PRD connection errors fail immediately without a misleading metadata error'
+  else
+    fail 'PRD connection errors fail immediately without a misleading metadata error'
+  fi
+}
+
+test_existing_maintenance_mode() {
+  new_case existing-maintenance
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+  if ! run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'automated sync is disabled before refresh' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl scale'; then
+    pass 'an unfinished maintenance state must be recovered before another refresh'
+  else
+    fail 'an unfinished maintenance state must be recovered before another refresh'
+  fi
+}
+
+test_resume_failed_refresh() {
+  new_case resume-failed-refresh
+  write_failed_run_receipt previous-failure
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+  : >"$FAKE_WORKLOADS_SCALED_FILE"
+
+  if RESUME_FAILED_RUN_ID_OVERRIDE=previous-failure \
+    RUN_ID_OVERRIDE=resume-run \
+    FAKE_STG_EMPTY_BEFORE=true \
+    DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    run_refresh &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == "automated" ]] &&
+    [[ ! -e "$REFRESH_DIR/previous-failure/after.json" ]] &&
+    [[ -f "$REFRESH_DIR/resume-run/before.json" ]] &&
+    [[ -f "$REFRESH_DIR/resume-run/after.json" ]] &&
+    jq -e '.resumedFromRunId == "previous-failure"' \
+      "$REFRESH_DIR/resume-run/before.json" >/dev/null &&
+    assert_contains "$FAKE_LOG" 'pg_restore target database=klicker' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app policy manual' &&
+    assert_contains "$OUTPUT_FILE" "Resuming fail-safe maintenance from run 'previous-failure'" &&
+    assert_contains "$OUTPUT_FILE" 'refresh completed successfully'; then
+    pass 'a receipt-bound resume safely completes a reset-before-restore failure'
+  else
+    fail 'a receipt-bound resume safely completes a reset-before-restore failure'
+  fi
+}
+
+test_resume_rejects_running_workload() {
+  new_case resume-running-workload
+  write_failed_run_receipt previous-failure
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+
+  if ! RESUME_FAILED_RUN_ID_OVERRIDE=previous-failure run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Cannot resume while any selected STG Deployment has desired or running replicas' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    [[ ! -e "$REFRESH_DIR/test-run" ]]; then
+    pass 'resume refuses to continue until every selected workload is stopped'
+  else
+    fail 'resume refuses to continue until every selected workload is stopped'
+  fi
+}
+
+test_resume_rejects_mismatched_receipt() {
+  new_case resume-mismatched-receipt
+  write_failed_run_receipt previous-failure
+  local before_receipt="$REFRESH_DIR/previous-failure/before.json"
+  jq '.targetBefore.database = "unexpected-target"' "$before_receipt" \
+    >"$before_receipt.tmp"
+  mv -- "$before_receipt.tmp" "$before_receipt"
+  printf '%s' manual >"$FAKE_ARGO_POLICY_FILE"
+  : >"$FAKE_WORKLOADS_SCALED_FILE"
+
+  if ! RESUME_FAILED_RUN_ID_OVERRIDE=previous-failure run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Resume receipt does not match the current source, target, or prior automated-sync state' &&
+    assert_not_contains "$FAKE_LOG" 'pg_dump source' &&
+    [[ ! -e "$REFRESH_DIR/test-run" ]]; then
+    pass 'resume refuses a receipt for a different database endpoint'
+  else
+    fail 'resume refuses a receipt for a different database endpoint'
+  fi
+}
+
+test_successful_refresh() {
+  new_case success
+  if DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    run_refresh &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == "automated" ]] &&
+    [[ -f "$REFRESH_DIR/test-run/before.json" ]] &&
+    [[ -f "$REFRESH_DIR/test-run/after.json" ]] &&
+    [[ ! -e "$REFRESH_DIR/test-run/prd.dump.gpg" ]] &&
+    assert_not_contains "$REFRESH_DIR/test-run/before.json" 'synthetic-test-key' &&
+    assert_not_contains "$REFRESH_DIR/test-run/before.json" 'prd-user' &&
+    jq -e '.argocdAutomatedPolicy == {
+      "prune": true,
+      "selfHeal": true,
+      "allowEmpty": false
+    }' "$REFRESH_DIR/test-run/before.json" >/dev/null &&
+    assert_contains "$FAKE_LOG" 'pg_restore list' &&
+    assert_before "$FAKE_LOG" 'pg_dump source' 'kubectl app policy manual' &&
+    assert_before "$FAKE_LOG" 'kubectl app policy manual' 'kubectl scale' &&
+    assert_before "$FAKE_LOG" 'kubectl scale' 'psql reset target' &&
+    assert_before "$FAKE_LOG" 'psql reset target' 'pg_restore target database=klicker' &&
+    assert_before "$FAKE_LOG" 'pg_restore target database=klicker' 'kubectl app sync hook' &&
+    assert_before "$FAKE_LOG" 'kubectl app sync hook' 'kubectl app policy automated' &&
+    assert_contains "$FAKE_LOG" 'kubectl app policy automated {"prune":true,"selfHeal":true,"allowEmpty":false}' &&
+    assert_contains "$OUTPUT_FILE" 'refresh completed successfully'; then
+    pass 'successful refresh follows the guarded dump, restore, hook, verify sequence'
+  else
+    fail 'successful refresh follows the guarded dump, restore, hook, verify sequence'
+  fi
+}
+
+test_catalog_validation_drains_decrypted_archive() {
+  new_case catalog-validation-drain
+  if DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_CATALOG_READS_PREFIX_ONLY=true \
+    run_refresh &&
+    assert_contains "$FAKE_LOG" 'pg_restore list' &&
+    assert_contains "$OUTPUT_FILE" 'refresh completed successfully'; then
+    pass 'catalog validation drains decrypted data after pg_restore stops reading'
+  else
+    fail 'catalog validation drains decrypted data after pg_restore stops reading'
+  fi
+}
+
+test_public_schema_owner_is_not_required() {
+  new_case public-schema-owner
+  if DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_PUBLIC_SCHEMA_NOT_OWNED=true \
+    run_refresh &&
+    assert_contains "$FAKE_LOG" 'psql reset target' &&
+    assert_contains "$OUTPUT_FILE" 'refresh completed successfully' &&
+    assert_not_contains "$OUTPUT_FILE" 'must be owner of schema public'; then
+    pass 'refresh preserves public when the STG role does not own the schema'
+  else
+    fail 'refresh preserves public when the STG role does not own the schema'
+  fi
+}
+
+test_restore_failure() {
+  new_case restore-failure
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_PG_RESTORE_FAIL=true \
+    run_refresh &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == "manual" ]] &&
+    [[ -f "$FAKE_WORKLOADS_SCALED_FILE" ]] &&
+    assert_contains "$OUTPUT_FILE" 'STG pg_restore failed' &&
+    assert_contains "$OUTPUT_FILE" 'fail-safe maintenance mode' &&
+    assert_contains "$OUTPUT_FILE" 'Do not submit an ArgoCD sync' &&
+    assert_contains "$OUTPUT_FILE" 'RESUME_FAILED_RUN_ID=test-run' &&
+    assert_not_contains "$FAKE_LOG" 'kubectl app sync hook'; then
+    pass 'restore failure keeps STG stopped and automated sync disabled'
+  else
+    fail 'restore failure keeps STG stopped and automated sync disabled'
+  fi
+}
+
+test_migration_failure() {
+  new_case migration-failure
+  if ! DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    FAKE_ARGO_SYNC_FAIL=true \
+    run_refresh &&
+    [[ "$(<"$FAKE_ARGO_POLICY_FILE")" == "manual" ]] &&
+    [[ -f "$FAKE_WORKLOADS_SCALED_FILE" ]] &&
+    assert_contains "$OUTPUT_FILE" 'ArgoCD sync or PreSync migration hook failed' &&
+    assert_contains "$OUTPUT_FILE" 'fail-safe maintenance mode' &&
+    assert_contains "$OUTPUT_FILE" 'After confirming the restored snapshot is intact, retry the hook sync' &&
+    [[ "$(grep -Fc 'kubectl scale' "$FAKE_LOG")" -ge 2 ]]; then
+    pass 'migration-hook failure forces STG back to maintenance mode'
+  else
+    fail 'migration-hook failure forces STG back to maintenance mode'
+  fi
+}
+
+test_replay_lock() {
+  new_case replay-lock
+  if DRY_RUN=false \
+    CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+    ALLOW_RAW_PRD_DATA_IN_STG=true \
+    run_refresh &&
+    ! DRY_RUN=false \
+      CONFIRM_PRD_TO_STG_REFRESH=ERASE_STG_AND_COPY_PRD \
+      ALLOW_RAW_PRD_DATA_IN_STG=true \
+      run_refresh &&
+    assert_contains "$OUTPUT_FILE" 'Run directory already exists'; then
+    pass 'a completed run ID cannot be replayed'
+  else
+    fail 'a completed run ID cannot be replayed'
+  fi
+}
+
+test_help
+test_dry_run
+test_confirmation_gate
+test_host_guard
+test_run_id_guard
+test_self_hosted_infisical_credentials
+test_prd_connection_failure
+test_existing_maintenance_mode
+test_resume_failed_refresh
+test_resume_rejects_running_workload
+test_resume_rejects_mismatched_receipt
+test_successful_refresh
+test_catalog_validation_drains_decrypted_archive
+test_public_schema_owner_is_not_required
+test_restore_failure
+test_migration_failure
+test_replay_lock
+
+printf '1..%s\n' "$TEST_COUNT"
+(( FAIL_COUNT == 0 ))


### PR DESCRIPTION
## Summary

This dependent PR hardens PR #5465's operator-run PRD-to-STG refresh before it can be used for another execution. It targets Patrick's branch `feat/prd-to-stg-database-refresh` at the exact parent head and is intended for review as a stacked follow-up.

Parent PR: #5465 (`feat/prd-to-stg-database-refresh`)

## Changes

- Bind both database URLs to expected database names and an explicit minimum TLS mode; re-check the STG database identity immediately before reset.
- Bind Kubernetes work to expected cluster namespace UIDs, the Argo Application destination namespace, write RBAC, and a resource-identity-bound Deployment set.
- Add an atomic Kubernetes Lease with run ownership, renewals, and guarded release so competing refreshes fail closed.
- Terminate and drain a timed-out Argo operation before recovery; preserve the first replica receipt and keep cleanup fail-safe on post-sync verification errors.
- Prove the externally provisioned migrator Secret targets the validated STG database and compare ordered Prisma migration names and checksums rather than counts alone.
- Require a raw-data approval reference, explicit outbound-integration isolation, and current free-storage evidence for execution.
- Update the operator README, Data & Migrations wiki page, archived plan, and the committed implementation plan.

## Verification

Local, values-free verification on the exact committed range `300f1b5eae3baee22036b5d75748e0c95cb11cf7..3f3db88c990f8f0af7c7688153109b4df8070d36`:

- `bash -n util/backup/refresh-stg-from-prd.sh util/backup/tests/refresh-stg-from-prd.test.sh` — passed.
- `shellcheck util/backup/refresh-stg-from-prd.sh util/backup/tests/refresh-stg-from-prd.test.sh` — passed.
- `ARGOCD_TIMEOUT_SECONDS=10 ARGOCD_POLL_SECONDS=1 WORKLOAD_DRAIN_TIMEOUT_SECONDS=10 bash util/backup/tests/refresh-stg-from-prd.test.sh` — 26/26 passed.
- `pnpm exec prettier --check` on all changed Markdown files — passed.
- Repository build and commit hooks — passed under Node 24.16.0; the build emitted existing frontend warnings but exited successfully.
- Diff-scoped gitleaks and `git diff --check` — passed.

## Review boundary

- No Infisical, PostgreSQL, Kubernetes, ArgoCD, deployment, production-data, or live application action was performed from this follow-up.
- Live cluster identity, free capacity, migrator Secret contents, post-sync health, integration isolation, retention, and alert routing remain operator-side evidence before any real execution.
- The OKF wiki validator still reports pre-existing repository-wide frontmatter errors in unrelated ADR and solution files; the changed pages introduce no new validator errors. Prettier and repository-native commit checks pass.
- GitGuardian Security Checks is failing on the new PR as it also did on PR #5465; the provider finding is not exposed through GitHub metadata. Local gitleaks is green, so the external check needs Patrick/repository-owner disposition before merge.

## Merge / runtime boundary

This PR must remain unmerged until Patrick's review, required CI, and the GitGuardian disposition are complete. A successful merge still does not constitute live refresh proof; the operator must run the documented preflight and capture values-free target, capacity, health, and isolation evidence separately.
