### PR TITLE
docs: add a shared CONTEXT.md and agent skill configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,20 @@ Skills live in `.agents/skills/` (the canonical location); `.claude/skills` and 
 
 <!-- devrouter -->
 
+## Agent skills
+
+### Issue tracker
+
+Issues and specs live in ClickUp, reached through the `clickup_*` MCP tools; GitHub Issues are not used. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles keep their default names and are applied as ClickUp tags. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one shared `CONTEXT.md` at the root plus `docs/adr/`, with no context map. See `docs/agents/domain.md`.
+
 ## devrouter
 
 This repository uses [devrouter](https://github.com/rschlaefli/devrouter) for local dev routing.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,131 @@
+# KlickerUZH Context
+
+The shared vocabulary for this repository. Every term here has one meaning
+across all apps and packages, and code, plans, issues, and reviews use these
+words rather than synonyms. Where the domain is easy to misread, the entry says
+what the term is **not**.
+
+This file stays high-level. Area-specific depth belongs in [docs/](docs/), and
+the reasoning behind a decision belongs in an ADR under [docs/adr/](docs/adr/).
+
+## People
+
+**User**: Someone who authors and runs teaching content — a lecturer, an
+assistant, or an administrator. Users own courses and elements, sign in through
+`apps/auth`, and work in the manage and control interfaces. A user is never
+called a participant, even when they preview a participant view.
+
+**Participant**: Someone who answers content — a student. Participants live in
+their own table with their own login mechanisms and never hold permissions on
+courses or elements. "Student" is acceptable in user-facing copy; code and
+plans say participant.
+
+**Temporary participant**: A participant created for a single live quiz under a
+pseudonym, with no durable account. Anything that assumes a persistent identity
+must exclude them explicitly.
+
+**Participation**: One participant's membership in one course. It is the
+carrier for course-scoped participant state — leaderboard entry, activity
+progress, and assessment identity — none of which belongs on the global
+participant account.
+
+## Courses
+
+**Course**: The container a user creates and participants join. Its
+`authType` decides how they get in: a **PIN course** admits anyone holding the
+numeric pin code, while an **SSO course** admits only people arriving through
+SWITCH edu-ID.
+
+**Assessment course**: A course whose participant results are used as formal
+assessment records and grade-matching inputs (`isAssessmentEnabled`). It is a
+mode of an ordinary course, not a separate type, and it changes what identity
+the system keeps and what it will attest to.
+
+**Course invitation**: A pending or accepted invitation addressed to one email
+for one course. An invitation is only ever auto-accepted against a **verified
+SWITCH edu-ID linked affiliation address**, never against an address a
+participant typed into their own profile. That is what makes the invitation
+address usable as evidence of who someone is.
+
+## Content
+
+The four content models are the most misread part of this codebase. They form a
+chain from reusable definition to what one participant actually sees.
+
+**Element**: The reusable, versioned definition of a single piece of content —
+a question, a flashcard, or a content slide. It is owned by a user, lives in
+their library independently of any course, and is never answered directly.
+
+**Element instance**: A copy of an element placed inside one activity. It
+carries its own results and its own frozen copy of the element's content, so
+editing the original element never rewrites what participants already answered.
+
+**Element stack**: The unit a participant is shown and submits at once — one or
+more element instances presented together. Practice quizzes, microlearnings,
+and group activities are built from stacks.
+
+**Element block**: A live-quiz-only grouping that a user activates and closes
+from the control interface, with its own time limit and execution counter.
+Blocks are not stacks; only live quizzes have them.
+
+**Activity**: The umbrella for the four things a course can run — **live
+quiz**, **practice quiz**, **microlearning**, and **group activity**. Use the
+specific name whenever the statement is only true of one of them.
+
+**Publication status**: The lifecycle an activity moves through — `DRAFT`,
+`SCHEDULED`, `PUBLISHED`, `ENDED`, `GRADED`, `TEMPLATE`. It governs whether an
+activity can be edited, run, or seen by participants, and is distinct from an
+element's own `DRAFT`/`REVIEW`/`READY` authoring status.
+
+## Results and gamification
+
+**Points**: What a participant earns for answering within an activity, subject
+to correctness and multipliers. Points are activity-scoped and are what
+assessment reporting reads.
+
+**Experience points (XP)**: A separate, account-level progression score that
+drives levels and achievements. Points and XP are never used
+interchangeably; a change to one is not a change to the other.
+
+**Leaderboard entry**: A participant's score in one scope — course-wide or a
+single live quiz. Leaderboards exist only where gamification is enabled for the
+course.
+
+## Identity and attestation
+
+**Assessment participation identity**: The given name, surname, and
+matriculation number tied to one person's participation in one assessment
+course. It is asserted by that person's verified SWITCH edu-ID login, may be
+incomplete when edu-ID does not release an attribute, and belongs to neither
+ordinary-course participation nor the global participant account.
+
+**Credential subject email**: The email address a credential names as its
+subject. It is always the accepted course-invitation address, never the address
+a participant sets on their own profile — the invitation address carries edu-ID
+provenance, the profile address is unvalidated and freely editable.
+
+**Public credential verification**: The bearer-token page that verifies an
+assessment credential. Its public projection contains only the student's full
+name; it never contains an email address or a matriculation number.
+
+**Catalyst**: The capability tier attached to a user, either institutional
+(derived from edu-ID affiliation) or individual (subscribed). It gates feature
+limits and capacities, and is a property of the user rather than of any course.
+
+**Delegated login**: Signing in as a user through a `UserLogin` record with a
+scope, rather than through edu-ID. The scope becomes the session's authority
+and is enforced field-by-field in the API layer.
+
+## Boundary rules
+
+- Participant-editable values never gain provenance by sitting next to verified
+  claims. Where something must be attested, it comes from the verified source
+  or it is absent.
+- Assessment participation identity is retained only for assessment
+  participation and is nullable everywhere else.
+- Public projections are deliberately smaller than private ones. Widening one
+  is a decision that belongs in an ADR, not in a rendering change.
+- An element instance keeps its own copy of the element's data and its own
+  results. Editing the source element bumps that element's version and flags
+  the instance as outdated; it never rewrites what participants already saw or
+  answered.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,43 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the shared glossary for the whole repository.
+- **`docs/adr/`** — read the ADRs that touch the area you're about to work in.
+- The relevant area guide under **`docs/`**, when one covers the area.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repository is **single-context**: one shared `CONTEXT.md` at the root and
+one `docs/adr/` directory, despite the pnpm workspace layout. The packages under
+`packages/` and the apps under `apps/` share one domain vocabulary rather than
+owning separate ones, so there is deliberately no `CONTEXT-MAP.md`.
+
+```
+/
+├── CONTEXT.md            ← the shared glossary
+├── docs/
+│   ├── adr/              ← decisions and their reasoning
+│   └── agents/           ← this directory
+├── apps/
+└── packages/
+```
+
+Area-specific depth lives in the top-level guides under `docs/`, which explain
+what and how; `CONTEXT.md` fixes the words and `docs/adr/` records the why.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,44 @@
+# Issue tracker: ClickUp
+
+Issues, specs, and task tracking for this repository live in **ClickUp**, not in
+GitHub Issues. GitHub Issues are not actively used; do not create them, and do
+not treat an absent GitHub issue as an absent ticket.
+
+Reach ClickUp through the ClickUp MCP tools (`clickup_*`). If those tools are
+not available in the current session, say so and stop rather than falling back
+to GitHub Issues or to local files.
+
+## Conventions
+
+- **Create a ticket**: `clickup_create_task` with a `listName` or `listId`. Ask
+  which list when the target is not obvious from the conversation — this
+  workspace has many, and a task in the wrong list is effectively lost.
+- **Read a ticket**: `clickup_get_task`. Add `clickup_get_task_comments` when
+  the discussion matters, which it usually does for anything already triaged.
+- **Find a ticket**: `clickup_search` for free text; `clickup_filter_tasks` when
+  you know the list, status, assignee, or tag you are filtering on.
+- **Comment**: `clickup_create_task_comment`.
+- **Update status, assignee, priority, or fields**: `clickup_update_task`.
+- **Tags**: `clickup_add_tag_to_task` / `clickup_remove_tag_from_task` — this is
+  how the triage vocabulary in `triage-labels.md` is applied.
+- **Orient in an unfamiliar space**: `clickup_get_workspace_hierarchy`.
+
+## Pull requests as a request surface
+
+**PRs as a request surface: no.** Pull requests on GitHub are the review surface
+for changes, not an intake queue for feature requests.
+
+## When a skill says "publish to the issue tracker"
+
+Create a ClickUp task with `clickup_create_task`, and report the task URL back.
+
+## When a skill says "fetch the relevant ticket"
+
+Resolve it with `clickup_get_task` (by id) or `clickup_search` (by description),
+and read its comments before acting on it.
+
+## Referencing work in Git
+
+Commits and pull request descriptions reference ClickUp tasks by URL or task id.
+Because this repository is public, keep those references to identifiers and
+titles — never paste ticket contents that carry personal data.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,18 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+In ClickUp these are applied as **tags** (`clickup_add_tag_to_task` /
+`clickup_remove_tag_from_task`), not as statuses — a task keeps its list status
+while carrying a triage tag. Edit the right-hand column if the workspace later
+settles on different tag names.


### PR DESCRIPTION
Adds one repository-wide glossary at the root, plus the per-repo configuration the engineering skills expect under `docs/agents/`.

## Why a shared `CONTEXT.md`

The vocabulary was being re-derived per change, which is how the same term ends up meaning two different things to two people. This gives it one home. It stays deliberately high-level: `docs/` guides explain what and how, `docs/adr/` records why, and this fixes the words.

It covers the distinctions that are easiest to misread:

- **User versus participant** — lecturers own content and permissions, participants answer it, and the two are never interchangeable even when a user previews a participant view.
- **Element → element instance → element stack → element block** — the chain from reusable definition to what one participant is shown. An instance keeps its own copy of the element data and its own results, so editing the source element flags the instance as outdated rather than rewriting answered history.
- **Points versus experience points** — activity-scoped scoring versus account-level progression. Assessment reporting reads the former.
- **Assessment identity and credential terms** — including the credential subject email, which is always the accepted invitation address and never the participant's own profile address.

Every claim is taken from the Prisma schema rather than from memory.

## Single-context, no map

The pnpm workspace layout would allow a `CONTEXT-MAP.md` with one context per package, but the apps and packages share one domain vocabulary rather than owning separate ones. A map would add indirection without adding meaning.

## Agent skill configuration

`docs/agents/` records what the skills otherwise guess at, and `AGENTS.md` gains a short `## Agent skills` section pointing at it:

- **`issue-tracker.md`** — ClickUp, via the `clickup_*` MCP tools. The skills default to GitHub Issues, which is wrong here; `AGENTS.md` already stated ClickUp is the source of truth, but nothing machine-readable said so.
- **`triage-labels.md`** — the five canonical triage roles keep their default names, applied as ClickUp tags rather than statuses.
- **`domain.md`** — how skills should consume the glossary and the ADRs before exploring.

## Notes

- `AGENTS.md` is the file edited; `CLAUDE.md` is a symlink to it.
- `node ./util/check-agents-md.mjs` passes with zero warnings, and Prettier is clean on all five files.
- Unrelated, but worth fixing separately: `docs/adr/` currently has duplicate numbers — two `0001`, two `0003`, and two `0008`, where the chat-scoped ADRs collided with the infra-scoped ones.

https://claude.ai/code/session_01Msr3JDB8Y98SEHYukQVLyY