### PR TITLE
enhance(chat): add lecturer review workflow for response examples

### DIFF
--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -25,6 +25,7 @@
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/shared-components": "workspace:*",
     "@klicker-uzh/types": "workspace:*",
+    "@klicker-uzh/util": "workspace:*",
     "@socialgouv/matomo-next": "1.9.1",
     "@tanstack/react-table": "8.20.5",
     "@uidotdev/usehooks": "2.4.1",

--- a/apps/frontend-manage/src/components/resources/Chatbots.tsx
+++ b/apps/frontend-manage/src/components/resources/Chatbots.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from '@apollo/client'
 import {
-  Chatbot,
-  ChatModelCapability,
+  type Chatbot,
   GetChatbotsInfoDocument,
-  GetChatModelRegistryDocument,
 } from '@klicker-uzh/graphql/dist/ops'
 import { H2 } from '@uzh-bf/design-system'
-import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
-import ChatbotDetails from './chatbots/ChatbotDetails'
+import { useTranslations } from 'next-intl'
+import { useEffect } from 'react'
 import ChatbotList from './chatbots/ChatbotList'
 
 function Chatbots() {
@@ -17,53 +15,41 @@ function Chatbots() {
   const { data, loading } = useQuery(GetChatbotsInfoDocument, {
     fetchPolicy: 'network-only',
   })
-  const { data: modelRegistryData, loading: modelRegistryLoading } = useQuery(
-    GetChatModelRegistryDocument,
-    {
-      fetchPolicy: 'cache-first',
+
+  const fetchedChatbots = data?.getChatbotsInfo
+  const chatbots = fetchedChatbots ?? []
+
+  useEffect(() => {
+    const legacyChatbotId = router.query.chatbotId
+    if (loading || typeof legacyChatbotId !== 'string' || !fetchedChatbots) {
+      return
     }
-  )
 
-  const chatbots = data?.getChatbotsInfo ?? []
-  const modelRegistry: ChatModelCapability[] =
-    modelRegistryData?.getChatModelRegistry ?? []
-  const selectedId =
-    typeof router.query?.chatbotId === 'string'
-      ? router.query.chatbotId
-      : undefined
-  const selectedChatbot =
-    chatbots.find((chatbot) => chatbot.id === selectedId) ?? chatbots[0]
+    const chatbot = fetchedChatbots.find(
+      (candidate) => candidate.id === legacyChatbotId
+    )
+    if (!chatbot) return
 
-  const handleSelect = (chatbot: Chatbot) => {
-    void router.push(
-      {
-        pathname: router.pathname,
-        query: { ...router.query, chatbotId: chatbot.id },
-      },
+    void router.replace(
+      `/resources/chatbots/${encodeURIComponent(chatbot.id)}`,
       undefined,
       { shallow: true }
     )
+  }, [fetchedChatbots, loading, router])
+
+  const handleOpenChatbot = (chatbot: Chatbot) => {
+    void router.push(`/resources/chatbots/${encodeURIComponent(chatbot.id)}`)
   }
 
   return (
     <div className="min-h-full w-full shrink-0">
       <H2>{t('manage.resources.chatbots')}</H2>
-      <div className="mt-6 flex flex-col lg:flex-row-reverse">
-        <div className="lg:w-1/2 lg:border-l lg:pl-4">
-          <ChatbotDetails
-            chatbot={selectedChatbot}
-            modelRegistry={modelRegistry}
-            loading={loading || modelRegistryLoading}
-          />
-        </div>
-        <div className="lg:w-1/2 lg:pr-4">
-          <ChatbotList
-            chatbots={chatbots}
-            loading={loading}
-            selectedId={selectedChatbot?.id}
-            onSelect={handleSelect}
-          />
-        </div>
+      <div className="mt-6 max-w-3xl">
+        <ChatbotList
+          chatbots={chatbots}
+          loading={loading}
+          onOpen={handleOpenChatbot}
+        />
       </div>
     </div>
   )

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotDetails.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotDetails.tsx
@@ -576,7 +576,7 @@ function ChatbotDetails({
           </div>
         )}
 
-        <ChatbotResponseExampleReview chatbotId={chatbot.id} />
+        <ChatbotResponseExampleReview key={chatbot.id} chatbotId={chatbot.id} />
 
         <div>
           <div className="mb-2 text-sm font-medium text-gray-700">

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotDetails.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotDetails.tsx
@@ -24,6 +24,7 @@ import { useTranslations } from 'next-intl'
 import { useEffect, useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { getChatbotStatusTranslationKey } from './chatbotStatus'
+import ChatbotResponseExampleReview from './ChatbotResponseExampleReview'
 
 type ReasoningConfigState = Record<string, string[]>
 
@@ -574,6 +575,8 @@ function ChatbotDetails({
             </div>
           </div>
         )}
+
+        <ChatbotResponseExampleReview chatbotId={chatbot.id} />
 
         <div>
           <div className="mb-2 text-sm font-medium text-gray-700">

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotItem.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotItem.tsx
@@ -9,10 +9,10 @@ import { getChatbotStatusTranslationKey } from './chatbotStatus'
 function ChatbotItem({
   chatbot,
   onOpen,
-}: {
+}: Readonly<{
   chatbot: Chatbot
   onOpen: () => void
-}) {
+}>) {
   const t = useTranslations()
   const courseNames = chatbot.courses?.map((course) => course.name) ?? []
 

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotItem.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotItem.tsx
@@ -1,4 +1,6 @@
-import type { Chatbot } from '@klicker-uzh/graphql/dist/ops'
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { type Chatbot } from '@klicker-uzh/graphql/dist/ops'
 import { Badge } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { twMerge } from 'tailwind-merge'
@@ -6,12 +8,10 @@ import { getChatbotStatusTranslationKey } from './chatbotStatus'
 
 function ChatbotItem({
   chatbot,
-  selected,
-  onSelect,
+  onOpen,
 }: {
   chatbot: Chatbot
-  selected?: boolean
-  onSelect: () => void
+  onOpen: () => void
 }) {
   const t = useTranslations()
   const courseNames = chatbot.courses?.map((course) => course.name) ?? []
@@ -19,10 +19,9 @@ function ChatbotItem({
   return (
     <button
       type="button"
-      onClick={onSelect}
+      onClick={onOpen}
       className={twMerge(
-        'my-[0.2rem] flex w-full items-center justify-between rounded-md border border-solid px-4 py-3 text-left shadow-sm transition-all hover:shadow-md',
-        selected && 'border-primary-100 bg-orange-50'
+        'my-[0.2rem] flex w-full items-center justify-between gap-3 rounded-md border border-gray-200 bg-white px-4 py-3 text-left shadow-sm transition-all hover:border-primary hover:shadow-md'
       )}
       data-cy={`chatbot-${chatbot.name}`}
     >
@@ -44,6 +43,10 @@ function ChatbotItem({
             : t('manage.resources.noLinkedCourses')}
         </div>
       </div>
+      <FontAwesomeIcon
+        icon={faChevronRight}
+        className="h-4 w-4 shrink-0 text-gray-400"
+      />
     </button>
   )
 }

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotList.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotList.tsx
@@ -7,13 +7,11 @@ import ChatbotItem from './ChatbotItem'
 function ChatbotList({
   chatbots,
   loading,
-  selectedId,
-  onSelect,
+  onOpen,
 }: {
   chatbots?: Chatbot[]
   loading: boolean
-  selectedId?: string
-  onSelect: (chatbot: Chatbot) => void
+  onOpen: (chatbot: Chatbot) => void
 }) {
   const t = useTranslations()
 
@@ -34,8 +32,7 @@ function ChatbotList({
             <ChatbotItem
               key={`chatbot-${chatbot.id}`}
               chatbot={chatbot}
-              selected={chatbot.id === selectedId}
-              onSelect={() => onSelect(chatbot)}
+              onOpen={() => onOpen(chatbot)}
             />
           ))}
         </div>

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotList.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotList.tsx
@@ -8,11 +8,11 @@ function ChatbotList({
   chatbots,
   loading,
   onOpen,
-}: {
+}: Readonly<{
   chatbots?: Chatbot[]
   loading: boolean
   onOpen: (chatbot: Chatbot) => void
-}) {
+}>) {
   const t = useTranslations()
 
   if (loading) {

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
@@ -1,0 +1,684 @@
+import { useMutation, useQuery } from '@apollo/client'
+import {
+  ApproveResponseExampleDocument,
+  EditAndApproveResponseExampleDocument,
+  GetChatbotResponseExamplesDocument,
+  RejectResponseExampleDocument,
+  type ResponseExampleDataFragment,
+  ResponseExampleStatus,
+  ResponseExampleStyle,
+} from '@klicker-uzh/graphql/dist/ops'
+import { Markdown } from '@klicker-uzh/markdown'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
+import {
+  Badge,
+  Button,
+  FormLabel,
+  Modal,
+  SelectField,
+  TextareaField,
+  UserNotification,
+} from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import ContentInput from '../../common/ContentInput'
+
+type ResponseExample = ResponseExampleDataFragment
+
+type EditValues = Pick<
+  ResponseExample,
+  'chatMode' | 'studentMessage' | 'referenceAnswer' | 'responseStyle'
+>
+
+type EditState = EditValues & Pick<ResponseExample, 'id' | 'updatedAt'>
+
+const RESPONSE_EXAMPLE_STUDENT_MESSAGE_MAX_LENGTH = 4_000
+const RESPONSE_EXAMPLE_REFERENCE_ANSWER_MAX_LENGTH = 20_000
+
+const RESPONSE_EXAMPLE_STYLE_OPTIONS = [
+  {
+    value: ResponseExampleStyle.GuidedQuestions,
+    labelKey: 'manage.resources.responseExampleStyleGuidedQuestions',
+  },
+  {
+    value: ResponseExampleStyle.StepByStepExplanation,
+    labelKey: 'manage.resources.responseExampleStyleStepByStepExplanation',
+  },
+  {
+    value: ResponseExampleStyle.ConciseAnswer,
+    labelKey: 'manage.resources.responseExampleStyleConciseAnswer',
+  },
+  {
+    value: ResponseExampleStyle.ClarifyingQuestion,
+    labelKey: 'manage.resources.responseExampleStyleClarifyingQuestion',
+  },
+  {
+    value: ResponseExampleStyle.WorkedExample,
+    labelKey: 'manage.resources.responseExampleStyleWorkedExample',
+  },
+  {
+    value: ResponseExampleStyle.CompareOptions,
+    labelKey: 'manage.resources.responseExampleStyleCompareOptions',
+  },
+] as const
+
+function responseExampleStatusKey(status: ResponseExampleStatus) {
+  switch (status) {
+    case ResponseExampleStatus.Approved:
+      return 'manage.resources.responseExampleApproved' as const
+    case ResponseExampleStatus.Rejected:
+      return 'manage.resources.responseExampleRejected' as const
+    case ResponseExampleStatus.NeedsReview:
+      return 'manage.resources.responseExampleNeedsReview' as const
+    case ResponseExampleStatus.Candidate:
+      return 'manage.resources.responseExampleCandidate' as const
+    default:
+      return status
+  }
+}
+
+function responseExampleStatusClass(status: ResponseExampleStatus) {
+  switch (status) {
+    case ResponseExampleStatus.Approved:
+      return 'bg-green-100 text-green-800 hover:bg-green-200'
+    case ResponseExampleStatus.Rejected:
+      return 'bg-red-100 text-red-800 hover:bg-red-200'
+    case ResponseExampleStatus.NeedsReview:
+      return 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
+    case ResponseExampleStatus.Candidate:
+      return 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+    default:
+      return 'bg-gray-100 text-gray-800 hover:bg-gray-200'
+  }
+}
+
+function responseExampleStyleKey(style: ResponseExample['responseStyle']) {
+  return RESPONSE_EXAMPLE_STYLE_OPTIONS.find(
+    (option) => option.value === style
+  )!.labelKey
+}
+
+function actionErrorCode(error: unknown) {
+  return (
+    error as {
+      graphQLErrors?: Array<{ extensions?: { code?: string } }>
+    }
+  ).graphQLErrors?.[0]?.extensions?.code
+}
+
+function ChatbotResponseExampleReview({ chatbotId }: { chatbotId: string }) {
+  const t = useTranslations()
+  const [editValues, setEditValues] = useState<EditState | null>(null)
+  const [activeActionId, setActiveActionId] = useState<string | null>(null)
+  const [reviewError, setReviewError] = useState<string | null>(null)
+
+  const {
+    data,
+    loading,
+    error,
+    refetch: refetchExamples,
+  } = useQuery(GetChatbotResponseExamplesDocument, {
+    variables: { chatbotId },
+    fetchPolicy: 'network-only',
+  })
+  const [approveResponseExample, { loading: approving }] = useMutation(
+    ApproveResponseExampleDocument
+  )
+  const [editAndApproveResponseExample, { loading: editing }] = useMutation(
+    EditAndApproveResponseExampleDocument
+  )
+  const [rejectResponseExample, { loading: rejecting }] = useMutation(
+    RejectResponseExampleDocument
+  )
+  const [staleEditId, setStaleEditId] = useState<string | null>(null)
+
+  const examples = data?.getChatbotResponseExamples?.examples ?? []
+  const chatModes = data?.getChatbotResponseExamples?.chatModes ?? []
+  const isMutating = approving || editing || rejecting
+
+  const chatModeLabel = (mode: string) => {
+    if (mode === 'tutor') return t('chat.modes.tutor')
+    if (mode === 'explainer') return t('chat.modes.explainer')
+    return mode
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, (letter) => letter.toUpperCase())
+  }
+
+  const openEditor = (example: ResponseExample) => {
+    setReviewError(null)
+    setStaleEditId(null)
+    setEditValues({
+      id: example.id,
+      updatedAt: example.updatedAt,
+      chatMode: example.chatMode,
+      studentMessage: example.studentMessage,
+      referenceAnswer: example.referenceAnswer,
+      responseStyle: example.responseStyle,
+    })
+  }
+
+  const closeEditor = () => {
+    if (editing) return
+    setEditValues(null)
+    setStaleEditId(null)
+    setReviewError(null)
+  }
+
+  const setEditValue = <K extends keyof EditValues>(
+    key: K,
+    value: EditValues[K]
+  ) => {
+    setEditValues((current) =>
+      current ? { ...current, [key]: value } : current
+    )
+  }
+
+  const handleApprove = async (id: string) => {
+    setActiveActionId(id)
+    setReviewError(null)
+
+    try {
+      const result = await approveResponseExample({ variables: { id } })
+      if (!result.data?.approveResponseExample) {
+        setReviewError(t('manage.resources.responseExampleReviewForbidden'))
+        return
+      }
+    } catch (error) {
+      setReviewError(
+        actionErrorCode(error) === 'RESPONSE_EXAMPLE_SOURCES_REQUIRED'
+          ? t('manage.resources.responseExampleSourcesRequired')
+          : actionErrorCode(error) === 'RESPONSE_EXAMPLE_MODE_UNAVAILABLE'
+            ? t('manage.resources.responseExampleModeUnavailable')
+            : actionErrorCode(error) === 'RESPONSE_EXAMPLE_DUPLICATE'
+              ? t('manage.resources.responseExampleDuplicate')
+              : t('manage.resources.responseExampleReviewActionError')
+      )
+    } finally {
+      setActiveActionId(null)
+    }
+  }
+
+  const handleReject = async (id: string) => {
+    setActiveActionId(id)
+    setReviewError(null)
+
+    try {
+      const result = await rejectResponseExample({ variables: { id } })
+      if (!result.data?.rejectResponseExample) {
+        setReviewError(t('manage.resources.responseExampleReviewForbidden'))
+        return
+      }
+    } catch (error) {
+      const code = actionErrorCode(error)
+      setReviewError(
+        code === 'RESPONSE_EXAMPLE_DUPLICATE'
+          ? t('manage.resources.responseExampleDuplicate')
+          : t('manage.resources.responseExampleReviewActionError')
+      )
+    } finally {
+      setActiveActionId(null)
+    }
+  }
+
+  const handleEditAndApprove = async () => {
+    if (!editValues) return
+
+    setReviewError(null)
+    try {
+      const result = await editAndApproveResponseExample({
+        variables: {
+          id: editValues.id,
+          chatMode: editValues.chatMode,
+          studentMessage: editValues.studentMessage,
+          referenceAnswer: editValues.referenceAnswer,
+          responseStyle: editValues.responseStyle,
+          expectedUpdatedAt: editValues.updatedAt,
+        },
+      })
+      if (!result.data?.editAndApproveResponseExample) {
+        setReviewError(t('manage.resources.responseExampleReviewForbidden'))
+        return
+      }
+      closeEditor()
+    } catch (error) {
+      const code = actionErrorCode(error)
+      if (code === 'RESPONSE_EXAMPLE_STALE_UPDATE') {
+        setStaleEditId(editValues.id)
+        setReviewError(t('manage.resources.responseExampleStaleUpdate'))
+        try {
+          await refetchExamples()
+        } catch {
+          // Keep the lecturer's draft open even if the refresh is unavailable.
+        }
+        return
+      }
+
+      setReviewError(
+        code === 'RESPONSE_EXAMPLE_SOURCES_REQUIRED'
+          ? t('manage.resources.responseExampleSourcesRequired')
+          : code === 'RESPONSE_EXAMPLE_MODE_UNAVAILABLE'
+            ? t('manage.resources.responseExampleModeUnavailable')
+            : code === 'RESPONSE_EXAMPLE_DUPLICATE'
+              ? t('manage.resources.responseExampleDuplicate')
+              : t('manage.resources.responseExampleReviewActionError')
+      )
+    }
+  }
+
+  const hasInvalidEdit =
+    !editValues ||
+    editValues.studentMessage.length >
+      RESPONSE_EXAMPLE_STUDENT_MESSAGE_MAX_LENGTH ||
+    editValues.referenceAnswer.length >
+      RESPONSE_EXAMPLE_REFERENCE_ANSWER_MAX_LENGTH
+
+  const hasIncompleteEdit =
+    !editValues ||
+    [
+      editValues.chatMode,
+      editValues.studentMessage,
+      editValues.referenceAnswer,
+      editValues.responseStyle,
+    ].some((value) => value.trim().length === 0)
+
+  return (
+    <section className="border-t pt-4" data-cy="response-examples-review">
+      <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-medium text-gray-700">
+          {t('manage.resources.responseExamples')}
+        </h3>
+        <span className="text-xs text-gray-500">
+          {t('manage.resources.responseExamplesDescription')}
+        </span>
+      </div>
+
+      {loading && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-cy="response-examples-loading"
+        >
+          <Loader />
+          <span className="sr-only">
+            {t('manage.resources.responseExamplesLoading')}
+          </span>
+        </div>
+      )}
+
+      {!loading && error && (
+        <UserNotification
+          type="error"
+          message={t('manage.resources.responseExamplesError')}
+          data={{ cy: 'response-examples-error' }}
+        />
+      )}
+
+      {!loading && !error && examples.length === 0 && (
+        <UserNotification
+          type="info"
+          message={t('manage.resources.responseExamplesEmpty')}
+          data={{ cy: 'response-examples-empty' }}
+        />
+      )}
+
+      {reviewError && (
+        <UserNotification
+          className={{ root: 'mb-3' }}
+          type="error"
+          message={reviewError}
+          data={{ cy: 'response-examples-action-error' }}
+        />
+      )}
+
+      {!loading && !error && examples.length > 0 && (
+        <div className="space-y-3" data-cy="response-examples-list">
+          {examples.map((example) => {
+            const chatModeAvailable = chatModes.includes(example.chatMode)
+            const actionBusy = isMutating && activeActionId === example.id
+            const citationParityComplete =
+              example.hasCompleteEligibleCitationParity
+
+            return (
+              <article
+                key={example.id}
+                className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                data-cy={`response-example-${example.id}`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span data-cy={`response-example-status-${example.id}`}>
+                      <Badge
+                        className={twMerge(
+                          'whitespace-nowrap',
+                          responseExampleStatusClass(example.status)
+                        )}
+                      >
+                        {t(responseExampleStatusKey(example.status))}
+                      </Badge>
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {t('manage.resources.responseExampleEditChatMode')}:{' '}
+                      {chatModeLabel(example.chatMode)}
+                    </span>
+                  </div>
+                  <span className="text-xs text-gray-500">
+                    {t('manage.resources.responseExampleResponseStyle')}:{' '}
+                    <span className="font-medium text-gray-700">
+                      {t(responseExampleStyleKey(example.responseStyle))}
+                    </span>
+                  </span>
+                </div>
+
+                <dl className="mt-3 space-y-3 text-sm">
+                  <div>
+                    <dt className="font-medium text-gray-700">
+                      {t('manage.resources.responseExampleQuestion')}
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-wrap text-gray-600">
+                      {example.studentMessage}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-gray-700">
+                      {t('manage.resources.responseExampleReferenceAnswer')}
+                    </dt>
+                    <dd className="prose prose-sm mt-1 max-w-none text-gray-600">
+                      <Markdown
+                        className={{ root: 'leading-6' }}
+                        content={example.referenceAnswer}
+                      />
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="mt-3 border-t pt-3">
+                  <div className="text-xs font-medium text-gray-700">
+                    {t('manage.resources.responseExampleSources')}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">
+                    {t('manage.resources.responseExampleSourcesDescription')}
+                  </p>
+                  <p
+                    className={twMerge(
+                      'mt-1 text-xs font-medium',
+                      citationParityComplete
+                        ? 'text-green-700'
+                        : 'text-yellow-700'
+                    )}
+                    data-cy={`response-example-citation-parity-${example.id}`}
+                  >
+                    {citationParityComplete
+                      ? t(
+                          'manage.resources.responseExampleCitationParityComplete'
+                        )
+                      : t(
+                          'manage.resources.responseExampleCitationParityIncomplete'
+                        )}
+                  </p>
+                  {example.evidenceReferences.length === 0 ? (
+                    <p className="mt-1 text-xs text-gray-500">
+                      {t('manage.resources.responseExampleNoSources')}
+                    </p>
+                  ) : (
+                    <ul
+                      className="mt-2 space-y-2 text-xs text-gray-600"
+                      data-cy={`response-example-evidence-${example.id}`}
+                    >
+                      {example.evidenceReferences.map((reference) => (
+                        <li
+                          key={reference.id}
+                          className="rounded border border-gray-100 bg-gray-50 p-2"
+                        >
+                          <div className="flex items-start gap-2">
+                            <span className="sr-only">
+                              {t(
+                                'manage.resources.responseExampleCitationLabel',
+                                { index: reference.citationIndex }
+                              )}
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded bg-blue-50 font-mono text-xs font-semibold text-blue-700"
+                            >
+                              {reference.citationIndex}
+                            </span>
+                            <div className="min-w-0">
+                              <div className="font-medium text-gray-800">
+                                {reference.citationAnchor}
+                              </div>
+                              <div
+                                className={twMerge(
+                                  'mt-1 font-medium',
+                                  reference.evidenceEligible
+                                    ? 'text-green-700'
+                                    : 'text-yellow-700'
+                                )}
+                              >
+                                {reference.evidenceEligible
+                                  ? t(
+                                      'manage.resources.responseExampleSourceAvailable'
+                                    )
+                                  : t(
+                                      'manage.resources.responseExampleSourceUnavailable'
+                                    )}
+                              </div>
+                            </div>
+                          </div>
+                          <details className="mt-2 text-xs text-gray-500">
+                            <summary className="cursor-pointer select-none">
+                              {t(
+                                'manage.resources.responseExampleSourceDetails'
+                              )}
+                            </summary>
+                            <div className="mt-1 grid gap-x-3 gap-y-1 sm:grid-cols-2">
+                              <span className="break-all">
+                                <span className="font-medium text-gray-700">
+                                  {t(
+                                    'manage.resources.responseExampleSourceId'
+                                  )}
+                                  :
+                                </span>{' '}
+                                {reference.sourceId}
+                              </span>
+                              <span className="break-all">
+                                <span className="font-medium text-gray-700">
+                                  {t('manage.resources.responseExampleChunkId')}
+                                  :
+                                </span>{' '}
+                                {reference.chunkId}
+                              </span>
+                              <span className="break-all">
+                                <span className="font-medium text-gray-700">
+                                  {t(
+                                    'manage.resources.responseExampleContentHash'
+                                  )}
+                                  :
+                                </span>{' '}
+                                {reference.contentHash}
+                              </span>
+                            </div>
+                          </details>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {(example.canApprove ||
+                  example.canEditAndApprove ||
+                  example.canReject) && (
+                  <div className="mt-3 flex flex-wrap gap-2 border-t pt-3">
+                    {example.canApprove &&
+                      (!citationParityComplete || !chatModeAvailable) && (
+                        <p className="basis-full text-xs text-yellow-700">
+                          {!chatModeAvailable
+                            ? t(
+                                'manage.resources.responseExampleModeUnavailable'
+                              )
+                            : t(
+                                'manage.resources.responseExampleSourcesRequired'
+                              )}
+                        </p>
+                      )}
+                    {example.canApprove && (
+                      <Button
+                        primary
+                        disabled={
+                          isMutating ||
+                          !chatModeAvailable ||
+                          !citationParityComplete
+                        }
+                        loading={actionBusy && approving}
+                        onClick={() => void handleApprove(example.id)}
+                        data={{
+                          cy: `response-example-approve-${example.id}`,
+                        }}
+                      >
+                        <Button.Label>
+                          {t('manage.resources.responseExampleApprove')}
+                        </Button.Label>
+                      </Button>
+                    )}
+                    {example.canEditAndApprove && (
+                      <Button
+                        disabled={isMutating}
+                        onClick={() => openEditor(example)}
+                        data={{
+                          cy: `response-example-edit-approve-${example.id}`,
+                        }}
+                      >
+                        <Button.Label>
+                          {t('manage.resources.responseExampleEditAndApprove')}
+                        </Button.Label>
+                      </Button>
+                    )}
+                    {example.canReject && (
+                      <Button
+                        disabled={isMutating}
+                        loading={actionBusy && rejecting}
+                        onClick={() => void handleReject(example.id)}
+                        data={{
+                          cy: `response-example-reject-${example.id}`,
+                        }}
+                      >
+                        <Button.Label>
+                          {t('manage.resources.responseExampleReject')}
+                        </Button.Label>
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {editValues && (
+        <Modal
+          open
+          onClose={closeEditor}
+          title={t('manage.resources.responseExampleEditTitle')}
+          primaryLabel={t('manage.resources.responseExampleSave')}
+          primaryButtonStyle="primary"
+          primaryDisabled={
+            hasIncompleteEdit ||
+            hasInvalidEdit ||
+            editing ||
+            staleEditId === editValues.id
+          }
+          primaryLoading={editing}
+          onPrimaryAction={() => void handleEditAndApprove()}
+          secondaryLabel={t('shared.generic.cancel')}
+          onSecondaryAction={closeEditor}
+          escapeDisabled={editing}
+          data={{ cy: 'response-example-edit-modal' }}
+          dataPrimaryAction={{ cy: 'response-example-edit-submit' }}
+          dataSecondaryAction={{ cy: 'response-example-edit-cancel' }}
+          className={{ content: 'max-w-2xl pb-2' }}
+        >
+          {reviewError && (
+            <UserNotification
+              className={{ root: 'mb-3' }}
+              type="error"
+              message={reviewError}
+              data={{ cy: 'response-example-edit-error' }}
+            />
+          )}
+          <div className="space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <SelectField
+                value={editValues.chatMode}
+                onChange={(value) => setEditValue('chatMode', value)}
+                label={t('manage.resources.responseExampleEditChatMode')}
+                required
+                items={chatModes.map((mode) => ({
+                  value: mode,
+                  label: chatModeLabel(mode),
+                }))}
+                data={{ cy: 'response-example-edit-chat-mode' }}
+              />
+              <SelectField
+                value={editValues.responseStyle}
+                onChange={(value) =>
+                  setEditValue(
+                    'responseStyle',
+                    value as ResponseExample['responseStyle']
+                  )
+                }
+                label={t('manage.resources.responseExampleEditResponseStyle')}
+                required
+                items={RESPONSE_EXAMPLE_STYLE_OPTIONS.map(
+                  ({ value, labelKey }) => ({
+                    value,
+                    label: t(labelKey),
+                  })
+                )}
+                data={{ cy: 'response-example-edit-response-style' }}
+              />
+            </div>
+            <TextareaField
+              value={editValues.studentMessage}
+              onChange={(value) => setEditValue('studentMessage', value)}
+              label={t('manage.resources.responseExampleEditQuestion')}
+              maxLength={RESPONSE_EXAMPLE_STUDENT_MESSAGE_MAX_LENGTH}
+              required
+              data={{ cy: 'response-example-edit-question' }}
+            />
+            <div>
+              <FormLabel
+                required
+                label={t('manage.resources.responseExampleEditReferenceAnswer')}
+                labelType="small"
+              />
+              <ContentInput
+                content={editValues.referenceAnswer}
+                touched={false}
+                onChange={(value: string) =>
+                  setEditValue('referenceAnswer', value)
+                }
+                placeholder={t(
+                  'manage.resources.responseExampleEditReferenceAnswerPlaceholder'
+                )}
+                data={{ cy: 'response-example-edit-reference-answer' }}
+                className={{ editor: 'min-h-48' }}
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                {t(
+                  'manage.resources.responseExampleEditReferenceAnswerLength',
+                  {
+                    count: editValues.referenceAnswer.length,
+                    max: RESPONSE_EXAMPLE_REFERENCE_ANSWER_MAX_LENGTH,
+                  }
+                )}
+              </p>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </section>
+  )
+}
+
+export default ChatbotResponseExampleReview

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
@@ -107,7 +107,22 @@ function actionErrorCode(error: unknown) {
   ).graphQLErrors?.[0]?.extensions?.code
 }
 
-function ChatbotResponseExampleReview({ chatbotId }: { chatbotId: string }) {
+function approvalErrorKey(code: string | undefined) {
+  switch (code) {
+    case 'RESPONSE_EXAMPLE_SOURCES_REQUIRED':
+      return 'manage.resources.responseExampleSourcesRequired' as const
+    case 'RESPONSE_EXAMPLE_MODE_UNAVAILABLE':
+      return 'manage.resources.responseExampleModeUnavailable' as const
+    case 'RESPONSE_EXAMPLE_DUPLICATE':
+      return 'manage.resources.responseExampleDuplicate' as const
+    default:
+      return 'manage.resources.responseExampleReviewActionError' as const
+  }
+}
+
+function ChatbotResponseExampleReview({
+  chatbotId,
+}: Readonly<{ chatbotId: string }>) {
   const t = useTranslations()
   const [editValues, setEditValues] = useState<EditState | null>(null)
   const [activeActionId, setActiveActionId] = useState<string | null>(null)
@@ -185,15 +200,7 @@ function ChatbotResponseExampleReview({ chatbotId }: { chatbotId: string }) {
         return
       }
     } catch (error) {
-      setReviewError(
-        actionErrorCode(error) === 'RESPONSE_EXAMPLE_SOURCES_REQUIRED'
-          ? t('manage.resources.responseExampleSourcesRequired')
-          : actionErrorCode(error) === 'RESPONSE_EXAMPLE_MODE_UNAVAILABLE'
-            ? t('manage.resources.responseExampleModeUnavailable')
-            : actionErrorCode(error) === 'RESPONSE_EXAMPLE_DUPLICATE'
-              ? t('manage.resources.responseExampleDuplicate')
-              : t('manage.resources.responseExampleReviewActionError')
-      )
+      setReviewError(t(approvalErrorKey(actionErrorCode(error))))
     } finally {
       setActiveActionId(null)
     }
@@ -254,15 +261,7 @@ function ChatbotResponseExampleReview({ chatbotId }: { chatbotId: string }) {
         return
       }
 
-      setReviewError(
-        code === 'RESPONSE_EXAMPLE_SOURCES_REQUIRED'
-          ? t('manage.resources.responseExampleSourcesRequired')
-          : code === 'RESPONSE_EXAMPLE_MODE_UNAVAILABLE'
-            ? t('manage.resources.responseExampleModeUnavailable')
-            : code === 'RESPONSE_EXAMPLE_DUPLICATE'
-              ? t('manage.resources.responseExampleDuplicate')
-              : t('manage.resources.responseExampleReviewActionError')
-      )
+      setReviewError(t(approvalErrorKey(code)))
     }
   }
 

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
@@ -593,7 +593,7 @@ function ChatbotResponseExampleReview({ chatbotId }: { chatbotId: string }) {
           secondaryLabel={t('shared.generic.cancel')}
           onSecondaryAction={closeEditor}
           escapeDisabled={editing}
-          data={{ cy: 'response-example-edit-modal' }}
+          dataContent={{ cy: 'response-example-edit-modal' }}
           dataPrimaryAction={{ cy: 'response-example-edit-submit' }}
           dataSecondaryAction={{ cy: 'response-example-edit-cancel' }}
           className={{ content: 'max-w-2xl pb-2' }}

--- a/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
+++ b/apps/frontend-manage/src/components/resources/chatbots/ChatbotResponseExampleReview.tsx
@@ -9,6 +9,7 @@ import {
   ResponseExampleStyle,
 } from '@klicker-uzh/graphql/dist/ops'
 import { Markdown } from '@klicker-uzh/markdown'
+import { citationTargetIdFor } from '@klicker-uzh/util/citations'
 import Loader from '@klicker-uzh/shared-components/src/Loader'
 import {
   Badge,
@@ -386,6 +387,8 @@ function ChatbotResponseExampleReview({
                       <Markdown
                         className={{ root: 'leading-6' }}
                         content={example.referenceAnswer}
+                        citationLinkScope={example.id}
+                        withCitationLinks
                       />
                     </dd>
                   </div>
@@ -438,6 +441,10 @@ function ChatbotResponseExampleReview({
                             </span>
                             <span
                               aria-hidden="true"
+                              id={citationTargetIdFor(
+                                reference.citationIndex,
+                                example.id
+                              )}
                               className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded bg-blue-50 font-mono text-xs font-semibold text-blue-700"
                             >
                               {reference.citationIndex}

--- a/apps/frontend-manage/src/pages/resources/chatbots/[chatbotId].tsx
+++ b/apps/frontend-manage/src/pages/resources/chatbots/[chatbotId].tsx
@@ -17,20 +17,24 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { GetStaticPropsContext } from 'next'
 import { useRouter } from 'next/router'
+import AiBetaUnavailable from '../../../components/AiBetaUnavailable'
 import ChatbotDetails from '../../../components/resources/chatbots/ChatbotDetails'
 import Layout from '../../../components/Layout'
+import { useAiFeaturesEnabled } from '../../../lib/hooks/useAiFeaturesEnabled'
 
 function ChatbotDetailPage() {
   const t = useTranslations()
   const router = useRouter()
+  const aiFeaturesEnabled = useAiFeaturesEnabled()
   const chatbotId = router.query.chatbotId
 
   const { data, loading } = useQuery(GetChatbotsInfoDocument, {
     fetchPolicy: 'network-only',
-    skip: typeof chatbotId !== 'string',
+    skip: !aiFeaturesEnabled || typeof chatbotId !== 'string',
   })
   const registryQuery = useQuery(GetChatModelRegistryDocument, {
     fetchPolicy: 'cache-first',
+    skip: !aiFeaturesEnabled,
   })
 
   const chatbots = data?.getChatbotsInfo ?? []
@@ -41,78 +45,86 @@ function ChatbotDetailPage() {
 
   return (
     <Layout displayName={chatbot?.name ?? t('manage.resources.chatbots')}>
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href="/resources/chatbots">
-                {t('manage.resources.chatbots')}
-              </Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            {loading || !chatbot ? (
-              <BreadcrumbPage>
-                {loading
-                  ? t('shared.generic.loading')
-                  : t('manage.resources.chatbotDetails')}
-              </BreadcrumbPage>
-            ) : (
-              <Select
-                value={chatbot.id}
-                onChange={(value) =>
-                  void router.push(
-                    `/resources/chatbots/${encodeURIComponent(value)}`
-                  )
-                }
-                placeholder={t('manage.resources.switchChatbot')}
-                contentPosition="popper"
-                items={chatbots.map((candidate) => ({
-                  value: candidate.id,
-                  label: candidate.name,
-                }))}
-                data={{ cy: 'chatbot-switcher' }}
-                className={{
-                  root: 'inline-flex',
-                  trigger: [
-                    'h-auto w-auto max-w-64 gap-1 rounded-md border-0',
-                    'bg-transparent -mx-1 px-1 py-0.5 text-left text-sm',
-                    'font-normal text-foreground shadow-none',
-                    'hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:border-0 focus-visible:ring-1',
-                    'data-[state=open]:bg-accent',
-                    'data-[state=open]:text-accent-foreground',
-                    'dark:bg-transparent dark:hover:bg-accent',
-                    '[&>svg]:size-3.5',
-                  ].join(' '),
-                  content: 'min-w-48',
-                }}
+      {aiFeaturesEnabled ? (
+        <>
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href="/resources/chatbots">
+                    {t('manage.resources.chatbots')}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {loading || !chatbot ? (
+                  <BreadcrumbPage>
+                    {loading
+                      ? t('shared.generic.loading')
+                      : t('manage.resources.chatbotDetails')}
+                  </BreadcrumbPage>
+                ) : (
+                  <Select
+                    value={chatbot.id}
+                    onChange={(value) =>
+                      void router.push(
+                        `/resources/chatbots/${encodeURIComponent(value)}`
+                      )
+                    }
+                    placeholder={t('manage.resources.switchChatbot')}
+                    contentPosition="popper"
+                    items={chatbots.map((candidate) => ({
+                      value: candidate.id,
+                      label: candidate.name,
+                    }))}
+                    data={{ cy: 'chatbot-switcher' }}
+                    className={{
+                      root: 'inline-flex',
+                      trigger: [
+                        'h-auto w-auto max-w-64 gap-1 rounded-md border-0',
+                        'bg-transparent -mx-1 px-1 py-0.5 text-left text-sm',
+                        'font-normal text-foreground shadow-none',
+                        'hover:bg-accent hover:text-accent-foreground',
+                        'focus-visible:border-0 focus-visible:ring-1',
+                        'data-[state=open]:bg-accent',
+                        'data-[state=open]:text-accent-foreground',
+                        'dark:bg-transparent dark:hover:bg-accent',
+                        '[&>svg]:size-3.5',
+                      ].join(' '),
+                      content: 'min-w-48',
+                    }}
+                  />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <h1 className="text-2xl font-bold">
+            {loading
+              ? t('shared.generic.loading')
+              : (chatbot?.name ?? t('manage.resources.chatbotDetails'))}
+          </h1>
+
+          {!loading && !chatbot && (
+            <UserNotification className={{ root: 'mt-6' }} type="error">
+              {t('manage.resources.chatbotNotFound')}
+            </UserNotification>
+          )}
+
+          {(loading || chatbot) && (
+            <div className="mt-6">
+              <ChatbotDetails
+                chatbot={chatbot}
+                modelRegistry={registryQuery.data?.getChatModelRegistry ?? []}
+                loading={loading || registryQuery.loading}
               />
-            )}
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      <h1 className="text-2xl font-bold">
-        {loading
-          ? t('shared.generic.loading')
-          : (chatbot?.name ?? t('manage.resources.chatbotDetails'))}
-      </h1>
-
-      {!loading && !chatbot && chatbots.length > 0 && (
-        <UserNotification className={{ root: 'mt-6' }} type="error">
-          {t('manage.resources.chatbotNotFound')}
-        </UserNotification>
+            </div>
+          )}
+        </>
+      ) : (
+        <AiBetaUnavailable />
       )}
-
-      <div className="mt-6">
-        <ChatbotDetails
-          chatbot={chatbot}
-          modelRegistry={registryQuery.data?.getChatModelRegistry ?? []}
-          loading={loading || registryQuery.loading}
-        />
-      </div>
     </Layout>
   )
 }

--- a/apps/frontend-manage/src/pages/resources/chatbots/[chatbotId].tsx
+++ b/apps/frontend-manage/src/pages/resources/chatbots/[chatbotId].tsx
@@ -1,0 +1,132 @@
+import { useQuery } from '@apollo/client'
+import {
+  GetChatbotsInfoDocument,
+  GetChatModelRegistryDocument,
+} from '@klicker-uzh/graphql/dist/ops'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Select,
+  UserNotification,
+} from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import Link from 'next/link'
+import { GetStaticPropsContext } from 'next'
+import { useRouter } from 'next/router'
+import ChatbotDetails from '../../../components/resources/chatbots/ChatbotDetails'
+import Layout from '../../../components/Layout'
+
+function ChatbotDetailPage() {
+  const t = useTranslations()
+  const router = useRouter()
+  const chatbotId = router.query.chatbotId
+
+  const { data, loading } = useQuery(GetChatbotsInfoDocument, {
+    fetchPolicy: 'network-only',
+    skip: typeof chatbotId !== 'string',
+  })
+  const registryQuery = useQuery(GetChatModelRegistryDocument, {
+    fetchPolicy: 'cache-first',
+  })
+
+  const chatbots = data?.getChatbotsInfo ?? []
+  const chatbot =
+    typeof chatbotId === 'string'
+      ? chatbots.find((candidate) => candidate.id === chatbotId)
+      : undefined
+
+  return (
+    <Layout displayName={chatbot?.name ?? t('manage.resources.chatbots')}>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/resources/chatbots">
+                {t('manage.resources.chatbots')}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            {loading || !chatbot ? (
+              <BreadcrumbPage>
+                {loading
+                  ? t('shared.generic.loading')
+                  : t('manage.resources.chatbotDetails')}
+              </BreadcrumbPage>
+            ) : (
+              <Select
+                value={chatbot.id}
+                onChange={(value) =>
+                  void router.push(
+                    `/resources/chatbots/${encodeURIComponent(value)}`
+                  )
+                }
+                placeholder={t('manage.resources.switchChatbot')}
+                contentPosition="popper"
+                items={chatbots.map((candidate) => ({
+                  value: candidate.id,
+                  label: candidate.name,
+                }))}
+                data={{ cy: 'chatbot-switcher' }}
+                className={{
+                  root: 'inline-flex',
+                  trigger: [
+                    'h-auto w-auto max-w-64 gap-1 rounded-md border-0',
+                    'bg-transparent -mx-1 px-1 py-0.5 text-left text-sm',
+                    'font-normal text-foreground shadow-none',
+                    'hover:bg-accent hover:text-accent-foreground',
+                    'focus-visible:border-0 focus-visible:ring-1',
+                    'data-[state=open]:bg-accent',
+                    'data-[state=open]:text-accent-foreground',
+                    'dark:bg-transparent dark:hover:bg-accent',
+                    '[&>svg]:size-3.5',
+                  ].join(' '),
+                  content: 'min-w-48',
+                }}
+              />
+            )}
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <h1 className="text-2xl font-bold">
+        {loading
+          ? t('shared.generic.loading')
+          : (chatbot?.name ?? t('manage.resources.chatbotDetails'))}
+      </h1>
+
+      {!loading && !chatbot && chatbots.length > 0 && (
+        <UserNotification className={{ root: 'mt-6' }} type="error">
+          {t('manage.resources.chatbotNotFound')}
+        </UserNotification>
+      )}
+
+      <div className="mt-6">
+        <ChatbotDetails
+          chatbot={chatbot}
+          modelRegistry={registryQuery.data?.getChatModelRegistry ?? []}
+          loading={loading || registryQuery.loading}
+        />
+      </div>
+    </Layout>
+  )
+}
+
+export async function getStaticProps({ locale }: GetStaticPropsContext) {
+  return {
+    props: {
+      messages: (await import(`@klicker-uzh/i18n/messages/${locale}`)).default,
+    },
+  }
+}
+
+export async function getStaticPaths() {
+  return { paths: [], fallback: 'blocking' }
+}
+
+export default ChatbotDetailPage

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -4264,6 +4264,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       mediaLibraryAvailableSoon:
         'Bald wird hier Ihre Mediathek verfügbar sein und Ihnen ermöglichen, hochgeladene Ressourcen einzusehen.',
       chatbots: 'Chatbots',
+      resources: 'Ressourcen',
+      switchChatbot: 'Chatbot wechseln',
+      chatbotNotFound:
+        'Dieser Chatbot wurde nicht gefunden oder Ihnen fehlt der Zugriff.',
       availableChatbots: 'Verfügbare Chatbots',
       noChatbots: 'Es wurden noch keine Chatbots erstellt.',
       chatbotDetails: 'Chatbot-Details',
@@ -4339,6 +4343,68 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       mcpPriority: 'Priorität',
       mcpAllowedTools: 'Erlaubte Tools',
       openChatbot: 'Chatbot öffnen',
+      responseExamples: 'Antwortbeispiele',
+      responseExamplesDescription:
+        'Überprüfen Sie Antwortbeispiele, bevor Sie sie aktivieren.',
+      responseExamplesLoading: 'Antwortbeispiele werden geladen ...',
+      responseExamplesError:
+        'Die Antwortbeispiele konnten nicht geladen werden. Bitte versuchen Sie es erneut.',
+      responseExamplesEmpty:
+        'Für diesen Chatbot sind keine Antwortbeispiele verfügbar.',
+      responseExampleCandidate: 'Vorschlag',
+      responseExampleApproved: 'Freigegeben',
+      responseExampleRejected: 'Abgelehnt',
+      responseExampleNeedsReview: 'Überprüfung erforderlich',
+      responseExampleQuestion: 'Frage',
+      responseExampleReferenceAnswer: 'Erwartete Chatbot-Antwort',
+      responseExampleResponseStyle: 'Antwortstil',
+      responseExampleSources: 'Quellennachweise',
+      responseExampleSourcesDescription:
+        'Diese Verweise zeigen, worauf sich die Zitate beziehen. Der Quelleninhalt wird hier nicht angezeigt.',
+      responseExampleCitationParityComplete:
+        'Alle hinterlegten Nachweise sind in dieser Antwort zitiert.',
+      responseExampleCitationParityIncomplete:
+        'Nachweise und Zitate müssen vor der Freigabe geprüft werden.',
+      responseExampleNoSources: 'Es sind keine Quellennachweise hinterlegt.',
+      responseExampleSourceId: 'Quellen-ID',
+      responseExampleChunkId: 'Chunk-ID',
+      responseExampleCitationIndex: 'Zitat',
+      responseExampleCitationAnchor: 'Zitationsanker',
+      responseExampleContentHash: 'Inhaltshash',
+      responseExampleSourceDetails: 'Technische Quelldetails',
+      responseExampleCitationLabel: 'Zitat {index}',
+      responseExampleSourceAvailable: 'Nachweis ist zugelassen',
+      responseExampleSourceUnavailable: 'Nachweis muss geprüft werden',
+      responseExampleStyleGuidedQuestions: 'Leitende Fragen stellen',
+      responseExampleStyleStepByStepExplanation: 'Schritt für Schritt erklären',
+      responseExampleStyleConciseAnswer: 'Kurz antworten',
+      responseExampleStyleClarifyingQuestion: 'Rückfrage stellen',
+      responseExampleStyleWorkedExample: 'An einem Beispiel erklären',
+      responseExampleStyleCompareOptions: 'Optionen vergleichen',
+      responseExampleSourcesRequired:
+        'Vor der Freigabe muss eine Quelle hinterlegt und als [1], [2], ... zitiert sein.',
+      responseExampleModeUnavailable:
+        'Wählen Sie einen verfügbaren Chat-Modus dieses Chatbots.',
+      responseExampleDuplicate:
+        'Ein Antwortbeispiel mit dieser Frage existiert für diesen Chat-Modus bereits.',
+      responseExampleApprove: 'Freigeben',
+      responseExampleEditAndApprove: 'Bearbeiten und freigeben',
+      responseExampleReject: 'Ablehnen',
+      responseExampleEditTitle: 'Antwortbeispiel bearbeiten',
+      responseExampleEditChatMode: 'Chat-Modus',
+      responseExampleEditQuestion: 'Frage',
+      responseExampleEditReferenceAnswer: 'Erwartete Chatbot-Antwort',
+      responseExampleEditReferenceAnswerPlaceholder:
+        'Schreiben Sie die erwartete Chatbot-Antwort aus. Formatierung wird automatisch angewendet; Quellen als [1], [2], ... zitieren.',
+      responseExampleEditReferenceAnswerLength: '{count} / {max} Zeichen',
+      responseExampleEditResponseStyle: 'Antwortstil',
+      responseExampleSave: 'Speichern und freigeben',
+      responseExampleReviewActionError:
+        'Dieses Antwortbeispiel konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.',
+      responseExampleStaleUpdate:
+        'Dieses Beispiel wurde während Ihrer Bearbeitung geändert. Ihr Entwurf ist weiterhin geöffnet. Schliessen Sie den Dialog und öffnen Sie das Beispiel erneut, bevor Sie wieder speichern.',
+      responseExampleReviewForbidden:
+        'Nur die Eigentümerin oder der Eigentümer des Chatbots kann Antwortbeispiele überprüfen.',
       answerCollections: 'Antwort-Sammlungen',
       answerCollectionsDescription:
         'Hier finden Sie alle Ihre Antwort-Sammlungen. Sie benötigen diese zur Erstellung bestimmter komplexer Fragetypen, wie beispielsweise Auswahl-Fragen und Fallstudien. Um bestehende Antwort-Sammlungen anderer Nutzer zu importieren oder Zugriff auf diese zu beantragen, besuchen Sie bitte den <link>Katalog</link>.',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -4182,6 +4182,10 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       mediaLibraryAvailableSoon:
         'Your media library will be available here soon, allowing you to access all your uploaded resources.',
       chatbots: 'Chatbots',
+      resources: 'Resources',
+      switchChatbot: 'Switch chatbot',
+      chatbotNotFound:
+        'This chatbot could not be found or you do not have access to it.',
       availableChatbots: 'Available Chatbots',
       noChatbots: 'No chatbots have been created yet.',
       chatbotDetails: 'Chatbot Details',
@@ -4256,6 +4260,68 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       mcpPriority: 'Priority',
       mcpAllowedTools: 'Allowed tools',
       openChatbot: 'Open Chatbot',
+      responseExamples: 'Response examples',
+      responseExamplesDescription:
+        'Review response examples before making them live.',
+      responseExamplesLoading: 'Loading response examples...',
+      responseExamplesError:
+        'Response examples could not be loaded. Please try again.',
+      responseExamplesEmpty:
+        'No response examples are available for this chatbot.',
+      responseExampleCandidate: 'Candidate',
+      responseExampleApproved: 'Approved',
+      responseExampleRejected: 'Rejected',
+      responseExampleNeedsReview: 'Needs review',
+      responseExampleQuestion: 'Question',
+      responseExampleReferenceAnswer: 'Expected chatbot answer',
+      responseExampleResponseStyle: 'Response style',
+      responseExampleSources: 'Evidence lineage',
+      responseExampleSourcesDescription:
+        'These references show where citations point. Source content is not shown here.',
+      responseExampleCitationParityComplete:
+        'All attached evidence is cited in this answer.',
+      responseExampleCitationParityIncomplete:
+        'The evidence and citations need review before approval.',
+      responseExampleNoSources: 'No evidence lineage is attached.',
+      responseExampleSourceId: 'Source ID',
+      responseExampleChunkId: 'Chunk ID',
+      responseExampleCitationIndex: 'Citation',
+      responseExampleCitationAnchor: 'Citation anchor',
+      responseExampleContentHash: 'Content hash',
+      responseExampleSourceDetails: 'Technical source details',
+      responseExampleCitationLabel: 'Citation {index}',
+      responseExampleSourceAvailable: 'Evidence is eligible',
+      responseExampleSourceUnavailable: 'Evidence needs review',
+      responseExampleStyleGuidedQuestions: 'Ask guiding questions',
+      responseExampleStyleStepByStepExplanation: 'Explain step by step',
+      responseExampleStyleConciseAnswer: 'Give a concise answer',
+      responseExampleStyleClarifyingQuestion: 'Ask for clarification',
+      responseExampleStyleWorkedExample: 'Work through an example',
+      responseExampleStyleCompareOptions: 'Compare options',
+      responseExampleSourcesRequired:
+        'A source must be attached and cited as [1], [2], ... before approving.',
+      responseExampleModeUnavailable:
+        'Select one of this chatbot’s available chat modes.',
+      responseExampleDuplicate:
+        'A response example with this question already exists for this chat mode.',
+      responseExampleApprove: 'Approve',
+      responseExampleEditAndApprove: 'Edit and approve',
+      responseExampleReject: 'Reject',
+      responseExampleEditTitle: 'Edit response example',
+      responseExampleEditChatMode: 'Chat mode',
+      responseExampleEditQuestion: 'Question',
+      responseExampleEditReferenceAnswer: 'Expected chatbot answer',
+      responseExampleEditReferenceAnswerPlaceholder:
+        'Write the full expected chatbot answer. Formatting is applied automatically; cite sources as [1], [2], ...',
+      responseExampleEditReferenceAnswerLength: '{count} / {max} characters',
+      responseExampleEditResponseStyle: 'Response style',
+      responseExampleSave: 'Save and approve',
+      responseExampleReviewActionError:
+        'This response example could not be updated. Please try again.',
+      responseExampleStaleUpdate:
+        'This example changed while you were editing. Your draft is still open. Close this dialog and reopen the example before saving again.',
+      responseExampleReviewForbidden:
+        'Only the chatbot owner can review response examples.',
       answerCollections: 'Answer Collections',
       answerCollectionsDescription:
         'Here you can find all your answer collections. You need these to create certain complex question types, such as selection questions and case studies. To import existing answer collections form other users or request access to these, please visit the <link>catalog</link>.',

--- a/packages/prisma-data/package.json
+++ b/packages/prisma-data/package.json
@@ -59,6 +59,7 @@
     "seed:qa": "ENV=development ../../util/_run_with_infisical.sh --env stg tsx src/data/seedTEST.ts",
     "seed:raw": "ENV=development run-s --npm-path pnpm seed:test seed:assessment-course",
     "seed:raw:course-awards": "tsx src/data/seedCourseAwards.ts",
+    "seed:response-examples": "ENV=development tsx src/data/seedResponseExamplesRunner.ts",
     "seed:test": "ENV=development tsx src/data/seedTEST.ts",
     "test": "run-s --npm-path pnpm test:node test:vitest",
     "test:demo-participants": "cross-env TEST_DATABASE_DISPOSABLE=1 TEST_DATABASE_DISPOSABLE_REQUIRED=1 vitest run src/scripts/2026-08-24_seed_demo_participants.test.ts",

--- a/packages/prisma-data/src/data/seedChatbots.ts
+++ b/packages/prisma-data/src/data/seedChatbots.ts
@@ -17,12 +17,12 @@ const SEEDED_CHATBOT_MODEL_IDS = [
 ]
 
 const tutorPrompt = readFileSync(
-  './src/data/data/tutorMode.txt',
+  new URL('./data/tutorMode.txt', import.meta.url),
   'utf-8'
 ).trim()
 
 const explainerPrompt = readFileSync(
-  './src/data/data/explainerMode.txt',
+  new URL('./data/explainerMode.txt', import.meta.url),
   'utf-8'
 ).trim()
 

--- a/packages/prisma-data/src/data/seedResponseExamples.ts
+++ b/packages/prisma-data/src/data/seedResponseExamples.ts
@@ -1,6 +1,5 @@
-import { createHash } from 'node:crypto'
 import * as Prisma from '@klicker-uzh/prisma/client'
-import type { Prisma as PrismaTypes } from '@klicker-uzh/prisma/client'
+import { computeResponseExampleSetDigest } from '@klicker-uzh/util/response-example-digest'
 import { USER_ID_TEST } from './constants.js'
 import { CHATBOT_ID_TEST } from './seedChatbots.js'
 
@@ -133,74 +132,6 @@ function reviewMetadata(status: Prisma.ResponseExampleStatus) {
     reviewedById: reviewed ? USER_ID_TEST : null,
     reviewedAt: reviewed ? REVIEWED_AT : null,
   }
-}
-
-function compareFields(left: object, right: object, fields: readonly string[]) {
-  for (const field of fields) {
-    const leftValue = String((left as Record<string, unknown>)[field])
-    const rightValue = String((right as Record<string, unknown>)[field])
-    if (leftValue < rightValue) return -1
-    if (leftValue > rightValue) return 1
-  }
-  return 0
-}
-
-function computeResponseExampleSetDigest(
-  set: PrismaTypes.ResponseExampleSetGetPayload<{
-    include: {
-      examples: { include: { evidenceReferences: true } }
-    }
-  }>
-) {
-  const canonical = {
-    setId: set.id,
-    chatbotId: set.chatbotId,
-    examples: [...set.examples]
-      .sort((left, right) =>
-        compareFields(left, right, [
-          'chatMode',
-          'studentMessage',
-          'referenceAnswer',
-          'responseStyle',
-          'status',
-          'id',
-          'setId',
-        ])
-      )
-      .map((example) => ({
-        id: example.id,
-        setId: example.setId,
-        chatMode: example.chatMode,
-        studentMessage: example.studentMessage,
-        referenceAnswer: example.referenceAnswer,
-        responseStyle: example.responseStyle,
-        status: example.status,
-        evidenceReferences: [...example.evidenceReferences]
-          .sort((left, right) =>
-            compareFields(left, right, [
-              'citationIndex',
-              'sourceId',
-              'chunkId',
-              'contentHash',
-              'citationAnchor',
-              'id',
-              'responseExampleId',
-            ])
-          )
-          .map((reference) => ({
-            id: reference.id,
-            responseExampleId: reference.responseExampleId,
-            citationIndex: reference.citationIndex,
-            sourceId: reference.sourceId,
-            chunkId: reference.chunkId,
-            contentHash: reference.contentHash,
-            citationAnchor: reference.citationAnchor,
-            evidenceEligible: reference.evidenceEligible,
-          })),
-      })),
-  }
-
-  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
 }
 
 export async function seedResponseExamples(prisma: Prisma.PrismaClient) {

--- a/packages/prisma-data/src/data/seedResponseExamples.ts
+++ b/packages/prisma-data/src/data/seedResponseExamples.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'node:crypto'
 import * as Prisma from '@klicker-uzh/prisma/client'
+import type { Prisma as PrismaTypes } from '@klicker-uzh/prisma/client'
 import { USER_ID_TEST } from './constants.js'
 import { CHATBOT_ID_TEST } from './seedChatbots.js'
 
@@ -133,6 +135,74 @@ function reviewMetadata(status: Prisma.ResponseExampleStatus) {
   }
 }
 
+function compareFields(left: object, right: object, fields: readonly string[]) {
+  for (const field of fields) {
+    const leftValue = String((left as Record<string, unknown>)[field])
+    const rightValue = String((right as Record<string, unknown>)[field])
+    if (leftValue < rightValue) return -1
+    if (leftValue > rightValue) return 1
+  }
+  return 0
+}
+
+function computeResponseExampleSetDigest(
+  set: PrismaTypes.ResponseExampleSetGetPayload<{
+    include: {
+      examples: { include: { evidenceReferences: true } }
+    }
+  }>
+) {
+  const canonical = {
+    setId: set.id,
+    chatbotId: set.chatbotId,
+    examples: [...set.examples]
+      .sort((left, right) =>
+        compareFields(left, right, [
+          'chatMode',
+          'studentMessage',
+          'referenceAnswer',
+          'responseStyle',
+          'status',
+          'id',
+          'setId',
+        ])
+      )
+      .map((example) => ({
+        id: example.id,
+        setId: example.setId,
+        chatMode: example.chatMode,
+        studentMessage: example.studentMessage,
+        referenceAnswer: example.referenceAnswer,
+        responseStyle: example.responseStyle,
+        status: example.status,
+        evidenceReferences: [...example.evidenceReferences]
+          .sort((left, right) =>
+            compareFields(left, right, [
+              'citationIndex',
+              'sourceId',
+              'chunkId',
+              'contentHash',
+              'citationAnchor',
+              'id',
+              'responseExampleId',
+            ])
+          )
+          .map((reference) => ({
+            id: reference.id,
+            responseExampleId: reference.responseExampleId,
+            citationIndex: reference.citationIndex,
+            sourceId: reference.sourceId,
+            chunkId: reference.chunkId,
+            contentHash: reference.contentHash,
+            citationAnchor: reference.citationAnchor,
+            evidenceEligible: reference.evidenceEligible,
+          })),
+      })),
+  }
+
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
+}
+
 export async function seedResponseExamples(prisma: Prisma.PrismaClient) {
   const set = await prisma.responseExampleSet.upsert({
     where: { chatbotId: CHATBOT_ID_TEST },
@@ -195,4 +265,15 @@ export async function seedResponseExamples(prisma: Prisma.PrismaClient) {
       })
     }
   }
+
+  const seededSet = await prisma.responseExampleSet.findUnique({
+    where: { id: set.id },
+    include: { examples: { include: { evidenceReferences: true } } },
+  })
+  if (!seededSet) throw new Error('Response-example seed set was not found')
+
+  await prisma.responseExampleSet.update({
+    where: { id: seededSet.id },
+    data: { digest: computeResponseExampleSetDigest(seededSet) },
+  })
 }

--- a/packages/prisma-data/src/data/seedResponseExamples.ts
+++ b/packages/prisma-data/src/data/seedResponseExamples.ts
@@ -1,0 +1,198 @@
+import * as Prisma from '@klicker-uzh/prisma/client'
+import { USER_ID_TEST } from './constants.js'
+import { CHATBOT_ID_TEST } from './seedChatbots.js'
+
+// Development-only synthetic data for exercising the owner review UI.
+const RESPONSE_EXAMPLE_SET_ID = '7f8f2d21-5b7e-4d6b-9c42-1c0e6e4d7a01'
+
+const REVIEWED_AT = new Date('2026-08-21T12:00:00.000Z')
+
+const SEEDED_RESPONSE_EXAMPLES = [
+  {
+    id: 'a1111111-1111-4111-8111-111111111111',
+    chatMode: 'tutor',
+    studentMessage:
+      'Why does a higher discount rate reduce the present value of a future cash flow?',
+    referenceAnswer: [
+      'A higher discount rate reduces the present value because each future cash flow is discounted more heavily.',
+      '',
+      'The present value is calculated as **PV = FV / (1 + r)^t**. When the rate *r* increases, the denominator grows and the discounted amount shrinks.',
+      '',
+      'As a guided step, compare the same future payment at two rates:',
+      '',
+      '- At 5%, a payment of 100 in one year is worth about 95.24 today.',
+      '- At 10%, it is only worth about 90.91 today.',
+      '',
+      'What does this tell you about long payment horizons? [1]',
+    ].join('\n'),
+    responseStyle: 'GUIDED_QUESTIONS',
+    status: Prisma.ResponseExampleStatus.CANDIDATE,
+    evidenceReferences: [
+      {
+        id: 'b1111111-1111-4111-8111-111111111111',
+        sourceId: 'seed-source-finance-01',
+        chunkId: 'seed-chunk-time-value-01',
+        contentHash: 'seed-hash-time-value-01',
+        citationIndex: 1,
+        citationAnchor: 'Time value of money, section 2',
+        evidenceEligible: true,
+      },
+    ],
+  },
+  {
+    id: 'a2222222-2222-4222-8222-222222222222',
+    chatMode: 'explainer',
+    studentMessage: 'Was bedeutet der Zeitwert des Geldes?',
+    referenceAnswer: [
+      'Der Zeitwert des Geldes bedeutet, dass ein Franken heute mehr wert ist als ein Franken in der Zukunft, weil er zwischenzeitlich investiert werden kann.',
+      '',
+      '**Schritt 1:** Ein heute angelegter Franken erwirtschaftet Zinsen.',
+      '**Schritt 2:** Deshalb muss ein zukuenftiger Betrag abgezinst werden, um seinen heutigen Wert zu bestimmen.',
+      '',
+      'Die Abzinsung macht diesen Unterschied rechnerisch sichtbar. [1]',
+    ].join('\n'),
+    responseStyle: 'STEP_BY_STEP_EXPLANATION',
+    status: Prisma.ResponseExampleStatus.NEEDS_REVIEW,
+    evidenceReferences: [
+      {
+        id: 'b2222222-2222-4222-8222-222222222222',
+        sourceId: 'seed-source-finance-01',
+        chunkId: 'seed-chunk-time-value-01',
+        contentHash: 'seed-hash-time-value-changed',
+        citationIndex: 1,
+        citationAnchor: 'Zeitwert des Geldes, Abschnitt 2',
+        evidenceEligible: false,
+      },
+    ],
+  },
+  {
+    id: 'a3333333-3333-4333-8333-333333333333',
+    chatMode: 'tutor',
+    studentMessage:
+      'Can you give me a hint for comparing two investments with different timing?',
+    referenceAnswer: [
+      'Before comparing the two options, put them on the same time basis.',
+      '',
+      'Two guiding questions help here:',
+      '',
+      '- Which cash flows occur at which point in time?',
+      '- Which rate lets you compare their present values or net present values?',
+      '',
+      'Once both are stated as present values, the comparison becomes like-for-like. [1]',
+    ].join('\n'),
+    responseStyle: 'COMPARE_OPTIONS',
+    status: Prisma.ResponseExampleStatus.APPROVED,
+    evidenceReferences: [
+      {
+        id: 'b3333333-3333-4333-8333-333333333333',
+        sourceId: 'seed-source-finance-01',
+        chunkId: 'seed-chunk-time-value-01',
+        contentHash: 'seed-hash-time-value-01',
+        citationIndex: 1,
+        citationAnchor: 'Time value of money, section 2',
+        evidenceEligible: true,
+      },
+    ],
+  },
+  {
+    id: 'a4444444-4444-4444-8444-444444444444',
+    chatMode: 'explainer',
+    studentMessage: 'What is a bond?',
+    referenceAnswer: [
+      'A bond is a debt instrument with two core promises from the issuer:',
+      '',
+      '- Regular interest payments on defined dates.',
+      '- Repayment of the principal at maturity.',
+      '',
+      'The buyer therefore lends money to the issuer and receives a contractual repayment stream in return. [1]',
+    ].join('\n'),
+    responseStyle: 'CONCISE_ANSWER',
+    status: Prisma.ResponseExampleStatus.REJECTED,
+    evidenceReferences: [
+      {
+        id: 'b4444444-4444-4444-8444-444444444444',
+        sourceId: 'seed-source-finance-01',
+        chunkId: 'seed-chunk-time-value-01',
+        contentHash: 'seed-hash-time-value-01',
+        citationIndex: 1,
+        citationAnchor: 'Time value of money, section 2',
+        evidenceEligible: true,
+      },
+    ],
+  },
+] as const
+
+function reviewMetadata(status: Prisma.ResponseExampleStatus) {
+  const reviewed =
+    status === Prisma.ResponseExampleStatus.APPROVED ||
+    status === Prisma.ResponseExampleStatus.REJECTED
+
+  return {
+    reviewedById: reviewed ? USER_ID_TEST : null,
+    reviewedAt: reviewed ? REVIEWED_AT : null,
+  }
+}
+
+export async function seedResponseExamples(prisma: Prisma.PrismaClient) {
+  const set = await prisma.responseExampleSet.upsert({
+    where: { chatbotId: CHATBOT_ID_TEST },
+    create: {
+      id: RESPONSE_EXAMPLE_SET_ID,
+      digest: '',
+      chatbot: { connect: { id: CHATBOT_ID_TEST } },
+    },
+    update: { digest: '' },
+  })
+
+  for (const example of SEEDED_RESPONSE_EXAMPLES) {
+    const metadata = reviewMetadata(example.status)
+
+    await prisma.responseExample.upsert({
+      where: { id: example.id },
+      create: {
+        id: example.id,
+        setId: set.id,
+        chatMode: example.chatMode,
+        studentMessage: example.studentMessage,
+        referenceAnswer: example.referenceAnswer,
+        responseStyle: example.responseStyle,
+        status: example.status,
+        ...metadata,
+      },
+      update: {
+        setId: set.id,
+        chatMode: example.chatMode,
+        studentMessage: example.studentMessage,
+        referenceAnswer: example.referenceAnswer,
+        responseStyle: example.responseStyle,
+        status: example.status,
+        ...metadata,
+      },
+    })
+
+    for (const reference of example.evidenceReferences) {
+      await prisma.responseExampleEvidenceReference.upsert({
+        where: { id: reference.id },
+        create: {
+          id: reference.id,
+          responseExampleId: example.id,
+          sourceId: reference.sourceId,
+          chunkId: reference.chunkId,
+          contentHash: reference.contentHash,
+          citationIndex: reference.citationIndex,
+          citationAnchor: reference.citationAnchor,
+          evidenceEligible: reference.evidenceEligible,
+        },
+        update: {
+          responseExampleId: example.id,
+          sourceId: reference.sourceId,
+          chunkId: reference.chunkId,
+          contentHash: reference.contentHash,
+          citationIndex: reference.citationIndex,
+          citationAnchor: reference.citationAnchor,
+          evidenceEligible: reference.evidenceEligible,
+        },
+      })
+    }
+  }
+}

--- a/packages/prisma-data/src/data/seedResponseExamplesRunner.ts
+++ b/packages/prisma-data/src/data/seedResponseExamplesRunner.ts
@@ -1,0 +1,5 @@
+import { prisma } from '@klicker-uzh/prisma'
+import { seedResponseExamples } from './seedResponseExamples.js'
+
+await seedResponseExamples(prisma)
+await prisma.$disconnect()

--- a/packages/prisma-data/src/data/seedTEST.ts
+++ b/packages/prisma-data/src/data/seedTEST.ts
@@ -41,6 +41,7 @@ import {
   seedMCPServers,
 } from './seedMCPServers.js'
 import { seedUsers } from './seedUsers.js'
+import { seedResponseExamples } from './seedResponseExamples.js'
 
 // uuids for 50 participants
 export const PARTICIPANT_IDS = [
@@ -377,6 +378,7 @@ async function seedTest(prisma: Prisma.PrismaClient) {
   )
 
   await seedChatbots(prisma)
+  await seedResponseExamples(prisma)
   const mcpServers = await seedMCPServers(prisma)
   await seedChatbotMCPConfigurations(prisma, mcpServers)
 

--- a/playwright/tests/Y-response-examples.spec.ts
+++ b/playwright/tests/Y-response-examples.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '../util/fixtures.js'
+import { URL_MANAGE } from '../util/constants.js'
+import { gotoCommit } from '../util/workflow.js'
+
+const CHATBOT_ID_TEST = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
+const CANDIDATE_ID = 'a1111111-1111-4111-8111-111111111111'
+const NEEDS_REVIEW_ID = 'a2222222-2222-4222-8222-222222222222'
+const APPROVED_ID = 'a3333333-3333-4333-8333-333333333333'
+const REJECTED_ID = 'a4444444-4444-4444-8444-444444444444'
+
+test.describe('Chatbot response-example review', () => {
+  test('lets the owner review seeded examples without losing a stale draft', async ({
+    loginLecturer,
+    page,
+  }, testInfo) => {
+    const manageUrl = process.env.URL_MANAGE ?? URL_MANAGE
+    await loginLecturer()
+    await gotoCommit(page, `${manageUrl}/resources/chatbots/${CHATBOT_ID_TEST}`)
+
+    const review = page.getByTestId('response-examples-review')
+    await expect(review).toBeVisible()
+    await expect(review.getByTestId('response-examples-loading')).toBeHidden()
+
+    const candidate = review.getByTestId(`response-example-${CANDIDATE_ID}`)
+    const needsReview = review.getByTestId(
+      `response-example-${NEEDS_REVIEW_ID}`
+    )
+    const approved = review.getByTestId(`response-example-${APPROVED_ID}`)
+    const rejected = review.getByTestId(`response-example-${REJECTED_ID}`)
+
+    await expect(candidate).toBeVisible()
+    await expect(needsReview).toBeVisible()
+    await expect(approved).toBeVisible()
+    await expect(rejected).toBeVisible()
+    await expect(
+      candidate.getByTestId(`response-example-citation-parity-${CANDIDATE_ID}`)
+    ).toContainText('All attached evidence is cited')
+    await expect(
+      needsReview.getByTestId(
+        `response-example-citation-parity-${NEEDS_REVIEW_ID}`
+      )
+    ).toContainText('need review before approval')
+    await expect(
+      needsReview.getByTestId(`response-example-approve-${NEEDS_REVIEW_ID}`)
+    ).toBeDisabled()
+    await expect(
+      rejected.getByTestId(`response-example-reject-${REJECTED_ID}`)
+    ).toHaveCount(0)
+
+    await page.screenshot({
+      path: testInfo.outputPath('response-examples-en-desktop.png'),
+      fullPage: true,
+    })
+
+    await candidate
+      .getByTestId(`response-example-approve-${CANDIDATE_ID}`)
+      .click()
+    await expect(
+      candidate.getByTestId(`response-example-status-${CANDIDATE_ID}`)
+    ).toContainText('Approved')
+
+    let staleOnce = true
+    await page.route('**/graphql', async (route) => {
+      const request = route.request()
+      if (request.method() !== 'POST' || !staleOnce) {
+        await route.continue()
+        return
+      }
+
+      const operationName = (
+        request.postDataJSON() as { operationName?: string }
+      ).operationName
+      if (operationName !== 'EditAndApproveResponseExample') {
+        await route.continue()
+        return
+      }
+
+      staleOnce = false
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          errors: [
+            {
+              message: 'Synthetic stale response-example update',
+              extensions: { code: 'RESPONSE_EXAMPLE_STALE_UPDATE' },
+            },
+          ],
+        }),
+      })
+    })
+
+    await candidate
+      .getByTestId(`response-example-edit-approve-${CANDIDATE_ID}`)
+      .click()
+    const modal = page.getByTestId('response-example-edit-modal')
+    await expect(modal).toBeVisible()
+    await expect(
+      modal.getByTestId('response-example-edit-reference-answer')
+    ).toBeVisible()
+
+    const draftQuestion = 'A draft that must survive a stale update.'
+    await modal
+      .getByTestId('response-example-edit-question')
+      .fill(draftQuestion)
+    await modal.getByTestId('response-example-edit-submit').click()
+    await expect(
+      modal.getByTestId('response-example-edit-error')
+    ).toContainText('changed while you were editing')
+    await expect(
+      modal.getByTestId('response-example-edit-question')
+    ).toHaveValue(draftQuestion)
+    await expect(
+      modal.getByTestId('response-example-edit-submit')
+    ).toBeDisabled()
+
+    await modal.getByTestId('response-example-edit-cancel').click()
+    await expect(modal).toBeHidden()
+    await candidate
+      .getByTestId(`response-example-edit-approve-${CANDIDATE_ID}`)
+      .click()
+    await expect(page.getByTestId('response-example-edit-modal')).toBeVisible()
+
+    const reopenedModal = page.getByTestId('response-example-edit-modal')
+    const editedQuestion =
+      'Why does a higher discount rate reduce present value?'
+    await reopenedModal
+      .getByTestId('response-example-edit-question')
+      .fill(editedQuestion)
+    await reopenedModal.getByTestId('response-example-edit-submit').click()
+    await expect(reopenedModal).toBeHidden()
+    await expect(
+      candidate.getByTestId(`response-example-status-${CANDIDATE_ID}`)
+    ).toContainText('Approved')
+
+    await needsReview
+      .getByTestId(`response-example-reject-${NEEDS_REVIEW_ID}`)
+      .click()
+    await expect(
+      needsReview.getByTestId(`response-example-status-${NEEDS_REVIEW_ID}`)
+    ).toContainText('Rejected')
+    await expect(
+      needsReview.getByTestId(
+        `response-example-edit-approve-${NEEDS_REVIEW_ID}`
+      )
+    ).toHaveCount(0)
+  })
+})

--- a/playwright/tests/Y-response-examples.spec.ts
+++ b/playwright/tests/Y-response-examples.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '../util/fixtures.js'
 import { URL_MANAGE } from '../util/constants.js'
+import { getPrisma } from '../global-setup.js'
+import { seedResponseExamples } from '../../packages/prisma-data/src/data/seedResponseExamples.js'
+import { ensureChatbotSeeded } from '../util/chat.js'
 import { gotoCommit } from '../util/workflow.js'
 
 const CHATBOT_ID_TEST = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
@@ -14,6 +17,8 @@ test.describe('Chatbot response-example review', () => {
     page,
   }, testInfo) => {
     const manageUrl = process.env.URL_MANAGE ?? URL_MANAGE
+    await ensureChatbotSeeded()
+    await seedResponseExamples(await getPrisma())
     await loginLecturer()
     await gotoCommit(page, `${manageUrl}/resources/chatbots/${CHATBOT_ID_TEST}`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,9 @@ importers:
       '@klicker-uzh/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@klicker-uzh/util':
+        specifier: workspace:*
+        version: link:../../packages/util
       '@socialgouv/matomo-next':
         specifier: 1.9.1
         version: 1.9.1(next@16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -183,10 +183,10 @@ No new product primitive is created or retired.
 
 | Item | Current evidence | Consequence |
 | --- | --- | --- |
-| `origin/v3-ai` | `332e044f34a1a5a0c8be00075795d8b3a19e7397`; sibling `trees/v3-ai-sync` is clean and exactly synchronized | The base-reconciliation dependency is resolved. This task still must not mutate the sibling worktree or branch. |
-| Current task head | K1 at `3659e5b22`, clean; 0 behind and 16 ahead of current `origin/v3-ai` | K1 corrections, review dispositions, and Gate 2 evidence are committed locally; K2 starts from its preserved pre-correction ref and is being restacked onto this K1 head. |
+| `origin/v3-ai` | `a1c63c644fdcdc52ff3dcddbbd3f58fcf363261d`; sibling `trees/v3-ai-sync` is clean and exactly synchronized | The base-reconciliation dependency is resolved. This task still must not mutate the sibling worktree or branch. |
+| Current task heads | K1 `3d30349441d4f042b65d92d42a950fc1df1df8e2` and K2 `be259ad5a82f56053ceac1248ddb6985f3837c92`, both clean and 0 behind current `origin/v3-ai` (20 and 27 commits ahead) | The corrected layers are locally complete and ready for publication after final evidence. |
 | PR #5474 | remote K1 head `eef688e0fa4b4d34ad00a02f1d8a65509d5c7189`; base has moved and GitHub merge state is recalculating | Treat the old head and CI as historical only. |
-| PR #5498 | remote K2 head `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`; currently conflicting | Restack after K1 is rebased and corrected. |
+| PR #5498 | remote K2 head `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`; GitHub currently reports `DIRTY` against its old published parent | Publish the reviewed corrected K1 then K2 heads with stack-aware force-with-lease; do not change remote topology. |
 | GitHub stack #5503 | remote order is K1 then K2 with the expected PRs and published heads | Preserve this topology. |
 | Local `gh-stack` metadata | repaired for local stack work; no remote topology mutation | Keep the existing K1 -> K2 order and use stack-aware force-with-lease only at the final publication boundary. |
 
@@ -441,9 +441,9 @@ Neither follow-up is authorized by this plan.
 
 ## Progress
 
-- Status: K1 Gate 2 evidence accepted; K2 correction implementation and
-  fallback/final reviews are complete locally; browser evidence and publication
-  remain pending
+- Status: K1 Gate 2 evidence accepted; K2 correction implementation, focused
+  browser journey, screenshots, and final integrated review are complete
+  locally; publication and corrected-head CI remain pending
 - Completed: external review analysis; focused correction scope; fresh Git,
   GitHub PR, GitHub stack, sibling-worktree, and local-stack evidence; planning
   specialist review; complete correction plan; local stack tracking repair;
@@ -457,7 +457,8 @@ Neither follow-up is authorized by this plan.
   `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`
 - Rebased local heads before correction: K1 `ec254bea755bfa3a3d9a93b760aa9ad715643444`;
   K2 `3b54dfb36cf747f4063341ea1bc85e4ade6aa67d`
-- Corrected local K1 head: `3d3034944` (latest documentation and evidence commit atop the corrected implementation)
+- Corrected local K1 head: `3d30349441d4f042b65d92d42a950fc1df1df8e2` (latest documentation and evidence commit atop the corrected implementation)
+- Corrected local K2 head: `be259ad5a82f56053ceac1248ddb6985f3837c92` (latest fixture-path and browser-journey correction atop K1)
 - Active slice: K2 lecturer-review workflow corrections
 - Plan commit: `6531937e3 docs(project): plan response-example review corrections`
 - K2 implementation commit: `3a1cbd45b fix(manage): align response-example review workflow`
@@ -465,18 +466,26 @@ Neither follow-up is authorized by this plan.
   restores the AI-beta gate and invalid-chatbot handling, resets review state
   when switching chatbots, computes the seeded digest canonically, and seeds
   the chatbot/examples inside the focused Playwright journey
+- K2 fixture-path correction commit: `6f63a11ca fix(test): resolve chatbot seed prompts from module`
+  anchors seed prompt files to the module instead of the caller's working
+  directory; the focused journey then exposed one unsupported Modal fixture
+  prop, corrected in `be259ad5a fix(test): expose response example modal fixture`
 - K2 fallback reviews: native and generic continuity routes were unavailable
   with `unreadable_encrypted_agent_task`; trusted GPT-5.6 Luna max fallback
   reports are recorded under `project/_local/reviews/`. Their findings were
   verified and dispositioned in the follow-up corrections.
-- Final integrated review found only the browser-verification gate and two low
-  documentation issues. The fixture wording and rebased Progress identities
-  are corrected; the browser gate remains open.
+- Final integrated review over `a1c63c644..be259ad5a` found no actionable
+  findings. It verified the fixture-path and supported Modal fixture fixes,
+  the owner workflow, migration/schema provenance, GraphQL contract, stale-write
+  integrity, parser boundary, UX/accessibility, and plan compliance.
 - K2 verification so far: direct Manage, Prisma-data, and Playwright TypeScript
   checks pass; focused Manage ESLint and Prettier checks pass; Markdown citation
   tests and focused response-example GraphQL contract/service tests pass; the
   isolated response-example seed runner exits successfully against the task
-  runtime.
+  runtime; the repository-native focused Playwright journey passes 1 test in
+  40.3 seconds against the disposable local database after global reset and
+  self-seeding.
+- Current browser screenshots: [EN desktop](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-be259ad5a.png), [DE mobile](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-be259ad5a.png), and [DE desktop](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-desktop-be259ad5a.png). They were captured from the reviewed K2 head; the fixture-only changes do not alter the rendered workflow.
 - Upstream boundary: the KB task's W8 work remains responsible for ingestion
   and producer activation seams. This package has no implementation overlap and
   does not assume graph delivery; response-example runtime activation remains
@@ -496,8 +505,7 @@ Neither follow-up is authorized by this plan.
   findings, including the documentation and non-owner edit follow-ups, were
   applied and reverified over immutable K1 range
   `332e044f34a1a5a0c8be00075795d8b3a19e7397..a86d5ae96`.
-- Next: obtain authorized focused Playwright and browser evidence, record the
-  final review disposition, publish the two corrected branches, update their
-  existing PRs, and wait once for corrected-head CI.
-- Delivery pending: browser evidence, corrected branch push, PR updates,
-  corrected-head CI, merge, deployment, runtime activation, K3, and Test & Teach
+- Next: publish the two corrected branches, update their existing PRs, and
+  wait once for corrected-head CI.
+- Delivery pending: corrected branch push, PR updates, corrected-head CI,
+  merge, deployment, runtime activation, K3, and Test & Teach

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -459,7 +459,7 @@ Neither follow-up is authorized by this plan.
   K2 `3b54dfb36cf747f4063341ea1bc85e4ade6aa67d`
 - Corrected local K1 head: `3d3034944` (latest documentation and evidence commit atop the corrected implementation)
 - Active slice: K2 lecturer-review workflow corrections
-- Plan commit: `c525e6c60 docs(project): plan response-example review corrections`
+- Plan commit: `6531937e3 docs(project): plan response-example review corrections`
 - K2 implementation commit: `3a1cbd45b fix(manage): align response-example review workflow`
 - K2 follow-up corrections commit: `007fa0dcc fix(manage): close response-example review gaps`
   restores the AI-beta gate and invalid-chatbot handling, resets review state

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -441,9 +441,9 @@ Neither follow-up is authorized by this plan.
 
 ## Progress
 
-- Status: K1 Gate 2 evidence accepted; K2 correction implementation and fallback
-  review are complete locally; final integrated review and publication remain
-  pending
+- Status: K1 Gate 2 evidence accepted; K2 correction implementation and
+  fallback/final reviews are complete locally; browser evidence and publication
+  remain pending
 - Completed: external review analysis; focused correction scope; fresh Git,
   GitHub PR, GitHub stack, sibling-worktree, and local-stack evidence; planning
   specialist review; complete correction plan; local stack tracking repair;
@@ -457,11 +457,11 @@ Neither follow-up is authorized by this plan.
   `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`
 - Rebased local heads before correction: K1 `ec254bea755bfa3a3d9a93b760aa9ad715643444`;
   K2 `3b54dfb36cf747f4063341ea1bc85e4ade6aa67d`
-- Corrected local K1 head: `c70bf0e8a` (latest documentation and evidence commit atop the corrected implementation)
+- Corrected local K1 head: `3d3034944` (latest documentation and evidence commit atop the corrected implementation)
 - Active slice: K2 lecturer-review workflow corrections
 - Plan commit: `c525e6c60 docs(project): plan response-example review corrections`
-- K2 implementation commit: `81082e32a fix(manage): align response-example review workflow`
-- K2 follow-up corrections commit: `a00c300a0 fix(manage): close response-example review gaps`
+- K2 implementation commit: `3a1cbd45b fix(manage): align response-example review workflow`
+- K2 follow-up corrections commit: `007fa0dcc fix(manage): close response-example review gaps`
   restores the AI-beta gate and invalid-chatbot handling, resets review state
   when switching chatbots, computes the seeded digest canonically, and seeds
   the chatbot/examples inside the focused Playwright journey
@@ -469,9 +469,14 @@ Neither follow-up is authorized by this plan.
   with `unreadable_encrypted_agent_task`; trusted GPT-5.6 Luna max fallback
   reports are recorded under `project/_local/reviews/`. Their findings were
   verified and dispositioned in the follow-up corrections.
+- Final integrated review found only the browser-verification gate and two low
+  documentation issues. The fixture wording and rebased Progress identities
+  are corrected; the browser gate remains open.
 - K2 verification so far: direct Manage, Prisma-data, and Playwright TypeScript
-  checks pass; focused Manage ESLint and Prettier checks pass; the isolated
-  response-example seed runner exits successfully against the task runtime.
+  checks pass; focused Manage ESLint and Prettier checks pass; Markdown citation
+  tests and focused response-example GraphQL contract/service tests pass; the
+  isolated response-example seed runner exits successfully against the task
+  runtime.
 - Upstream boundary: the KB task's W8 work remains responsible for ingestion
   and producer activation seams. This package has no implementation overlap and
   does not assume graph delivery; response-example runtime activation remains
@@ -491,8 +496,8 @@ Neither follow-up is authorized by this plan.
   findings, including the documentation and non-owner edit follow-ups, were
   applied and reverified over immutable K1 range
   `332e044f34a1a5a0c8be00075795d8b3a19e7397..a86d5ae96`.
-- Next: commit the K2 follow-up corrections, run the final integrated review,
-  publish the two corrected branches, update their existing PRs, and wait once
-  for corrected-head CI.
-- Delivery pending: K2 correction, corrected branch push, PR updates,
+- Next: obtain authorized focused Playwright and browser evidence, record the
+  final review disposition, publish the two corrected branches, update their
+  existing PRs, and wait once for corrected-head CI.
+- Delivery pending: browser evidence, corrected branch push, PR updates,
   corrected-head CI, merge, deployment, runtime activation, K3, and Test & Teach

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -183,21 +183,23 @@ No new product primitive is created or retired.
 
 | Item | Current evidence | Consequence |
 | --- | --- | --- |
-| `origin/v3-ai` | `a1c63c644fdcdc52ff3dcddbbd3f58fcf363261d`; sibling `trees/v3-ai-sync` is clean and exactly synchronized | The base-reconciliation dependency is resolved. This task still must not mutate the sibling worktree or branch. |
-| Reviewed product-code heads | K1 `3d30349441d4f042b65d92d42a950fc1df1df8e2` and K2 `be259ad5a82f56053ceac1248ddb6985f3837c92`, both clean and 0 behind current `origin/v3-ai` at the review gate (20 and 27 commits ahead) | The corrected layers are locally complete. Documentation-only Progress commits follow the reviewed K2 code head; re-read the branch tip immediately before publication. |
-| PR #5474 | remote K1 head `eef688e0fa4b4d34ad00a02f1d8a65509d5c7189`; base has moved and GitHub merge state is recalculating | Treat the old head and CI as historical only. |
-| PR #5498 | remote K2 head `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`; GitHub currently reports `DIRTY` against its old published parent | Publish the reviewed corrected K1 then K2 heads with stack-aware force-with-lease; do not change remote topology. |
+| `origin/v3-ai` | `c8e1c9b22c96716288469d18dca85aecb1b3d990`; it advanced by three KB-ingestion commits during this package and both layers were rebased again without semantic conflicts | The final review and publication evidence use the actual current target. This task still must not mutate the sibling `v3-ai` worktree or branch. |
+| Reviewed product-code heads | K1 `2504e270edee043e22449a89d368122fa9002cd2` and K2 `84be8f3a549054dc737a331be4625f6c2091d13b`; both worktrees are clean, K1 is 0 behind current `origin/v3-ai`, and K2 is directly stacked on K1 | The corrected layers are locally complete pending the final integrated review and publication ledger commit. |
+| PR #5474 | remote K1 head `3d30349441d4f042b65d92d42a950fc1df1df8e2`; open and non-draft with historical failing checks on that superseded head | Publish the reviewed corrected K1 head with stack-aware force-with-lease; treat old CI as historical only. |
+| PR #5498 | remote K2 head `bdba64d94d7b0dc8ce6701ca2a0e3f8567acff85`; open and non-draft on K1 | Publish K1 then K2 without changing the remote topology. |
 | GitHub stack #5503 | remote order is K1 then K2 with the expected PRs and published heads | Preserve this topology. |
 | Local `gh-stack` metadata | repaired for local stack work; no remote topology mutation | Keep the existing K1 -> K2 order and use stack-aware force-with-lease only at the final publication boundary. |
 
 ### Code findings
 
-- `packages/util/src/citations.ts` is a roughly 2,000-line second Markdown
-  grammar with an avoidable repeated suffix scan and an open CodeQL discrepancy
-  around alternate HTML comment termination.
-- `packages/markdown` already owns `unified`, `remark-parse`, `remark-math`, and
-  the citation-marker AST transformer. Its `./citations` entry can be kept
-  React-free and consumed by GraphQL as a workspace dependency.
+- The pre-correction `packages/util/src/citations.ts` was a roughly 2,000-line
+  second Markdown grammar with an avoidable repeated suffix scan and an open
+  CodeQL discrepancy around alternate HTML comment termination.
+- The corrected package boundary keeps the canonical React-free citation AST
+  transformer and digest helper in `packages/util`. Markdown re-exports the
+  citation transformer for compatibility and uses it in the renderer; GraphQL
+  consumes the same utility contract without pulling UI peers into the
+  `mcp-student` pruned dependency closure.
 - The renderer normalizes Markdown before parsing. Validation must use that
   same normalization, Remark parser, math settings, and marker transformer;
   matching regexes are not sufficient.
@@ -219,9 +221,9 @@ No new product primitive is created or retired.
 - Verdict: `DONE_WITH_CONCERNS`
 - Accepted: final data and API contract belongs in K1; K2 owns only the
   lecturer workflow; one K1 migration replaces both current migration deltas;
-  the custom scanner is deleted rather than patched; the React-free Markdown
-  citations subpath becomes the shared parser; K1 receives a mandatory Gate 2;
-  local-only stack tracking repair is explicit authority.
+  the custom scanner is deleted rather than patched; one React-free citation
+  AST contract is shared by validation and Markdown rendering; K1 receives a
+  mandatory Gate 2; local-only stack tracking repair is explicit authority.
 - Verified correction: the review initially observed an active sibling base,
   but fresh readback now proves `v3-ai` is clean and synchronized at the
   revision above. The remaining pre-execution blocker is Gate 1 approval for
@@ -440,6 +442,32 @@ extending this stack:
 Neither follow-up is authorized by this plan.
 
 ## Progress
+
+- 2026-08-26 CI correction: moved canonical citation parsing and response-set
+  digest computation into React-free utility exports. GraphQL no longer pulls
+  Markdown and its UI peers into `mcp-student`; Markdown renders through the
+  same citation transformer. The exact `mcp-student` Docker builder target now
+  completes on both architectures' shared Dockerfile path.
+- 2026-08-26 review correction: preserved JavaScript code-unit ordering,
+  threaded the renderer's single-dollar math setting through citation parity,
+  removed the duplicate K2 seed digest implementation, centralized approval
+  error mapping, and made the three reported component prop objects readonly.
+  K1 simplification and risk correction reviews pass. K2 simplification passes;
+  its risk correction review and the integrated final review are in progress.
+- Current base: `origin/v3-ai` at
+  `c8e1c9b22c96716288469d18dca85aecb1b3d990`.
+- Current local heads: K1
+  `2504e270edee043e22449a89d368122fa9002cd2`; K2
+  `84be8f3a549054dc737a331be4625f6c2091d13b`.
+- Current runtime limitation: the K2 managed DevPod passes package checks, but
+  its post-start cannot resolve the workspace Azurite alias. Existing browser
+  screenshots remain valid because the CI correction does not alter rendered
+  UI. No local runtime or product code was changed to work around this route.
+- Active slice: F1 final review, publication, PR description refresh, and one
+  CI wait.
+
+The entries below are the retained pre-CI-correction execution history. Their
+hashes are historical and are superseded by the current heads above.
 
 - Status: K1 Gate 2 evidence accepted; K2 correction implementation, focused
   browser journey, screenshots, and final integrated review are complete

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -460,11 +460,11 @@ Neither follow-up is authorized by this plan.
 - Corrected local K1 head: `c70bf0e8a` (latest documentation and evidence commit atop the corrected implementation)
 - Active slice: K2 lecturer-review workflow corrections
 - Plan commit: `c525e6c60 docs(project): plan response-example review corrections`
-- K2 implementation commit: `7bb04ae6c fix(manage): align response-example review workflow`
-- K2 follow-up corrections pending commit: restore the AI-beta gate and
-  invalid-chatbot handling, reset review state when switching chatbots, compute
-  the seeded digest canonically, and seed the chatbot/examples inside the
-  focused Playwright journey
+- K2 implementation commit: `81082e32a fix(manage): align response-example review workflow`
+- K2 follow-up corrections commit: `a00c300a0 fix(manage): close response-example review gaps`
+  restores the AI-beta gate and invalid-chatbot handling, resets review state
+  when switching chatbots, computes the seeded digest canonically, and seeds
+  the chatbot/examples inside the focused Playwright journey
 - K2 fallback reviews: native and generic continuity routes were unavailable
   with `unreadable_encrypted_agent_task`; trusted GPT-5.6 Luna max fallback
   reports are recorded under `project/_local/reviews/`. Their findings were

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -184,7 +184,7 @@ No new product primitive is created or retired.
 | Item | Current evidence | Consequence |
 | --- | --- | --- |
 | `origin/v3-ai` | `a1c63c644fdcdc52ff3dcddbbd3f58fcf363261d`; sibling `trees/v3-ai-sync` is clean and exactly synchronized | The base-reconciliation dependency is resolved. This task still must not mutate the sibling worktree or branch. |
-| Current task heads | K1 `3d30349441d4f042b65d92d42a950fc1df1df8e2` and K2 `be259ad5a82f56053ceac1248ddb6985f3837c92`, both clean and 0 behind current `origin/v3-ai` (20 and 27 commits ahead) | The corrected layers are locally complete and ready for publication after final evidence. |
+| Reviewed product-code heads | K1 `3d30349441d4f042b65d92d42a950fc1df1df8e2` and K2 `be259ad5a82f56053ceac1248ddb6985f3837c92`, both clean and 0 behind current `origin/v3-ai` at the review gate (20 and 27 commits ahead) | The corrected layers are locally complete. Documentation-only Progress commits follow the reviewed K2 code head; re-read the branch tip immediately before publication. |
 | PR #5474 | remote K1 head `eef688e0fa4b4d34ad00a02f1d8a65509d5c7189`; base has moved and GitHub merge state is recalculating | Treat the old head and CI as historical only. |
 | PR #5498 | remote K2 head `3d54fbdbee5378212e65ff97bccf6dbc87f8ceba`; GitHub currently reports `DIRTY` against its old published parent | Publish the reviewed corrected K1 then K2 heads with stack-aware force-with-lease; do not change remote topology. |
 | GitHub stack #5503 | remote order is K1 then K2 with the expected PRs and published heads | Preserve this topology. |
@@ -458,7 +458,7 @@ Neither follow-up is authorized by this plan.
 - Rebased local heads before correction: K1 `ec254bea755bfa3a3d9a93b760aa9ad715643444`;
   K2 `3b54dfb36cf747f4063341ea1bc85e4ade6aa67d`
 - Corrected local K1 head: `3d30349441d4f042b65d92d42a950fc1df1df8e2` (latest documentation and evidence commit atop the corrected implementation)
-- Corrected local K2 head: `be259ad5a82f56053ceac1248ddb6985f3837c92` (latest fixture-path and browser-journey correction atop K1)
+- Reviewed local K2 product-code head: `be259ad5a82f56053ceac1248ddb6985f3837c92` (latest fixture-path and browser-journey correction atop K1)
 - Active slice: K2 lecturer-review workflow corrections
 - Plan commit: `6531937e3 docs(project): plan response-example review corrections`
 - K2 implementation commit: `3a1cbd45b fix(manage): align response-example review workflow`
@@ -485,7 +485,7 @@ Neither follow-up is authorized by this plan.
   runtime; the repository-native focused Playwright journey passes 1 test in
   40.3 seconds against the disposable local database after global reset and
   self-seeding.
-- Current browser screenshots: [EN desktop](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-be259ad5a.png), [DE mobile](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-be259ad5a.png), and [DE desktop](../../../.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-desktop-be259ad5a.png). They were captured from the reviewed K2 head; the fixture-only changes do not alter the rendered workflow.
+- Current browser screenshots are local-only artifacts, not repository links. Verified files are `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-be259ad5a.png`, `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-be259ad5a.png`, and `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-desktop-be259ad5a.png`. They were captured from the reviewed K2 head; the fixture-only changes do not alter the rendered workflow.
 - Upstream boundary: the KB task's W8 work remains responsible for ingestion
   and producer activation seams. This package has no implementation overlap and
   does not assume graph delivery; response-example runtime activation remains

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -461,13 +461,16 @@ Neither follow-up is authorized by this plan.
   errors. This verifies the opt-in scoped citation fix against the selected
   `v3-ai` base using synthetic local examples.
 - 2026-08-27 review evidence: K1 and K2 simplification passes and the K2
-  risk-selected review pass. The integrated final review and the one
-  corrected-head CI wait remain before `pr_ready`.
+  risk-selected review pass. The integrated final review passed every code,
+  migration, schema, authorization, data-integrity, Markdown, UX, upstream,
+  and plan-compliance lens. Its one evidence finding was resolved by capturing
+  current EN desktop, DE mobile, and German stale-edit screenshots from K2
+  product head `34f01f1a0`.
 - Current base: `origin/v3-ai` at
   `e49804e3327609436e211cbe5d3765d7d408ed55`.
-- Active slice: F1 integrated final review, PR description refresh, one CI
-  wait, and exact runtime shutdown. Merge, deployment, live activation, K3,
-  and Test & Teach remain withheld.
+- Active slice: F1 PR description refresh, one corrected-head CI wait, and
+  exact runtime shutdown. Merge, deployment, live activation, K3, and Test &
+  Teach remain withheld.
 
 - 2026-08-26 CI correction: moved canonical citation parsing and response-set
   digest computation into React-free utility exports. GraphQL no longer pulls
@@ -539,7 +542,15 @@ hashes are historical and are superseded by the current heads above.
   runtime; the repository-native focused Playwright journey passes 1 test in
   40.3 seconds against the disposable local database after global reset and
   self-seeding.
-- Current browser screenshots are local-only artifacts, not repository links. Verified files are `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-be259ad5a.png`, `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-be259ad5a.png`, and `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-desktop-be259ad5a.png`. They were captured from the reviewed K2 head; the fixture-only changes do not alter the rendered workflow.
+- Current browser screenshots are local-only artifacts, not repository links.
+  Verified files are
+  `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-citations-34f01f1a0.png`,
+  `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-34f01f1a0.png`,
+  and
+  `/Users/rschlae/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-stale-de-desktop-34f01f1a0.png`.
+  They cover the current scoped-citation link and matching evidence target,
+  both required locale/viewport combinations, and stale-save draft
+  preservation with the save action disabled after the coded stale response.
 - Upstream boundary: the KB task's W8 work remains responsible for ingestion
   and producer activation seams. This package has no implementation overlap and
   does not assume graph delivery; response-example runtime activation remains

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -441,7 +441,9 @@ Neither follow-up is authorized by this plan.
 
 ## Progress
 
-- Status: K1 Gate 2 evidence accepted; K2 lecturer-review corrections are now in progress
+- Status: K1 Gate 2 evidence accepted; K2 correction implementation and fallback
+  review are complete locally; final integrated review and publication remain
+  pending
 - Completed: external review analysis; focused correction scope; fresh Git,
   GitHub PR, GitHub stack, sibling-worktree, and local-stack evidence; planning
   specialist review; complete correction plan; local stack tracking repair;
@@ -458,6 +460,22 @@ Neither follow-up is authorized by this plan.
 - Corrected local K1 head: `c70bf0e8a` (latest documentation and evidence commit atop the corrected implementation)
 - Active slice: K2 lecturer-review workflow corrections
 - Plan commit: `c525e6c60 docs(project): plan response-example review corrections`
+- K2 implementation commit: `7bb04ae6c fix(manage): align response-example review workflow`
+- K2 follow-up corrections pending commit: restore the AI-beta gate and
+  invalid-chatbot handling, reset review state when switching chatbots, compute
+  the seeded digest canonically, and seed the chatbot/examples inside the
+  focused Playwright journey
+- K2 fallback reviews: native and generic continuity routes were unavailable
+  with `unreadable_encrypted_agent_task`; trusted GPT-5.6 Luna max fallback
+  reports are recorded under `project/_local/reviews/`. Their findings were
+  verified and dispositioned in the follow-up corrections.
+- K2 verification so far: direct Manage, Prisma-data, and Playwright TypeScript
+  checks pass; focused Manage ESLint and Prettier checks pass; the isolated
+  response-example seed runner exits successfully against the task runtime.
+- Upstream boundary: the KB task's W8 work remains responsible for ingestion
+  and producer activation seams. This package has no implementation overlap and
+  does not assume graph delivery; response-example runtime activation remains
+  deferred.
 - K1 evidence: focused Markdown citation tests pass, including 100,000 unmatched
   brackets and 5,000 nested blockquotes; focused response-example GraphQL
   contract and service tests pass, including every transition, rejected edit,
@@ -473,6 +491,8 @@ Neither follow-up is authorized by this plan.
   findings, including the documentation and non-owner edit follow-ups, were
   applied and reverified over immutable K1 range
   `332e044f34a1a5a0c8be00075795d8b3a19e7397..a86d5ae96`.
-- Next: restack the preserved K2 branch onto the corrected K1 head and implement the lecturer-review corrections.
+- Next: commit the K2 follow-up corrections, run the final integrated review,
+  publish the two corrected branches, update their existing PRs, and wait once
+  for corrected-head CI.
 - Delivery pending: K2 correction, corrected branch push, PR updates,
   corrected-head CI, merge, deployment, runtime activation, K3, and Test & Teach

--- a/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
+++ b/project/2026-08-26-pr-5474-response-example-review-corrections-plan.md
@@ -183,10 +183,10 @@ No new product primitive is created or retired.
 
 | Item | Current evidence | Consequence |
 | --- | --- | --- |
-| `origin/v3-ai` | `c8e1c9b22c96716288469d18dca85aecb1b3d990`; it advanced by three KB-ingestion commits during this package and both layers were rebased again without semantic conflicts | The final review and publication evidence use the actual current target. This task still must not mutate the sibling `v3-ai` worktree or branch. |
-| Reviewed product-code heads | K1 `2504e270edee043e22449a89d368122fa9002cd2` and K2 `84be8f3a549054dc737a331be4625f6c2091d13b`; both worktrees are clean, K1 is 0 behind current `origin/v3-ai`, and K2 is directly stacked on K1 | The corrected layers are locally complete pending the final integrated review and publication ledger commit. |
-| PR #5474 | remote K1 head `3d30349441d4f042b65d92d42a950fc1df1df8e2`; open and non-draft with historical failing checks on that superseded head | Publish the reviewed corrected K1 head with stack-aware force-with-lease; treat old CI as historical only. |
-| PR #5498 | remote K2 head `bdba64d94d7b0dc8ce6701ca2a0e3f8567acff85`; open and non-draft on K1 | Publish K1 then K2 without changing the remote topology. |
+| `origin/v3-ai` | `e49804e3327609436e211cbe5d3765d7d408ed55`; both layers were rebased onto this target without semantic conflicts | The final review and publication evidence use the actual integrated target. This task still must not mutate the sibling `v3-ai` worktree or branch. |
+| Reviewed product-code heads | K1 `c1626000f3dbff73aa16b93235459335d1b8fc7f` and K2 `43e5416ab826b95cd334d2feea91e61d52e1d97a`; both worktrees were clean, K1 was 0 behind the selected `origin/v3-ai`, and K2 was directly stacked on K1 | The corrected product-code layers are published. This progress update becomes the final K2 evidence head before integrated review and CI. |
+| PR #5474 | remote K1 head `c1626000f3dbff73aa16b93235459335d1b8fc7f`; open, non-draft, and mergeable | Preserve its `v3-ai` base and wait once for corrected-head CI. |
+| PR #5498 | remote K2 product-code head `43e5416ab826b95cd334d2feea91e61d52e1d97a`; open, non-draft, mergeable, and based on K1 | Publish this progress update without changing the remote topology, then wait once for corrected-head CI. |
 | GitHub stack #5503 | remote order is K1 then K2 with the expected PRs and published heads | Preserve this topology. |
 | Local `gh-stack` metadata | repaired for local stack work; no remote topology mutation | Keep the existing K1 -> K2 order and use stack-aware force-with-lease only at the final publication boundary. |
 
@@ -225,14 +225,14 @@ No new product primitive is created or retired.
   AST contract is shared by validation and Markdown rendering; K1 receives a
   mandatory Gate 2; local-only stack tracking repair is explicit authority.
 - Verified correction: the review initially observed an active sibling base,
-  but fresh readback now proves `v3-ai` is clean and synchronized at the
-  revision above. The remaining pre-execution blocker is Gate 1 approval for
-  local stack repair and rebase.
+  but fresh readback proved `v3-ai` clean at the selected revision above. The
+  approved local stack repair, rebase, correction, and product-code publication
+  are complete without changing stack topology.
 
 ### Limitations
 
-- No implementation or corrected-head check has run. Old CI cannot prove the
-  rebased correction.
+- Corrected product-code checks and browser verification have run locally.
+  Corrected-head GitHub CI remains the final external evidence gate.
 - Local synthetic fixtures prove product behavior, not KB source freshness,
   model quality, deployment, or production activation.
 - PR #5092 remains outside this package even though it targets `v3`.
@@ -442,6 +442,32 @@ extending this stack:
 Neither follow-up is authorized by this plan.
 
 ## Progress
+
+- 2026-08-27 publication: rebased K1 and K2 onto `origin/v3-ai`
+  `e49804e3327609436e211cbe5d3765d7d408ed55` and published the corrected
+  product-code heads with exact force-with-lease protection. PR #5474 now
+  points to K1 `c1626000f3dbff73aa16b93235459335d1b8fc7f`; PR #5498 pointed to K2
+  `43e5416ab826b95cd334d2feea91e61d52e1d97a` before this progress commit. Both
+  PRs remain open, non-draft, mergeable, and retain the approved K1 -> K2
+  topology.
+- 2026-08-27 current-base verification: K1 focused response-example GraphQL
+  tests pass 10/10, utility tests pass 113/113, Markdown tests pass 37/37, and
+  the GraphQL, utility, Markdown, and Manage package checks pass after current
+  Prisma and GraphQL generation. Both force-with-lease pushes passed the
+  repository pre-push production build with 26/26 Turbo tasks.
+- 2026-08-27 browser evidence: the local K2 route rendered four repeated `[1]`
+  citation markers as four example-scoped links with four distinct targets.
+  Following the first link selected its one matching target with no browser
+  errors. This verifies the opt-in scoped citation fix against the selected
+  `v3-ai` base using synthetic local examples.
+- 2026-08-27 review evidence: K1 and K2 simplification passes and the K2
+  risk-selected review pass. The integrated final review and the one
+  corrected-head CI wait remain before `pr_ready`.
+- Current base: `origin/v3-ai` at
+  `e49804e3327609436e211cbe5d3765d7d408ed55`.
+- Active slice: F1 integrated final review, PR description refresh, one CI
+  wait, and exact runtime shutdown. Merge, deployment, live activation, K3,
+  and Test & Teach remain withheld.
 
 - 2026-08-26 CI correction: moved canonical citation parsing and response-set
   digest computation into React-free utility exports. GraphQL no longer pulls


### PR DESCRIPTION
## What This Adds

This stacked PR adds the lecturer review workflow for chatbot response examples on top of [#5474](https://github.com/uzh-bf/klicker-uzh/pull/5474).

- Adds a chatbot overview and full-width detail route with breadcrumbs and an integrated chatbot switcher.
- Presents response-example cards with long-form Markdown answers, evidence lineage, status, chat mode, and response style.
- Lets chatbot owners approve, reject, or edit and approve examples through the server-owned lifecycle contract.
- Uses the existing Slate-based `ContentInput`, so lecturers edit structured answer content without managing Markdown syntax.
- Seeds deterministic synthetic examples and a focused local/test journey without using production corpus data.
- Scopes repeated citation numbers to each example, so every rendered link selects exactly one matching source card.

## How It Works

`ChatbotResponseExampleReview` consumes the owner-only GraphQL surface and its server-computed action flags. It sends the editor's observed `updatedAt` value for edit-and-approve. A stale response keeps the draft open, refreshes the current server state, and requires reopening before another save. Reference answers render through Markdown with the example ID as an opt-in citation scope; source cards use the same scope for their targets.

## Important Details

- Approved examples remain editable. Rejected examples are terminal.
- Chat mode and response style are lecturer-facing dropdowns. The contract has no locale or behavior-tag field.
- Source cards describe evidence lineage and state that source content is not shown.
- This layer adds no migration and does not change the K1 API or lifecycle rules.

## Branch Coverage

- Base: `feat/response-examples-foundation` at `c1626000f3dbff73aa16b93235459335d1b8fc7f` ([#5474](https://github.com/uzh-bf/klicker-uzh/pull/5474)).
- Head: `15c4e9105c3e48b80efbec416321d0de8f8b9be3`.
- Reviewed: 14 commits; 17 files changed, 1,513 additions, and 85 deletions.
- Substantive size: 15 files and 1,449 changed lines after excluding `pnpm-lock.yaml`, generated GraphQL public artifacts, and `project/` plan documents.
- Covered: chatbot overview and detail navigation, lecturer review cards and actions, Slate editing, English and German copy, deterministic fixtures, focused Playwright coverage, scoped citation links, review corrections, and final progress evidence.

## Review Focus

- Confirm stale saves preserve the lecturer's draft and cannot overwrite newer server state.
- Confirm the actions shown for candidate, needs-review, approved, and rejected examples match the server contract.
- Confirm repeated citation indexes link to one example-scoped target and preserve accessible link and target semantics.
- Confirm the UI does not imply that lineage identifiers are source excerpts or proof of semantic support.

## Verification

Current head:

- Manage package check passed after current Prisma, utility, Markdown, and GraphQL generation.
- Commit hook passed all 29 repository typecheck tasks and six static gates.
- Repository pre-push production build passed 26 of 26 Turbo tasks.
- Local browser verification rendered four repeated `[1]` markers as four distinct links and four distinct targets. Following the first link selected its one matching target, with no browser errors.
- K2 simplification and risk-selected reviews passed. The integrated final review passed after its screenshot-ledger finding was resolved on the final head.

Earlier branch verification that still applies:

- The self-seeded response-example Playwright journey passed one test in 40.3 seconds against the disposable local database.
- English desktop and German mobile review layouts were captured from the same product behavior before the docs-only final progress commit.

Failed / warning:

- Local runs used Node 26.7.0 while the repository requests Node 24. Existing engine, framework, localization, and large-page warnings did not fail the checks above.
- Corrected-head GitHub CI is terminal. Response-example-related builds, static checks, GraphQL, MCP, security, and analysis checks passed.
- `test-unit` fails in model-registry parity tests for GPT-5.1, GPT-5.4, and GPT-5.5. The exact `v3-ai` base fails with the same assertions ([stack run](https://github.com/uzh-bf/klicker-uzh/actions/runs/33029403200), [base run](https://github.com/uzh-bf/klicker-uzh/actions/runs/33024406799)).
- Playwright shard 5 fails three existing chatbot tests. The exact `v3-ai` base reproduces the same tests ([stack run](https://github.com/uzh-bf/klicker-uzh/actions/runs/33029403431), [base run](https://github.com/uzh-bf/klicker-uzh/actions/runs/33024406964)). The response-example journey is not among the failures.
- `Final AI review / trusted_policy` fails before review because the default-branch workflow reports that its own workflow commit cannot be verified, although the commit resolves through GitHub ([run](https://github.com/uzh-bf/klicker-uzh/actions/runs/33029536064)). This is outside the stack diff.

## Screenshots

Machine-local visual evidence:

- English desktop with scoped citation link and matching evidence target: `~/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-en-desktop-citations-34f01f1a0.png`
- German mobile: `~/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-de-mobile-34f01f1a0.png`
- German stale-edit desktop: `~/.codex/visualizations/2026/08/21/01a024db-5268-7242-955f-d505e8a295e4/response-examples-k2-final-stale-de-desktop-34f01f1a0.png`

These are synthetic local fixtures, not production data.

## Security / Privacy

- Owner authorization and stale-write integrity are enforced by K1 and consumed without client-side bypasses.
- No secret values, personal data, participant content, production payloads, or copied corpus content are included.

## Blocking Before Merge

- [ ] Fix the inherited `v3-ai` model-registry and Playwright baselines.
- [ ] Repair and rerun the default-branch `Final AI review` trusted-policy gate.
- [ ] After those upstream fixes, authorize one upstream integration pass and rerun affected checks on both stack layers.
- [ ] Merge remains a separate explicit user decision.

## Follow-Up After Merge

- [ ] Add lecturer-only save-from-preview as a separate Test & Teach package.
- [ ] Activate runtime use and examples-excluded evaluation only after their KB and runtime dependencies are ready.

No merge, deployment, or live activation is requested by this update.

## Local Session Artifacts

- Machine: `Rolands-Mac-Studio.local`
- Worktree: `trees/chatbot-response-examples-review` in repository `klicker-uzh`
- Review reports: `project/_local/reviews/`
- Preview: `https://manage.klicker.feat-response-examples-review.localhost/resources/chatbots/8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f`
