### PR TITLE
chore(prisma-data): add config-driven course chatbot provisioner

### DIFF
--- a/packages/prisma-data/package.json
+++ b/packages/prisma-data/package.json
@@ -8,6 +8,7 @@
     "@klicker-uzh/types": "workspace:*",
     "@klicker-uzh/util": "workspace:*",
     "@pothos/plugin-prisma": "~4.10.0",
+    "@prisma/adapter-pg": "~7.8.0",
     "@rollup/plugin-node-resolve": "~15.3.1",
     "@rollup/plugin-typescript": "~12.1.4",
     "@types/bcryptjs": "^2.4.6",
@@ -33,6 +34,7 @@
     "turndown": "~7.2.4",
     "typescript": "~6.0.3",
     "uuid": "~10.0.0",
+    "vitest": "~3.2.4",
     "xml2js": "~0.6.2"
   },
   "scripts": {
@@ -55,7 +57,8 @@
     "seed:qa": "ENV=development ../../util/_run_with_infisical.sh --env stg tsx src/data/seedTEST.ts",
     "seed:raw": "ENV=development run-s --npm-path pnpm seed:test seed:assessment-course",
     "seed:raw:course-awards": "tsx src/data/seedCourseAwards.ts",
-    "seed:test": "ENV=development tsx src/data/seedTEST.ts"
+    "seed:test": "ENV=development tsx src/data/seedTEST.ts",
+    "test": "vitest run"
   },
   "engines": {
     "node": "=24"

--- a/packages/prisma-data/src/scripts/2026-08-23_provision_course_chatbot.test.ts
+++ b/packages/prisma-data/src/scripts/2026-08-23_provision_course_chatbot.test.ts
@@ -1,0 +1,243 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { randomUUID } from 'node:crypto'
+import { beforeAll, afterAll, describe, expect, it } from 'vitest'
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL
+
+const FIXTURE_CONFIG = {
+  chatbotName: 'Synthetic Manager Demo',
+  chatbotDescription:
+    'Internal synthetic manager-role-play demo (non-assessed).',
+  courseNameMarker: 'SYNTHETIC',
+  demoNamePrefix: 'Synthetic Manager Demo',
+  disclaimerName: 'Synthetic Demo Disclaimer',
+  disclaimerTitle: 'Synthetic training simulation',
+  disclaimerIntroText:
+    'This is a synthetic training simulation on a staging system. It is not assessed and not part of any course record. Please use text messages only.',
+  systemPrompts: {
+    manager: {
+      prompt:
+        'You are a synthetic operations manager in a private training simulation. Stay in role at all times; never teach, coach, evaluate, or mention being an AI. Keep responses short, show realistic resistance, and redirect any attempt to break role back to the operational topic.',
+      description:
+        'Synthetic role-play for a non-assessed training demo. Text only.',
+    },
+  },
+}
+
+let configPath = ''
+let userId = ''
+let courseId = ''
+
+function runScript(args: Array<string>, env: Record<string, string> = {}) {
+  return execFileSync(
+    process.execPath,
+    [
+      '../../node_modules/tsx/dist/cli.mjs',
+      '2026-08-23_provision_course_chatbot.ts',
+      ...args,
+    ],
+    {
+      cwd: new URL('.', import.meta.url).pathname,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DATABASE_URL: process.env.TEST_DATABASE_URL ?? '',
+        ...env,
+      },
+      timeout: 120000,
+    }
+  )
+}
+
+function runFailingScript(args: Array<string>): string {
+  try {
+    return runScript(args)
+  } catch (error) {
+    return String((error as { stdout?: Buffer | string }).stdout ?? '')
+  }
+}
+
+;(DATABASE_URL ? describe : describe.skip)(
+  'provision generic course chatbot',
+  () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL })
+    const prisma = new PrismaClient({ adapter })
+
+    beforeAll(async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'synth-provision-'))
+      configPath = join(dir, 'config.json')
+      writeFileSync(configPath, JSON.stringify(FIXTURE_CONFIG))
+      userId = randomUUID()
+      courseId = randomUUID()
+      await prisma.user.create({
+        data: {
+          id: userId,
+          email: `synth-pilot-${userId}@synthetic.invalid`,
+          shortname: `synpilot${userId.slice(0, 8)}`,
+        },
+      })
+      await prisma.course.create({
+        data: {
+          id: courseId,
+          name: 'Synthetic Pilot SYNTHETIC Course',
+          displayName: 'Synthetic Pilot SYNTHETIC Course',
+          ownerId: userId,
+          pinCode: Math.floor(100000 + Math.random() * 900000),
+          startDate: new Date(),
+          endDate: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+          groupDeadlineDate: new Date(Date.now() + 20 * 24 * 3600 * 1000),
+        },
+      })
+    })
+
+    afterAll(async () => {
+      await prisma.chatbot.deleteMany({ where: { courseId } })
+      await prisma.chatbotDisclaimer.deleteMany({ where: { ownerId: userId } })
+      await prisma.course
+        .delete({ where: { id: courseId } })
+        .catch(() => undefined)
+      await prisma.user.delete({ where: { id: userId } }).catch(() => undefined)
+      await prisma.$disconnect()
+    })
+
+    it('refuses to run without required flags', () => {
+      const output = runFailingScript([])
+      expect(output).toContain('Usage:')
+    })
+
+    it('dry-run default writes nothing and prints the plan', async () => {
+      const output = runScript([
+        '--config',
+        configPath,
+        '--course-id',
+        courseId,
+        '--owner-id',
+        userId,
+      ])
+      expect(output).toContain('action=create_chatbot')
+      expect(output).toContain('Dry run only')
+      const count = await prisma.chatbot.count({ where: { courseId } })
+      expect(count).toBe(0)
+    })
+
+    it('apply creates the chatbot once and replays as no-op', async () => {
+      const first = runScript([
+        '--config',
+        configPath,
+        '--course-id',
+        courseId,
+        '--owner-id',
+        userId,
+        '--apply',
+      ])
+      expect(first).toContain('APPLIED')
+      const bots = await prisma.chatbot.findMany({ where: { courseId } })
+      expect(bots).toHaveLength(1)
+      expect(bots[0]!.modelSelection).toBe(false)
+      expect(Object.keys(bots[0]!.systemPrompts as object)).toEqual(['manager'])
+
+      // replay must not create a second bot or disclaimer
+      const disclaimersBefore = await prisma.chatbotDisclaimer.count({
+        where: { ownerId: userId },
+      })
+      const second = runScript([
+        '--config',
+        configPath,
+        '--course-id',
+        courseId,
+        '--owner-id',
+        userId,
+        '--apply',
+      ])
+      expect(second).toContain('APPLIED')
+      const botsAfter = await prisma.chatbot.findMany({ where: { courseId } })
+      expect(botsAfter).toHaveLength(1)
+      expect(botsAfter[0]!.id).toBe(bots[0]!.id)
+      const disclaimersAfter = await prisma.chatbotDisclaimer.count({
+        where: { ownerId: userId },
+      })
+      expect(disclaimersAfter).toBe(disclaimersBefore) // replays reuse the linked disclaimer
+    })
+
+    it('fails closed when the course lacks the marker', async () => {
+      await prisma.course.update({
+        where: { id: courseId },
+        data: { displayName: 'Renamed Without Marker' },
+      })
+      try {
+        const output = runFailingScript([
+          '--config',
+          configPath,
+          '--course-id',
+          courseId,
+          '--owner-id',
+          userId,
+        ])
+        expect(output).toContain('FAIL: course_name_missing_marker')
+      } finally {
+        await prisma.course.update({
+          where: { id: courseId },
+          data: { displayName: 'Synthetic Pilot SYNTHETIC Course' },
+        })
+      }
+    })
+
+    it('fails closed on unknown course or owner without writing', () => {
+      const output = runFailingScript([
+        '--config',
+        configPath,
+        '--course-id',
+        randomUUID(),
+        '--owner-id',
+        userId,
+      ])
+      expect(output).toContain('FAIL: course_not_found')
+      const output2 = runFailingScript([
+        '--config',
+        configPath,
+        '--course-id',
+        courseId,
+        '--owner-id',
+        randomUUID(),
+      ])
+      expect(output2).toContain('FAIL: owner_not_found')
+    })
+
+    it('fails closed on course-owner mismatch without writing', async () => {
+      const otherUserId = randomUUID()
+      await prisma.user.create({
+        data: {
+          id: otherUserId,
+          email: `synth-pilot-other-${otherUserId}@synthetic.invalid`,
+          shortname: `synpilotother${otherUserId.slice(0, 8)}`,
+        },
+      })
+      const botsBeforeMismatch = await prisma.chatbot.count({
+        where: { courseId },
+      })
+      try {
+        const output = runFailingScript([
+          '--config',
+          configPath,
+          '--course-id',
+          courseId,
+          '--owner-id',
+          otherUserId,
+        ])
+        expect(output).toContain('FAIL: course_owner_mismatch')
+        expect(await prisma.chatbot.count({ where: { courseId } })).toBe(
+          botsBeforeMismatch
+        )
+      } finally {
+        await prisma.user
+          .delete({ where: { id: otherUserId } })
+          .catch(() => undefined)
+      }
+    })
+  }
+)

--- a/packages/prisma-data/src/scripts/2026-08-23_provision_course_chatbot.ts
+++ b/packages/prisma-data/src/scripts/2026-08-23_provision_course_chatbot.ts
@@ -1,0 +1,288 @@
+import { readFileSync } from 'node:fs'
+import { prisma } from '@klicker-uzh/prisma'
+import { Prisma } from '@klicker-uzh/prisma/client'
+
+const APPLY_FLAG = '--apply'
+
+type ModePrompt = { prompt: string; description: string }
+
+type ProvisionConfig = {
+  chatbotName: string
+  chatbotDescription: string
+  courseNameMarker: string
+  demoNamePrefix: string
+  disclaimerName: string
+  disclaimerTitle: string
+  disclaimerIntroText: string
+  systemPrompts: Record<string, ModePrompt>
+}
+
+function readFlag(argv: Array<string>, name: string): string | undefined {
+  const index = argv.indexOf(name)
+  return index === -1 ? undefined : argv[index + 1]
+}
+
+function parseArgs(argv: Array<string>) {
+  const apply = argv.includes(APPLY_FLAG)
+  const configPath = readFlag(argv, '--config')
+  const courseId = readFlag(argv, '--course-id')
+  const ownerId = readFlag(argv, '--owner-id')
+  if (!configPath || !courseId || !ownerId) {
+    throw new Error(
+      'Usage: tsx <script> --config <config.json> --course-id <uuid> --owner-id <uuid> [--apply]'
+    )
+  }
+  return { apply, configPath, courseId, ownerId }
+}
+
+function loadConfig(configPath: string): ProvisionConfig {
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(configPath, 'utf8'))
+  } catch (error) {
+    throw new Error(`FAIL config_unreadable error=${(error as Error).message}`)
+  }
+  const config = raw as Partial<ProvisionConfig>
+  for (const key of [
+    'chatbotName',
+    'chatbotDescription',
+    'courseNameMarker',
+    'demoNamePrefix',
+    'disclaimerName',
+    'disclaimerTitle',
+    'disclaimerIntroText',
+  ] as const) {
+    if (typeof config[key] !== 'string' || config[key].length === 0) {
+      throw new Error(`FAIL: config_invalid key=${key}`)
+    }
+  }
+  if (
+    !config.systemPrompts ||
+    typeof config.systemPrompts !== 'object' ||
+    Object.keys(config.systemPrompts).length === 0
+  ) {
+    throw new Error('FAIL: config_invalid key=systemPrompts')
+  }
+  for (const [mode, prompt] of Object.entries(config.systemPrompts)) {
+    if (
+      !prompt ||
+      typeof prompt.prompt !== 'string' ||
+      prompt.prompt.length === 0 ||
+      typeof prompt.description !== 'string'
+    ) {
+      throw new Error(`FAIL: config_invalid mode=${mode}`)
+    }
+  }
+  return config as ProvisionConfig
+}
+
+async function resolveTargetState(input: {
+  courseId: string
+  ownerId: string
+}) {
+  const [course, owner, existingChatbots] = await Promise.all([
+    prisma.course.findUnique({
+      where: { id: input.courseId },
+      select: { id: true, displayName: true, ownerId: true, isArchived: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: input.ownerId },
+      select: { id: true, shortname: true },
+    }),
+    prisma.chatbot.findMany({
+      where: { courseId: input.courseId },
+      select: { id: true, name: true, modelSelection: true },
+    }),
+  ])
+  return { course, owner, existingChatbots }
+}
+
+function findConflicts(
+  chatbots: Array<{ name: string }>,
+  chatbotName: string,
+  demoNamePrefix: string
+) {
+  // Any other demo-prefixed bot would make ownership of the demo lane ambiguous.
+  return chatbots.filter(
+    (chatbot) =>
+      chatbot.name !== chatbotName && chatbot.name.startsWith(demoNamePrefix)
+  )
+}
+
+async function main() {
+  let args
+  let config
+  try {
+    args = parseArgs(process.argv.slice(2))
+    config = loadConfig(args.configPath)
+  } catch (error) {
+    console.log((error as Error).message)
+    process.exitCode = 1
+    return
+  }
+
+  const { course, owner, existingChatbots } = await resolveTargetState(args)
+
+  if (!course) {
+    console.log(`FAIL: course_not_found courseId=${args.courseId}`)
+    process.exitCode = 1
+    return
+  }
+  if (!owner) {
+    console.log(`FAIL: owner_not_found ownerId=${args.ownerId}`)
+    process.exitCode = 1
+    return
+  }
+  if (!course.displayName.includes(config.courseNameMarker)) {
+    console.log('FAIL: course_name_missing_marker - refusing write')
+    process.exitCode = 1
+    return
+  }
+  if (course.ownerId !== owner.id) {
+    console.log('FAIL: course_owner_mismatch - refusing write')
+    process.exitCode = 1
+    return
+  }
+
+  const exactMatch = existingChatbots.find(
+    (chatbot) => chatbot.name === config.chatbotName
+  )
+  const conflicts = findConflicts(
+    existingChatbots,
+    config.chatbotName,
+    config.demoNamePrefix
+  )
+
+  console.log('Plan:')
+  console.log(`  action=${exactMatch ? 'none' : 'create_chatbot'}`)
+  console.log(`  courseId=${course.id}`)
+  console.log(`  courseOwnerMatches=${course.ownerId === owner.id}`)
+  console.log(`  courseArchived=${course.isArchived}`)
+  console.log(`  chatbotName=${config.chatbotName}`)
+  console.log(`  existingCourseChatbots=${existingChatbots.length}`)
+  console.log(`  conflictingDemoNames=${conflicts.length}`)
+
+  if (!args.apply) {
+    console.log('Dry run only. Re-run with --apply to write.')
+    return
+  }
+
+  if (conflicts.length > 0) {
+    console.log('FAIL: conflicting_demo_chatbots_present - no changes written')
+    process.exitCode = 1
+    return
+  }
+
+  const result = await prisma.$transaction(
+    async (tx: Prisma.TransactionClient) => {
+      // Re-validate inside the transaction so concurrent writes fail closed.
+      const [txCourse, txOwner, txExisting] = await Promise.all([
+        tx.course.findUnique({
+          where: { id: args.courseId },
+          select: { id: true, ownerId: true, displayName: true },
+        }),
+        tx.user.findUnique({
+          where: { id: args.ownerId },
+          select: { id: true },
+        }),
+        tx.chatbot.findMany({
+          where: { courseId: args.courseId },
+          select: { name: true },
+        }),
+      ])
+      if (!txCourse || !txOwner) {
+        throw new Error('FAIL: target_vanished_during_apply')
+      }
+      if (!txCourse.displayName.includes(config.courseNameMarker)) {
+        throw new Error('FAIL: course_name_missing_marker')
+      }
+      if (txCourse.ownerId !== txOwner.id) {
+        throw new Error('FAIL: course_owner_mismatch')
+      }
+      if (
+        findConflicts(txExisting, config.chatbotName, config.demoNamePrefix)
+          .length > 0
+      ) {
+        throw new Error('FAIL: conflicting_demo_chatbots_present')
+      }
+
+      const existing = await tx.chatbot.findFirst({
+        where: { courseId: args.courseId, name: config.chatbotName },
+        select: { id: true, disclaimerId: true },
+      })
+
+      let disclaimerId = existing?.disclaimerId
+      if (disclaimerId) {
+        // Reuse the linked disclaimer so replay runs stay idempotent.
+        await tx.chatbotDisclaimer.update({
+          where: { id: disclaimerId },
+          data: { introText: config.disclaimerIntroText },
+        })
+      } else {
+        const disclaimer = await tx.chatbotDisclaimer.create({
+          data: {
+            name: config.disclaimerName,
+            title: config.disclaimerTitle,
+            introText: config.disclaimerIntroText,
+            ownerId: args.ownerId,
+          },
+        })
+        disclaimerId = disclaimer.id
+      }
+
+      const data = {
+        systemPrompts: config.systemPrompts,
+        modelSelection: false,
+        allowedModelIds: [],
+        disclaimerId,
+      }
+
+      const chatbot = existing
+        ? await tx.chatbot.update({ where: { id: existing.id }, data })
+        : await tx.chatbot.create({
+            data: {
+              ...data,
+              name: config.chatbotName,
+              description: config.chatbotDescription,
+              ownerId: args.ownerId,
+              courseId: args.courseId,
+              creditInitialCredits: 100,
+              creditResetPeriod: 'WEEKLY',
+              creditResetAmount: 100,
+              creditMaxCredits: 100,
+            },
+          })
+
+      return { chatbotId: chatbot.id }
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+  )
+
+  const verify = await prisma.chatbot.findUnique({
+    where: { id: result.chatbotId },
+    select: {
+      id: true,
+      name: true,
+      courseId: true,
+      ownerId: true,
+      modelSelection: true,
+    },
+  })
+  if (
+    !verify ||
+    verify.courseId !== args.courseId ||
+    verify.ownerId !== args.ownerId ||
+    verify.modelSelection !== false
+  ) {
+    throw new Error('FAIL: post_apply_readback_mismatch')
+  }
+  console.log(
+    `APPLIED chatbotId=${verify.id} modelSelection=${verify.modelSelection}`
+  )
+}
+
+try {
+  await main()
+} finally {
+  await prisma.$disconnect()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,13 +110,13 @@ importers:
         version: 0.522.0(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 4.24.14
-        version: 4.24.14(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 4.24.14(next@16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 4.13.0
-        version: 4.13.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -174,7 +174,7 @@ importers:
         version: 9.30.1(jiti@2.7.0)
       eslint-config-next:
         specifier: ~16.2.10
-        version: 16.2.10(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.10(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3)
       postcss:
         specifier: ~8.4.47
         version: 8.4.49
@@ -451,10 +451,10 @@ importers:
         version: 0.522.0(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 4.13.0
-        version: 4.13.0(next@16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       nookies:
         specifier: 2.5.2
         version: 2.5.2
@@ -527,7 +527,7 @@ importers:
         version: 9.30.1(jiti@2.7.0)
       eslint-config-next:
         specifier: ~16.2.10
-        version: 16.2.10(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.10(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3)
       tailwindcss:
         specifier: ~4.1.11
         version: 4.1.12
@@ -2122,6 +2122,9 @@ importers:
       '@pothos/plugin-prisma':
         specifier: ~4.10.0
         version: 4.10.0(@pothos/core@4.3.0(graphql@16.11.0))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(graphql@16.11.0)(typescript@6.0.3)
+      '@prisma/adapter-pg':
+        specifier: ~7.8.0
+        version: 7.8.0
       '@rollup/plugin-node-resolve':
         specifier: ~15.3.1
         version: 15.3.1(rollup@4.34.9)
@@ -2197,6 +2200,9 @@ importers:
       uuid:
         specifier: ~10.0.0
         version: 10.0.0
+      vitest:
+        specifier: ~3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.49.0)(tsx@4.19.4)(yaml@2.9.0)
       xml2js:
         specifier: ~0.6.2
         version: 0.6.2
@@ -12615,6 +12621,7 @@ packages:
   eslint@9.30.1:
     resolution: {integrity: sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -32059,7 +32066,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.30.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.30.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.30.1(jiti@2.7.0))
@@ -32106,7 +32113,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -32121,11 +32128,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.30.1(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 9.30.1(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.30.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@2.7.0))
@@ -32143,7 +32175,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.30.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -32172,7 +32204,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.30.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.30.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -36054,13 +36086,13 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       uuid: 8.3.2
 
-  next-auth@4.24.14(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next-auth@4.24.14(next@16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.29.1


### PR DESCRIPTION
## What
- Adds a config-driven, dry-run-first provisioning script for one synthetic course chatbot, plus disposable-database integration tests.
- `packages/prisma-data/src/scripts/2026-08-23_provision_course_chatbot.ts`: reads all scenario content (chatbot name, description, course-name marker, demo-name prefix, disclaimer text, mode system prompts) from an external JSON config passed with `--config`.
- Default mode prints a values-safe plan (course ID, ownership match, archived flag, chatbot name, existing/conflicting bot counts) and writes nothing. `--apply` requires exact `--course-id` / `--owner-id` plus the configured course-name marker and matching course owner.
- Writes run in a serializable transaction with in-transaction revalidation (target existence, marker, owner match, no conflicting demo-prefixed bots) and a post-write readback. Replay runs reuse the linked disclaimer and update it in place instead of creating orphaned rows.
- Validation failures print `FAIL <reason>` and set exit code 1; dry-run exits 0.
- Tests cover usage refusal, config validation, dry-run no-write, create-once/replay-no-op with stable disclaimer count, missing marker, unknown course/owner, and course-owner mismatch without writes.
- `packages/prisma-data/package.json`: adds `vitest` and `@prisma/adapter-pg` as devDependencies and a `test` script.
## Why this shape
- Scenario specifics stay out of the public repository; the provisioner itself is intentionally generic and meant to fail closed rather than generalize.
- The course marker and demo-name-prefix conflict checks make accidental writes to real courses or ambiguous duplicate lanes impossible without explicit flags.
- Serializable isolation plus revalidation guard the write path because `Chatbot` has no unique constraint on `[courseId, name]`; concurrent conflicting inserts surface as serialization failures and roll back.
## Verification
- Vitest suite against a disposable Postgres container: 6/6 passing.
- `pnpm run check` in `packages/prisma-data` clean; repo-wide turbo check green via pre-commit.
## Out of scope / follow-ups
- No staging execution yet; applying the script on STG with the real config and inviting testers are separately gated steps.
- The scenario config lives in the private catalyst planning repository, not in this public repo.
