### PR TITLE
chore(deploy): promote b67cceb09221 to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -27,7 +27,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '5918af158c52'
+        rollout.klicker.uzh.ch/release: 'b67cceb09221'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -49,7 +49,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '5918af158c52'
+        rollout.klicker.uzh.ch/release: 'b67cceb09221'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -71,7 +71,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '5918af158c52'
+        rollout.klicker.uzh.ch/release: 'b67cceb09221'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -105,7 +105,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -159,7 +159,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -313,7 +313,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -365,7 +365,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -418,7 +418,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -470,7 +470,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -538,7 +538,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -590,7 +590,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
   replicaCount: 1
 
   affinity:
@@ -639,7 +639,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '5918af158c52'
+    rollout.klicker.uzh.ch/release: 'b67cceb09221'
 
   replicaCount: 1
 
@@ -692,7 +692,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '5918af158c52'
+      rollout.klicker.uzh.ch/release: 'b67cceb09221'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -755,7 +755,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '5918af158c52'
+      rollout.klicker.uzh.ch/release: 'b67cceb09221'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -832,7 +832,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '5918af158c52'
+      rollout.klicker.uzh.ch/release: 'b67cceb09221'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `b67cceb09221e39ea2297f9b993a40e737ecf823`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
