### PR TITLE
fix(ci): expose GrowthBook environment variables

### DIFF
--- a/.github/workflows/v3_auth-prd.yml
+++ b/.github/workflows/v3_auth-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -65,6 +68,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_auth-stg.yml
+++ b/.github/workflows/v3_auth-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -74,6 +77,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_chat-prd.yml
+++ b/.github/workflows/v3_chat-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -65,6 +68,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_chat-stg.yml
+++ b/.github/workflows/v3_chat-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -74,6 +77,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-control-docker-prd.yml
+++ b/.github/workflows/v3_frontend-control-docker-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -66,6 +69,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-control-docker-stg.yml
+++ b/.github/workflows/v3_frontend-control-docker-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -75,6 +78,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-manage-docker-prd.yml
+++ b/.github/workflows/v3_frontend-manage-docker-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -66,6 +69,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-manage-docker-stg.yml
+++ b/.github/workflows/v3_frontend-manage-docker-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -75,6 +78,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-pwa-docker-assessment-prd.yml
+++ b/.github/workflows/v3_frontend-pwa-docker-assessment-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -66,6 +69,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-pwa-docker-assessment-stg.yml
+++ b/.github/workflows/v3_frontend-pwa-docker-assessment-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -75,6 +78,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-pwa-docker-prd.yml
+++ b/.github/workflows/v3_frontend-pwa-docker-prd.yml
@@ -16,6 +16,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -66,6 +69,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/v3_frontend-pwa-docker-stg.yml
+++ b/.github/workflows/v3_frontend-pwa-docker-stg.yml
@@ -25,6 +25,9 @@ jobs:
   build-arm:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write
@@ -75,6 +78,9 @@ jobs:
   build-amd:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment:
+      name: Growthbook
+      deployment: false
     permissions:
       contents: read
       packages: write

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -2,7 +2,7 @@
 type: Operations
 title: CI & Deployment
 description: PR gates, image builds, the standard-version release flow, Helm deployment reality, and what is NOT in this repo.
-timestamp: '2026-08-22'
+timestamp: '2026-08-24'
 tags:
   - ci
   - deployment
@@ -37,14 +37,17 @@ Build context is the repo root with `file: apps/<app>/Dockerfile` — Dockerfile
 The five Next images (auth, chat, control, manage, PWA) consume Next's `.next/standalone` output. Auth and chat production builds use Turbopack. Control, manage, and PWA production builds explicitly use Webpack while `@ducanh2912/next-pwa` remains responsible for `sw.js`, Workbox chunks, and the custom worker bundle copied by their Dockerfiles. Before publishing a framework upgrade, run the mixed production build, inspect those artifacts, smoke the standalone server paths, and require both AMD and ARM image jobs. These are **config-derived** contracts until the corresponding command and CI check are recorded for the release SHA.
 
 The same five images receive browser GrowthBook configuration at build time.
-Staging workflows use the repository variables
+Staging workflows use the environment-scoped variables
 `NEXT_PUBLIC_GROWTHBOOK_API_HOST_STG` and
 `NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY_STG`; production workflows use the matching
-`_PRD` names. These values are deliberately GitHub Actions variables rather than
-secrets because every `NEXT_PUBLIC_*` value is embedded in public browser
-assets. The Dockerfiles declare and export matching build arguments before the
-Next build. See [Feature Flags](./feature-flags.md) for the complete runtime and
-operator contract.
+`_PRD` names. Every ARM and AMD build job references the `Growthbook` GitHub
+Actions environment with deployment creation disabled, which exposes the
+environment variables without recording image builds as deployments. These
+values are deliberately variables rather than secrets because every
+`NEXT_PUBLIC_*` value is embedded in public browser assets. The Dockerfiles
+declare and export matching build arguments before the Next build. See
+[Feature Flags](./feature-flags.md) for the complete runtime and operator
+contract.
 
 ## Release flow
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -2,7 +2,7 @@
 type: Feature Flags
 title: Feature Flags
 description: Shared GrowthBook contracts, frontend and backend connectivity, targeting attributes, failure behavior, and the adoption checklist.
-timestamp: '2026-08-22'
+timestamp: '2026-08-24'
 tags:
   - architecture
   - frontend
@@ -104,7 +104,7 @@ All five deployed Next.js images are build-time ready for browser adoption:
 `auth`, `chat`, `frontend-control`, `frontend-manage`, and `frontend-pwa`
 (including the assessment build). Their Dockerfiles accept the two GrowthBook
 variables above, and their staging/production workflows pass environment-specific
-GitHub Actions repository variables:
+variables from the `Growthbook` GitHub Actions environment:
 
 | Deployment | Public SDK host variable              | Public SDK client-key variable          |
 | ---------- | ------------------------------------- | --------------------------------------- |
@@ -114,7 +114,9 @@ GitHub Actions repository variables:
 Configure these as GitHub Actions **variables**, not secrets. They are
 non-sensitive SDK connection values that Next.js embeds into public browser
 assets; GitHub documents variables as the store for non-sensitive configuration
-and warns that they are not masked. Missing variables still produce a valid
+and warns that they are not masked. Every ARM and AMD image-build job references
+the environment with `deployment: false`, retaining variable access without
+creating deployment-history entries. Missing variables still produce a valid
 image, but the browser adapter performs no SDK request and keeps flags off.
 
 ## Node.js adoption


### PR DESCRIPTION
## What This Fixes

The GrowthBook build arguments read four variables stored in the `Growthbook` GitHub Actions environment, but the ARM and AMD image jobs did not reference that environment. GitHub therefore resolved the `${{ vars.NEXT_PUBLIC_GROWTHBOOK_* }}` expressions without access to those environment-scoped values.

This PR scopes all 24 GrowthBook-consuming image-build jobs to `Growthbook` with `deployment: false`. The jobs can read the environment variables without creating deployment-history entries. The CI and feature-flag documentation now reflects that setup.

## Branch Coverage

- Base: `v3`
- Head: `5993003f6`
- Reviewed: 1 commit, 14 files, 87 insertions, 10 deletions

## Verification

- `volta run pnpm run build` — passed, 23/23 tasks
- `volta run pnpm run check:all` — passed, 25/25 checks and 7/7 lint tasks
- Dedicated YAML contract — passed for 12 workflows / 24 jobs
- `git diff --check` and Prettier — passed
- Multi-architecture image jobs — not run locally; these workflows skip image builds while the PR is a draft and will exercise the change after it is marked ready

## Security / Privacy

- No secret or environment-variable values are committed.
- The `NEXT_PUBLIC_*` values remain intentionally public browser build configuration.
- `deployment: false` avoids deployment-history noise while retaining environment-variable access.
- The local `gitleaks` binary was unavailable; CI still enforces the repository's secret scan.

## Blocking Before Merge

- Mark the PR ready for review and confirm the affected image-build jobs pass.