### PR TITLE
chore(deploy): promote e0b04d711d2e to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -27,7 +27,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '03ce39223395'
+        rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -49,7 +49,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '03ce39223395'
+        rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -71,7 +71,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '03ce39223395'
+        rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -105,7 +105,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -159,7 +159,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -313,7 +313,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -365,7 +365,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -418,7 +418,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -470,7 +470,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -538,7 +538,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -590,7 +590,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
   replicaCount: 1
 
   affinity:
@@ -639,7 +639,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '03ce39223395'
+    rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
 
   replicaCount: 1
 
@@ -692,7 +692,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '03ce39223395'
+      rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -755,7 +755,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '03ce39223395'
+      rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -832,7 +832,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '03ce39223395'
+      rollout.klicker.uzh.ch/release: 'e0b04d711d2e'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `e0b04d711d2ef23a788dc1c5511fdbdd891498fb`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging deployment rollout configuration for Hatchet workers and application components, including assessment services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->