### PR TITLE
docs(agents): clarify Infisical profile mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Traefik reverse proxy serves the apps on `*.klicker.com` domains (needs `/etc/ho
 ### Authenticated load-test login
 
 - Keep participant credential values only in Infisical. Do not put them in this file, repository files, command arguments, logs, or chat.
-- The approved runtime profile is `klicker-dev` (project `klicker-uzh-dev`, environment `dev`). Inject the allowlisted names directly into the child process:
+- The approved operator profile is `klicker-dev`; it intentionally maps to Infisical project `klicker-uzh-dev` in environment `dev`. Inject the allowlisted names directly into the child process:
 
   ```bash
   rs-infisical-operator --profile klicker-dev run \


### PR DESCRIPTION
## Summary

- Clarifies that operator profile `klicker-dev` maps to Infisical project `klicker-uzh-dev` in environment `dev`.
- Preserves the existing values-free credential-injection guidance.

## Review Focus

- Confirm the profile/project/environment mapping is explicit and unambiguous.

## Verification

- Current head: `cadc276b2`.
- `git diff --check` passed.
- Branch diff: one file changed, one line added and one line removed.
- No secret access, runtime action, deployment, or cluster mutation was performed.

## Blocking Before Merge

None.

## Follow-Up After Merge

None.

## Security / Privacy

Documentation only; no credential values or runtime configuration changed.

## Local Session Artifacts

- On the development machine, worktree: `trees/infisical-profile-v3`.