### PR TITLE
ci: add advisory OpenCodeReview PR review

### DIFF
--- a/.github/workflows/check-ocr-review.yml
+++ b/.github/workflows/check-ocr-review.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   ocr-review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -26,7 +27,6 @@ jobs:
           llm_auth_token: ${{ secrets.OPENROUTER_API_KEY }}
           llm_model: deepseek/deepseek-v4-flash-0731
           llm_use_anthropic: 'false'
-          llm_extra_body: '{"reasoning":{"enabled":false}}'
           ocr_version: '1.9.10'
           sticky_summary: 'true'
           incremental: 'true'

--- a/.github/workflows/check-ocr-review.yml
+++ b/.github/workflows/check-ocr-review.yml
@@ -1,0 +1,34 @@
+name: AI code review (OpenCodeReview)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+# The action checks out only the trusted base and reads PR-head objects for the diff.
+# Do not add checkout, build, test, install, or execution steps for PR-head content here.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ocr-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@66120291271b2e605e420e9f11fbd6448f06163f # v1.9.10
+        with:
+          llm_url: https://openrouter.ai/api/v1/chat/completions
+          llm_auth_token: ${{ secrets.OPENROUTER_API_KEY }}
+          llm_model: deepseek/deepseek-v4-flash-0731
+          llm_use_anthropic: 'false'
+          llm_extra_body: '{"reasoning":{"enabled":false}}'
+          ocr_version: '1.9.10'
+          sticky_summary: 'true'
+          incremental: 'true'
+          route_severity_below: 'low'
+          upload_artifacts: 'false'

--- a/project/2026-08-24-open-code-review-plan.md
+++ b/project/2026-08-24-open-code-review-plan.md
@@ -68,7 +68,7 @@
 
 ## Progress
 
-- Status: plan reviewed; implementation pending.
-- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review.
-- Remaining: create workflow, verify, run slice review, commit, run final review.
+- Status: implementation committed and slice-reviewed with `PASS_WITH_CONCERNS`; final integrated review pending.
+- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, and slice review.
+- Remaining: run final review and complete close-out verification.
 - Delivery: local commit only; live activation is pending.

--- a/project/2026-08-24-open-code-review-plan.md
+++ b/project/2026-08-24-open-code-review-plan.md
@@ -28,6 +28,7 @@
 - Evidence: The upstream workflow uses `pull_request_target` for fork secret access and requires `contents: read` plus `pull-requests: write`.
 - Evidence: OpenRouter documents `https://openrouter.ai/api/v1/chat/completions`, Bearer authentication, the exact model slug `deepseek/deepseek-v4-flash-0731`, and the `reasoning` request object.
 - Evidence: The upstream `v1.9.10` tag resolves to commit `66120291271b2e605e420e9f11fbd6448f06163f`; the annotated tag object is not used as the Action pin.
+- Evidence: OpenCodeReview `v1.9.10` writes `llm_extra_body` to its config file, but its required `OCR_LLM_*` environment resolution path does not carry that body into the resolved endpoint. This preparation therefore leaves reasoning at the selected model/provider default rather than claiming it is disabled.
 - Limitation: The OpenCodeReview npm postinstall downloads the native executable and checksum from GitHub release assets. Pinning the Action and CLI versions does not eliminate that residual supply-chain dependency.
 - Planning review: The native planner returned `DONE_WITH_CONCERNS`; its concerns are accepted as residual risks below.
 
@@ -36,6 +37,7 @@
 - Risk: `pull_request_target` has access to secrets and a write-capable GitHub token. Control: pin the Action to the resolved commit, keep the workflow free of checkout/build/test steps, and grant only `contents: read` and `pull-requests: write`.
 - Risk: Fork PRs can consume the OpenRouter key. Control: use a dedicated OpenRouter key restricted to this model and a bounded budget; do not reuse production credentials.
 - Risk: Review artifacts and logs may retain model output. Control: set `upload_artifacts: 'false'`; workflow logs remain a residual GitHub Actions retention surface.
+- Risk: The pinned OCR release cannot apply an OpenRouter `reasoning` override on its environment-resolved endpoint. Control: do not claim reasoning is disabled; treat the selected model/provider default as an initial-test condition and revisit after an upstream fix is pinned.
 - Risk: AI findings are noisy and non-authoritative. Control: keep the job advisory and do not add it to required checks in this slice.
 
 ## Primitive and ADR disposition
@@ -62,13 +64,13 @@
 ## Slice S1: prepare the advisory workflow
 
 - Route: main.
-- Acceptance: Only `.github/workflows/check-ocr-review.yml` changes; the workflow uses `pull_request_target`, the resolved Action commit, `ocr_version: '1.9.10'`, OpenRouter's endpoint and model slug, `OPENROUTER_API_KEY`, OpenRouter-native disabled reasoning, least-privilege permissions, sticky/incremental comments, and no artifact upload.
+- Acceptance: Only `.github/workflows/check-ocr-review.yml` changes; the workflow uses `pull_request_target`, the resolved Action commit, `ocr_version: '1.9.10'`, OpenRouter's endpoint and model slug, `OPENROUTER_API_KEY`, explicit OpenAI-compatible mode, least-privilege permissions, sticky/incremental comments, no artifact upload, and skips Dependabot PRs whose events cannot use this secret/write-token path.
 - Check: Repository-native YAML formatting/checks where available, YAML parse, `git diff --check`, staged-path audit, and static security review.
 - Commit: `ci: add advisory OpenCodeReview PR review`
 
 ## Progress
 
-- Status: implementation committed and slice-reviewed with `PASS_WITH_CONCERNS`; final integrated review pending.
-- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, and slice review.
-- Remaining: run final review and complete close-out verification.
+- Status: final review found and the main session is correcting two issues: an ineffective reasoning override and Dependabot secret-path failures.
+- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, and bounded slice review.
+- Remaining: verify the correction, rerun the risk review, run final review, and complete close-out verification.
 - Delivery: local commit only; live activation is pending.

--- a/project/2026-08-24-open-code-review-plan.md
+++ b/project/2026-08-24-open-code-review-plan.md
@@ -70,7 +70,7 @@
 
 ## Progress
 
-- Status: final review found and the main session is correcting two issues: an ineffective reasoning override and Dependabot secret-path failures.
-- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, and bounded slice review.
-- Remaining: verify the correction, rerun the risk review, run final review, and complete close-out verification.
+- Status: correction committed and risk-reviewed with `PASS`; final integrated review pending.
+- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, bounded slice review, and correction review.
+- Remaining: run final review and complete close-out verification.
 - Delivery: local commit only; live activation is pending.

--- a/project/2026-08-24-open-code-review-plan.md
+++ b/project/2026-08-24-open-code-review-plan.md
@@ -70,7 +70,7 @@
 
 ## Progress
 
-- Status: correction committed and risk-reviewed with `PASS`; final integrated review pending.
-- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, bounded slice review, and correction review.
-- Remaining: run final review and complete close-out verification.
+- Status: final integrated review passed; local preparation is complete.
+- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review, workflow implementation, static checks, bounded slice review, correction review, and final review.
+- Remaining: merge to `v3`, add the repository secret, and activate the workflow when explicitly approved.
 - Delivery: local commit only; live activation is pending.

--- a/project/2026-08-24-open-code-review-plan.md
+++ b/project/2026-08-24-open-code-review-plan.md
@@ -1,0 +1,74 @@
+# OpenCodeReview advisory PR review
+
+## Goal and non-goals
+
+- Problem: Add an initial advisory OpenCodeReview workflow for pull requests in KlickerUZH.
+- Decision: Use the OpenCodeReview GitHub Action with OpenRouter's OpenAI-compatible API and `deepseek/deepseek-v4-flash-0731`.
+- Non-goals: Create GitHub secrets or variables, change branch protection, push, open a PR, add pnpm dependencies, add a local agent plugin, or activate a live workflow.
+
+## Execution contract
+
+- Authority: The user's request authorizes the local workflow preparation, verification, and one local commit.
+- Withheld: GitHub settings changes, secret creation, push, PR creation, branch-protection changes, and live activation.
+- Boundary owner: self.
+- Terminal: One committed workflow file with static verification complete; activation remains pending the repository secret and merge to `v3`.
+- Pause: Stop if the model endpoint, model slug, or privileged workflow boundary changes.
+
+## Plan identity
+
+- Branch: `rs/open-code-review`
+- Worktree: `trees/rs-open-code-review`
+- Target: `v3`
+- PR: none
+- Related draft: the untracked primary-checkout draft at `.github/workflows/check-ocr-review.yml`; it remains untouched.
+
+## Research
+
+- Evidence: OpenCodeReview's official action checks out the trusted base, fetches PR-head objects, and reviews the diff without materializing or executing PR code.
+- Evidence: The upstream workflow uses `pull_request_target` for fork secret access and requires `contents: read` plus `pull-requests: write`.
+- Evidence: OpenRouter documents `https://openrouter.ai/api/v1/chat/completions`, Bearer authentication, the exact model slug `deepseek/deepseek-v4-flash-0731`, and the `reasoning` request object.
+- Evidence: The upstream `v1.9.10` tag resolves to commit `66120291271b2e605e420e9f11fbd6448f06163f`; the annotated tag object is not used as the Action pin.
+- Limitation: The OpenCodeReview npm postinstall downloads the native executable and checksum from GitHub release assets. Pinning the Action and CLI versions does not eliminate that residual supply-chain dependency.
+- Planning review: The native planner returned `DONE_WITH_CONCERNS`; its concerns are accepted as residual risks below.
+
+## Risk and controls
+
+- Risk: `pull_request_target` has access to secrets and a write-capable GitHub token. Control: pin the Action to the resolved commit, keep the workflow free of checkout/build/test steps, and grant only `contents: read` and `pull-requests: write`.
+- Risk: Fork PRs can consume the OpenRouter key. Control: use a dedicated OpenRouter key restricted to this model and a bounded budget; do not reuse production credentials.
+- Risk: Review artifacts and logs may retain model output. Control: set `upload_artifacts: 'false'`; workflow logs remain a residual GitHub Actions retention surface.
+- Risk: AI findings are noisy and non-authoritative. Control: keep the job advisory and do not add it to required checks in this slice.
+
+## Primitive and ADR disposition
+
+- Product primitives: none affected; this changes repository automation only.
+- ADR gate: not triggered. The workflow does not establish an application or public product contract. Reconsider if the review becomes a required release gate or introduces a durable external data-retention policy.
+
+## Skill routing
+
+- `rs-sliced-development-workflow`: full path because the change crosses secrets, fork trust, third-party execution, and a write-token boundary.
+- Planning: native read-only planner completed before this plan.
+- Implementation: main session; the slice is security-sensitive and indivisible.
+- Slice review: required for the privileged workflow and external LLM data boundary.
+- Final review: required after the committed slice and fresh verification.
+
+## Test portfolio
+
+| Risk or behavior | Obligation | Primary evidence | Distinct failure protected |
+| --- | --- | --- | --- |
+| Fork PR trigger and privileged boundary | none | Static workflow review plus upstream action source | A forked PR receives secrets or executes PR code |
+| OpenRouter model and authentication wiring | none | YAML parse/format check and key-name inspection | Wrong endpoint, protocol, model, or secret mapping |
+| Comment posting behavior | none | Upstream action contract; no local reimplementation | Duplicate or missing comments caused by local glue |
+
+## Slice S1: prepare the advisory workflow
+
+- Route: main.
+- Acceptance: Only `.github/workflows/check-ocr-review.yml` changes; the workflow uses `pull_request_target`, the resolved Action commit, `ocr_version: '1.9.10'`, OpenRouter's endpoint and model slug, `OPENROUTER_API_KEY`, OpenRouter-native disabled reasoning, least-privilege permissions, sticky/incremental comments, and no artifact upload.
+- Check: Repository-native YAML formatting/checks where available, YAML parse, `git diff --check`, staged-path audit, and static security review.
+- Commit: `ci: add advisory OpenCodeReview PR review`
+
+## Progress
+
+- Status: plan reviewed; implementation pending.
+- Completed: fresh `origin/v3` baseline, upstream/OpenRouter research, dedicated worktree, planning review.
+- Remaining: create workflow, verify, run slice review, commit, run final review.
+- Delivery: local commit only; live activation is pending.


### PR DESCRIPTION
## What This Adds

This PR adds an advisory GitHub Actions workflow that reviews pull requests with OpenCodeReview and OpenRouter's `deepseek/deepseek-v4-flash-0731` model.

1. Triggers on opened, synchronized, and reopened pull requests.
2. Uses the pinned OpenCodeReview `v1.9.10` action commit and OpenRouter's OpenAI-compatible Chat Completions endpoint.
3. Posts sticky, incremental review comments without uploading raw review artifacts.

## How It Works

- Uses `pull_request_target` so the trusted workflow can access the repository secret and comment on fork pull requests.
- The pinned action checks out the trusted base and reads PR-head Git objects for the diff; the workflow adds no checkout, build, test, install, or execution step for PR content.
- Grants only `contents: read` and `pull-requests: write`.
- Skips Dependabot-authored pull requests because their event context cannot use this secret/write-token path.
- Routes findings at or below low severity to the summary while keeping the job advisory.

## Important Details

- The exact model slug is `deepseek/deepseek-v4-flash-0731`.
- The action is pinned to `66120291271b2e605e420e9f11fbd6448f06163f`; the OCR CLI is pinned to `1.9.10`.
- OCR `v1.9.10` does not carry `llm.extra_body` into the required `OCR_LLM_*` environment resolution path. The workflow therefore does not claim to disable reasoning; initial testing uses the selected model/provider default.
- Substantive size is 34 added workflow lines. The 76 added plan/progress lines are project metadata; together they form a complete cohesive single-file CI package.

## Branch Coverage

- Base: `v3`
- Head: `ab435d5c26`
- Reviewed: 6 commits from `origin/v3..HEAD`; 2 changed files, 110 added lines total.
- Covered: integration plan, workflow implementation, verification records, correction for OCR configuration behavior, Dependabot exclusion, and final close-out metadata.

## Review Focus

- Confirm the `pull_request_target` trust boundary remains limited to the pinned action and trusted-base diff review.
- Confirm the OpenRouter secret is not exposed to PR-head code and the model/provider mapping is correct.
- Confirm the reasoning limitation is explicit rather than represented by an ineffective configuration input.
- Confirm artifact upload remains disabled and the workflow stays advisory.

## Verification

Current head:

- Prettier check for the workflow and plan -> pass.
- YAML parse using the repository's installed `yaml` package -> pass.
- `git diff --check origin/v3..HEAD` -> pass.
- GitHub API lookup for the action commit pin -> exact SHA confirmed.
- Native final integrated review -> `PASS`, with no findings on the corrected package.

Earlier branch verification:

- Bounded slice review -> `PASS_WITH_CONCERNS`; accepted residual risks were recorded in `project/_local/reviews/`.
- Correction review -> `PASS`; verified removal of the ineffective reasoning override and Dependabot exclusion.

Failed/Warning:

- The configured native slice-review route was unavailable because its provider returned a terminal credit-limit error. A bounded read-only fallback review completed the slice and correction reviews; the native final reviewer passed the integrated package.

Not run:

- GitHub Actions execution and an OpenRouter request were not run because the repository secret has not been added and the workflow has not been activated.
- `actionlint` and `zizmor` were unavailable locally; adding new tooling is outside this PR.

## Security / Privacy

- Review: privileged-workflow review plus final integrated review.
- Result: no blocking findings remain in the prepared package; `pull_request_target` and third-party action supply-chain risks remain explicit follow-up concerns.
- Sensitive data: no secrets or private payloads are committed. The workflow references `OPENROUTER_API_KEY` only. GitHub Actions logs may still retain prompts, source excerpts, or model output.

## Blocking Before Merge

- [ ] Add `OPENROUTER_API_KEY` as a repository Actions secret using a dedicated, model-restricted, budget-capped key.
- [ ] Explicitly approve activation of this privileged advisory workflow after reviewing the secret and fork-PR trust boundary.

## Follow-Up After Merge

- [ ] Run a synthetic pull-request test and verify comments are posted, no artifacts are uploaded, and PR-head code is never executed.
- [ ] Revisit forced reasoning control after OpenCodeReview supports `llm_extra_body` for environment-resolved endpoints.
- [ ] Keep the review advisory unless a separate decision approves making it a required check.

## Local Session Artifacts

Machine-local pointers for a session resuming this branch, not review evidence.

- Machine: macOS development host
- Worktree: `klicker-uzh/trees/rs-open-code-review`
- Review reports: `project/_local/reviews/`
