### PR TITLE
chore(ocr): add PR title context

### DIFF
--- a/.github/workflows/check-ocr-review.yml
+++ b/.github/workflows/check-ocr-review.yml
@@ -26,6 +26,7 @@ jobs:
           llm_url: https://openrouter.ai/api/v1/chat/completions
           llm_auth_token: ${{ secrets.OPENROUTER_API_KEY }}
           llm_model: deepseek/deepseek-v4-flash-0731
+          background: ${{ github.event.pull_request.title }}
           llm_use_anthropic: 'false'
           ocr_version: '1.9.10'
           sticky_summary: 'true'


### PR DESCRIPTION
## What This Adds

This PR passes the pull request title to OpenCodeReview as background context so the review can better align findings with the change's stated intent.

The workflow's model, trigger, permissions, action pin, secret, severity routing, and artifact handling remain unchanged.

## Branch Coverage

- Base: `v3`
- Head: `305ab72f0b`
- Reviewed: 1 commit from `origin/v3..HEAD`; 1 workflow file, 1 added line.
- This is a complete single-file CI configuration update; no separate implementation slice is warranted.

## Risk

The PR title is now included in the existing review request sent to OpenRouter. No permissions, credentials, execution steps, or application runtime behavior change.

## Verification

Current head:

- `git diff --check origin/v3...HEAD` -> pass.
- Clean branch with the expected one-line workflow diff.

Not run:

- Repository-wide tests were not run because this change only adjusts GitHub Actions configuration.

## Security / Privacy

- No secrets or private payloads are committed.
- The existing OpenRouter data boundary now receives the PR title as additional review context.

## Blocking Before Merge

None.

## Local Session Artifacts

- Machine: macOS development host
- Worktree: `klicker-uzh/trees/rs-open-code-review-background` in repository `klicker-uzh`
