### PR TITLE
ci(ocr): tolerate slow draft reviews

### DIFF
--- a/.github/workflows/check-ocr-review.yml
+++ b/.github/workflows/check-ocr-review.yml
@@ -47,7 +47,9 @@ jobs:
           llm_model: deepseek/deepseek-v4-flash-0731
           background: ${{ steps.context.outputs.background }}
           llm_use_anthropic: 'false'
+          llm_timeout: '540'
           ocr_version: '1.9.10'
+          review_concurrency: '2'
           sticky_summary: 'true'
           incremental: 'true'
           route_severity_below: 'low'


### PR DESCRIPTION
## Summary

- extend OpenCodeReview's LLM request timeout from its five-minute default to nine minutes
- limit concurrent file reviews to two to reduce OpenRouter provider contention
- keep the request timeout below OpenCodeReview's ten-minute per-file deadline

## Why

The continuous review on #5538 completed only half of its selected files. The failed plan and main reviews returned HTTP 200 but exceeded the action's default five-minute LLM request timeout during context processing.

## Verification

- `git diff --check origin/v3...HEAD`
- workflow YAML parses successfully
- independent final review passed with no findings
- live effectiveness of the new continuous-review settings must be observed after merge because `pull_request_target` runs the workflow from the trusted base branch

## Scope

This does not change the model, permissions, trigger policy, manual final-review workflow, or branch protection.