### PR TITLE
ci: consolidate checks and lightweight unit workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     services:
       postgres:

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   filter:
     runs-on: ubuntu-latest
@@ -28,8 +31,6 @@ jobs:
     needs: filter
     if: needs.filter.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     services:
       postgres:

--- a/.github/workflows/test-olat-api.yml
+++ b/.github/workflows/test-olat-api.yml
@@ -3,9 +3,27 @@ name: Test OLAT-API functionalities
 on:
   push:
     branches: ['v3', 'v3*']
+    paths:
+      - 'apps/olat-api/**'
+      - 'packages/prisma/**'
+      - 'packages/grading/**'
+      - 'packages/util/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
+      - '.github/workflows/test-olat-api.yml'
   pull_request:
     branches: ['v3', 'v3*']
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'apps/olat-api/**'
+      - 'packages/prisma/**'
+      - 'packages/grading/**'
+      - 'packages/util/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
+      - '.github/workflows/test-olat-api.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -17,36 +35,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for changes
-        id: filter
-        uses: ./.github/actions/changed-paths
-        with:
-          pattern: '^(apps/olat-api/|packages/prisma/|packages/grading/|packages/util/|package\.json|pnpm-lock\.yaml|tsconfig\.json|\.github/workflows/test-olat-api\.yml|\.github/actions/changed-paths/)'
-
       - name: Set up Docker Buildx
-        if: steps.filter.outputs.should_run == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Define node version
-        if: steps.filter.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
 
       - uses: pnpm/action-setup@v4
-        if: steps.filter.outputs.should_run == 'true'
         with:
           version: 11.5.0
           run_install: true
 
       - name: Run tests using Docker
-        if: steps.filter.outputs.should_run == 'true'
         run: |
           cd packages/prisma
           pnpm run build

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,6 +1,7 @@
 name: Test lightweight unit suites
 
 on:
+  workflow_dispatch:
   push:
     branches: ['v3', 'v3*']
     paths:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,94 @@
+name: Test lightweight unit suites
+
+on:
+  push:
+    branches: ['v3', 'v3*']
+    paths:
+      - 'apps/chat/**'
+      - 'packages/grading/**'
+      - 'packages/graphql/**'
+      - 'packages/i18n/**'
+      - 'packages/markdown/**'
+      - 'packages/next-config/**'
+      - 'packages/prisma/**'
+      - 'packages/shared-components/**'
+      - 'packages/types/**'
+      - 'packages/util/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.json'
+      - '.github/workflows/test-unit.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'apps/chat/**'
+      - 'packages/grading/**'
+      - 'packages/graphql/**'
+      - 'packages/i18n/**'
+      - 'packages/markdown/**'
+      - 'packages/next-config/**'
+      - 'packages/prisma/**'
+      - 'packages/shared-components/**'
+      - 'packages/types/**'
+      - 'packages/util/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.json'
+      - '.github/workflows/test-unit.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-unit:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+
+      - name: Set up Node.js with pnpm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build unit-test dependencies
+        id: build
+        shell: bash
+        run: |
+          pnpm --filter @klicker-uzh/prisma build
+          pnpm --filter @klicker-uzh/types build
+          pnpm --filter @klicker-uzh/grading build
+          pnpm --filter @klicker-uzh/util build
+
+      - name: Test chat app
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/chat test:run
+
+      - name: Test grading package
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/grading test
+
+      - name: Test markdown package
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/markdown test
+
+      - name: Test util package
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/util test

--- a/project/2026-08-25-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-ci-workflow-efficiency-plan.md
@@ -190,13 +190,15 @@ Do not delete a workflow if any readback differs from the expected set.
 
 ## Progress
 
-- Status: plan frozen; implementation pending.
-- Completed: remote freshness and worktree audit, current required-context
-  readback, same-commit Actions timing sample, duplicate-workflow inventory,
-  Docker/image follow-up investigation, Actions audit/validation/list, required
-  planner challenge, and isolated devcontainer startup.
-- Remaining: commit the plan, refresh the base, implement and verify slice 1,
-  run slice reviews, push and open the draft PR, prove replacement contexts,
-  request settings authority, complete the cutover, and run final review.
+- Status: slice 1 implemented and locally verified; specialist review pending.
+- Completed: plan commit and post-commit freshness check; replacement workflow
+  implementation; Actions audit, validation, and discovery; exact Node 24
+  dependency builds; all four unit suites; Prettier and diff checks; and the
+  full monorepo build. The root `check:all` gate reached 6 of 7 tasks but the
+  analytics lint task could not build pandas because the devcontainer has no C
+  compiler; this is unrelated to the workflow-only diff.
+- Remaining: commit slice 1, run slice reviews, push and open the draft PR,
+  prove replacement contexts, request settings authority, complete the cutover,
+  and run final review.
 - Delivery boundary: branch-protection mutation, ready transition, merge,
   deployment, and cleanup remain withheld.

--- a/project/2026-08-25-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-ci-workflow-efficiency-plan.md
@@ -191,8 +191,8 @@ Do not delete a workflow if any readback differs from the expected set.
 
 ## Progress
 
-- Status: slice 1 implemented, locally verified, and specialist-reviewed;
-  review correction pending commit.
+- Status: slice 1 implemented, locally verified, specialist-reviewed, and
+  corrected; ready to publish as a draft PR.
 - Completed: plan commit and post-commit freshness check; replacement workflow
   implementation; Actions audit, validation, and discovery; exact Node 24
   dependency builds; all four unit suites; Prettier and diff checks; and the
@@ -201,8 +201,7 @@ Do not delete a workflow if any readback differs from the expected set.
   compiler; this is unrelated to the workflow-only diff. The specialist review
   accepted the consolidation and identified one least-privilege gap: GraphQL's
   filter and status jobs now receive workflow-level `contents: read`.
-- Remaining: commit the review correction, push and open the draft PR, prove
-  replacement contexts, request settings authority, complete the cutover, and
-  run final review.
+- Remaining: push and open the draft PR, prove replacement contexts, request
+  settings authority, complete the cutover, and run final review.
 - Delivery boundary: branch-protection mutation, ready transition, merge,
   deployment, and cleanup remain withheld.

--- a/project/2026-08-25-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-ci-workflow-efficiency-plan.md
@@ -144,9 +144,10 @@ review gates remain required.
 - Push normally and open a draft PR against `v3`.
 - Rename this plan to include the assigned PR number, update its identity,
   commit, and push normally.
-- Require successful `check`, `check-gitleaks`, and `test-unit` on one exact PR
-  head. Confirm the unit log contains one install, the dependency-build chain,
-  and all four test steps.
+- Obtain successful `check`, `check-gitleaks`, and `test-unit` runs on one exact
+  PR head. Confirm the unit log contains one install, the dependency-build
+  chain, and all four test steps. `test-unit` remains path-filtered and is not
+  added to branch protection.
 
 ## Slice 3: migrate branch protection
 
@@ -190,15 +191,18 @@ Do not delete a workflow if any readback differs from the expected set.
 
 ## Progress
 
-- Status: slice 1 implemented and locally verified; specialist review pending.
+- Status: slice 1 implemented, locally verified, and specialist-reviewed;
+  review correction pending commit.
 - Completed: plan commit and post-commit freshness check; replacement workflow
   implementation; Actions audit, validation, and discovery; exact Node 24
   dependency builds; all four unit suites; Prettier and diff checks; and the
   full monorepo build. The root `check:all` gate reached 6 of 7 tasks but the
   analytics lint task could not build pandas because the devcontainer has no C
-  compiler; this is unrelated to the workflow-only diff.
-- Remaining: commit slice 1, run slice reviews, push and open the draft PR,
-  prove replacement contexts, request settings authority, complete the cutover,
-  and run final review.
+  compiler; this is unrelated to the workflow-only diff. The specialist review
+  accepted the consolidation and identified one least-privilege gap: GraphQL's
+  filter and status jobs now receive workflow-level `contents: read`.
+- Remaining: commit the review correction, push and open the draft PR, prove
+  replacement contexts, request settings authority, complete the cutover, and
+  run final review.
 - Delivery boundary: branch-protection mutation, ready transition, merge,
   deployment, and cleanup remain withheld.

--- a/project/2026-08-25-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-ci-workflow-efficiency-plan.md
@@ -1,0 +1,202 @@
+# CI workflow efficiency consolidation
+
+## Goal and non-goals
+
+- Reduce pull-request queue pressure by removing duplicated code-quality runs
+  and combining four lightweight unit-test workflows into one install and one
+  dependency-build chain.
+- Preserve the existing check commands, advisory checks, package test commands,
+  GraphQL required-status behavior, OLAT Docker boundary, and image-build and
+  staging-promotion contracts.
+- Correct the documented branch-protection mismatch by requiring both `check`
+  and `check-gitleaks` after they pass on the draft pull-request head.
+- Non-goals: merge or mark the pull request ready, deploy, change image build or
+  promotion behavior, enable Docker layer caching, extract reusable image
+  workflows, change Playwright sharding, or delete the worktree or runtime data.
+
+## Execution contract
+
+- Authority: the user authorized a new branch and pull request against `v3`,
+  implementation, repository-native verification, conventional commits, and a
+  normal push.
+- Withheld: branch-protection mutation requires one explicit repository-admin
+  approval after the replacement contexts pass on the same draft PR head.
+  Merge, ready-for-review transition, deployment, force push, and cleanup also
+  remain withheld.
+- Execution owner and boundary owner: main session. The workflow definitions,
+  hosted proof, and required-context migration remain coupled in one owner.
+- Terminal: the draft PR contains the complete cutover; replacement checks pass
+  on its exact final head; branch protection is migrated and read back; required
+  reviews are resolved; no merge or deployment occurs.
+- Pause: stop on a missing or skipped replacement context, incomplete unit-test
+  diagnostics, a protection readback mismatch, a concurrent workflow/protection
+  edit that cannot be preserved, a required force push, or a new credential.
+
+## Plan identity
+
+- Plan: `project/2026-08-25-ci-workflow-efficiency-plan.md` until a PR number is
+  assigned, then rename it to include `pr-<id>`.
+- Branch: `rs/ci-workflow-efficiency`.
+- Worktree: `trees/ci-workflow-efficiency`.
+- Target: `origin/v3` at `5ffc6a6d2bc4b12f6f38b5119718a7545e039256`.
+- Pull request: draft PR to be created after the replacement workflows are
+  committed and locally verified.
+- Package: one ordinary PR because replacement proof, required-context
+  migration, and deletion of superseded workflow files form one cutover.
+
+## Current evidence and decisions
+
+- Current branch protection requires `check-format`, `check-lint`,
+  `check-syncpack`, `check-types`, `test-graphql-status`,
+  `test-playwright-status`, `build-amd`, and `build-arm`. It does not currently
+  require `check`, `check-gitleaks`, or advisory `check-knip`.
+- PR #5304 added `check.yml` beside the five old check workflows so an
+  administrator could migrate required contexts safely. That migration and
+  cleanup never happened.
+- On one same-commit hosted sample, `check` used 245 seconds while the five
+  split check jobs used 871 seconds in aggregate. The consolidated job had a
+  warm Turbo cache, so this is evidence of duplicated work and queue pressure,
+  not a standalone runtime forecast.
+- `check.yml` preserves all old commands and uniquely enforces
+  `check:removed-doc-artifacts`; it remains unconditional so required checks do
+  not get stuck pending through workflow-level path filters.
+- `test-chat`, `test-grading`, `test-markdown`, and `test-util` each check out,
+  install, and partially rebuild the same workspace. Their contexts are not
+  required, so one path-filtered `test-unit` workflow can safely replace them.
+- OLAT stays separate because its test script owns a Docker test boundary.
+  GraphQL keeps its filter and always-reporting status job because that status
+  is required.
+- The new unit workflow uses one frozen install, builds Prisma, types, grading,
+  and util once in that order, then runs four separately visible test steps.
+  Later suites run after an earlier suite failure but not after setup or build
+  failure, preserving useful diagnostics.
+- The consolidated check and unit workflows receive `contents: read` only.
+  Unused `packages: write` permissions are removed from GraphQL and OLAT.
+- The current wiki skill reserves `docs/log.md` and `docs/log/` as absent.
+  Durable updates go only to `docs/ci-and-deployment.md`, `docs/testing.md`, and
+  `.agents/skills/klicker-testing-verification/SKILL.md`.
+- No ADR is needed: this is a reversible CI-configuration consolidation that
+  preserves product, data, deployment, and public contracts. Reusable image
+  workflow extraction or promotion-contract changes would reopen the ADR gate.
+
+## Planner disposition and delegation
+
+The required planner returned `DONE_WITH_CONCERNS`. Accepted corrections:
+
+- require `check` and the documented blocking `check-gitleaks` only after both
+  pass on one exact draft PR head;
+- preserve later unit-suite diagnostics after an earlier suite failure;
+- keep OLAT and GraphQL separate, use least permissions, and limit new pnpm
+  caching to `test-unit`;
+- defer all Docker/image optimizations;
+- perform the protection migration incrementally and preserve every concurrent
+  context and app binding.
+
+The planner's dated CI-log suggestion is rejected because the current
+repository wiki procedure explicitly forbids creating that reserved path.
+
+| Workstream | Owner | Acceptance boundary |
+| --- | --- | --- |
+| Plan, workflows, docs, integration | main | Critical-path coupling across local and hosted state |
+| Planning challenge | planner | Completed; concerns dispositioned above |
+| Slice simplification and risk review | specialists | Review immutable substantive commits |
+| Integrated readiness review | final reviewer | Review the verified final committed package |
+
+Execution-tier implementation delegation is skipped because one writer must
+preserve the required-check and workflow-deletion ordering. Read-only specialist
+review gates remain required.
+
+## Test portfolio
+
+| Consequential behavior | Obligation | Evidence |
+| --- | --- | --- |
+| Consolidated checks preserve all blocking and advisory commands | static equivalence plus hosted run | workflow diff, Actions validation, successful `check` |
+| Four lightweight suites share setup without losing diagnostics | local command proof plus hosted run | exact dependency builds and four test steps; successful `test-unit` |
+| Irrelevant OLAT changes create no checkout-only job | trigger review | workflow-level path union and Actions validation |
+| GraphQL keeps required fail-open/fail-closed semantics | static review | unchanged filter and status jobs; successful required context |
+| Required contexts migrate without a merge deadlock | hosted and admin proof | same-head replacement checks plus exact before/after protection readback |
+| Documentation matches delivered CI behavior | wiki validation | OKF validator, Prettier, direct-link inspection |
+
+## Slice 0: freeze the plan
+
+- Commit this reviewed execution contract before implementation.
+- Refresh `origin/v3` immediately afterward. Re-baseline if it moved; stop if a
+  concurrent change overlaps the planned workflows.
+- Commit: `docs(project): add CI workflow efficiency plan`.
+
+## Slice 1: add replacement workflows without removing safety nets
+
+- Add least permissions to `check.yml` without changing its command order or
+  unconditional execution.
+- Add `test-unit.yml` with the old source/manifest path union, one cached frozen
+  install, one dependency-build chain, and four separately visible test steps.
+- Move OLAT filtering to workflow triggers and remove its package-write token.
+- Remove only GraphQL's unused package-write token.
+- Keep all superseded workflows in place.
+- Verify Actions structure, the exact dependency builds and unit commands, wiki
+  formatting, and repository gates in the isolated devcontainer.
+- Commit: `ci: consolidate lightweight unit workflows`.
+- Run the simplifier and a required-context/security slice review on the
+  immutable commit range; correct and re-review material findings.
+
+## Slice 2: establish hosted replacement proof
+
+- Push normally and open a draft PR against `v3`.
+- Rename this plan to include the assigned PR number, update its identity,
+  commit, and push normally.
+- Require successful `check`, `check-gitleaks`, and `test-unit` on one exact PR
+  head. Confirm the unit log contains one install, the dependency-build chain,
+  and all four test steps.
+
+## Slice 3: migrate branch protection
+
+Pause for explicit repository-admin approval. After approval:
+
+1. Read the current strict setting and complete app-bound context set.
+2. Add `check`, then read back its GitHub Actions binding.
+3. Add `check-gitleaks`, then read back again.
+4. Remove only `check-format`, `check-lint`, `check-syncpack`, and `check-types`.
+5. Verify the final set equals the fresh starting set minus those four plus the
+   two replacements. Preserve strict mode, `test-graphql-status`,
+   `test-playwright-status`, `build-amd`, `build-arm`, and every concurrent
+   context such as `final-ai-review`.
+
+Do not delete a workflow if any readback differs from the expected set.
+
+## Slice 4: complete the cutover
+
+- Delete `check-format.yml`, `check-lint.yml`, `check-syncpack.yml`,
+  `check-types.yml`, `check-knip.yml`, `test-chat.yml`, `test-grading.yml`,
+  `test-markdown.yml`, and `test-util.yml` only after the protection migration.
+- Update the CI guide, testing guide, testing-verification skill, and plan
+  progress to describe the delivered state and measured follow-ups.
+- Run Actions validation, repository-native checks, the required slice review,
+  and one integrated final reviewer. Update the draft PR, but do not mark it
+  ready, merge, deploy, or clean up the branch/worktree.
+- Commit: `ci: complete workflow efficiency consolidation`.
+
+## Deferred efficiency packages
+
+- Remove unnecessary QEMU setup from native AMD and ARM image jobs only after a
+  separate hosted image-build proof.
+- Guard registry login on PR image builds that use `push: false`.
+- Pilot BuildKit/GitHub Actions layer caching separately; Dockerfiles run
+  unpinned `apk update`, so cache freshness and security policy need a decision.
+- Extract reusable image workflows only with explicit promotion-name,
+  required-context, backend-migrator, PR no-push, release-tag, and build-argument
+  contract tests.
+- Reassess Playwright shard count and PR image-build scope after this job-count
+  reduction is measured in hosted CI.
+
+## Progress
+
+- Status: plan frozen; implementation pending.
+- Completed: remote freshness and worktree audit, current required-context
+  readback, same-commit Actions timing sample, duplicate-workflow inventory,
+  Docker/image follow-up investigation, Actions audit/validation/list, required
+  planner challenge, and isolated devcontainer startup.
+- Remaining: commit the plan, refresh the base, implement and verify slice 1,
+  run slice reviews, push and open the draft PR, prove replacement contexts,
+  request settings authority, complete the cutover, and run final review.
+- Delivery boundary: branch-protection mutation, ready transition, merge,
+  deployment, and cleanup remain withheld.

--- a/project/2026-08-25-pr-5551-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-pr-5551-ci-workflow-efficiency-plan.md
@@ -68,6 +68,9 @@
   and util once in that order, then runs four separately visible test steps.
   Later suites run after an earlier suite failure but not after setup or build
   failure, preserving useful diagnostics.
+- Draft pull requests retain the existing unit-suite skip behavior. A manual
+  dispatch trigger provides exact-head hosted proof without marking the draft
+  ready or running the suite automatically on every draft update.
 - The consolidated check and unit workflows receive `contents: read` only.
   Unused `packages: write` permissions are removed from GraphQL and OLAT.
 - The current wiki skill reserves `docs/log.md` and `docs/log/` as absent.
@@ -142,10 +145,10 @@ review gates remain required.
 - Push normally and open a draft PR against `v3`.
 - Rename this plan to include the assigned PR number, update its identity,
   commit, and push normally.
-- Obtain successful `check`, `check-gitleaks`, and `test-unit` runs on one exact
-  PR head. Confirm the unit log contains one install, the dependency-build
-  chain, and all four test steps. `test-unit` remains path-filtered and is not
-  added to branch protection.
+- Obtain successful `check` and `check-gitleaks` PR runs plus a manually
+  dispatched `test-unit` run on one exact PR head. Confirm the unit log contains
+  one install, the dependency-build chain, and all four test steps. `test-unit`
+  remains path-filtered and is not added to branch protection.
 
 ## Slice 3: migrate branch protection
 
@@ -189,7 +192,8 @@ Do not delete a workflow if any readback differs from the expected set.
 
 ## Progress
 
-- Status: slice 1 published in draft PR #5551; hosted replacement proof pending.
+- Status: slice 1 published in draft PR #5551; hosted checks running and manual
+  unit-proof trigger pending publication.
 - Completed: plan commit and post-commit freshness check; replacement workflow
   implementation; Actions audit, validation, and discovery; exact Node 24
   dependency builds; all four unit suites; Prettier and diff checks; and the
@@ -198,8 +202,11 @@ Do not delete a workflow if any readback differs from the expected set.
   compiler; this is unrelated to the workflow-only diff. The specialist review
   accepted the consolidation and identified one least-privilege gap: GraphQL's
   filter and status jobs now receive workflow-level `contents: read`. Draft PR
-  #5551 is open against `v3`.
-- Remaining: push this plan identity update, prove replacement contexts, request
-  settings authority, complete the cutover, and run final review.
+  #5551 is open against `v3`. Its initial `test-unit` PR job skipped as designed
+  because the PR is draft, so a manual dispatch trigger now supplies proof
+  without crossing the withheld ready-for-review boundary.
+- Remaining: commit and push the manual proof trigger, prove replacement
+  contexts, request settings authority, complete the cutover, and run final
+  review.
 - Delivery boundary: branch-protection mutation, ready transition, merge,
   deployment, and cleanup remain withheld.

--- a/project/2026-08-25-pr-5551-ci-workflow-efficiency-plan.md
+++ b/project/2026-08-25-pr-5551-ci-workflow-efficiency-plan.md
@@ -34,13 +34,11 @@
 
 ## Plan identity
 
-- Plan: `project/2026-08-25-ci-workflow-efficiency-plan.md` until a PR number is
-  assigned, then rename it to include `pr-<id>`.
+- Plan: `project/2026-08-25-pr-5551-ci-workflow-efficiency-plan.md`.
 - Branch: `rs/ci-workflow-efficiency`.
 - Worktree: `trees/ci-workflow-efficiency`.
 - Target: `origin/v3` at `5ffc6a6d2bc4b12f6f38b5119718a7545e039256`.
-- Pull request: draft PR to be created after the replacement workflows are
-  committed and locally verified.
+- Pull request: draft PR #5551 against `v3`.
 - Package: one ordinary PR because replacement proof, required-context
   migration, and deletion of superseded workflow files form one cutover.
 
@@ -191,8 +189,7 @@ Do not delete a workflow if any readback differs from the expected set.
 
 ## Progress
 
-- Status: slice 1 implemented, locally verified, specialist-reviewed, and
-  corrected; ready to publish as a draft PR.
+- Status: slice 1 published in draft PR #5551; hosted replacement proof pending.
 - Completed: plan commit and post-commit freshness check; replacement workflow
   implementation; Actions audit, validation, and discovery; exact Node 24
   dependency builds; all four unit suites; Prettier and diff checks; and the
@@ -200,8 +197,9 @@ Do not delete a workflow if any readback differs from the expected set.
   analytics lint task could not build pandas because the devcontainer has no C
   compiler; this is unrelated to the workflow-only diff. The specialist review
   accepted the consolidation and identified one least-privilege gap: GraphQL's
-  filter and status jobs now receive workflow-level `contents: read`.
-- Remaining: push and open the draft PR, prove replacement contexts, request
+  filter and status jobs now receive workflow-level `contents: read`. Draft PR
+  #5551 is open against `v3`.
+- Remaining: push this plan identity update, prove replacement contexts, request
   settings authority, complete the cutover, and run final review.
 - Delivery boundary: branch-protection mutation, ready transition, merge,
   deployment, and cleanup remain withheld.


### PR DESCRIPTION
## What This Changes

This draft starts a staged CI cutover that reduces duplicated setup and runner
queue pressure without removing current required checks before their replacements
are proven.

- Adds one path-filtered `test-unit` job for chat, grading, markdown, and util,
  with one frozen install and one ordered dependency-build chain.
- Keeps each unit suite as a separately visible step and continues later suites
  after an earlier test failure, preserving diagnostic coverage.
- Moves OLAT filtering to workflow triggers so irrelevant changes do not create
  a checkout-only job, while retaining its Docker test boundary.
- Applies explicit `contents: read` permissions to consolidated check, GraphQL,
  OLAT, and unit workflows; removes unused `packages: write` access.
- Keeps every superseded workflow in place until hosted proof and an explicitly
  approved branch-protection migration make deletion safe.

## How It Works

- `test-unit` runs for the union of the four existing suites' source and shared
  dependency paths. It installs once, builds Prisma, types, grading, and util in
  order, then runs the four existing package commands.
- `check` stays unconditional because it is intended to replace four required
  split contexts without creating path-filtered pending checks.
- GraphQL keeps its changed-path filter and always-reporting
  `test-graphql-status` bridge. OLAT remains separate because its suite runs
  through Docker.
- `test-unit` remains path-filtered and will not be added to branch protection.

## Branch Coverage

- Base: `v3` at `5ffc6a6d2bc4b12f6f38b5119718a7545e039256`
- Head: `e8ab3b3978c4ca57bbffd7e4ce0b6caa787bf00a`
- Reviewed: 4 commits and 5 changed paths; 132 substantive added/deleted lines
  after excluding the committed plan/progress artifact
- Covered: execution plan, replacement unit workflow, OLAT trigger filtering,
  workflow permission reduction, specialist review correction, and progress
  evidence

## Review Focus

- Confirm the `test-unit` path union and ordered build chain cover the four
  superseded unit workflows without broadening required status checks.
- Confirm later unit suites still run after one suite fails, but do not run
  after setup or dependency-build failure.
- Confirm OLAT's workflow-level path filter is equivalent to its former
  changed-path action and that its Docker test command is unchanged.
- Confirm GraphQL's filter and always-reporting required status behavior remain
  unchanged while all jobs receive read-only contents access.

## Verification

Current head:

- Actions audit, syntax validation, and job discovery through the repository's
  safe local Actions wrapper -> pass; `test-unit` discovered
- ordered Prisma, types, grading, and util builds under Node 24 -> pass
- grading -> 10 tests passed
- chat -> 40 files and 351 tests passed
- markdown -> 1 file and 34 tests passed
- util -> 4 files and 49 tests passed
- `pnpm run build` under Node 24 -> 23/23 tasks passed
- Prettier checks, `git diff --check`, and staged gitleaks scans -> pass
- independent simplification and risk reviews -> no remaining workflow finding

Failed/Warning:

- `pnpm run check:all` reached 6/7 tasks, then analytics lint could not build
  pandas because the devcontainer has no C compiler. This is unrelated to the
  workflow-only diff.
- The host pre-push hook uses Node 26 and attempted a non-interactive pnpm
  reinstall. The push used `HUSKY=0` after the equivalent Node 24 container
  build passed 23/23 tasks.

Not run:

- Local workflow execution was not run because the configured Actions runner
  image is absent. GitHub Actions is authoritative for cache and hosted-runner
  behavior.

## Security / Privacy

- The branch reduces GitHub token permissions and adds no credential, secret,
  authentication, deployment, or application data flow.
- Staged gitleaks scans passed, and review reports contain no secret values or
  private payloads.

## Blocking Before Merge

- [ ] `check`, `check-gitleaks`, and `test-unit` pass on one exact draft PR head.
- [ ] Repository-admin approval is granted for the incremental branch-protection
  migration from four split contexts to `check` plus `check-gitleaks`.
- [ ] After protection readback succeeds, remove superseded workflows, update
  the CI/testing wiki and skill, rerun verification, and complete final review.

## Follow-Up After Merge

- [ ] Evaluate native-runner QEMU removal and PR-only registry-login guards as a
  separate image-workflow package.
- [ ] Pilot BuildKit caching only after defining cache-freshness policy for
  Dockerfiles that run unpinned `apk update`.
- [ ] Consider reusable image workflows only with promotion-name, required-job,
  migrator, no-push, release-tag, and build-argument contract tests.

## Local Session Artifacts

Machine-local pointers for resuming this draft; these are not reviewer-accessible
evidence.

- Machine: `MacBook-Pro`
- Worktree: `trees/ci-workflow-efficiency` in repository `klicker-uzh`
- Review reports: `trees/ci-workflow-efficiency/project/_local/reviews/`
- Environment: DevPod workspace `rs-ci-workflow-efficiency`; the application
  container is running, while devrouter's host lock helper currently cannot
  identify its process
