### PR TITLE
chore(deploy): roll production apps to alpha.72

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -29,7 +29,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.71
+        tag: v3.4.0-alpha.72
       resources:
         requests:
           cpu: 50m
@@ -68,7 +68,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.71
+        tag: v3.4.0-alpha.72
       resources:
         requests:
           cpu: 50m
@@ -107,7 +107,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.71
+        tag: v3.4.0-alpha.72
       resources:
         requests:
           cpu: 50m
@@ -177,7 +177,7 @@ auth:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/auth-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   ingress:
     annotations:
@@ -330,7 +330,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   ingress:
     annotations:
@@ -385,7 +385,7 @@ frontendPWA:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-pwa-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   ingress:
     className: haproxy
@@ -438,7 +438,7 @@ frontendManage:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-manage-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   ingress:
     className: haproxy
@@ -476,7 +476,7 @@ frontendControl:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   autoscaling:
     enabled: false
@@ -545,7 +545,7 @@ backendGraphql:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   appManageSubdomain: manage
   appStudentSubdomain: pwa
@@ -598,7 +598,7 @@ olatApi:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/olat-api-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   autoscaling:
     enabled: false
@@ -671,7 +671,7 @@ lti:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/lti-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
 
   ingress:
     className: haproxy
@@ -703,7 +703,7 @@ responseApi:
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
-    tag: v3.4.0-alpha.71
+    tag: v3.4.0-alpha.72
     pullPolicy: IfNotPresent
 
   autoscaling:
@@ -798,7 +798,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/frontend-assessment-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.71
+      tag: v3.4.0-alpha.72
 
     ingress:
       className: haproxy
@@ -875,7 +875,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.71
+      tag: v3.4.0-alpha.72
 
     appManageSubdomain: manage
     appStudentSubdomain: assessment
@@ -954,7 +954,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.71
+      tag: v3.4.0-alpha.72
 
     ingress:
       className: haproxy


### PR DESCRIPTION
## Summary

- Promote all 15 production image pins from `v3.4.0-alpha.71` to
  `v3.4.0-alpha.72`.
- Keep the existing ArgoCD PreSync migration hook enabled.
- Change no application code, chart templates, schema or migration files,
  dependencies, documentation, or secret values.

## Why

`v3.4.0-alpha.72` is the current release at
`7f3c0aab1470de9b7f1ad1d59b553b94ff8f19d2`. The annotated tag peels to the
same commit, and all 13 production-image workflows succeeded for that exact
tag and SHA. The [backend workflow](https://github.com/uzh-bf/klicker-uzh/actions/runs/32938868785)
built and pushed the ARM migrator before the dependent ARM application image;
the [frontend-manage workflow](https://github.com/uzh-bf/klicker-uzh/actions/runs/32938868825)
was the final successful image build.

No Prisma migration files were added between alpha.71 and alpha.72. The
existing migration hook remains enabled and uses the alpha.72 backend tag.

## Branch Coverage

- Base: `v3` at `7f3c0aab1470de9b7f1ad1d59b553b94ff8f19d2`
- Head: `e56939c4c10ec9732f94c63e05548edea450886f`
- Reviewed: one commit; one file; 15 additions and 15 deletions
- Scope: exactly 15 production image-pin replacements
- Packaging: isolated production-rollout exception to the usual substantive
  PR floor

## Review Focus

- Confirm all 15 production workloads move together to alpha.72.
- Confirm `migrator.enabled: true` and every unrelated production value remain
  unchanged.
- Keep merge, deployment, database work, and live proof outside this PR
  preparation task.

## Verification

Current head:

- 15 alpha.72 pins and zero alpha.71 pins in the production values.
- `migrator.enabled: true` preserved.
- All 13 production-image workflows completed successfully for the release SHA.
- Helm lint passed for `deploy/charts/klicker-uzh-v3` with the production
  values.
- Production Helm rendering passed with 16 alpha.72 image references: 15
  explicit pins plus the inherited migrator image, and zero alpha.71
  references.
- Scoped Prettier, `git diff --check`, and one-commit Gitleaks checks passed.
- Integrated final review passed with no findings.

Not run:

- Cluster, ArgoCD, database, deployment, and live-health checks were outside
  this task and require separate authority before merge or rollout.

## Security / Privacy

- Review: integrated final review; security lens not applicable to this
  mechanical declarative pin update.
- Result: no blocking findings.
- Sensitive data: no secrets, production data, or private payloads included.

## Blocking Before Merge

- [ ] Obtain separate merge and production-rollout authority.
- [ ] Complete the current PRD GitOps, recovery, database-target, CI, and
  review preflight before merging.

## Follow-Up After Merge

- [ ] Prove the exact ArgoCD revision, migration hook, workload images,
  readiness, and public health under separately authorized live verification.

## Local Session Artifacts

Machine-local pointers on `Rolands-Mac-Studio.local`:

- Worktree: `trees/rs/deploy-roll-prd-alpha72`
- Review report:
  `project/_local/reviews/2026-08-26-alpha72-prd-combined-final.md`
