### PR TITLE
ci(playwright): restore generated client artifact

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -273,6 +273,11 @@ jobs:
         with:
           name: playwright-build-artifact
 
+      - name: Restore generated GraphQL client
+        run: |
+          mkdir -p packages/graphql/src/public
+          cp packages/graphql/dist/client.json packages/graphql/src/public/client.json
+
       - name: Restore Next build outputs
         run: tar -xf playwright-next-builds.tar
 


### PR DESCRIPTION
## What This Fixes

This PR restores the generated GraphQL client map after each Playwright shard downloads the shared build artifact.

The GraphQL build now publishes `client.json` under `packages/graphql/dist`, while the Playwright course tests still read `packages/graphql/src/public/client.json`. The workflow copies the already-built file back to that source-tree path before starting services. It does not regenerate GraphQL output in every shard or change application behavior.

This is a separate CI-regression fix so the timing-only [PR #5565](https://github.com/uzh-bf/klicker-uzh/pull/5565) can remain limited to `playwright/timings.json`.

## Branch Coverage

- Base: `v3` at `861afd19383412a7338f491de46ad4ce3b761750`
- Head: `3f82d29996423d50631270cbfa872f1ac198056a`
- Reviewed: 1 substantive fix plus GitHub's sanctioned base-update merge; 1 workflow file; 5 additions and 0 deletions
- Packaging: urgent CI-regression exemption below the normal package floor

The base advanced by one unrelated devcontainer-cache commit after this branch was created. GitHub's sanctioned branch-update mechanism integrated it without overlap or conflict.

## Verification

Current head:

- Required final AI review: pass with no actionable findings on exact head `3f82d2999642`.
- Independent local final-package review: pass with no findings on the substantive fix commit.
- [Playwright run 32957425491](https://github.com/uzh-bf/klicker-uzh/actions/runs/32957425491): all eight shards passed; `test-playwright-status` passed. Shard 8 completed in 16m27s.
- Hosted required checks, CodeQL, SonarCloud, OpenCodeReview, and security checks: pass on the exact head.
- Pre-commit `pnpm run check:all`: pass; 25/25 check tasks and 7/7 lint tasks succeeded.
- Pre-push `pnpm run build`: pass; 23/23 build tasks succeeded.
- Node 24 DevPod: focused Prettier check passed for `.github/workflows/test-playwright.yml`.
- Staged Gitleaks and `git diff --check`: pass.
- Artifact replay: `packages/graphql/dist/client.json` existed, the source-tree path did not, and the workflow's copy sequence produced a byte-identical file.

Earlier failure evidence:

- [Playwright run 32951745232](https://github.com/uzh-bf/klicker-uzh/actions/runs/32951745232) passed shards 1-7. Shard 8 reported 131 passes and three deterministic `ENOENT` failures for `packages/graphql/src/public/client.json`; the aggregate failed.

Warnings:

- The host hooks used Node 22 and reported the repository's Node 24 engine warning. The changed workflow was formatted separately in the Node 24 DevPod, and the host checks and build completed successfully.
- GitHub reports the exact head mergeable with no unresolved review conversations.

## Security / Privacy

- The copy uses fixed repository paths and fails closed if the built artifact is absent.
- No permissions, secrets, personal data, dependencies, or external providers change.

## Blocking Before Merge

None.

## Follow-Up After Merge

- Update [PR #5565](https://github.com/uzh-bf/klicker-uzh/pull/5565) onto the fixed `v3` head and verify its timing-only Playwright run.

## Local Session Artifacts

- Machine: `Rolands-Mac-Studio`
- Worktree: `trees/rs-fix-playwright-generated-client-handoff` in repository `klicker-uzh`
