### PR TITLE
chore(deploy): roll production apps to alpha.73

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ## Quick Reference
 
 - **Monorepo**: pnpm 11.x + Turborepo, Node.js 24 (Volta-pinned; see `volta` in root `package.json` for exact versions)
-- **Main branch**: `v3`
+- **Main branch**: `v3` (active development)
+- **Legacy branches**: `dev` and `master` belong to the older Klicker variant and are not actively developed.
 - **Package names**: `@klicker-uzh/<name>` (e.g., `@klicker-uzh/graphql`)
 
 ## Stacked PRs

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -29,7 +29,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.72
+        tag: v3.4.0-alpha.73
       resources:
         requests:
           cpu: 50m
@@ -68,7 +68,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.72
+        tag: v3.4.0-alpha.73
       resources:
         requests:
           cpu: 50m
@@ -107,7 +107,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.72
+        tag: v3.4.0-alpha.73
       resources:
         requests:
           cpu: 50m
@@ -177,7 +177,7 @@ auth:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/auth-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   ingress:
     annotations:
@@ -330,7 +330,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   ingress:
     annotations:
@@ -385,7 +385,7 @@ frontendPWA:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-pwa-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   ingress:
     className: haproxy
@@ -438,7 +438,7 @@ frontendManage:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-manage-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   ingress:
     className: haproxy
@@ -476,7 +476,7 @@ frontendControl:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   autoscaling:
     enabled: false
@@ -545,7 +545,7 @@ backendGraphql:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   appManageSubdomain: manage
   appStudentSubdomain: pwa
@@ -598,7 +598,7 @@ olatApi:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/olat-api-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   autoscaling:
     enabled: false
@@ -671,7 +671,7 @@ lti:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/lti-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
 
   ingress:
     className: haproxy
@@ -703,7 +703,7 @@ responseApi:
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
-    tag: v3.4.0-alpha.72
+    tag: v3.4.0-alpha.73
     pullPolicy: IfNotPresent
 
   autoscaling:
@@ -798,7 +798,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/frontend-assessment-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.72
+      tag: v3.4.0-alpha.73
 
     ingress:
       className: haproxy
@@ -875,7 +875,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.72
+      tag: v3.4.0-alpha.73
 
     appManageSubdomain: manage
     appStudentSubdomain: assessment
@@ -954,7 +954,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.72
+      tag: v3.4.0-alpha.73
 
     ingress:
       className: haproxy


### PR DESCRIPTION
## Summary

- Promote all 15 explicit production image pins from `v3.4.0-alpha.72` to `v3.4.0-alpha.73`.
- Keep the existing ArgoCD PreSync migration hook enabled; its rendered migrator Job inherits the alpha.73 backend tag.
- Record in `AGENTS.md` that `v3` is the repository default and active development branch, while `dev` and `master` are legacy branches for the older Klicker variant and are not actively developed.
- Change no application code, chart templates, schema or migration files, dependencies, or secret values.

## Why

`v3.4.0-alpha.73` is published at release commit `bad33cae19680ab6e8f5be81cc5739caa19c8be6`. It contains the merged auth same-origin redirect fix from [auth fix PR #5570](https://github.com/uzh-bf/klicker-uzh/pull/5570).

Production still points at alpha.72. This PR advances the GitOps desired state to the new release; it does not merge, sync ArgoCD, or prove the live application.

## Branch Coverage

- Base: `v3` at `bad33cae19680ab6e8f5be81cc5739caa19c8be6`
- Head: `rs/deploy-roll-prd-alpha73` at `874e36c6e17712c8be6ec142d16d563abced319c`
- Reviewed: one commit; two files; 17 additions and 16 deletions
- Scope: exactly 15 production image-pin replacements plus the requested branch-policy clarification
- Packaging: isolated production-rollout exception to the usual substantive PR floor

## Review Focus

- Confirm all 15 production workloads move atomically to alpha.73.
- Confirm `migrator.enabled: true` remains unchanged and the inherited migrator image resolves to alpha.73.
- Confirm every unrelated production value remains unchanged.
- Confirm the branch guidance does not route active work to the legacy `dev` or `master` variants.

## Verification

Current head:

- 15 alpha.73 pins and zero alpha.72 pins in `deploy/env-uzh-prd/values.yaml`.
- `migrator.enabled: true` preserved.
- Helm lint passed for `deploy/charts/klicker-uzh-v3` with the production values.
- Helm rendering passed with 16 alpha.73 image references: 15 explicit pins plus the inherited migrator image.
- `node ./util/check-agents-md.mjs` passed with zero warnings.
- Scoped Prettier, `git diff --check`, and one-commit Gitleaks checks passed.
- The independent final review passed with no findings.

Release-artifact gate:

- 13 alpha.73 production image workflows were triggered for the release commit. At the latest read-back, 9 succeeded, frontend-manage was in progress, and analytics, backend-docker, and frontend-control were queued. The [auth image build](https://github.com/uzh-bf/klicker-uzh/actions/runs/32968250000) has succeeded; the [frontend-manage build](https://github.com/uzh-bf/klicker-uzh/actions/runs/32968249999), [backend build](https://github.com/uzh-bf/klicker-uzh/actions/runs/32968250044), and [analytics build](https://github.com/uzh-bf/klicker-uzh/actions/runs/32968250120) remain gates before merge.

## Delivery Contract

- Authority: branch creation, scoped edits, commit, push, and draft PR creation are authorized. Merge, cluster access, ArgoCD sync, database work, and live smoke proof remain withheld.
- Terminal: keep this PR in draft until all required alpha.73 production images, including the implicitly selected migrator image, are published from the release commit.
- Pause: leave the PR draft if any image is missing, fails, has mismatched provenance, or if the diff expands beyond the two included paths.

## Security / Privacy

- No secrets, production data, or private payloads are included.
- The final review found no concrete security or architecture issue; those lenses were not applicable to this mechanical pin and agent-guidance update.

## Blocking Before Merge

- [ ] All 13 production image workflows succeed and publish artifacts from the alpha.73 release commit.
- [ ] Complete the current production GitOps, migration, database-target, and rollback preflight.
- [ ] Obtain separate merge and production-rollout authority.

## Follow-Up After Merge

- [ ] Verify the exact ArgoCD revision, PreSync migration hook result, workload image identities, readiness, and the public community redirect under separately authorized live verification.

## Local Session Artifacts

Machine-local pointers on `Rolands-Mac-Studio.local`:

- Worktree: `trees/rs/deploy-roll-prd-alpha73`
- Review report: `project/_local/reviews/2026-08-26-alpha73-prd-combined-final.md`