### PR TITLE
chore(deploy): promote d110469d1510 to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -27,7 +27,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'b11e14489da2'
+        rollout.klicker.uzh.ch/release: 'd110469d1510'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -52,7 +52,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'b11e14489da2'
+        rollout.klicker.uzh.ch/release: 'd110469d1510'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -74,7 +74,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'b11e14489da2'
+        rollout.klicker.uzh.ch/release: 'd110469d1510'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -108,7 +108,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -162,7 +162,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -316,7 +316,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -368,7 +368,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -421,7 +421,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -473,7 +473,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -541,7 +541,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -593,7 +593,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
   replicaCount: 1
 
   affinity:
@@ -642,7 +642,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'b11e14489da2'
+    rollout.klicker.uzh.ch/release: 'd110469d1510'
 
   replicaCount: 1
 
@@ -695,7 +695,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'b11e14489da2'
+      rollout.klicker.uzh.ch/release: 'd110469d1510'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -758,7 +758,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'b11e14489da2'
+      rollout.klicker.uzh.ch/release: 'd110469d1510'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -835,7 +835,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'b11e14489da2'
+      rollout.klicker.uzh.ch/release: 'd110469d1510'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `d110469d1510bbe683f384824baa6f86502d75e1`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
