### PR TITLE
fix(chat): restore staging auto and student practice access

### DIFF
--- a/.agents/skills/klicker-graphql-api/SKILL.md
+++ b/.agents/skills/klicker-graphql-api/SKILL.md
@@ -32,6 +32,11 @@ Facts (auth ladder, layering, error conventions): [docs/graphql-api-layer.md](..
 
    Participant-facing fields usually need only `t.withAuth(asParticipant)`. Note `withPermission` returns `null` on failure (client sees a null field, not an error) — don't "fix" that. Owner-only aggregates that have no `PermissionCheck` key, including `KB`, keep the role gate on the schema field and must resolve the persisted owner relation inside every service entry point. Do not invent a permission key or make an owner-only aggregate shareable only to reuse this wrapper.
 
+   For participant course membership, check that the composite-key
+   `Participation` row exists. Never use `Participation.isActive` as enrollment
+   or access control: it is only the participant's course-leaderboard opt-in.
+   Student MCP practice additionally requires the exact chatbot/course pair.
+
    Multi-object batch fields are the deliberate exception: `withPermission`
    accepts one object selector and can only return one nullable field. Protect
    the batch with the appropriate `t.withAuth(...)` scope, then have the service

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -179,23 +179,26 @@ chat:
     enabled: false
 
   automaticModels:
-    primaryId: gpt-5.5
+    primaryId: auto
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
-    # "Auto" routes through the LiteLLM complexity-router, which self-selects the
-    # tier per request (SIMPLE=gpt-4.1, MEDIUM=gpt-5.4-low, COMPLEX=gpt-5.4-medium,
-    # REASONING=gpt-5.5-low). It is a normal selectable model (fallback: false), so
-    # it does NOT change automatic selection for existing chatbots — they still
-    # default to gpt-5.5. A chatbot can be pinned to Auto-only via its DB columns
+    # "Auto" routes through the LiteLLM auto-router, which self-selects the
+    # tier per request (SIMPLE=gpt-5.6-luna-medium, MEDIUM=gpt-5.6-luna-high,
+    # COMPLEX=gpt-5.6-luna-xhigh, REASONING=gpt-5.6-sol-medium; match_threshold
+    # 0.55). It is a normal selectable model (fallback: false) and is also the
+    # global automatic-model primary. Chatbots using automatic model selection
+    # therefore use Auto by default; explicit model selections remain respected.
+    # A chatbot can be pinned to Auto-only via its DB columns
     # (modelSelection=false + allowedModelIds=["auto"]); see the vorkurs chatbot.
-    # cost mirrors the gpt-5.4 tier (the typical COMPLEX route); REASONING (gpt-5.5)
-    # is rare. Tune if the routed mix shifts.
+    # cost mirrors the gpt-5.6-luna tier (the typical COMPLEX route); REASONING
+    # (gpt-5.6-sol-medium) is rare. Tune if the routed mix shifts.
     - id: auto
-      deploymentId: klickeruzh/azure/complexity-router
+      deploymentId: klickeruzh/azure/auto-router
       name: Auto
       description: Automatic model selection (routes to the best model per request)
       supportsImageAttachments: true
+      usesResponsesApi: true
       fallback: false
       cost:
         input: 1.25

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -2,7 +2,7 @@
 type: App Guide
 title: Chat Platform
 description: The apps/chat island — app router, zustand, assistant-ui, route-handler auth guards, and the model registry.
-timestamp: '2026-08-22'
+timestamp: '2026-08-26'
 tags:
   - frontend
   - chat
@@ -159,6 +159,9 @@ Participant practice questions reach the chat through a second FastMCP server, n
 Three properties matter when debugging it:
 
 - The lookup runs **only in `tutor` mode** (`src/app/api/chatbots/[chatbotId]/chat/route.ts`); other modes never register `start_student_practice_quiz`.
+- Student practice authorization requires a matching chatbot/course pair and an
+  existing `Participation` row for the participant. `Participation.isActive`
+  is only the course-leaderboard opt-in and must not gate MCP practice access.
 - A failed lookup degrades silently: the route logs `Student practice lookup failed; continuing without quiz candidates` and answers without the tool. A missing practice quiz is therefore an infrastructure symptom, not necessarily a model one.
 - `getStudentPracticeMcpUrl` falls back to `http://localhost:7080` **only** when `NODE_ENV=development`; in production an unset `MCP_STUDENT_URL`/`MCP_STUDENT_HOST` yields `null` and the feature is simply off. The devcontainer starts both `mcp-student` and `mcp-lecturer` through `package.json:dev:container`, so tutor-mode practice tools and lecturer tools are available without a separate MCP process.
 
@@ -179,6 +182,11 @@ direct GPT-5.6 picker option; the router's tier targets are internal.
 Both staging and production now use `auto` as the global automatic-model
 primary, so chatbots using automatic model selection use Auto by default.
 Chatbots with an explicit model selection can continue using that selection.
+Keep the `v3-ai` staging values aligned with this block when resolving merges:
+`CHAT_PRIMARY_MODEL_ID=auto`, the `auto` registry entry targets
+`klickeruzh/azure/auto-router`, and that entry sets `usesResponsesApi: true`.
+This repository controls those consumer values but does not prove that the
+external LiteLLM key or team is authorized for the deployment.
 Model registry capabilities separate the student-facing reasoning-effort
 selector from the provider protocol: `supportsReasoning` controls whether the
 effort picker is offered, while `usesResponsesApi` selects OpenAI Responses so

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -2,7 +2,7 @@
 type: Domain Model
 title: Domain Model
 description: Core entities (User vs Participant, Course, Element, activities), status lifecycles, and the two-track gamification system.
-timestamp: '2026-08-24'
+timestamp: '2026-08-26'
 tags:
   - backend
   - prisma
@@ -25,7 +25,7 @@ Schema sources live in [packages/prisma/src/prisma/schema/](../packages/prisma/s
 
 They are unrelated models — never conflate them. A `Participant` joins a `Course` through **`Participation`** (`@@unique([courseId, participantId])`, carries `isActive`) — the domain word is _Participation_, not "Enrollment". Course names like "Testkurs" are seed data only (`packages/prisma-data/src/data/seedTEST.ts`).
 
-`Participation.isActive` is the **course-leaderboard opt-in**, not an enrollment flag. It defaults to `false`; joining the course leaderboard flips it to `true`, and leaving the leaderboard sets it back to `false` while keeping the row and collected points. Assessment course access and assessment report issuance are backed by the **accepted course invitation** plus an active participant account — never by `Participation.isActive` — so leaderboard-inactive students keep their assessment access.
+`Participation.isActive` is the **course-leaderboard opt-in**, not an enrollment flag. It defaults to `false`; joining the course leaderboard flips it to `true`, and leaving the leaderboard sets it back to `false` while keeping the row and collected points. The existence of the `Participation` row is the course-membership check used by participant chatbot discovery and student MCP practice access. Assessment course access and assessment report issuance are backed by the **accepted course invitation** plus an active participant account — never by `Participation.isActive` — so leaderboard-inactive students keep their assessment and practice access.
 
 ### Assessment participant invitations
 

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -4123,7 +4123,7 @@ export async function getStudentMcpCoursePracticeQuiz(
       where: { courseId, id: chatbotId },
     }),
     ctx.prisma.participation.findUnique({
-      select: { id: true, isActive: true },
+      select: { id: true },
       where: {
         courseId_participantId: {
           courseId,
@@ -4133,7 +4133,7 @@ export async function getStudentMcpCoursePracticeQuiz(
     }),
   ])
 
-  if (!chatbot || !participation?.isActive) {
+  if (!chatbot || !participation) {
     return null
   }
 

--- a/packages/graphql/test/courseChatbots.test.ts
+++ b/packages/graphql/test/courseChatbots.test.ts
@@ -1,8 +1,9 @@
 import type { Hatchet } from '@hatchet-dev/typescript-sdk'
-import { PrismaClient, UserRole } from '@klicker-uzh/prisma/client'
-import { EventEmitter } from 'events'
+import { type PrismaClient, UserRole } from '@klicker-uzh/prisma/client'
+import type { EventEmitter } from 'events'
 import type { Context, ContextWithUser } from '../src/lib/context.js'
 import { getParticipantCourseChatbots } from '../src/services/chatbots.js'
+import { getStudentMcpCoursePracticeQuiz } from '../src/services/courses.js'
 import {
   initializePrisma,
   seedCourse,
@@ -58,14 +59,14 @@ describe('Integration tests for the public courseChatbots query', () => {
   }
 
   // participant tokens carry no scope (see createParticipantToken)
-  function participantContext(participantId: string): Context {
+  function participantContext(participantId: string): ContextWithUser {
     return {
       ...userOneCtx,
       user: {
         sub: participantId,
         role: UserRole.PARTICIPANT,
       },
-    } as unknown as Context
+    } as unknown as ContextWithUser
   }
 
   it('returns an empty list for anonymous visitors instead of throwing', async () => {
@@ -128,5 +129,83 @@ describe('Integration tests for the public courseChatbots query', () => {
         avatar: null,
       },
     ])
+  })
+
+  it('allows a leaderboard-inactive participant to load student MCP practice', async () => {
+    const { course, chatbot } = await seedCourseWithChatbot()
+    const participant = await prisma.participant.create({
+      data: {
+        username: 'studentMcpParticipantEnrolled',
+        password: 'abcdabcd',
+        participations: {
+          create: [{ courseId: course.id, isActive: false }],
+        },
+      },
+    })
+
+    const quiz = await getStudentMcpCoursePracticeQuiz(
+      { chatbotId: chatbot.id, courseId: course.id },
+      participantContext(participant.id)
+    )
+
+    expect(quiz?.courseId).toBe(course.id)
+    expect(
+      await prisma.participation.findUnique({
+        where: {
+          courseId_participantId: {
+            courseId: course.id,
+            participantId: participant.id,
+          },
+        },
+        select: { isActive: true },
+      })
+    ).toEqual({ isActive: false })
+  })
+
+  it('rejects student MCP practice for a participant outside the course', async () => {
+    const { course, chatbot } = await seedCourseWithChatbot()
+    const participant = await prisma.participant.create({
+      data: {
+        username: 'studentMcpParticipantUnenrolled',
+        password: 'abcdabcd',
+      },
+    })
+
+    const quiz = await getStudentMcpCoursePracticeQuiz(
+      { chatbotId: chatbot.id, courseId: course.id },
+      participantContext(participant.id)
+    )
+
+    expect(quiz).toBeNull()
+  })
+
+  it('rejects student MCP practice when the chatbot belongs to another course', async () => {
+    const { course } = await seedCourseWithChatbot()
+    const { chatbot: otherChatbot } = await seedCourseWithChatbot()
+    const participant = await prisma.participant.create({
+      data: {
+        username: 'studentMcpParticipantWrongChatbot',
+        password: 'abcdabcd',
+        participations: { create: [{ courseId: course.id }] },
+      },
+    })
+
+    const quiz = await getStudentMcpCoursePracticeQuiz(
+      { chatbotId: otherChatbot.id, courseId: course.id },
+      participantContext(participant.id)
+    )
+
+    expect(quiz).toBeNull()
+  })
+
+  it('rejects student MCP practice for a lecturer', async () => {
+    const { course, chatbot } = await seedCourseWithChatbot()
+
+    const quiz = await getStudentMcpCoursePracticeQuiz(
+      { chatbotId: chatbot.id, courseId: course.id },
+      userOneCtx
+    )
+
+    expect(quiz).toBeNull()
   })
 })

--- a/project/2026-08-26-staging-auto-student-practice-fix-plan.md
+++ b/project/2026-08-26-staging-auto-student-practice-fix-plan.md
@@ -112,6 +112,18 @@ runtime proof remain follow-up gates after merge and an authorized sync.
 - [x] Refreshed `origin/v3-ai` and created the isolated worktree at its exact
   head.
 - [x] Confirmed the stale model block and the leaderboard-opt-in coupling.
-- [ ] Implement the service, test, values, documentation, and skill changes.
-- [ ] Run targeted and full verification.
+- [x] Implemented the service, test, values, documentation, and skill changes.
+- [x] Verified the focused GraphQL spec: 8 tests passed, including the four new
+  authorization cases.
+- [x] Verified the focused GraphQL type check and schema-generation check.
+- [x] Rendered the staging Chat ConfigMap and confirmed `auto`,
+  `klickeruzh/azure/auto-router`, and Responses API support.
+- [x] Completed the repository-wide build: 26 of 26 tasks passed.
+- [x] Ran `check:all`: all 29 TypeScript check tasks passed, but the command
+  exited non-zero because the managed container lacks a C compiler for the
+  analytics package's first-time `pandas==2.2.2` build.
+- [x] Ran the wiki validator: it reported 19 existing bundle-wide frontmatter
+  errors and no new error in either changed guide.
+- [x] Rechecked target drift. `origin/v3-ai` advanced by one unrelated Manage
+  assistant-URL commit; no changed path overlaps this package.
 - [ ] Commit, push, and create the draft PR.

--- a/project/2026-08-26-staging-auto-student-practice-fix-plan.md
+++ b/project/2026-08-26-staging-auto-student-practice-fix-plan.md
@@ -126,4 +126,5 @@ runtime proof remain follow-up gates after merge and an authorized sync.
   errors and no new error in either changed guide.
 - [x] Rechecked target drift. `origin/v3-ai` advanced by one unrelated Manage
   assistant-URL commit; no changed path overlaps this package.
-- [ ] Commit, push, and create the draft PR.
+- [x] Committed and pushed the package, then opened draft PR #5586 against
+  `v3-ai`.

--- a/project/2026-08-26-staging-auto-student-practice-fix-plan.md
+++ b/project/2026-08-26-staging-auto-student-practice-fix-plan.md
@@ -1,0 +1,117 @@
+# Restore staging Auto routing and student practice access
+
+## Goal
+
+Restore the intended Luna-backed Auto model configuration on the `v3-ai`
+staging branch and let every enrolled participant use the tutor-mode student
+practice MCP, regardless of course-leaderboard opt-in.
+
+## Execution contract
+
+- **Repository:** `uzh-bf/klicker-uzh`
+- **Worktree:** `trees/rs/fix-stg-auto-student-practice`
+- **Branch:** `rs/fix-stg-auto-student-practice`
+- **Target:** `v3-ai`
+- **Fresh base:** `origin/v3-ai` at
+  `b9e38e89d22c6efbf0d5be1081eff1fa23f3e94c`, fetched 2026-08-26
+- **Authority:** edit, test, commit, push this branch, and create a draft PR
+  against `v3-ai`.
+- **Withheld:** merge, deployment, ArgoCD sync, cluster writes, secret changes,
+  live database changes, and external AI-deployment repository changes.
+- **Terminal:** a draft PR contains the source fix, regression coverage,
+  documentation, and verified check evidence.
+- **Pause:** stop if the target branch advances materially, the external
+  LiteLLM deployment does not expose or authorize `klickeruzh/azure/auto-router`,
+  or the fix requires a broader authentication or data-model change.
+
+This side conversation cannot dispatch the mandatory planner and final-reviewer
+passes. The PR therefore remains draft and explicitly records that review gap.
+
+## Root cause
+
+The `v3-ai` merge commit `d110469d1510` retained an obsolete staging model
+block during conflict resolution. It preserved `gpt-5.5` as the automatic
+primary and mapped `auto` to `klickeruzh/azure/complexity-router`, while current
+`v3` maps the automatic primary to `auto` and the model to
+`klickeruzh/azure/auto-router` with Responses API support.
+
+The student practice lookup independently treats `Participation.isActive` as
+course enrollment. That field is the course-leaderboard opt-in. Joining a
+course creates a `Participation` row with `isActive: false`, so ordinary
+enrolled participants are rejected before the student MCP can receive quiz
+candidates.
+
+## Product and authorization contracts
+
+| Primitive | Existing contract | Change |
+| --- | --- | --- |
+| Course participation | A `Participation` row connects a participant to a course | Reuse row existence as the student-practice membership gate |
+| Leaderboard participation | `Participation.isActive` opts into course points and leaderboard updates | Keep unchanged; stop using it as MCP authorization |
+| Student practice MCP | Tutor-mode tool for a participant, chatbot, and matching course | Allow enrolled participants whether leaderboard-active or inactive |
+| Staging Auto model | Global automatic model routed by the deployed LiteLLM Auto endpoint | Restore current `v3` Luna Auto registry values on `v3-ai` |
+
+The participant role check, exact chatbot/course pairing, course membership,
+student MCP JWT purpose and scopes, and tutor-mode gate remain unchanged. No
+new primitive, schema, migration, or ADR is needed because this restores the
+existing separation between enrollment and leaderboard policy.
+
+## Implementation slices
+
+### Slice 1: Student practice authorization
+
+- In `getStudentMcpCoursePracticeQuiz`, select only the participation id.
+- Require the participation row to exist instead of requiring `isActive`.
+- Add focused database-backed coverage for an inactive enrolled participant,
+  a participant without a participation row, a mismatched chatbot/course, and
+  a non-participant caller where the existing seam makes those cases cheap.
+
+Acceptance: an inactive enrolled participant receives the generated course
+practice quiz, while callers outside the existing course and role boundaries
+still receive `null`.
+
+### Slice 2: Staging model configuration
+
+- Restore the `automaticModels` and `modelRegistry` Auto entries from current
+  `origin/v3` into the `v3-ai` staging values file.
+- Preserve every `v3-ai`-specific MCP, KB, image-tag, rollout, and resource
+  setting around that block.
+- Confirm rendered environment variables select `auto`, target
+  `klickeruzh/azure/auto-router`, and enable Responses API for Auto.
+
+Acceptance: the values diff changes only the intended model block and the
+rendered Chat configuration contains the three expected values.
+
+### Slice 3: Documentation
+
+- Update the Chat platform guide with the student-practice membership rule and
+  the staging conflict-regression warning.
+- Update the domain-model guide so every consumer treats
+  `Participation.isActive` only as leaderboard opt-in.
+- Update the relevant GraphQL skill with this authorization invariant.
+
+Acceptance: documentation states the same boundary as the service and focused
+test, with no claim that this repository proves external LiteLLM key access.
+
+## Verification
+
+Run container-dependent commands in the task's managed devcontainer:
+
+1. Focused GraphQL test for the student practice access seam.
+2. Render the staging chart and inspect the Chat model environment variables.
+3. `pnpm run check:all`.
+4. `pnpm run build`.
+5. Inspect the complete diff, staged content, generated files, secrets, and
+   personal data before each commit.
+
+No browser check is required because the change has no frontend code or UI
+contract. No live staging smoke is authorized by this plan; deployment and
+runtime proof remain follow-up gates after merge and an authorized sync.
+
+## Progress
+
+- [x] Refreshed `origin/v3-ai` and created the isolated worktree at its exact
+  head.
+- [x] Confirmed the stale model block and the leaderboard-opt-in coupling.
+- [ ] Implement the service, test, values, documentation, and skill changes.
+- [ ] Run targeted and full verification.
+- [ ] Commit, push, and create the draft PR.


### PR DESCRIPTION
## What This Fixes

This PR restores the intended staging Auto model route and removes an incorrect
leaderboard dependency from student MCP practice access.

- STG Chat now selects `auto`, targets `klickeruzh/azure/auto-router`, and uses
  the Responses API, matching the current Luna/Sol configuration on `v3`.
- Student practice now treats an existing `Participation` row as course
  membership. `Participation.isActive` remains only the course-leaderboard
  opt-in.
- Existing participant-role, exact chatbot/course, and non-member boundaries
  remain enforced and have focused database-backed regression coverage.
- The domain guide, Chat platform guide, and GraphQL skill record the restored
  contracts.

## Branch Coverage

- Target: current `v3-ai@0fab2e33d`; branch merge-base:
  `b9e38e89d`
- Head: `c14a387df`
- Reviewed locally: 3 commits, 7 files, `+243/-18`; the final commit only
  records PR publication in the project plan
- Substantive size: `+113/-18` after excluding the committed project plan;
  this clears the packaging floor
- Target drift: one unrelated Manage assistant-URL commit with no overlapping
  changed path; this branch was not rebased or merged

## Review Focus

- Confirm `Participation.isActive` is not used as course enrollment or MCP
  access control.
- Confirm the participant-role, membership, and exact chatbot/course checks
  remain intact.
- Confirm the staging values change only the model block and preserve all
  `v3-ai` MCP, KB, image, resource, and rollout settings.
- Treat external LiteLLM authorization and live staging proof as separate
  rollout gates.

## Verification

Current implementation state (the final branch commit changes only plan
progress):

- `pnpm --filter @klicker-uzh/graphql test courseChatbots.test.ts` -> 8/8 tests
  passed in the managed Node 24 devcontainer
- `pnpm --filter @klicker-uzh/graphql check` -> passed, including GraphQL
  generation and schema-diff checks
- STG Chat ConfigMap render -> confirmed `CHAT_PRIMARY_MODEL_ID=auto`,
  `klickeruzh/azure/auto-router`, and `usesResponsesApi: true`
- `pnpm run build` -> 26/26 tasks passed in the managed Node 24 devcontainer
- Prettier check for changed Markdown/YAML -> passed
- `git diff --check` -> passed
- Staged gitleaks scan -> no findings

Failed/Warning:

- `pnpm run check:all` completed all 29 TypeScript check tasks, then failed in
  analytics lint because the managed container lacks a C compiler for the
  first-time `pandas==2.2.2` build.
- The repository wiki validator reports 19 pre-existing bundle-wide
  frontmatter errors; neither changed guide has a new validation error.
- The host pre-push build failed under unsupported Node 26 in the unchanged
  knowledge-graph package. The repository-pinned Node 24 container build above
  passed; the hook was skipped for publication.
- The required integrated final-reviewer pass is unavailable in this side
  conversation, so this PR remains draft.

## Security / Privacy

- No credentials, secret values, personal data, or production content are
  included.
- The source configuration does not prove that the STG Chat key or LiteLLM team
  is authorized for `klickeruzh/azure/auto-router`.
- The authorization change broadens practice access only from
  leaderboard-active members to all members; non-members, lecturers, and
  mismatched chatbot/course requests still return `null`.

## Blocking Before Merge

- [ ] Run the integrated final review when a reviewer route is available.
- [ ] Require applicable exact-head GitHub checks to pass and mark the draft
  ready.
- [ ] Merge requires separate authorization.

## Follow-Up After Merge

- Verify the STG Chat key/team can access `klickeruzh/azure/auto-router`.
- Deploy or sync the resulting STG revision under separate authorization.
- Smoke Auto routing and tutor-mode `start_student_practice_quiz` as a
  leaderboard-inactive enrolled student.

## Local Session Artifacts

- Machine: `MacBook-Pro`
- Worktree: `trees/rs/fix-stg-auto-student-practice` in repository
  `klicker-uzh`
- DevPod: `rs-fix-stg-auto-student-practice`; still running because an older
  managed `devrouter ensure` process owns the lifecycle lock and blocked the
  exact `devrouter stop` command
