### PR TITLE
feat(analytics): add participant data-use API

### DIFF
--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -2,7 +2,7 @@
 type: Data Layer
 title: Data & Migrations
 description: Split Prisma schema, the migrate→sync→build ritual, seeding paths, typed Json fields, and schema-level gotchas.
-timestamp: '2026-08-25'
+timestamp: '2026-08-26'
 tags:
   - backend
   - prisma
@@ -35,13 +35,21 @@ The Python twin (`apps/analytics/prisma/schema/py.prisma`) uses `prisma-client-p
 
 Participant-global data-use state lives in `Participant`: both research and
 learning-analytics choices default to `false` and retain only the current
-choice, choice time, and disclosure version. A future research export may
-include all stored canonical data when research consent is `true` and none when
-it is `false`. Learning-analytics re-enable uses
+choice, choice time, and disclosure version. The participant-only
+`selfDataUse` query exposes those seven fields; the generic `Participant`
+GraphQL object does not. The two Boolean mutations store server-owned
+disclosure version `v1` and use PostgreSQL transaction time. Learning-analytics
+changes take the global advisory gate with a bounded lock timeout; research
+changes do not take that gate.
+
+A future research export may include all stored canonical data when research
+consent is `true` and none when it is `false`. Learning-analytics re-enable uses
 `learningAnalyticsIncludedFrom` as a prospective boundary, with no backfill.
-`Participation` remains course membership and carries no
-per-course data-use choice or history. The schema foundation is inert until
-the owning export and analytics paths explicitly consume these fields.
+The existing individual analytics reads also require true current consent,
+complete metadata and `Course.analyticsLastComputedAt >=
+Participant.learningAnalyticsIncludedFrom`; aggregate and canonical outputs are
+unchanged. `Participation` remains course membership and carries no
+per-course data-use choice or history.
 
 Analytics tables keyed by a chatbot or live quiz do not duplicate `courseId`;
 course scope resolves through the owning `Chatbot` or `LiveQuiz`. This prevents

--- a/docs/data-and-migrations.md
+++ b/docs/data-and-migrations.md
@@ -38,9 +38,9 @@ learning-analytics choices default to `false` and retain only the current
 choice, choice time, and disclosure version. The participant-only
 `selfDataUse` query exposes those seven fields; the generic `Participant`
 GraphQL object does not. The two Boolean mutations store server-owned
-disclosure version `v1` and use PostgreSQL transaction time. Learning-analytics
-changes take the global advisory gate with a bounded lock timeout; research
-changes do not take that gate.
+disclosure version `v1` and capture PostgreSQL `clock_timestamp()` immediately
+before the write. Learning-analytics changes take the global advisory gate with
+a bounded lock timeout; research changes do not take that gate.
 
 A future research export may include all stored canonical data when research
 consent is `true` and none when it is `false`. Learning-analytics re-enable uses

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -40,8 +40,9 @@ canonical data for that participant; `false` excludes all of it. Returning to
 `true` makes all stored canonical data eligible for future exports again.
 `learningAnalyticsConsent` follows the same current-state rule: `true` makes
 all stored canonical data eligible for learning analytics and `false` excludes
-all of it. The separate
-`Course.isLearningAnalyticsEnabled` course control also defaults to `false`.
+all of it. Individual results become readable only after a course computation
+newer than the current choice. The separate `Course.isLearningAnalyticsEnabled`
+course control also defaults to `false`.
 
 `Participation` remains the course-membership row and keeps its existing
 leaderboard meaning. It carries no research or learning-analytics choice or
@@ -49,9 +50,8 @@ history, and participants have no per-course data-use choice in this schema.
 
 The public Prisma schema is the sole authority for these models. Catalyst must
 pin the exact immutable public commit and digest it consumes; a moving branch,
-dirty tree, or generated Analytics mirror is not provenance. These fields are
-an inert schema foundation: their presence does not enable export, computation,
-or workflow dispatch by itself.
+dirty tree, or generated Analytics mirror is not provenance. The stored fields
+alone do not enable export, computation, or workflow dispatch.
 
 Chatbot and live-quiz analytics rows reference their owning `Chatbot` or
 `LiveQuiz` instead of storing a second, independently writable `courseId`.

--- a/docs/graphql-api-layer.md
+++ b/docs/graphql-api-layer.md
@@ -2,7 +2,7 @@
 type: API Layer
 title: GraphQL API Layer
 description: Pothos code-first schema, the three-layer authorization pattern, service contract, operation naming, and the codegen ritual.
-timestamp: '2026-08-21'
+timestamp: '2026-08-26'
 tags:
   - backend
   - graphql
@@ -48,6 +48,32 @@ pnpm --filter @klicker-uzh/graphql generate
 ```
 
 The package build runs this generation before Rollup. Commit the handwritten operation/schema sources and the generated `src/public/schema.graphql` SDL snapshot; do not commit `src/ops.ts` or `src/public/{client,server}.json`, which are ignored build outputs. Frontends import typed documents from `@klicker-uzh/graphql/dist/ops`, and outside dev/test the backend only executes hashes present in `server.json` (see [Architecture Overview](./architecture-overview.md)). A missing generation step fails in two distinct ways: typecheck errors for missing documents or runtime persisted-query rejection for an unknown hash.
+
+### Participant data-use API
+
+`selfDataUse` is the only GraphQL read for participant research and
+learning-analytics choices. It requires an authenticated `PARTICIPANT` login
+and returns exactly the seven current-state `Participant` fields: the two
+Boolean choices, their choice timestamps and disclosure versions, and the
+learning-analytics inclusion boundary. The generic `Participant` object does
+not expose any of these fields, so public profiles and lecturer-facing queries
+cannot reveal them.
+
+`setResearchConsent` and `setLearningAnalyticsConsent` are separate participant
+mutations. Each accepts only a Boolean `consent`; the server records disclosure
+version `v1`. The mutations retain current state only. Same-value requests with
+recorded `v1` metadata are no-ops; a new disclosure version updates choice
+metadata without moving the learning-analytics boundary. Learning-analytics
+changes use PostgreSQL `clock_timestamp()` and the global advisory gate after a
+bounded `SET LOCAL lock_timeout`; research changes do not take that gate.
+
+Existing individual analytics reads apply the learning-analytics predicate in
+their source queries. A participant result is returned only when the current
+choice is true, all choice metadata and the inclusion boundary are present, and
+the course's `analyticsLastComputedAt` is on or after that boundary. Aggregate
+and canonical outputs are unaffected. The read paths use a repeatable database
+snapshot while resolving eligible participant IDs, so withdrawn or not-yet-
+recomputed individual rows never reach the response for that snapshot.
 
 ### Assessment invitation API
 

--- a/docs/graphql-api-layer.md
+++ b/docs/graphql-api-layer.md
@@ -53,27 +53,25 @@ The package build runs this generation before Rollup. Commit the handwritten ope
 
 `selfDataUse` is the only GraphQL read for participant research and
 learning-analytics choices. It requires an authenticated `PARTICIPANT` login
-and returns exactly the seven current-state `Participant` fields: the two
-Boolean choices, their choice timestamps and disclosure versions, and the
-learning-analytics inclusion boundary. The generic `Participant` object does
+and returns exactly the six current-state `Participant` fields: the two
+Boolean choices, their choice timestamps, and disclosure versions. The generic `Participant` object does
 not expose any of these fields, so public profiles and lecturer-facing queries
 cannot reveal them.
 
 `setResearchConsent` and `setLearningAnalyticsConsent` are separate participant
 mutations. Each accepts only a Boolean `consent`; the server records disclosure
 version `v1`. The mutations retain current state only. Same-value requests with
-recorded `v1` metadata are no-ops; a new disclosure version updates choice
-metadata without moving the learning-analytics boundary. Learning-analytics
+recorded `v1` metadata are no-ops; otherwise the server records the new choice
+timestamp and disclosure version. Learning-analytics
 changes use PostgreSQL `clock_timestamp()` and the global advisory gate after a
 bounded `SET LOCAL lock_timeout`; research changes do not take that gate.
 
 Existing individual analytics reads apply the learning-analytics predicate in
 their source queries. A participant result is returned only when the current
-choice is true, all choice metadata and the inclusion boundary are present, and
-the course's `analyticsLastComputedAt` is on or after that boundary. Aggregate
+choice is true, all choice metadata is present, and the course's
+`analyticsLastComputedAt` is strictly newer than the current choice timestamp.
+Aggregate
 and canonical outputs are unaffected. The read paths use a repeatable database
-snapshot while resolving eligible participant IDs, so withdrawn or not-yet-
-recomputed individual rows never reach the response for that snapshot.
 
 ### Assessment invitation API
 

--- a/packages/graphql/src/graphql/ops/FParticipantDataUseData.graphql
+++ b/packages/graphql/src/graphql/ops/FParticipantDataUseData.graphql
@@ -5,5 +5,4 @@ fragment ParticipantDataUseData on ParticipantDataUse {
   learningAnalyticsConsent
   learningAnalyticsChoiceAt
   learningAnalyticsDisclosureVersion
-  learningAnalyticsIncludedFrom
 }

--- a/packages/graphql/src/graphql/ops/FParticipantDataUseData.graphql
+++ b/packages/graphql/src/graphql/ops/FParticipantDataUseData.graphql
@@ -1,0 +1,9 @@
+fragment ParticipantDataUseData on ParticipantDataUse {
+  researchConsent
+  researchConsentChoiceAt
+  researchConsentDisclosureVersion
+  learningAnalyticsConsent
+  learningAnalyticsChoiceAt
+  learningAnalyticsDisclosureVersion
+  learningAnalyticsIncludedFrom
+}

--- a/packages/graphql/src/graphql/ops/MSetLearningAnalyticsConsent.graphql
+++ b/packages/graphql/src/graphql/ops/MSetLearningAnalyticsConsent.graphql
@@ -1,0 +1,11 @@
+mutation SetLearningAnalyticsConsent($consent: Boolean!) {
+  setLearningAnalyticsConsent(consent: $consent) {
+    researchConsent
+    researchConsentChoiceAt
+    researchConsentDisclosureVersion
+    learningAnalyticsConsent
+    learningAnalyticsChoiceAt
+    learningAnalyticsDisclosureVersion
+    learningAnalyticsIncludedFrom
+  }
+}

--- a/packages/graphql/src/graphql/ops/MSetLearningAnalyticsConsent.graphql
+++ b/packages/graphql/src/graphql/ops/MSetLearningAnalyticsConsent.graphql
@@ -1,11 +1,5 @@
 mutation SetLearningAnalyticsConsent($consent: Boolean!) {
   setLearningAnalyticsConsent(consent: $consent) {
-    researchConsent
-    researchConsentChoiceAt
-    researchConsentDisclosureVersion
-    learningAnalyticsConsent
-    learningAnalyticsChoiceAt
-    learningAnalyticsDisclosureVersion
-    learningAnalyticsIncludedFrom
+    ...ParticipantDataUseData
   }
 }

--- a/packages/graphql/src/graphql/ops/MSetResearchConsent.graphql
+++ b/packages/graphql/src/graphql/ops/MSetResearchConsent.graphql
@@ -1,0 +1,11 @@
+mutation SetResearchConsent($consent: Boolean!) {
+  setResearchConsent(consent: $consent) {
+    researchConsent
+    researchConsentChoiceAt
+    researchConsentDisclosureVersion
+    learningAnalyticsConsent
+    learningAnalyticsChoiceAt
+    learningAnalyticsDisclosureVersion
+    learningAnalyticsIncludedFrom
+  }
+}

--- a/packages/graphql/src/graphql/ops/MSetResearchConsent.graphql
+++ b/packages/graphql/src/graphql/ops/MSetResearchConsent.graphql
@@ -1,11 +1,5 @@
 mutation SetResearchConsent($consent: Boolean!) {
   setResearchConsent(consent: $consent) {
-    researchConsent
-    researchConsentChoiceAt
-    researchConsentDisclosureVersion
-    learningAnalyticsConsent
-    learningAnalyticsChoiceAt
-    learningAnalyticsDisclosureVersion
-    learningAnalyticsIncludedFrom
+    ...ParticipantDataUseData
   }
 }

--- a/packages/graphql/src/graphql/ops/QGetParticipantDataUse.graphql
+++ b/packages/graphql/src/graphql/ops/QGetParticipantDataUse.graphql
@@ -1,0 +1,11 @@
+query GetParticipantDataUse {
+  selfDataUse {
+    researchConsent
+    researchConsentChoiceAt
+    researchConsentDisclosureVersion
+    learningAnalyticsConsent
+    learningAnalyticsChoiceAt
+    learningAnalyticsDisclosureVersion
+    learningAnalyticsIncludedFrom
+  }
+}

--- a/packages/graphql/src/graphql/ops/QGetParticipantDataUse.graphql
+++ b/packages/graphql/src/graphql/ops/QGetParticipantDataUse.graphql
@@ -1,11 +1,5 @@
 query GetParticipantDataUse {
   selfDataUse {
-    researchConsent
-    researchConsentChoiceAt
-    researchConsentDisclosureVersion
-    learningAnalyticsConsent
-    learningAnalyticsChoiceAt
-    learningAnalyticsDisclosureVersion
-    learningAnalyticsIncludedFrom
+    ...ParticipantDataUseData
   }
 }

--- a/packages/graphql/src/lib/learningAnalytics.ts
+++ b/packages/graphql/src/lib/learningAnalytics.ts
@@ -23,7 +23,6 @@ export type ParticipantDataUseFields = Pick<
   | 'learningAnalyticsConsent'
   | 'learningAnalyticsChoiceAt'
   | 'learningAnalyticsDisclosureVersion'
-  | 'learningAnalyticsIncludedFrom'
 >
 
 export const participantDataUseSelect = {
@@ -33,5 +32,4 @@ export const participantDataUseSelect = {
   learningAnalyticsConsent: true,
   learningAnalyticsChoiceAt: true,
   learningAnalyticsDisclosureVersion: true,
-  learningAnalyticsIncludedFrom: true,
 } satisfies DB.Prisma.ParticipantSelect

--- a/packages/graphql/src/lib/learningAnalytics.ts
+++ b/packages/graphql/src/lib/learningAnalytics.ts
@@ -1,0 +1,47 @@
+import type * as DB from '@klicker-uzh/prisma/client'
+
+/**
+ * The version identifies the disclosure shown with the current participant
+ * choice. It is owned by the server; clients only submit the Boolean choice.
+ */
+export const PARTICIPANT_DATA_USE_DISCLOSURE_VERSION = 'v1'
+
+/**
+ * This gate serializes global learning-analytics choice changes with course
+ * writers. The two-key form is shared with the course-level analytics code.
+ */
+export const LEARNING_ANALYTICS_ADVISORY_LOCK = {
+  classId: 1279340545,
+  objectId: 0,
+} as const
+
+export const learningAnalyticsParticipantWhere = {
+  learningAnalyticsConsent: true,
+  learningAnalyticsChoiceAt: { not: null },
+  // Raw read predicates additionally trim this value. Prisma relation filters
+  // cannot compare the trimmed value, but excluding the empty string here
+  // keeps the ORM guard aligned for ordinary recorded states.
+  learningAnalyticsDisclosureVersion: { not: '' },
+  learningAnalyticsIncludedFrom: { not: null },
+} satisfies DB.Prisma.ParticipantWhereInput
+
+export type ParticipantDataUseFields = Pick<
+  DB.Participant,
+  | 'researchConsent'
+  | 'researchConsentChoiceAt'
+  | 'researchConsentDisclosureVersion'
+  | 'learningAnalyticsConsent'
+  | 'learningAnalyticsChoiceAt'
+  | 'learningAnalyticsDisclosureVersion'
+  | 'learningAnalyticsIncludedFrom'
+>
+
+export const participantDataUseSelect = {
+  researchConsent: true,
+  researchConsentChoiceAt: true,
+  researchConsentDisclosureVersion: true,
+  learningAnalyticsConsent: true,
+  learningAnalyticsChoiceAt: true,
+  learningAnalyticsDisclosureVersion: true,
+  learningAnalyticsIncludedFrom: true,
+} satisfies DB.Prisma.ParticipantSelect

--- a/packages/graphql/src/lib/learningAnalytics.ts
+++ b/packages/graphql/src/lib/learningAnalytics.ts
@@ -15,16 +15,6 @@ export const LEARNING_ANALYTICS_ADVISORY_LOCK = {
   objectId: 0,
 } as const
 
-export const learningAnalyticsParticipantWhere = {
-  learningAnalyticsConsent: true,
-  learningAnalyticsChoiceAt: { not: null },
-  // Raw read predicates additionally trim this value. Prisma relation filters
-  // cannot compare the trimmed value, but excluding the empty string here
-  // keeps the ORM guard aligned for ordinary recorded states.
-  learningAnalyticsDisclosureVersion: { not: '' },
-  learningAnalyticsIncludedFrom: { not: null },
-} satisfies DB.Prisma.ParticipantWhereInput
-
 export type ParticipantDataUseFields = Pick<
   DB.Participant,
   | 'researchConsent'

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -2366,7 +2366,6 @@ type ParticipantDataUse {
   learningAnalyticsChoiceAt: Date
   learningAnalyticsConsent: Boolean!
   learningAnalyticsDisclosureVersion: String
-  learningAnalyticsIncludedFrom: Date
   researchConsent: Boolean!
   researchConsentChoiceAt: Date
   researchConsentDisclosureVersion: String

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -2082,7 +2082,9 @@ type Mutation {
   scheduleLiveQuiz(availableFrom: Date, id: String!): LiveQuizMeta
   sendMagicLink(usernameOrEmail: String!): Boolean
   setActivityReviewStatus(activityId: String!, activityType: ActivityType!, isReviewed: Boolean!): ReviewStatus
+  setLearningAnalyticsConsent(consent: Boolean!): ParticipantDataUse
   setLiveQuizPin(liveQuizId: String!, pin: String!): Boolean!
+  setResearchConsent(consent: Boolean!): ParticipantDataUse
   shareElementsBatch(elementIds: [Int!]!, permissionLevel: PermissionLevel!, shortnameOrEmail: String, userGroupId: Int): ElementBatchSharingResult!
   shareObject(objectId: String!, objectType: ObjectType!, permissionLevel: PermissionLevel!, propagation: Boolean!, shortnameOrEmail: String, userGroupId: Int): PermissionInfo
   startCourseDuplication(color: String, description: String, displayName: String!, duplicateGroupActivities: Boolean, duplicateLiveQuizzes: Boolean, duplicateMicrolearnings: Boolean, duplicatePracticeQuizzes: Boolean, endDate: Date!, groupDeadlineDate: Date!, isGamificationEnabled: Boolean, isGroupCreationEnabled: Boolean!, language: LocaleType!, maxGroupSize: Int!, name: String!, notificationEmail: String, preferredGroupSize: Int!, sourceCourseId: String!, startDate: Date!): CourseDuplicationStatus
@@ -2358,6 +2360,16 @@ type ParticipantCourseActivity {
   activeWeeks: Int!
   activityLevel: ActivityLevel!
   meanElementsPerDay: Float!
+}
+
+type ParticipantDataUse {
+  learningAnalyticsChoiceAt: Date
+  learningAnalyticsConsent: Boolean!
+  learningAnalyticsDisclosureVersion: String
+  learningAnalyticsIncludedFrom: Date
+  researchConsent: Boolean!
+  researchConsentChoiceAt: Date
+  researchConsentDisclosureVersion: String
 }
 
 type ParticipantGroup {
@@ -2643,6 +2655,7 @@ type Query {
   previousPointCorrections(courseId: String, instanceId: Int, liveQuizId: String): [PointCorrection!]
   publicParticipantProfile(participantId: String!): Participant
   self(liveQuizId: String): Participant
+  selfDataUse: ParticipantDataUse
   selfWithAchievements: ParticipantWithAchievements
   shortnameQuizzes(shortname: String!): [LiveQuiz!]
   studentAssessmentResults(courseId: String!): StudentAssessmentResults

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -57,6 +57,7 @@ import {
   GroupMessage,
   LeaveCourseParticipation,
   Participant,
+  ParticipantDataUse,
   ParticipantGroup,
   ParticipantLearningData,
   ParticipantTokenData,
@@ -451,6 +452,28 @@ export const Mutation = builder.mutationType({
         },
         resolve: async (_, args, ctx) => {
           return await ParticipantService.updateParticipantAvatar(args, ctx)
+        },
+      }),
+
+      setResearchConsent: t.withAuth(asParticipant).field({
+        nullable: true,
+        type: ParticipantDataUse,
+        args: {
+          consent: t.arg.boolean({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ParticipantService.setResearchConsent(args, ctx)
+        },
+      }),
+
+      setLearningAnalyticsConsent: t.withAuth(asParticipant).field({
+        nullable: true,
+        type: ParticipantDataUse,
+        args: {
+          consent: t.arg.boolean({ required: true }),
+        },
+        resolve: async (_, args, ctx) => {
+          return await ParticipantService.setLearningAnalyticsConsent(args, ctx)
         },
       }),
 

--- a/packages/graphql/src/schema/participant.ts
+++ b/packages/graphql/src/schema/participant.ts
@@ -1,31 +1,32 @@
-import * as DB from '@klicker-uzh/prisma/client'
-import {
-  type AvatarSettingsInput as AvatarSettingsInputType,
-  type AvatarSettings as AvatarSettingsType,
-  type SubscriptionKeysInput as SubscriptionKeysInputType,
-  type SubscriptionObjectInput as SubscriptionObjectInputType,
+import type * as DB from '@klicker-uzh/prisma/client'
+import type {
+  AvatarSettingsInput as AvatarSettingsInputType,
+  AvatarSettings as AvatarSettingsType,
+  SubscriptionKeysInput as SubscriptionKeysInputType,
+  SubscriptionObjectInput as SubscriptionObjectInputType,
 } from '@klicker-uzh/types'
 import { levelFromXp } from '@klicker-uzh/util'
 import builder from '../builder.js'
+import type { ParticipantDataUseFields } from '../lib/learningAnalytics.js'
 import {
+  AchievementRef,
   type IAchievement,
   type IParticipantAchievementInstance,
-  AchievementRef,
   ParticipantAchievementInstanceRef,
 } from './achievement.js'
 import {
+  CourseRef,
+  GroupLeaderboardEntry,
   type ICourse,
   type IGroupLeaderboardEntry,
   type ILeaderboardEntry,
   type ILeaderboardStatistics,
-  CourseRef,
-  GroupLeaderboardEntry,
   LeaderboardEntryRef,
   LeaderboardStatistics,
 } from './course.js'
 import {
-  type IGroupActivityInstance,
   GroupActivityInstanceRef,
+  type IGroupActivityInstance,
 } from './groupActivity.js'
 import { LocaleType, UserRole } from './user.js'
 
@@ -99,6 +100,35 @@ export const AvatarSettings = AvatarSettingsRef.implement({
     hairColor: t.exposeString('hairColor'),
     clothing: t.exposeString('clothing'),
     clothingColor: t.exposeString('clothingColor'),
+  }),
+})
+
+export const ParticipantDataUseRef =
+  builder.objectRef<ParticipantDataUseFields>('ParticipantDataUse')
+export const ParticipantDataUse = ParticipantDataUseRef.implement({
+  fields: (t) => ({
+    researchConsent: t.exposeBoolean('researchConsent'),
+    researchConsentChoiceAt: t.expose('researchConsentChoiceAt', {
+      type: 'Date',
+      nullable: true,
+    }),
+    researchConsentDisclosureVersion: t.exposeString(
+      'researchConsentDisclosureVersion',
+      { nullable: true }
+    ),
+    learningAnalyticsConsent: t.exposeBoolean('learningAnalyticsConsent'),
+    learningAnalyticsChoiceAt: t.expose('learningAnalyticsChoiceAt', {
+      type: 'Date',
+      nullable: true,
+    }),
+    learningAnalyticsDisclosureVersion: t.exposeString(
+      'learningAnalyticsDisclosureVersion',
+      { nullable: true }
+    ),
+    learningAnalyticsIncludedFrom: t.expose('learningAnalyticsIncludedFrom', {
+      type: 'Date',
+      nullable: true,
+    }),
   }),
 })
 

--- a/packages/graphql/src/schema/participant.ts
+++ b/packages/graphql/src/schema/participant.ts
@@ -125,10 +125,6 @@ export const ParticipantDataUse = ParticipantDataUseRef.implement({
       'learningAnalyticsDisclosureVersion',
       { nullable: true }
     ),
-    learningAnalyticsIncludedFrom: t.expose('learningAnalyticsIncludedFrom', {
-      type: 'Date',
-      nullable: true,
-    }),
   }),
 })
 

--- a/packages/graphql/src/schema/query.ts
+++ b/packages/graphql/src/schema/query.ts
@@ -82,6 +82,7 @@ import {
 import { MicroLearning } from './microLearning.js'
 import {
   Participant,
+  ParticipantDataUse,
   ParticipantGroup,
   ParticipantLearningData,
   ParticipantWithAchievements,
@@ -140,6 +141,14 @@ export const Query = builder.queryType({
         type: Participant,
         args: { liveQuizId: t.arg.string({ required: false }) },
         resolve: async (_, args, ctx) => ParticipantService.getSelf(args, ctx),
+      }),
+
+      selfDataUse: t.withAuth(asParticipant).field({
+        nullable: true,
+        type: ParticipantDataUse,
+        resolve: async (_, __, ctx) => {
+          return await ParticipantService.getParticipantDataUse(ctx)
+        },
       }),
 
       selfWithAchievements: t.withAuth(asParticipant).field({

--- a/packages/graphql/src/services/analytics.ts
+++ b/packages/graphql/src/services/analytics.ts
@@ -25,10 +25,8 @@ async function getEligibleParticipantIdsForCourseAnalytics(
       AND p."learningAnalyticsConsent" IS TRUE
       AND p."learningAnalyticsChoiceAt" IS NOT NULL
       AND NULLIF(btrim(p."learningAnalyticsDisclosureVersion"), '') IS NOT NULL
-      AND p."learningAnalyticsIncludedFrom" IS NOT NULL
-      AND p."learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt"
       AND c."analyticsLastComputedAt" IS NOT NULL
-      AND c."analyticsLastComputedAt" >= p."learningAnalyticsIncludedFrom"
+      AND c."analyticsLastComputedAt" > p."learningAnalyticsChoiceAt"
   `
 
   return rows.map(({ participantId }) => participantId)
@@ -65,10 +63,8 @@ async function getEligibleParticipantIdsForPerformanceAnalytics(
     WHERE p."learningAnalyticsConsent" IS TRUE
       AND p."learningAnalyticsChoiceAt" IS NOT NULL
       AND NULLIF(btrim(p."learningAnalyticsDisclosureVersion"), '') IS NOT NULL
-      AND p."learningAnalyticsIncludedFrom" IS NOT NULL
-      AND p."learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt"
       AND c."analyticsLastComputedAt" IS NOT NULL
-      AND c."analyticsLastComputedAt" >= p."learningAnalyticsIncludedFrom"
+      AND c."analyticsLastComputedAt" > p."learningAnalyticsChoiceAt"
   `
 
   return rows.map(({ participantId }) => participantId)

--- a/packages/graphql/src/services/analytics.ts
+++ b/packages/graphql/src/services/analytics.ts
@@ -11,7 +11,6 @@ import { ActivityType } from '@klicker-uzh/types'
 import type { PrismaTransactionClient } from '@klicker-uzh/util'
 import dayjs from 'dayjs'
 import type { ContextWithUser } from '@/lib/context.js'
-import { learningAnalyticsParticipantWhere } from '../lib/learningAnalytics.js'
 
 async function getEligibleParticipantIdsForCourseAnalytics(
   prisma: PrismaTransactionClient,
@@ -59,7 +58,7 @@ async function getEligibleParticipantIdsForPerformanceAnalytics(
       JOIN "MicroLearning" AS ml ON ml."id" = pap."microLearningId"
       WHERE ml."courseId" = CAST(${courseId} AS uuid)
     )
-    SELECT DISTINCT individual_rows."participantId" AS "participantId"
+    SELECT individual_rows."participantId" AS "participantId"
     FROM individual_rows
     JOIN "Participant" AS p ON p."id" = individual_rows."participantId"
     JOIN "Course" AS c ON c."id" = CAST(${courseId} AS uuid)
@@ -92,10 +91,7 @@ export async function getCourseActivityAnalytics(
           },
           aggregatedCourseAnalytics: true,
           participantCourseAnalytics: {
-            where: {
-              participantId: { in: eligibleParticipantIds },
-              participant: learningAnalyticsParticipantWhere,
-            },
+            where: { participantId: { in: eligibleParticipantIds } },
           },
         },
       })
@@ -145,7 +141,11 @@ export async function getCourseActivityAnalytics(
         participantCourseAnalytics: course.participantCourseAnalytics,
       }
     },
-    { isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead }
+    {
+      maxWait: 10_000,
+      timeout: 60_000,
+      isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead,
+    }
   )
 }
 
@@ -556,7 +556,6 @@ export async function getCoursePerformanceAnalytics(
         await getEligibleParticipantIdsForPerformanceAnalytics(prisma, courseId)
       const participantFilter = {
         participantId: { in: eligibleParticipantIds },
-        participant: learningAnalyticsParticipantWhere,
       }
       const course = await prisma.course.findUnique({
         where: { id: courseId },
@@ -648,7 +647,11 @@ export async function getCoursePerformanceAnalytics(
         activityFeedbacks,
       }
     },
-    { isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead }
+    {
+      maxWait: 10_000,
+      timeout: 60_000,
+      isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead,
+    }
   )
 }
 

--- a/packages/graphql/src/services/analytics.ts
+++ b/packages/graphql/src/services/analytics.ts
@@ -1,76 +1,152 @@
-import { ContextWithUser } from '@/lib/context.js'
 import * as DB from '@klicker-uzh/prisma/client'
-import {
+import type {
   ActivityFeedback,
   ActivityPerformance,
-  ActivityType,
   InstanceFeedback,
   InstancePerformance,
   InstanceQuizAnalytics,
   ParticipantActivityPerformance,
 } from '@klicker-uzh/types'
+import { ActivityType } from '@klicker-uzh/types'
+import type { PrismaTransactionClient } from '@klicker-uzh/util'
 import dayjs from 'dayjs'
+import type { ContextWithUser } from '@/lib/context.js'
+import { learningAnalyticsParticipantWhere } from '../lib/learningAnalytics.js'
+
+async function getEligibleParticipantIdsForCourseAnalytics(
+  prisma: PrismaTransactionClient,
+  courseId: string
+) {
+  const rows = await prisma.$queryRaw<Array<{ participantId: string }>>`
+    SELECT pca."participantId" AS "participantId"
+    FROM "ParticipantCourseAnalytics" AS pca
+    JOIN "Participant" AS p ON p."id" = pca."participantId"
+    JOIN "Course" AS c ON c."id" = pca."courseId"
+    WHERE pca."courseId" = CAST(${courseId} AS uuid)
+      AND p."learningAnalyticsConsent" IS TRUE
+      AND p."learningAnalyticsChoiceAt" IS NOT NULL
+      AND NULLIF(btrim(p."learningAnalyticsDisclosureVersion"), '') IS NOT NULL
+      AND p."learningAnalyticsIncludedFrom" IS NOT NULL
+      AND p."learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt"
+      AND c."analyticsLastComputedAt" IS NOT NULL
+      AND c."analyticsLastComputedAt" >= p."learningAnalyticsIncludedFrom"
+  `
+
+  return rows.map(({ participantId }) => participantId)
+}
+
+async function getEligibleParticipantIdsForPerformanceAnalytics(
+  prisma: PrismaTransactionClient,
+  courseId: string
+) {
+  const rows = await prisma.$queryRaw<Array<{ participantId: string }>>`
+    WITH individual_rows AS (
+      SELECT pp."participantId" AS "participantId"
+      FROM "ParticipantPerformance" AS pp
+      WHERE pp."courseId" = CAST(${courseId} AS uuid)
+
+      UNION
+
+      SELECT pap."participantId" AS "participantId"
+      FROM "ParticipantActivityPerformance" AS pap
+      JOIN "PracticeQuiz" AS pq ON pq."id" = pap."practiceQuizId"
+      WHERE pq."courseId" = CAST(${courseId} AS uuid)
+
+      UNION
+
+      SELECT pap."participantId" AS "participantId"
+      FROM "ParticipantActivityPerformance" AS pap
+      JOIN "MicroLearning" AS ml ON ml."id" = pap."microLearningId"
+      WHERE ml."courseId" = CAST(${courseId} AS uuid)
+    )
+    SELECT DISTINCT individual_rows."participantId" AS "participantId"
+    FROM individual_rows
+    JOIN "Participant" AS p ON p."id" = individual_rows."participantId"
+    JOIN "Course" AS c ON c."id" = CAST(${courseId} AS uuid)
+    WHERE p."learningAnalyticsConsent" IS TRUE
+      AND p."learningAnalyticsChoiceAt" IS NOT NULL
+      AND NULLIF(btrim(p."learningAnalyticsDisclosureVersion"), '') IS NOT NULL
+      AND p."learningAnalyticsIncludedFrom" IS NOT NULL
+      AND p."learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt"
+      AND c."analyticsLastComputedAt" IS NOT NULL
+      AND c."analyticsLastComputedAt" >= p."learningAnalyticsIncludedFrom"
+  `
+
+  return rows.map(({ participantId }) => participantId)
+}
 
 export async function getCourseActivityAnalytics(
   { courseId }: { courseId: string },
   ctx: ContextWithUser
 ) {
-  const course = await ctx.prisma.course.findUnique({
-    where: { id: courseId },
-    include: {
-      participations: true,
-      aggregatedAnalytics: {
-        orderBy: { timestamp: 'asc' },
-      },
-      aggregatedCourseAnalytics: true,
-      participantCourseAnalytics: true,
+  return ctx.prisma.$transaction(
+    async (prisma) => {
+      const eligibleParticipantIds =
+        await getEligibleParticipantIdsForCourseAnalytics(prisma, courseId)
+      const course = await prisma.course.findUnique({
+        where: { id: courseId },
+        include: {
+          participations: true,
+          aggregatedAnalytics: {
+            orderBy: { timestamp: 'asc' },
+          },
+          aggregatedCourseAnalytics: true,
+          participantCourseAnalytics: {
+            where: {
+              participantId: { in: eligibleParticipantIds },
+              participant: learningAnalyticsParticipantWhere,
+            },
+          },
+        },
+      })
+
+      if (!course) {
+        return null
+      }
+
+      // map daily and weekly student activity into the format required by the frontend
+      const dailyActivity = course.aggregatedAnalytics
+        .filter((analytics) => analytics.type === 'DAILY')
+        .map((analytics) => ({
+          date: analytics.timestamp,
+          activeParticipants: analytics.participantCount,
+        }))
+      const weeklyActivity = course.aggregatedAnalytics
+        .filter((analytics) => analytics.type === 'WEEKLY')
+        .map((analytics) => ({
+          date: analytics.timestamp,
+          activeParticipants: analytics.participantCount,
+        }))
+
+      // compute the duration of the course in weeks (until current date, if course is still running)
+      const courseWeeks = Math.ceil(
+        dayjs(
+          course.endDate && dayjs(course.endDate).isBefore(dayjs())
+            ? course.endDate
+            : dayjs()
+        ).diff(dayjs(course.startDate), 'week', true)
+      )
+
+      return {
+        name: course.name,
+        courseWeeks,
+        totalParticipants: course.participations.length,
+        dailyActivity,
+        weeklyActivity,
+        activeDays: {
+          monday: course.aggregatedCourseAnalytics?.activityMonday ?? 0,
+          tuesday: course.aggregatedCourseAnalytics?.activityTuesday ?? 0,
+          wednesday: course.aggregatedCourseAnalytics?.activityWednesday ?? 0,
+          thursday: course.aggregatedCourseAnalytics?.activityThursday ?? 0,
+          friday: course.aggregatedCourseAnalytics?.activityFriday ?? 0,
+          saturday: course.aggregatedCourseAnalytics?.activitySaturday ?? 0,
+          sunday: course.aggregatedCourseAnalytics?.activitySunday ?? 0,
+        },
+        participantCourseAnalytics: course.participantCourseAnalytics,
+      }
     },
-  })
-
-  if (!course) {
-    return null
-  }
-
-  // map daily and weekly student activity into the format required by the frontend
-  const dailyActivity = course.aggregatedAnalytics
-    .filter((analytics) => analytics.type === 'DAILY')
-    .map((analytics) => ({
-      date: analytics.timestamp,
-      activeParticipants: analytics.participantCount,
-    }))
-  const weeklyActivity = course.aggregatedAnalytics
-    .filter((analytics) => analytics.type === 'WEEKLY')
-    .map((analytics) => ({
-      date: analytics.timestamp,
-      activeParticipants: analytics.participantCount,
-    }))
-
-  // compute the duration of the course in weeks (until current date, if course is still running)
-  const courseWeeks = Math.ceil(
-    dayjs(
-      course.endDate && dayjs(course.endDate).isBefore(dayjs())
-        ? course.endDate
-        : dayjs()
-    ).diff(dayjs(course.startDate), 'week', true)
+    { isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead }
   )
-
-  return {
-    name: course.name,
-    courseWeeks,
-    totalParticipants: course.participations.length,
-    dailyActivity,
-    weeklyActivity,
-    activeDays: {
-      monday: course.aggregatedCourseAnalytics?.activityMonday ?? 0,
-      tuesday: course.aggregatedCourseAnalytics?.activityTuesday ?? 0,
-      wednesday: course.aggregatedCourseAnalytics?.activityWednesday ?? 0,
-      thursday: course.aggregatedCourseAnalytics?.activityThursday ?? 0,
-      friday: course.aggregatedCourseAnalytics?.activityFriday ?? 0,
-      saturday: course.aggregatedCourseAnalytics?.activitySaturday ?? 0,
-      sunday: course.aggregatedCourseAnalytics?.activitySunday ?? 0,
-    },
-    participantCourseAnalytics: course.participantCourseAnalytics,
-  }
 }
 
 export async function getCourseWeeklyActivity(
@@ -474,89 +550,106 @@ export async function getCoursePerformanceAnalytics(
   { courseId }: { courseId: string },
   ctx: ContextWithUser
 ) {
-  const course = await ctx.prisma.course.findUnique({
-    where: { id: courseId },
-    include: {
-      _count: { select: { participations: true } },
-      practiceQuizzes: {
+  return ctx.prisma.$transaction(
+    async (prisma) => {
+      const eligibleParticipantIds =
+        await getEligibleParticipantIdsForPerformanceAnalytics(prisma, courseId)
+      const participantFilter = {
+        participantId: { in: eligibleParticipantIds },
+        participant: learningAnalyticsParticipantWhere,
+      }
+      const course = await prisma.course.findUnique({
+        where: { id: courseId },
         include: {
-          progress: true,
-          performance: true,
-          participantPerformances: { include: { participant: true } },
-          stacks: {
+          _count: { select: { participations: true } },
+          practiceQuizzes: {
             include: {
-              elements: {
-                include: { instancePerformance: true, feedbacks: true },
+              progress: true,
+              performance: true,
+              participantPerformances: {
+                where: participantFilter,
+                include: { participant: true },
+              },
+              stacks: {
+                include: {
+                  elements: {
+                    include: { instancePerformance: true, feedbacks: true },
+                  },
+                },
               },
             },
+            orderBy: { createdAt: 'desc' },
           },
-        },
-        orderBy: { createdAt: 'desc' },
-      },
-      microLearnings: {
-        include: {
-          progress: true,
-          performance: true,
-          participantPerformances: { include: { participant: true } },
-          stacks: {
+          microLearnings: {
             include: {
-              elements: {
-                include: { instancePerformance: true, feedbacks: true },
+              progress: true,
+              performance: true,
+              participantPerformances: {
+                where: participantFilter,
+                include: { participant: true },
+              },
+              stacks: {
+                include: {
+                  elements: {
+                    include: { instancePerformance: true, feedbacks: true },
+                  },
+                },
               },
             },
+            orderBy: { scheduledStartAt: 'desc' },
           },
+          participantPerformances: { where: participantFilter },
         },
-        orderBy: { scheduledStartAt: 'desc' },
-      },
-      participantPerformances: true,
+      })
+
+      if (!course) {
+        return null
+      }
+
+      if (
+        course.practiceQuizzes.length === 0 &&
+        course.microLearnings.length === 0
+      ) {
+        return {
+          name: course.name,
+          totalParticipants: course._count.participations,
+          activityProgresses: [],
+          activityPerformances: [],
+          participantActivityPerformances: [],
+          instancePerformances: [],
+          participantPerformances: course.participantPerformances,
+          instanceFeedbacks: [],
+          activityFeedbacks: [],
+        }
+      }
+
+      // map the metrics for all activities in the course to the desired performance and progress values
+      const {
+        activityProgresses,
+        activityPerformances,
+        participantActivityPerformances,
+        instancePerformances,
+      } = computeActivityInstancePerformance({
+        course,
+      })
+
+      const { instanceFeedbacks, activityFeedbacks } =
+        computeActivityInstanceFeedbacks({ course })
+
+      return {
+        name: course.name,
+        totalParticipants: course._count.participations,
+        activityProgresses,
+        activityPerformances,
+        participantActivityPerformances,
+        instancePerformances,
+        participantPerformances: course.participantPerformances,
+        instanceFeedbacks,
+        activityFeedbacks,
+      }
     },
-  })
-
-  if (!course) {
-    return null
-  }
-
-  if (
-    course.practiceQuizzes.length === 0 &&
-    course.microLearnings.length === 0
-  ) {
-    return {
-      name: course.name,
-      totalParticipants: course._count.participations,
-      activityProgresses: [],
-      activityPerformances: [],
-      participantActivityPerformances: [],
-      instancePerformances: [],
-      participantPerformances: course.participantPerformances,
-      instanceFeedbacks: [],
-      activityFeedbacks: [],
-    }
-  }
-
-  // map the metrics for all activities in the course to the desired performance and progress values
-  const {
-    activityProgresses,
-    activityPerformances,
-    participantActivityPerformances,
-    instancePerformances,
-  } = computeActivityInstancePerformance({
-    course,
-  })
-
-  const { instanceFeedbacks, activityFeedbacks } =
-    computeActivityInstanceFeedbacks({ course })
-
-  return {
-    name: course.name,
-    totalParticipants: course._count.participations,
-    activityProgresses,
-    activityPerformances,
-    participantActivityPerformances,
-    instancePerformances,
-    participantPerformances: course.participantPerformances,
-    instanceFeedbacks,
-    activityFeedbacks,
-  }
+    { isolationLevel: DB.Prisma.TransactionIsolationLevel.RepeatableRead }
+  )
 }
 
 export async function getActivityAnalytics(

--- a/packages/graphql/src/services/participants.ts
+++ b/packages/graphql/src/services/participants.ts
@@ -262,41 +262,6 @@ function isRecordedChoice(
   )
 }
 
-function isMalformedLearningAnalyticsState({
-  learningAnalyticsConsent,
-  learningAnalyticsChoiceAt,
-  learningAnalyticsDisclosureVersion,
-  learningAnalyticsIncludedFrom,
-}: ParticipantDataUseFields) {
-  const hasImpossibleEnabledOrdering =
-    learningAnalyticsConsent &&
-    learningAnalyticsChoiceAt !== null &&
-    learningAnalyticsIncludedFrom !== null &&
-    learningAnalyticsIncludedFrom.getTime() >
-      learningAnalyticsChoiceAt.getTime()
-
-  if (hasImpossibleEnabledOrdering) return true
-
-  const hasChoiceMetadata =
-    learningAnalyticsChoiceAt !== null &&
-    learningAnalyticsDisclosureVersion !== null &&
-    learningAnalyticsDisclosureVersion.trim().length > 0
-
-  // The migrated/default false + null state is the only valid unrecorded
-  // state. Once a choice is recorded, the inclusion boundary must agree with
-  // the current Boolean so an invalid row can never be returned as eligible.
-  if (!hasChoiceMetadata) {
-    return (
-      learningAnalyticsConsent ||
-      learningAnalyticsChoiceAt !== null ||
-      learningAnalyticsDisclosureVersion !== null ||
-      learningAnalyticsIncludedFrom !== null
-    )
-  }
-
-  return learningAnalyticsConsent !== (learningAnalyticsIncludedFrom !== null)
-}
-
 function dataUseError(code: string) {
   return new GraphQLError(code, { extensions: { code } })
 }
@@ -420,13 +385,7 @@ export async function setLearningAnalyticsConsent(
         })
         if (!participant) return null
 
-        const malformedState = isMalformedLearningAnalyticsState(participant)
-        if (malformedState && consent) {
-          throw dataUseError('PARTICIPANT_DATA_USE_MALFORMED_STATE')
-        }
-
         const sameRecordedChoice =
-          !malformedState &&
           participant.learningAnalyticsConsent === consent &&
           isRecordedChoice(
             participant.learningAnalyticsChoiceAt,
@@ -440,15 +399,6 @@ export async function setLearningAnalyticsConsent(
           learningAnalyticsChoiceAt: choiceAt,
           learningAnalyticsDisclosureVersion:
             PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        }
-
-        // A genuine transition changes the prospective boundary. A metadata
-        // acknowledgement under the same Boolean never moves that boundary.
-        if (
-          malformedState ||
-          participant.learningAnalyticsConsent !== consent
-        ) {
-          data.learningAnalyticsIncludedFrom = consent ? choiceAt : null
         }
 
         return prisma.participant.update({

--- a/packages/graphql/src/services/participants.ts
+++ b/packages/graphql/src/services/participants.ts
@@ -306,7 +306,6 @@ function isLockTimeoutError(error: unknown): boolean {
 
   const candidate = error as {
     code?: unknown
-    message?: unknown
     meta?: unknown
     cause?: unknown
   }
@@ -315,18 +314,17 @@ function isLockTimeoutError(error: unknown): boolean {
     candidate.meta && typeof candidate.meta === 'object'
       ? (candidate.meta as { code?: unknown }).code
       : undefined
+  const driverCause =
+    candidate.meta && typeof candidate.meta === 'object'
+      ? (
+          candidate.meta as {
+            driverAdapterError?: { cause?: { code?: unknown } }
+          }
+        ).driverAdapterError?.cause
+      : undefined
   if (
     candidate.code === 'P2010' &&
-    (metaCode === '55P03' ||
-      (typeof candidate.message === 'string' &&
-        /55P03|lock timeout/i.test(candidate.message)))
-  ) {
-    return true
-  }
-  if (
-    candidate.code === 'P2028' &&
-    typeof candidate.message === 'string' &&
-    /timeout|expired/i.test(candidate.message)
+    (metaCode === '55P03' || driverCause?.code === '55P03')
   ) {
     return true
   }

--- a/packages/graphql/src/services/participants.ts
+++ b/packages/graphql/src/services/participants.ts
@@ -5,9 +5,16 @@ import { PrismaTransactionClient } from '@klicker-uzh/util'
 import bcrypt from 'bcryptjs'
 import dayjs from 'dayjs'
 import isoWeek from 'dayjs/plugin/isoWeek.js'
+import { GraphQLError } from 'graphql'
 import { prop, sortBy } from 'remeda'
 import isEmail from 'validator/lib/isEmail.js'
 import type { Context, ContextWithUser } from '../lib/context.js'
+import {
+  LEARNING_ANALYTICS_ADVISORY_LOCK,
+  PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+  type ParticipantDataUseFields,
+  participantDataUseSelect,
+} from '../lib/learningAnalytics.js'
 
 dayjs.extend(isoWeek)
 
@@ -241,6 +248,229 @@ export async function getParticipation(
   })
 
   return participation
+}
+
+type ParticipantConsentArgs = { consent: boolean }
+
+function isRecordedChoice(
+  choiceAt: Date | null,
+  disclosureVersion: string | null
+) {
+  return (
+    choiceAt !== null &&
+    disclosureVersion === PARTICIPANT_DATA_USE_DISCLOSURE_VERSION
+  )
+}
+
+function isMalformedLearningAnalyticsState({
+  learningAnalyticsConsent,
+  learningAnalyticsChoiceAt,
+  learningAnalyticsDisclosureVersion,
+  learningAnalyticsIncludedFrom,
+}: ParticipantDataUseFields) {
+  const hasImpossibleEnabledOrdering =
+    learningAnalyticsConsent &&
+    learningAnalyticsChoiceAt !== null &&
+    learningAnalyticsIncludedFrom !== null &&
+    learningAnalyticsIncludedFrom.getTime() >
+      learningAnalyticsChoiceAt.getTime()
+
+  if (hasImpossibleEnabledOrdering) return true
+
+  const hasChoiceMetadata =
+    learningAnalyticsChoiceAt !== null &&
+    learningAnalyticsDisclosureVersion !== null &&
+    learningAnalyticsDisclosureVersion.trim().length > 0
+
+  // The migrated/default false + null state is the only valid unrecorded
+  // state. Once a choice is recorded, the inclusion boundary must agree with
+  // the current Boolean so an invalid row can never be returned as eligible.
+  if (!hasChoiceMetadata) {
+    return (
+      learningAnalyticsConsent ||
+      learningAnalyticsChoiceAt !== null ||
+      learningAnalyticsDisclosureVersion !== null ||
+      learningAnalyticsIncludedFrom !== null
+    )
+  }
+
+  return learningAnalyticsConsent !== (learningAnalyticsIncludedFrom !== null)
+}
+
+function dataUseError(code: string) {
+  return new GraphQLError(code, { extensions: { code } })
+}
+
+function isLockTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const candidate = error as {
+    code?: unknown
+    message?: unknown
+    meta?: unknown
+    cause?: unknown
+  }
+  if (candidate.code === '55P03') return true
+  const metaCode =
+    candidate.meta && typeof candidate.meta === 'object'
+      ? (candidate.meta as { code?: unknown }).code
+      : undefined
+  if (
+    candidate.code === 'P2010' &&
+    (metaCode === '55P03' ||
+      (typeof candidate.message === 'string' &&
+        /55P03|lock timeout/i.test(candidate.message)))
+  ) {
+    return true
+  }
+  if (
+    candidate.code === 'P2028' &&
+    typeof candidate.message === 'string' &&
+    /timeout|expired/i.test(candidate.message)
+  ) {
+    return true
+  }
+
+  return isLockTimeoutError(candidate.cause)
+}
+
+async function getDatabaseTime(prisma: PrismaTransactionClient) {
+  const rows = await prisma.$queryRaw<Array<{ now: Date }>>`
+    SELECT clock_timestamp() AS "now"
+  `
+  const now = rows[0]?.now
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
+    throw dataUseError('PARTICIPANT_DATA_USE_CLOCK_FAILURE')
+  }
+  return now
+}
+
+export async function getParticipantDataUse(
+  ctx: ContextWithUser
+): Promise<ParticipantDataUseFields | null> {
+  if (ctx.user.role !== DB.UserRole.PARTICIPANT) return null
+
+  return ctx.prisma.participant.findUnique({
+    where: { id: ctx.user.sub },
+    select: participantDataUseSelect,
+  })
+}
+
+export async function setResearchConsent(
+  { consent }: ParticipantConsentArgs,
+  ctx: ContextWithUser
+): Promise<ParticipantDataUseFields | null> {
+  if (ctx.user.role !== DB.UserRole.PARTICIPANT) return null
+
+  return ctx.prisma.$transaction(
+    async (prisma) => {
+      const participant = await prisma.participant.findUnique({
+        where: { id: ctx.user.sub },
+        select: participantDataUseSelect,
+      })
+      if (!participant) return null
+
+      if (
+        participant.researchConsent === consent &&
+        isRecordedChoice(
+          participant.researchConsentChoiceAt,
+          participant.researchConsentDisclosureVersion
+        )
+      ) {
+        return participant
+      }
+
+      const choiceAt = await getDatabaseTime(prisma)
+      return prisma.participant.update({
+        where: { id: ctx.user.sub },
+        data: {
+          researchConsent: consent,
+          researchConsentChoiceAt: choiceAt,
+          researchConsentDisclosureVersion:
+            PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        },
+        select: participantDataUseSelect,
+      })
+    },
+    { maxWait: 10_000, timeout: 60_000 }
+  )
+}
+
+export async function setLearningAnalyticsConsent(
+  { consent }: ParticipantConsentArgs,
+  ctx: ContextWithUser
+): Promise<ParticipantDataUseFields | null> {
+  if (ctx.user.role !== DB.UserRole.PARTICIPANT) return null
+
+  try {
+    return await ctx.prisma.$transaction(
+      async (prisma) => {
+        await prisma.$executeRaw`
+          SET LOCAL lock_timeout = '5s'
+        `
+        await prisma.$executeRaw`
+          SELECT pg_advisory_xact_lock(
+            ${LEARNING_ANALYTICS_ADVISORY_LOCK.classId},
+            ${LEARNING_ANALYTICS_ADVISORY_LOCK.objectId}
+          )
+        `
+
+        // The participant is intentionally read only after the global gate.
+        const participant = await prisma.participant.findUnique({
+          where: { id: ctx.user.sub },
+          select: participantDataUseSelect,
+        })
+        if (!participant) return null
+
+        const malformedState = isMalformedLearningAnalyticsState(participant)
+        if (malformedState && consent) {
+          throw dataUseError('PARTICIPANT_DATA_USE_MALFORMED_STATE')
+        }
+
+        const sameRecordedChoice =
+          !malformedState &&
+          participant.learningAnalyticsConsent === consent &&
+          isRecordedChoice(
+            participant.learningAnalyticsChoiceAt,
+            participant.learningAnalyticsDisclosureVersion
+          )
+        if (sameRecordedChoice) return participant
+
+        const choiceAt = await getDatabaseTime(prisma)
+        const data: DB.Prisma.ParticipantUpdateInput = {
+          learningAnalyticsConsent: consent,
+          learningAnalyticsChoiceAt: choiceAt,
+          learningAnalyticsDisclosureVersion:
+            PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        }
+
+        // A genuine transition changes the prospective boundary. A metadata
+        // acknowledgement under the same Boolean never moves that boundary.
+        if (
+          malformedState ||
+          participant.learningAnalyticsConsent !== consent
+        ) {
+          data.learningAnalyticsIncludedFrom = consent ? choiceAt : null
+        }
+
+        return prisma.participant.update({
+          where: { id: ctx.user.sub },
+          data,
+          select: participantDataUseSelect,
+        })
+      },
+      {
+        maxWait: 10_000,
+        timeout: 60_000,
+        isolationLevel: DB.Prisma.TransactionIsolationLevel.ReadCommitted,
+      }
+    )
+  } catch (error) {
+    if (isLockTimeoutError(error)) {
+      throw dataUseError('PARTICIPANT_DATA_USE_LOCK_TIMEOUT')
+    }
+    throw error
+  }
 }
 
 // interface RegisterParticipantFromLTIArgs {

--- a/packages/graphql/test/participantDataUse.integration.test.ts
+++ b/packages/graphql/test/participantDataUse.integration.test.ts
@@ -91,12 +91,11 @@ async function expectLearningAnalyticsWriterGateReleased() {
   expect(result[0]?.acquired).toBe(true)
 }
 
-async function createParticipant(label: string, consent = false) {
+async function createParticipant(label: string) {
   const participant = await prisma.participant.create({
     data: {
       username: `${TEST_PREFIX}-${label}`,
       password: 'integration-test-password',
-      learningAnalyticsConsent: consent,
     },
   })
   fixtureIds.participants.push(participant.id)
@@ -200,10 +199,11 @@ async function createCourse(ownerId: string, participantId: string) {
       endDate,
       groupDeadlineDate: endDate,
       authType: CourseAuthType.SSO,
-      ownerId,
+      isLearningAnalyticsEnabled: true,
       participations: {
         create: { participantId },
       },
+      ownerId,
     },
   })
   fixtureIds.courses.push(course.id)
@@ -231,17 +231,6 @@ async function createCourse(ownerId: string, participantId: string) {
   })
 
   return { course, practiceQuiz }
-}
-
-async function readActivityAnalytics(courseId: string, ctx: ContextWithUser) {
-  return getCourseActivityAnalytics({ courseId }, ctx)
-}
-
-async function readPerformanceAnalytics(
-  courseId: string,
-  ctx: ContextWithUser
-) {
-  return getCoursePerformanceAnalytics({ courseId }, ctx)
 }
 
 describe('participant data-use PostgreSQL integration', () => {
@@ -272,7 +261,7 @@ describe('participant data-use PostgreSQL integration', () => {
     await prisma.$disconnect()
   })
 
-  it('waits for the global LA lock and records choiceAt from the database clock', async () => {
+  it('waits for the global LA lock and records only the current choice', async () => {
     const participant = await createParticipant('exclusive-lock')
     const ctx = participantContext(participant.id)
     const before = await prisma.$queryRaw<Array<{ now: Date }>>`
@@ -288,23 +277,22 @@ describe('participant data-use PostgreSQL integration', () => {
         }
       )
 
-      await wait(150)
+      await new Promise((resolve) => setTimeout(resolve, 25))
       expect(settled).toBe(false)
-      expect((await getParticipantDataUse(ctx))?.learningAnalyticsConsent).toBe(
-        false
-      )
+      await expect(getParticipantDataUse(ctx)).resolves.toMatchObject({
+        learningAnalyticsConsent: false,
+        learningAnalyticsChoiceAt: null,
+      })
 
       holder.release()
       const result = await mutation
-      await holder.done
       const after = await prisma.$queryRaw<Array<{ now: Date }>>`
         SELECT clock_timestamp() AS "now"
       `
-
       expect(result?.learningAnalyticsConsent).toBe(true)
       expect(result?.learningAnalyticsChoiceAt).toBeInstanceOf(Date)
-      expect(result?.learningAnalyticsIncludedFrom).toEqual(
-        result?.learningAnalyticsChoiceAt
+      expect(result?.learningAnalyticsDisclosureVersion).toBe(
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION
       )
       expect(
         result!.learningAnalyticsChoiceAt!.getTime()
@@ -312,11 +300,13 @@ describe('participant data-use PostgreSQL integration', () => {
       expect(result!.learningAnalyticsChoiceAt!.getTime()).toBeLessThanOrEqual(
         after[0]!.now.getTime()
       )
+      await holder.done
+      await expectLearningAnalyticsWriterGateReleased()
     } finally {
       holder.release()
       await holder.done.catch(() => undefined)
     }
-  }, 10_000)
+  })
 
   it('maps a real lock timeout, rolls back, and releases the lock for the next mutation', async () => {
     const participant = await createParticipant('timeout')
@@ -331,24 +321,22 @@ describe('participant data-use PostgreSQL integration', () => {
       })
       expect(Date.now() - startedAt).toBeGreaterThanOrEqual(4_500)
 
-      const rolledBack = await getParticipantDataUse(ctx)
-      expect(rolledBack).toMatchObject({
+      await expect(getParticipantDataUse(ctx)).resolves.toMatchObject({
         learningAnalyticsConsent: false,
         learningAnalyticsChoiceAt: null,
         learningAnalyticsDisclosureVersion: null,
-        learningAnalyticsIncludedFrom: null,
       })
 
       holder.release()
       await holder.done
-      const nextMutation = await setLearningAnalyticsConsent(
-        { consent: true },
-        ctx
-      )
-      expect(nextMutation?.learningAnalyticsConsent).toBe(true)
-      expect(nextMutation?.learningAnalyticsIncludedFrom).toEqual(
-        nextMutation?.learningAnalyticsChoiceAt
-      )
+      await expect(
+        setLearningAnalyticsConsent({ consent: true }, ctx)
+      ).resolves.toMatchObject({
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: expect.any(Date),
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      })
     } finally {
       holder.release()
       await holder.done.catch(() => undefined)
@@ -371,10 +359,12 @@ describe('participant data-use PostgreSQL integration', () => {
       expect(result).toMatchObject({
         researchConsent: true,
         researchConsentChoiceAt: expect.any(Date),
+        researchConsentDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
       })
-      expect((await getParticipantDataUse(ctx))?.learningAnalyticsConsent).toBe(
-        false
-      )
+      await expect(getParticipantDataUse(ctx)).resolves.toMatchObject({
+        learningAnalyticsConsent: false,
+      })
 
       holder.release()
       await holder.done
@@ -386,8 +376,8 @@ describe('participant data-use PostgreSQL integration', () => {
     }
   }, 10_000)
 
-  it('releases the lock after malformed enablement so withdrawal can repair it', async () => {
-    const participant = await createParticipant('malformed')
+  it('repairs incomplete current metadata and releases the writer lock', async () => {
+    const participant = await createParticipant('incomplete-metadata')
     const ctx = participantContext(participant.id)
     await prisma.participant.update({
       where: { id: participant.id },
@@ -396,280 +386,140 @@ describe('participant data-use PostgreSQL integration', () => {
         learningAnalyticsChoiceAt: null,
         learningAnalyticsDisclosureVersion:
           PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: null,
       },
     })
 
     await expect(
       setLearningAnalyticsConsent({ consent: true }, ctx)
-    ).rejects.toMatchObject({
-      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
-    })
-    await expectLearningAnalyticsWriterGateReleased()
-
-    await expect(
-      setLearningAnalyticsConsent({ consent: false }, ctx)
     ).resolves.toMatchObject({
-      learningAnalyticsConsent: false,
+      learningAnalyticsConsent: true,
       learningAnalyticsChoiceAt: expect.any(Date),
       learningAnalyticsDisclosureVersion:
         PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      learningAnalyticsIncludedFrom: null,
-    })
-  })
-
-  it('fails closed on impossible enabled ordering in raw analytics reads and repairs on withdrawal', async () => {
-    const owner = await createOwner('impossible-ordering')
-    const participant = await createParticipant('impossible-ordering')
-    const ctx = participantContext(participant.id)
-    const { course, practiceQuiz } = await createCourse(
-      owner.id,
-      participant.id
-    )
-    await createIndividualAnalyticsRows({
-      courseId: course.id,
-      participantId: participant.id,
-      practiceQuizId: practiceQuiz.id,
-    })
-
-    const choiceAt = new Date('2026-08-20T12:00:00.000Z')
-    const impossibleBoundary = new Date('2026-08-20T12:00:01.000Z')
-    await prisma.participant.update({
-      where: { id: participant.id },
-      data: {
-        learningAnalyticsConsent: true,
-        learningAnalyticsChoiceAt: choiceAt,
-        learningAnalyticsDisclosureVersion:
-          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: impossibleBoundary,
-      },
-    })
-    await prisma.course.update({
-      where: { id: course.id },
-      data: { analyticsLastComputedAt: impossibleBoundary },
-    })
-
-    const activity = await readActivityAnalytics(course.id, ctx)
-    const performance = await readPerformanceAnalytics(course.id, ctx)
-    expect(activity?.participantCourseAnalytics).toHaveLength(0)
-    expect(performance?.participantPerformances).toHaveLength(0)
-    expect(performance?.participantActivityPerformances).toHaveLength(0)
-
-    await expect(
-      setLearningAnalyticsConsent({ consent: false }, ctx)
-    ).resolves.toMatchObject({
-      learningAnalyticsConsent: false,
-      learningAnalyticsIncludedFrom: null,
-      learningAnalyticsChoiceAt: expect.any(Date),
     })
     await expectLearningAnalyticsWriterGateReleased()
   })
 
-  it('filters current and prospective individual analytics while preserving aggregates', async () => {
-    const owner = await createOwner('analytics')
-    const participant = await createParticipant('analytics')
+  it('keeps analytics hidden until computation is strictly newer than the current choice', async () => {
+    const owner = await createOwner('strict-freshness')
+    const participant = await createParticipant('strict-freshness')
     const ctx = participantContext(participant.id)
     const { course, practiceQuiz } = await createCourse(
       owner.id,
       participant.id
     )
-
-    const initial = await setLearningAnalyticsConsent({ consent: true }, ctx)
-    const initialBoundary = initial!.learningAnalyticsIncludedFrom!
-    await prisma.course.update({
-      where: { id: course.id },
-      data: {
-        analyticsLastComputedAt: initialBoundary,
-      },
-    })
+    const enabled = await setLearningAnalyticsConsent({ consent: true }, ctx)
+    const choiceAt = enabled!.learningAnalyticsChoiceAt!
     await createIndividualAnalyticsRows({
       courseId: course.id,
       participantId: participant.id,
       practiceQuizId: practiceQuiz.id,
     })
 
-    const initiallyVisibleActivity = await readActivityAnalytics(course.id, ctx)
-    const initiallyVisiblePerformance = await readPerformanceAnalytics(
-      course.id,
-      ctx
-    )
-    expect(initiallyVisibleActivity?.participantCourseAnalytics).toHaveLength(1)
-    expect(initiallyVisibleActivity?.dailyActivity).toHaveLength(1)
-    expect(initiallyVisiblePerformance?.participantPerformances).toHaveLength(1)
-    expect(
-      initiallyVisiblePerformance?.participantActivityPerformances
-    ).toHaveLength(1)
-
-    const initialActivityAggregates = {
-      totalParticipants: initiallyVisibleActivity!.totalParticipants,
-      dailyActivity: initiallyVisibleActivity!.dailyActivity,
-      weeklyActivity: initiallyVisibleActivity!.weeklyActivity,
-      activeDays: initiallyVisibleActivity!.activeDays,
-    }
-    const initialPerformanceAggregates = {
-      totalParticipants: initiallyVisiblePerformance!.totalParticipants,
-      activityProgresses: initiallyVisiblePerformance!.activityProgresses,
-      activityPerformances: initiallyVisiblePerformance!.activityPerformances,
-      instancePerformances: initiallyVisiblePerformance!.instancePerformances,
-      instanceFeedbacks: initiallyVisiblePerformance!.instanceFeedbacks,
-      activityFeedbacks: initiallyVisiblePerformance!.activityFeedbacks,
-    }
-
-    await prisma.participant.update({
-      where: { id: participant.id },
-      data: { learningAnalyticsDisclosureVersion: 'legacy-v0' },
+    await prisma.course.update({
+      where: { id: course.id },
+      data: { analyticsLastComputedAt: choiceAt },
     })
-    const legacyDisclosureActivity = await readActivityAnalytics(course.id, ctx)
-    const legacyDisclosurePerformance = await readPerformanceAnalytics(
-      course.id,
+    const equalActivity = await getCourseActivityAnalytics(
+      { courseId: course.id },
       ctx
     )
-    expect(legacyDisclosureActivity?.participantCourseAnalytics).toHaveLength(1)
-    expect(legacyDisclosurePerformance?.participantPerformances).toHaveLength(1)
-    expect(
-      legacyDisclosurePerformance?.participantActivityPerformances
-    ).toHaveLength(1)
+    const equalPerformance = await getCoursePerformanceAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    expect(equalActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(equalActivity?.dailyActivity).toHaveLength(1)
+    expect(equalPerformance?.participantPerformances).toHaveLength(0)
+    expect(equalPerformance?.participantActivityPerformances).toHaveLength(0)
+
+    await prisma.course.update({
+      where: { id: course.id },
+      data: { analyticsLastComputedAt: new Date(choiceAt.getTime() + 1) },
+    })
+    const freshActivity = await getCourseActivityAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    const freshPerformance = await getCoursePerformanceAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    expect(freshActivity?.participantCourseAnalytics).toHaveLength(1)
+    expect(freshPerformance?.participantPerformances).toHaveLength(1)
+    expect(freshPerformance?.participantActivityPerformances).toHaveLength(1)
+
+    await setLearningAnalyticsConsent({ consent: false }, ctx)
+    const withdrawnActivity = await getCourseActivityAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    expect(withdrawnActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(withdrawnActivity?.dailyActivity).toHaveLength(1)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const reenabled = await setLearningAnalyticsConsent({ consent: true }, ctx)
+    const reenabledChoiceAt = reenabled!.learningAnalyticsChoiceAt!
+    const staleActivity = await getCourseActivityAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    expect(staleActivity?.participantCourseAnalytics).toHaveLength(0)
+
+    await prisma.course.update({
+      where: { id: course.id },
+      data: {
+        analyticsLastComputedAt: new Date(reenabledChoiceAt.getTime() + 1),
+      },
+    })
+    const recomputedActivity = await getCourseActivityAnalytics(
+      { courseId: course.id },
+      ctx
+    )
+    expect(recomputedActivity?.participantCourseAnalytics).toHaveLength(1)
+  })
+
+  it('requires complete current choice metadata and preserves aggregate output', async () => {
+    const owner = await createOwner('metadata')
+    const participant = await createParticipant('metadata')
+    const ctx = participantContext(participant.id)
+    const { course, practiceQuiz } = await createCourse(
+      owner.id,
+      participant.id
+    )
+    const enabled = await setLearningAnalyticsConsent({ consent: true }, ctx)
+    const choiceAt = enabled!.learningAnalyticsChoiceAt!
+    await createIndividualAnalyticsRows({
+      courseId: course.id,
+      participantId: participant.id,
+      practiceQuizId: practiceQuiz.id,
+    })
+    await prisma.course.update({
+      where: { id: course.id },
+      data: { analyticsLastComputedAt: new Date(choiceAt.getTime() + 1) },
+    })
 
     await prisma.participant.update({
       where: { id: participant.id },
       data: { learningAnalyticsDisclosureVersion: '   ' },
     })
-    const blankDisclosureActivity = await readActivityAnalytics(course.id, ctx)
-    const blankDisclosurePerformance = await readPerformanceAnalytics(
-      course.id,
+    const result = await getCourseActivityAnalytics(
+      { courseId: course.id },
       ctx
     )
-    expect(blankDisclosureActivity?.participantCourseAnalytics).toHaveLength(0)
-    expect(blankDisclosureActivity?.dailyActivity).toHaveLength(1)
-    expect(blankDisclosurePerformance?.participantPerformances).toHaveLength(0)
-    expect(
-      blankDisclosurePerformance?.participantActivityPerformances
-    ).toHaveLength(0)
-    await prisma.participant.update({
-      where: { id: participant.id },
-      data: {
-        learningAnalyticsDisclosureVersion:
-          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      },
-    })
+    expect(result?.participantCourseAnalytics).toHaveLength(0)
+    expect(result?.dailyActivity).toHaveLength(1)
 
-    await setLearningAnalyticsConsent({ consent: false }, ctx)
-    const withdrawnActivity = await readActivityAnalytics(course.id, ctx)
-    const withdrawnPerformance = await readPerformanceAnalytics(course.id, ctx)
-    expect(withdrawnActivity?.participantCourseAnalytics).toHaveLength(0)
-    expect(withdrawnActivity?.dailyActivity).toHaveLength(1)
-    expect(withdrawnPerformance?.participantPerformances).toHaveLength(0)
-    expect(withdrawnPerformance?.participantActivityPerformances).toHaveLength(
-      0
-    )
-
-    await wait(10)
-    const reenabled = await setLearningAnalyticsConsent({ consent: true }, ctx)
-    const reenabledBoundary = reenabled!.learningAnalyticsIncludedFrom!
-    expect(reenabledBoundary.getTime()).toBeGreaterThan(
-      initialBoundary.getTime()
-    )
-
-    const beforeRecomputeActivity = await readActivityAnalytics(course.id, ctx)
-    const beforeRecomputePerformance = await readPerformanceAnalytics(
-      course.id,
-      ctx
-    )
-    expect(beforeRecomputeActivity?.participantCourseAnalytics).toHaveLength(0)
-    expect(beforeRecomputeActivity?.dailyActivity).toHaveLength(1)
-    expect(beforeRecomputePerformance?.participantPerformances).toHaveLength(0)
-    expect(
-      beforeRecomputePerformance?.participantActivityPerformances
-    ).toHaveLength(0)
-
-    // The writer must clean up rows from the previous consent window before
-    // publishing replacement rows and advancing the recomputation marker.
-    await prisma.participantCourseAnalytics.deleteMany({
-      where: { courseId: course.id, participantId: participant.id },
+    await expect(
+      setResearchConsent({ consent: true }, ctx)
+    ).resolves.toMatchObject({
+      researchConsent: true,
+      researchConsentChoiceAt: expect.any(Date),
+      researchConsentDisclosureVersion: PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
     })
-    await prisma.participantPerformance.deleteMany({
-      where: { courseId: course.id, participantId: participant.id },
+    await expect(getParticipantDataUse(ctx)).resolves.toMatchObject({
+      researchConsent: true,
+      learningAnalyticsConsent: true,
     })
-    await prisma.participantActivityPerformance.deleteMany({
-      where: { participantId: participant.id, practiceQuizId: practiceQuiz.id },
-    })
-    await createIndividualAnalyticsRows({
-      courseId: course.id,
-      participantId: participant.id,
-      practiceQuizId: practiceQuiz.id,
-      overrides: {
-        activeWeeks: 9,
-        activeDaysPerWeek: 8,
-        meanElementsPerDay: 7,
-        activityLevel: ActivityLevel.LOW,
-        firstErrorRate: 0.9,
-        firstPerformance: PerformanceLevel.HIGH,
-        lastErrorRate: 0.8,
-        lastPerformance: PerformanceLevel.HIGH,
-        totalErrorRate: 0.85,
-        totalPerformance: PerformanceLevel.MEDIUM,
-        totalScore: 99,
-        completion: 0.5,
-      },
-    })
-    await prisma.course.update({
-      where: { id: course.id },
-      data: {
-        analyticsLastComputedAt: new Date(reenabledBoundary.getTime() + 1_000),
-      },
-    })
-    const recomputedActivity = await readActivityAnalytics(course.id, ctx)
-    const recomputedPerformance = await readPerformanceAnalytics(course.id, ctx)
-    expect(recomputedActivity?.participantCourseAnalytics).toHaveLength(1)
-    expect(recomputedActivity?.dailyActivity).toHaveLength(1)
-    expect(recomputedActivity?.participantCourseAnalytics[0]).toMatchObject({
-      activeWeeks: 9,
-      activeDaysPerWeek: 8,
-      meanElementsPerDay: 7,
-      activityLevel: ActivityLevel.LOW,
-    })
-    expect(recomputedPerformance?.participantPerformances).toHaveLength(1)
-    expect(recomputedPerformance?.participantActivityPerformances).toHaveLength(
-      1
-    )
-    expect(recomputedPerformance?.participantPerformances[0]).toMatchObject({
-      firstErrorRate: 0.9,
-      firstPerformance: PerformanceLevel.HIGH,
-      lastErrorRate: 0.8,
-      lastPerformance: PerformanceLevel.HIGH,
-      totalErrorRate: 0.85,
-      totalPerformance: PerformanceLevel.MEDIUM,
-    })
-    expect(
-      recomputedPerformance?.participantActivityPerformances[0]
-        ?.activityPerformances[0]
-    ).toMatchObject({ totalScore: 99, completion: 0.5 })
-    expect({
-      totalParticipants: recomputedActivity!.totalParticipants,
-      dailyActivity: recomputedActivity!.dailyActivity,
-      weeklyActivity: recomputedActivity!.weeklyActivity,
-      activeDays: recomputedActivity!.activeDays,
-    }).toEqual(initialActivityAggregates)
-    expect({
-      totalParticipants: recomputedPerformance!.totalParticipants,
-      activityProgresses: recomputedPerformance!.activityProgresses,
-      activityPerformances: recomputedPerformance!.activityPerformances,
-      instancePerformances: recomputedPerformance!.instancePerformances,
-      instanceFeedbacks: recomputedPerformance!.instanceFeedbacks,
-      activityFeedbacks: recomputedPerformance!.activityFeedbacks,
-    }).toEqual(initialPerformanceAggregates)
-
-    await setLearningAnalyticsConsent({ consent: false }, ctx)
-    const withdrawnAgainActivity = await readActivityAnalytics(course.id, ctx)
-    const withdrawnAgainPerformance = await readPerformanceAnalytics(
-      course.id,
-      ctx
-    )
-    expect(withdrawnAgainActivity?.participantCourseAnalytics).toHaveLength(0)
-    expect(withdrawnAgainActivity?.dailyActivity).toHaveLength(1)
-    expect(withdrawnAgainPerformance?.participantPerformances).toHaveLength(0)
-    expect(
-      withdrawnAgainPerformance?.participantActivityPerformances
-    ).toHaveLength(0)
-  }, 15_000)
+  })
 })

--- a/packages/graphql/test/participantDataUse.integration.test.ts
+++ b/packages/graphql/test/participantDataUse.integration.test.ts
@@ -1,0 +1,675 @@
+import { prisma } from '@klicker-uzh/prisma'
+import {
+  ActivityLevel,
+  AnalyticsType,
+  CourseAuthType,
+  PerformanceLevel,
+  UserLoginScope,
+  UserRole,
+} from '@klicker-uzh/prisma/client'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { ContextWithUser } from '../src/lib/context.js'
+import {
+  LEARNING_ANALYTICS_ADVISORY_LOCK,
+  PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+} from '../src/lib/learningAnalytics.js'
+import {
+  getCourseActivityAnalytics,
+  getCoursePerformanceAnalytics,
+} from '../src/services/analytics.js'
+import {
+  getParticipantDataUse,
+  setLearningAnalyticsConsent,
+  setResearchConsent,
+} from '../src/services/participants.js'
+
+const TEST_PREFIX = `participant-data-use-integration-${Date.now()}`
+const fixtureIds = {
+  courses: [] as string[],
+  participants: [] as string[],
+  users: [] as string[],
+}
+
+function participantContext(participantId: string): ContextWithUser {
+  return {
+    prisma,
+    user: {
+      sub: participantId,
+      role: UserRole.PARTICIPANT,
+      scope: UserLoginScope.FULL_ACCESS,
+      catalystInstitutional: false,
+      catalystIndividual: false,
+    },
+  } as unknown as ContextWithUser
+}
+
+function defer() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+async function wait(milliseconds: number) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+async function holdLearningAnalyticsWriterGate() {
+  const acquired = defer()
+  const release = defer()
+  const transaction = prisma.$transaction(
+    async (tx) => {
+      await tx.$executeRaw`
+        SELECT pg_advisory_xact_lock_shared(
+          ${LEARNING_ANALYTICS_ADVISORY_LOCK.classId},
+          ${LEARNING_ANALYTICS_ADVISORY_LOCK.objectId}
+        )
+      `
+      acquired.resolve()
+      await release.promise
+    },
+    { maxWait: 10_000, timeout: 20_000 }
+  )
+
+  await acquired.promise
+  return {
+    release: release.resolve,
+    done: transaction,
+  }
+}
+
+async function expectLearningAnalyticsWriterGateReleased() {
+  const result = await prisma.$transaction(async (tx) => {
+    return tx.$queryRaw<Array<{ acquired: boolean }>>`
+      SELECT pg_try_advisory_xact_lock(
+        ${LEARNING_ANALYTICS_ADVISORY_LOCK.classId},
+        ${LEARNING_ANALYTICS_ADVISORY_LOCK.objectId}
+      ) AS acquired
+    `
+  })
+  expect(result[0]?.acquired).toBe(true)
+}
+
+async function createParticipant(label: string, consent = false) {
+  const participant = await prisma.participant.create({
+    data: {
+      username: `${TEST_PREFIX}-${label}`,
+      password: 'integration-test-password',
+      learningAnalyticsConsent: consent,
+    },
+  })
+  fixtureIds.participants.push(participant.id)
+  return participant
+}
+
+async function createOwner(label: string) {
+  const user = await prisma.user.create({
+    data: {
+      email: `${TEST_PREFIX}-${label}@example.test`,
+      shortname: `${TEST_PREFIX}-${label}`,
+    },
+  })
+  fixtureIds.users.push(user.id)
+  return user
+}
+
+type IndividualAnalyticsValues = {
+  activeWeeks: number
+  activeDaysPerWeek: number
+  meanElementsPerDay: number
+  activityLevel: ActivityLevel
+  firstErrorRate: number
+  firstPerformance: PerformanceLevel
+  lastErrorRate: number
+  lastPerformance: PerformanceLevel
+  totalErrorRate: number
+  totalPerformance: PerformanceLevel
+  totalScore: number
+  completion: number
+}
+
+const defaultIndividualAnalyticsValues: IndividualAnalyticsValues = {
+  activeWeeks: 1,
+  activeDaysPerWeek: 2,
+  meanElementsPerDay: 3,
+  activityLevel: ActivityLevel.HIGH,
+  firstErrorRate: 0.1,
+  firstPerformance: PerformanceLevel.LOW,
+  lastErrorRate: 0.2,
+  lastPerformance: PerformanceLevel.MEDIUM,
+  totalErrorRate: 0.15,
+  totalPerformance: PerformanceLevel.LOW,
+  totalScore: 10,
+  completion: 1,
+}
+
+async function createIndividualAnalyticsRows({
+  courseId,
+  participantId,
+  practiceQuizId,
+  overrides = {},
+}: {
+  courseId: string
+  participantId: string
+  practiceQuizId: string
+  overrides?: Partial<IndividualAnalyticsValues>
+}) {
+  const values = { ...defaultIndividualAnalyticsValues, ...overrides }
+
+  await prisma.participantCourseAnalytics.create({
+    data: {
+      courseId,
+      participantId,
+      activeWeeks: values.activeWeeks,
+      activeDaysPerWeek: values.activeDaysPerWeek,
+      meanElementsPerDay: values.meanElementsPerDay,
+      activityLevel: values.activityLevel,
+    },
+  })
+  await prisma.participantPerformance.create({
+    data: {
+      courseId,
+      participantId,
+      firstErrorRate: values.firstErrorRate,
+      firstPerformance: values.firstPerformance,
+      lastErrorRate: values.lastErrorRate,
+      lastPerformance: values.lastPerformance,
+      totalErrorRate: values.totalErrorRate,
+      totalPerformance: values.totalPerformance,
+    },
+  })
+  await prisma.participantActivityPerformance.create({
+    data: {
+      participantId,
+      practiceQuizId,
+      totalScore: values.totalScore,
+      completion: values.completion,
+    },
+  })
+}
+
+async function createCourse(ownerId: string, participantId: string) {
+  const startDate = new Date('2026-08-01T00:00:00.000Z')
+  const endDate = new Date('2026-09-01T00:00:00.000Z')
+  const course = await prisma.course.create({
+    data: {
+      name: `${TEST_PREFIX}-course`,
+      displayName: `${TEST_PREFIX}-course`,
+      startDate,
+      endDate,
+      groupDeadlineDate: endDate,
+      authType: CourseAuthType.SSO,
+      ownerId,
+      participations: {
+        create: { participantId },
+      },
+    },
+  })
+  fixtureIds.courses.push(course.id)
+
+  const practiceQuiz = await prisma.practiceQuiz.create({
+    data: {
+      name: `${TEST_PREFIX}-practice-quiz`,
+      displayName: `${TEST_PREFIX}-practice-quiz`,
+      ownerId,
+      courseId: course.id,
+    },
+  })
+  await prisma.aggregatedAnalytics.create({
+    data: {
+      courseId: course.id,
+      type: AnalyticsType.DAILY,
+      timestamp: new Date('2026-08-25T00:00:00.000Z'),
+      responseCount: 1,
+      participantCount: 1,
+      totalScore: 1,
+      totalPoints: 1,
+      totalXp: 1,
+      totalElementsAvailable: 1,
+    },
+  })
+
+  return { course, practiceQuiz }
+}
+
+async function readActivityAnalytics(courseId: string, ctx: ContextWithUser) {
+  return getCourseActivityAnalytics({ courseId }, ctx)
+}
+
+async function readPerformanceAnalytics(
+  courseId: string,
+  ctx: ContextWithUser
+) {
+  return getCoursePerformanceAnalytics({ courseId }, ctx)
+}
+
+describe('participant data-use PostgreSQL integration', () => {
+  beforeAll(async () => {
+    await prisma.$connect()
+  })
+
+  afterEach(async () => {
+    if (fixtureIds.courses.length > 0) {
+      await prisma.course.deleteMany({
+        where: { id: { in: fixtureIds.courses } },
+      })
+      fixtureIds.courses.length = 0
+    }
+    if (fixtureIds.participants.length > 0) {
+      await prisma.participant.deleteMany({
+        where: { id: { in: fixtureIds.participants } },
+      })
+      fixtureIds.participants.length = 0
+    }
+    if (fixtureIds.users.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: fixtureIds.users } } })
+      fixtureIds.users.length = 0
+    }
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  it('waits for the global LA lock and records choiceAt from the database clock', async () => {
+    const participant = await createParticipant('exclusive-lock')
+    const ctx = participantContext(participant.id)
+    const before = await prisma.$queryRaw<Array<{ now: Date }>>`
+      SELECT clock_timestamp() AS "now"
+    `
+    const holder = await holdLearningAnalyticsWriterGate()
+    try {
+      let settled = false
+      const mutation = setLearningAnalyticsConsent({ consent: true }, ctx).then(
+        (result) => {
+          settled = true
+          return result
+        }
+      )
+
+      await wait(150)
+      expect(settled).toBe(false)
+      expect((await getParticipantDataUse(ctx))?.learningAnalyticsConsent).toBe(
+        false
+      )
+
+      holder.release()
+      const result = await mutation
+      await holder.done
+      const after = await prisma.$queryRaw<Array<{ now: Date }>>`
+        SELECT clock_timestamp() AS "now"
+      `
+
+      expect(result?.learningAnalyticsConsent).toBe(true)
+      expect(result?.learningAnalyticsChoiceAt).toBeInstanceOf(Date)
+      expect(result?.learningAnalyticsIncludedFrom).toEqual(
+        result?.learningAnalyticsChoiceAt
+      )
+      expect(
+        result!.learningAnalyticsChoiceAt!.getTime()
+      ).toBeGreaterThanOrEqual(before[0]!.now.getTime())
+      expect(result!.learningAnalyticsChoiceAt!.getTime()).toBeLessThanOrEqual(
+        after[0]!.now.getTime()
+      )
+    } finally {
+      holder.release()
+      await holder.done.catch(() => undefined)
+    }
+  }, 10_000)
+
+  it('maps a real lock timeout, rolls back, and releases the lock for the next mutation', async () => {
+    const participant = await createParticipant('timeout')
+    const ctx = participantContext(participant.id)
+    const holder = await holdLearningAnalyticsWriterGate()
+    try {
+      const startedAt = Date.now()
+
+      const timedOut = setLearningAnalyticsConsent({ consent: true }, ctx)
+      await expect(timedOut).rejects.toMatchObject({
+        extensions: { code: 'PARTICIPANT_DATA_USE_LOCK_TIMEOUT' },
+      })
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(4_500)
+
+      const rolledBack = await getParticipantDataUse(ctx)
+      expect(rolledBack).toMatchObject({
+        learningAnalyticsConsent: false,
+        learningAnalyticsChoiceAt: null,
+        learningAnalyticsDisclosureVersion: null,
+        learningAnalyticsIncludedFrom: null,
+      })
+
+      holder.release()
+      await holder.done
+      const nextMutation = await setLearningAnalyticsConsent(
+        { consent: true },
+        ctx
+      )
+      expect(nextMutation?.learningAnalyticsConsent).toBe(true)
+      expect(nextMutation?.learningAnalyticsIncludedFrom).toEqual(
+        nextMutation?.learningAnalyticsChoiceAt
+      )
+    } finally {
+      holder.release()
+      await holder.done.catch(() => undefined)
+    }
+  }, 15_000)
+
+  it('updates research consent while the learning-analytics lock is held', async () => {
+    const participant = await createParticipant('research-while-locked')
+    const ctx = participantContext(participant.id)
+    const holder = await holdLearningAnalyticsWriterGate()
+    let researchMutation: ReturnType<typeof setResearchConsent> | undefined
+    try {
+      researchMutation = setResearchConsent({ consent: true }, ctx)
+      const result = await Promise.race([
+        researchMutation,
+        wait(1_000).then(() => null),
+      ])
+
+      expect(result).not.toBeNull()
+      expect(result).toMatchObject({
+        researchConsent: true,
+        researchConsentChoiceAt: expect.any(Date),
+      })
+      expect((await getParticipantDataUse(ctx))?.learningAnalyticsConsent).toBe(
+        false
+      )
+
+      holder.release()
+      await holder.done
+      await researchMutation
+    } finally {
+      holder.release()
+      await holder.done.catch(() => undefined)
+      await researchMutation?.catch(() => undefined)
+    }
+  }, 10_000)
+
+  it('releases the lock after malformed enablement so withdrawal can repair it', async () => {
+    const participant = await createParticipant('malformed')
+    const ctx = participantContext(participant.id)
+    await prisma.participant.update({
+      where: { id: participant.id },
+      data: {
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: null,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: null,
+      },
+    })
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, ctx)
+    ).rejects.toMatchObject({
+      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
+    })
+    await expectLearningAnalyticsWriterGateReleased()
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: false }, ctx)
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsChoiceAt: expect.any(Date),
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      learningAnalyticsIncludedFrom: null,
+    })
+  })
+
+  it('fails closed on impossible enabled ordering in raw analytics reads and repairs on withdrawal', async () => {
+    const owner = await createOwner('impossible-ordering')
+    const participant = await createParticipant('impossible-ordering')
+    const ctx = participantContext(participant.id)
+    const { course, practiceQuiz } = await createCourse(
+      owner.id,
+      participant.id
+    )
+    await createIndividualAnalyticsRows({
+      courseId: course.id,
+      participantId: participant.id,
+      practiceQuizId: practiceQuiz.id,
+    })
+
+    const choiceAt = new Date('2026-08-20T12:00:00.000Z')
+    const impossibleBoundary = new Date('2026-08-20T12:00:01.000Z')
+    await prisma.participant.update({
+      where: { id: participant.id },
+      data: {
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: choiceAt,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: impossibleBoundary,
+      },
+    })
+    await prisma.course.update({
+      where: { id: course.id },
+      data: { analyticsLastComputedAt: impossibleBoundary },
+    })
+
+    const activity = await readActivityAnalytics(course.id, ctx)
+    const performance = await readPerformanceAnalytics(course.id, ctx)
+    expect(activity?.participantCourseAnalytics).toHaveLength(0)
+    expect(performance?.participantPerformances).toHaveLength(0)
+    expect(performance?.participantActivityPerformances).toHaveLength(0)
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: false }, ctx)
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsIncludedFrom: null,
+      learningAnalyticsChoiceAt: expect.any(Date),
+    })
+    await expectLearningAnalyticsWriterGateReleased()
+  })
+
+  it('filters current and prospective individual analytics while preserving aggregates', async () => {
+    const owner = await createOwner('analytics')
+    const participant = await createParticipant('analytics')
+    const ctx = participantContext(participant.id)
+    const { course, practiceQuiz } = await createCourse(
+      owner.id,
+      participant.id
+    )
+
+    const initial = await setLearningAnalyticsConsent({ consent: true }, ctx)
+    const initialBoundary = initial!.learningAnalyticsIncludedFrom!
+    await prisma.course.update({
+      where: { id: course.id },
+      data: {
+        analyticsLastComputedAt: initialBoundary,
+      },
+    })
+    await createIndividualAnalyticsRows({
+      courseId: course.id,
+      participantId: participant.id,
+      practiceQuizId: practiceQuiz.id,
+    })
+
+    const initiallyVisibleActivity = await readActivityAnalytics(course.id, ctx)
+    const initiallyVisiblePerformance = await readPerformanceAnalytics(
+      course.id,
+      ctx
+    )
+    expect(initiallyVisibleActivity?.participantCourseAnalytics).toHaveLength(1)
+    expect(initiallyVisibleActivity?.dailyActivity).toHaveLength(1)
+    expect(initiallyVisiblePerformance?.participantPerformances).toHaveLength(1)
+    expect(
+      initiallyVisiblePerformance?.participantActivityPerformances
+    ).toHaveLength(1)
+
+    const initialActivityAggregates = {
+      totalParticipants: initiallyVisibleActivity!.totalParticipants,
+      dailyActivity: initiallyVisibleActivity!.dailyActivity,
+      weeklyActivity: initiallyVisibleActivity!.weeklyActivity,
+      activeDays: initiallyVisibleActivity!.activeDays,
+    }
+    const initialPerformanceAggregates = {
+      totalParticipants: initiallyVisiblePerformance!.totalParticipants,
+      activityProgresses: initiallyVisiblePerformance!.activityProgresses,
+      activityPerformances: initiallyVisiblePerformance!.activityPerformances,
+      instancePerformances: initiallyVisiblePerformance!.instancePerformances,
+      instanceFeedbacks: initiallyVisiblePerformance!.instanceFeedbacks,
+      activityFeedbacks: initiallyVisiblePerformance!.activityFeedbacks,
+    }
+
+    await prisma.participant.update({
+      where: { id: participant.id },
+      data: { learningAnalyticsDisclosureVersion: 'legacy-v0' },
+    })
+    const legacyDisclosureActivity = await readActivityAnalytics(course.id, ctx)
+    const legacyDisclosurePerformance = await readPerformanceAnalytics(
+      course.id,
+      ctx
+    )
+    expect(legacyDisclosureActivity?.participantCourseAnalytics).toHaveLength(1)
+    expect(legacyDisclosurePerformance?.participantPerformances).toHaveLength(1)
+    expect(
+      legacyDisclosurePerformance?.participantActivityPerformances
+    ).toHaveLength(1)
+
+    await prisma.participant.update({
+      where: { id: participant.id },
+      data: { learningAnalyticsDisclosureVersion: '   ' },
+    })
+    const blankDisclosureActivity = await readActivityAnalytics(course.id, ctx)
+    const blankDisclosurePerformance = await readPerformanceAnalytics(
+      course.id,
+      ctx
+    )
+    expect(blankDisclosureActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(blankDisclosureActivity?.dailyActivity).toHaveLength(1)
+    expect(blankDisclosurePerformance?.participantPerformances).toHaveLength(0)
+    expect(
+      blankDisclosurePerformance?.participantActivityPerformances
+    ).toHaveLength(0)
+    await prisma.participant.update({
+      where: { id: participant.id },
+      data: {
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      },
+    })
+
+    await setLearningAnalyticsConsent({ consent: false }, ctx)
+    const withdrawnActivity = await readActivityAnalytics(course.id, ctx)
+    const withdrawnPerformance = await readPerformanceAnalytics(course.id, ctx)
+    expect(withdrawnActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(withdrawnActivity?.dailyActivity).toHaveLength(1)
+    expect(withdrawnPerformance?.participantPerformances).toHaveLength(0)
+    expect(withdrawnPerformance?.participantActivityPerformances).toHaveLength(
+      0
+    )
+
+    await wait(10)
+    const reenabled = await setLearningAnalyticsConsent({ consent: true }, ctx)
+    const reenabledBoundary = reenabled!.learningAnalyticsIncludedFrom!
+    expect(reenabledBoundary.getTime()).toBeGreaterThan(
+      initialBoundary.getTime()
+    )
+
+    const beforeRecomputeActivity = await readActivityAnalytics(course.id, ctx)
+    const beforeRecomputePerformance = await readPerformanceAnalytics(
+      course.id,
+      ctx
+    )
+    expect(beforeRecomputeActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(beforeRecomputeActivity?.dailyActivity).toHaveLength(1)
+    expect(beforeRecomputePerformance?.participantPerformances).toHaveLength(0)
+    expect(
+      beforeRecomputePerformance?.participantActivityPerformances
+    ).toHaveLength(0)
+
+    // The writer must clean up rows from the previous consent window before
+    // publishing replacement rows and advancing the recomputation marker.
+    await prisma.participantCourseAnalytics.deleteMany({
+      where: { courseId: course.id, participantId: participant.id },
+    })
+    await prisma.participantPerformance.deleteMany({
+      where: { courseId: course.id, participantId: participant.id },
+    })
+    await prisma.participantActivityPerformance.deleteMany({
+      where: { participantId: participant.id, practiceQuizId: practiceQuiz.id },
+    })
+    await createIndividualAnalyticsRows({
+      courseId: course.id,
+      participantId: participant.id,
+      practiceQuizId: practiceQuiz.id,
+      overrides: {
+        activeWeeks: 9,
+        activeDaysPerWeek: 8,
+        meanElementsPerDay: 7,
+        activityLevel: ActivityLevel.LOW,
+        firstErrorRate: 0.9,
+        firstPerformance: PerformanceLevel.HIGH,
+        lastErrorRate: 0.8,
+        lastPerformance: PerformanceLevel.HIGH,
+        totalErrorRate: 0.85,
+        totalPerformance: PerformanceLevel.MEDIUM,
+        totalScore: 99,
+        completion: 0.5,
+      },
+    })
+    await prisma.course.update({
+      where: { id: course.id },
+      data: {
+        analyticsLastComputedAt: new Date(reenabledBoundary.getTime() + 1_000),
+      },
+    })
+    const recomputedActivity = await readActivityAnalytics(course.id, ctx)
+    const recomputedPerformance = await readPerformanceAnalytics(course.id, ctx)
+    expect(recomputedActivity?.participantCourseAnalytics).toHaveLength(1)
+    expect(recomputedActivity?.dailyActivity).toHaveLength(1)
+    expect(recomputedActivity?.participantCourseAnalytics[0]).toMatchObject({
+      activeWeeks: 9,
+      activeDaysPerWeek: 8,
+      meanElementsPerDay: 7,
+      activityLevel: ActivityLevel.LOW,
+    })
+    expect(recomputedPerformance?.participantPerformances).toHaveLength(1)
+    expect(recomputedPerformance?.participantActivityPerformances).toHaveLength(
+      1
+    )
+    expect(recomputedPerformance?.participantPerformances[0]).toMatchObject({
+      firstErrorRate: 0.9,
+      firstPerformance: PerformanceLevel.HIGH,
+      lastErrorRate: 0.8,
+      lastPerformance: PerformanceLevel.HIGH,
+      totalErrorRate: 0.85,
+      totalPerformance: PerformanceLevel.MEDIUM,
+    })
+    expect(
+      recomputedPerformance?.participantActivityPerformances[0]
+        ?.activityPerformances[0]
+    ).toMatchObject({ totalScore: 99, completion: 0.5 })
+    expect({
+      totalParticipants: recomputedActivity!.totalParticipants,
+      dailyActivity: recomputedActivity!.dailyActivity,
+      weeklyActivity: recomputedActivity!.weeklyActivity,
+      activeDays: recomputedActivity!.activeDays,
+    }).toEqual(initialActivityAggregates)
+    expect({
+      totalParticipants: recomputedPerformance!.totalParticipants,
+      activityProgresses: recomputedPerformance!.activityProgresses,
+      activityPerformances: recomputedPerformance!.activityPerformances,
+      instancePerformances: recomputedPerformance!.instancePerformances,
+      instanceFeedbacks: recomputedPerformance!.instanceFeedbacks,
+      activityFeedbacks: recomputedPerformance!.activityFeedbacks,
+    }).toEqual(initialPerformanceAggregates)
+
+    await setLearningAnalyticsConsent({ consent: false }, ctx)
+    const withdrawnAgainActivity = await readActivityAnalytics(course.id, ctx)
+    const withdrawnAgainPerformance = await readPerformanceAnalytics(
+      course.id,
+      ctx
+    )
+    expect(withdrawnAgainActivity?.participantCourseAnalytics).toHaveLength(0)
+    expect(withdrawnAgainActivity?.dailyActivity).toHaveLength(1)
+    expect(withdrawnAgainPerformance?.participantPerformances).toHaveLength(0)
+    expect(
+      withdrawnAgainPerformance?.participantActivityPerformances
+    ).toHaveLength(0)
+  }, 15_000)
+})

--- a/packages/graphql/test/participantDataUse.test.ts
+++ b/packages/graphql/test/participantDataUse.test.ts
@@ -40,11 +40,13 @@ function participantContext({
   databaseTime = nextTime,
   role = UserRole.PARTICIPANT,
   lockError = false,
+  transactionError,
 }: {
   state?: ParticipantDataUseFields
   databaseTime?: Date
   role?: UserRole
   lockError?: boolean
+  transactionError?: unknown
 } = {}) {
   const current = { ...state }
   const queryStatements: string[] = []
@@ -87,8 +89,11 @@ function participantContext({
     participant,
     $queryRaw: queryRaw,
     $executeRaw: executeRaw,
-    $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) =>
-      callback(transaction)
+    $transaction: vi.fn(
+      async (callback: (tx: typeof transaction) => unknown) => {
+        if (transactionError) throw transactionError
+        return callback(transaction)
+      }
     ),
   }
   const ctx = {
@@ -114,7 +119,6 @@ function participantContext({
 
 type ParticipantAnalyticsFilter = {
   participantId: { in: string[] }
-  participant: Record<string, unknown>
 }
 
 type CourseFindUniqueArgs = {
@@ -455,12 +459,7 @@ describe('participant data-use API', () => {
     }
     const activityWhere = activityCall.include.participantCourseAnalytics.where
     expect(activityWhere.participantId.in).toEqual([participantId])
-    expect(activityWhere.participant).toMatchObject({
-      learningAnalyticsConsent: true,
-      learningAnalyticsChoiceAt: { not: null },
-      learningAnalyticsDisclosureVersion: { not: '' },
-      learningAnalyticsIncludedFrom: { not: null },
-    })
+    expect(activityWhere).not.toHaveProperty('participant')
     expect(activityResult?.dailyActivity).toHaveLength(1)
     expect(activityResult?.participantCourseAnalytics).toHaveLength(1)
     expect(queryStatements[0]).toContain('analyticsLastComputedAt')
@@ -480,14 +479,25 @@ describe('participant data-use API', () => {
     const performanceWhere =
       performanceCall.include.participantPerformances.where
     expect(performanceWhere.participantId.in).toEqual([participantId])
-    expect(performanceWhere.participant).toMatchObject({
-      learningAnalyticsConsent: true,
-      learningAnalyticsIncludedFrom: { not: null },
-    })
+    expect(performanceWhere).not.toHaveProperty('participant')
     expect(queryStatements[1]).toContain('ParticipantPerformance')
     expect(queryStatements[1]).toContain('ParticipantActivityPerformance')
     expect(queryStatements[1]).toContain(
       'learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt'
     )
+  })
+
+  it('propagates generic transaction timeouts instead of relabeling them as lock timeouts', async () => {
+    const transactionError = {
+      code: 'P2028',
+      message: 'Transaction already closed: expired transaction timeout',
+    }
+    const fixture = participantContext({ transactionError })
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).rejects.toBe(transactionError)
+    expect(fixture.executeStatements).toHaveLength(0)
+    expect(fixture.participant.findUnique).not.toHaveBeenCalled()
   })
 })

--- a/packages/graphql/test/participantDataUse.test.ts
+++ b/packages/graphql/test/participantDataUse.test.ts
@@ -30,7 +30,6 @@ function participantState(
     learningAnalyticsConsent: false,
     learningAnalyticsChoiceAt: null,
     learningAnalyticsDisclosureVersion: null,
-    learningAnalyticsIncludedFrom: null,
     ...overrides,
   }
 }
@@ -129,7 +128,7 @@ type CourseFindUniqueArgs = {
 }
 
 describe('participant data-use API', () => {
-  it('returns only the seven current-state fields and keeps them out of Participant', () => {
+  it('exposes six current-state fields and keeps them out of Participant', () => {
     const dataUseType = schema.getType('ParticipantDataUse')
     expect(dataUseType).toBeDefined()
     if (!dataUseType) return
@@ -140,7 +139,6 @@ describe('participant data-use API', () => {
       'learningAnalyticsChoiceAt',
       'learningAnalyticsConsent',
       'learningAnalyticsDisclosureVersion',
-      'learningAnalyticsIncludedFrom',
       'researchConsent',
       'researchConsentChoiceAt',
       'researchConsentDisclosureVersion',
@@ -152,8 +150,16 @@ describe('participant data-use API', () => {
     const participantFields = (
       participantType as { getFields: () => Record<string, unknown> }
     ).getFields()
-    expect(participantFields).not.toHaveProperty('researchConsent')
-    expect(participantFields).not.toHaveProperty('learningAnalyticsConsent')
+    for (const field of [
+      'researchConsent',
+      'researchConsentChoiceAt',
+      'researchConsentDisclosureVersion',
+      'learningAnalyticsConsent',
+      'learningAnalyticsChoiceAt',
+      'learningAnalyticsDisclosureVersion',
+    ]) {
+      expect(participantFields).not.toHaveProperty(field)
+    }
 
     const queryField = schema.getQueryType()!.getFields().selfDataUse
     expect(queryField).toBeDefined()
@@ -174,41 +180,44 @@ describe('participant data-use API', () => {
     expect(userContext.prisma.$transaction).not.toHaveBeenCalled()
   })
 
-  it('records the initial explicit no with database time and v1', async () => {
-    const fixture = participantContext()
-    const result = await setResearchConsent({ consent: false }, fixture.ctx)
-
-    expect(result).toMatchObject({
+  it('records current choices with database time and server-owned v1 metadata', async () => {
+    const researchFixture = participantContext()
+    await expect(
+      setResearchConsent({ consent: false }, researchFixture.ctx)
+    ).resolves.toMatchObject({
       researchConsent: false,
       researchConsentChoiceAt: nextTime,
       researchConsentDisclosureVersion: PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
     })
-    expect(fixture.current.researchConsentChoiceAt).toEqual(nextTime)
-    expect(fixture.current.learningAnalyticsIncludedFrom).toBeNull()
-    expect(fixture.queryStatements).toEqual([
+    expect(researchFixture.queryStatements).toEqual([
       expect.stringContaining('clock_timestamp'),
     ])
-    expect(fixture.executeStatements).toHaveLength(0)
+    expect(researchFixture.executeStatements).toHaveLength(0)
 
     const learningAnalyticsFixture = participantContext()
-    const learningAnalyticsResult = await setLearningAnalyticsConsent(
-      { consent: false },
-      learningAnalyticsFixture.ctx
-    )
-    expect(learningAnalyticsResult).toMatchObject({
-      learningAnalyticsConsent: false,
+    await expect(
+      setLearningAnalyticsConsent(
+        {
+          consent: true,
+        },
+        learningAnalyticsFixture.ctx
+      )
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: true,
       learningAnalyticsChoiceAt: nextTime,
       learningAnalyticsDisclosureVersion:
         PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      learningAnalyticsIncludedFrom: null,
     })
     expect(learningAnalyticsFixture.executeStatements[0]).toContain(
       'lock_timeout'
     )
+    expect(learningAnalyticsFixture.executeStatements[1]).toContain(
+      'pg_advisory_xact_lock'
+    )
+    expect(learningAnalyticsFixture.participant.update).toHaveBeenCalledOnce()
   })
 
   it('keeps a same-state recorded choice idempotent', async () => {
-    const boundary = new Date('2026-08-01T00:00:00.000Z')
     const choiceAt = new Date('2026-08-02T00:00:00.000Z')
     const fixture = participantContext({
       state: participantState({
@@ -220,7 +229,6 @@ describe('participant data-use API', () => {
         learningAnalyticsChoiceAt: choiceAt,
         learningAnalyticsDisclosureVersion:
           PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: boundary,
       }),
     })
 
@@ -231,68 +239,57 @@ describe('participant data-use API', () => {
       setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
     ).resolves.toEqual(fixture.current)
     expect(fixture.participant.update).not.toHaveBeenCalled()
+    expect(fixture.queryStatements).not.toContain(
+      expect.stringContaining('clock_timestamp')
+    )
     expect(fixture.executeStatements).toEqual([
       expect.stringContaining('lock_timeout'),
       expect.stringContaining('pg_advisory_xact_lock'),
     ])
-    expect(fixture.queryStatements).not.toContain(
-      expect.stringContaining('clock_timestamp')
-    )
-    expect(fixture.current.learningAnalyticsIncludedFrom).toEqual(boundary)
   })
 
-  it('refreshes disclosure metadata without moving the learning boundary', async () => {
-    const boundary = new Date('2026-08-01T00:00:00.000Z')
+  it('refreshes disclosure metadata and the current choice timestamp', async () => {
     const fixture = participantContext({
       state: participantState({
         learningAnalyticsConsent: true,
         learningAnalyticsChoiceAt: initialTime,
         learningAnalyticsDisclosureVersion: 'previous-v1',
-        learningAnalyticsIncludedFrom: boundary,
-      }),
-    })
-    expect(boundary.getTime()).toBeLessThan(initialTime.getTime())
-
-    const result = await setLearningAnalyticsConsent(
-      { consent: true },
-      fixture.ctx
-    )
-
-    expect(result).toMatchObject({
-      learningAnalyticsConsent: true,
-      learningAnalyticsChoiceAt: nextTime,
-      learningAnalyticsDisclosureVersion:
-        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      learningAnalyticsIncludedFrom: boundary,
-    })
-    expect(fixture.participant.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.not.objectContaining({
-          learningAnalyticsIncludedFrom: expect.anything(),
-        }),
-      })
-    )
-  })
-
-  it('fails closed on an enabled boundary after its recorded choice and repairs on withdrawal', async () => {
-    const choiceAt = new Date('2026-08-02T00:00:00.000Z')
-    const impossibleBoundary = new Date('2026-08-03T00:00:00.000Z')
-    const fixture = participantContext({
-      state: participantState({
-        learningAnalyticsConsent: true,
-        learningAnalyticsChoiceAt: choiceAt,
-        learningAnalyticsDisclosureVersion:
-          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: impossibleBoundary,
       }),
     })
 
     await expect(
       setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
-    ).rejects.toMatchObject({
-      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
     })
-    expect(fixture.participant.update).not.toHaveBeenCalled()
+    expect(fixture.participant.update).toHaveBeenCalledOnce()
+  })
+
+  it('repairs incomplete current metadata instead of using a second boundary', async () => {
+    const fixture = participantContext({
+      state: participantState({ learningAnalyticsConsent: true }),
+    })
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+    })
+    expect(fixture.participant.update).toHaveBeenCalledOnce()
+  })
+
+  it('normalizes a recorded false choice when its metadata is incomplete', async () => {
+    const fixture = participantContext({
+      state: participantState({
+        learningAnalyticsChoiceAt: initialTime,
+      }),
+    })
 
     await expect(
       setLearningAnalyticsConsent({ consent: false }, fixture.ctx)
@@ -301,81 +298,30 @@ describe('participant data-use API', () => {
       learningAnalyticsChoiceAt: nextTime,
       learningAnalyticsDisclosureVersion:
         PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      learningAnalyticsIncludedFrom: null,
     })
+    expect(fixture.participant.update).toHaveBeenCalledOnce()
   })
 
-  it('uses one database timestamp for a false-to-true boundary and clears it on withdrawal', async () => {
+  it('uses database time for each changed current choice', async () => {
     const fixture = participantContext()
-    const included = await setLearningAnalyticsConsent(
-      { consent: true },
-      fixture.ctx
-    )
-    expect(included).toMatchObject({
-      learningAnalyticsConsent: true,
-      learningAnalyticsChoiceAt: nextTime,
-      learningAnalyticsIncludedFrom: nextTime,
-    })
-
-    const withdrawn = await setLearningAnalyticsConsent(
-      { consent: false },
-      fixture.ctx
-    )
-    expect(withdrawn).toMatchObject({
-      learningAnalyticsConsent: false,
-      learningAnalyticsChoiceAt: nextTime,
-      learningAnalyticsIncludedFrom: null,
-    })
-    expect(fixture.executeStatements).toHaveLength(4)
-    expect(fixture.executeStatements[0]).toContain('lock_timeout')
-    expect(
-      fixture.queryStatements.filter((sql) => sql.includes('clock_timestamp'))
-    ).toHaveLength(2)
-  })
-
-  it('fails closed on malformed enablement and normalizes withdrawal', async () => {
-    const fixture = participantContext({
-      state: participantState({
-        learningAnalyticsConsent: true,
-        learningAnalyticsChoiceAt: null,
-        learningAnalyticsDisclosureVersion:
-          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: null,
-      }),
-    })
 
     await expect(
       setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
-    ).rejects.toMatchObject({
-      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
-    })
-    expect(fixture.participant.update).not.toHaveBeenCalled()
-    expect(fixture.queryStatements).not.toContain(
-      expect.stringContaining('clock_timestamp')
-    )
-
-    const contradictoryWithdrawal = participantContext({
-      state: participantState({
-        learningAnalyticsConsent: false,
-        learningAnalyticsChoiceAt: initialTime,
-        learningAnalyticsDisclosureVersion:
-          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-        learningAnalyticsIncludedFrom: initialTime,
-      }),
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: nextTime,
     })
     await expect(
-      setLearningAnalyticsConsent(
-        { consent: false },
-        contradictoryWithdrawal.ctx
-      )
+      setLearningAnalyticsConsent({ consent: false }, fixture.ctx)
     ).resolves.toMatchObject({
       learningAnalyticsConsent: false,
       learningAnalyticsChoiceAt: nextTime,
-      learningAnalyticsDisclosureVersion:
-        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
-      learningAnalyticsIncludedFrom: null,
     })
-    expect(contradictoryWithdrawal.participant.update).toHaveBeenCalledOnce()
+
+    expect(fixture.executeStatements).toHaveLength(4)
+    expect(
+      fixture.queryStatements.filter((sql) => sql.includes('clock_timestamp'))
+    ).toHaveLength(2)
   })
 
   it('uses a bounded global lock and maps lock timeout without changing state', async () => {
@@ -402,7 +348,7 @@ describe('participant data-use API', () => {
     )
   })
 
-  it('filters individual analytics at the source while preserving aggregate output', async () => {
+  it('filters individual analytics with a strict current-choice freshness check', async () => {
     const queryStatements: string[] = []
     const courseFindUnique = vi.fn(async (args: CourseFindUniqueArgs) => {
       if (args.include.participantCourseAnalytics) {
@@ -415,14 +361,7 @@ describe('participant data-use API', () => {
             { type: 'DAILY', timestamp: initialTime, participantCount: 2 },
           ],
           aggregatedCourseAnalytics: null,
-          participantCourseAnalytics: [
-            {
-              activeWeeks: 1,
-              activeDaysPerWeek: 1,
-              meanElementsPerDay: 1,
-              activityLevel: 'HIGH',
-            },
-          ],
+          participantCourseAnalytics: [{ activeWeeks: 1 }],
         }
       }
 
@@ -457,33 +396,21 @@ describe('participant data-use API', () => {
     if (!activityCall?.include.participantCourseAnalytics) {
       throw new Error('missing activity analytics query')
     }
-    const activityWhere = activityCall.include.participantCourseAnalytics.where
-    expect(activityWhere.participantId.in).toEqual([participantId])
-    expect(activityWhere).not.toHaveProperty('participant')
+    expect(
+      activityCall.include.participantCourseAnalytics.where.participantId.in
+    ).toEqual([participantId])
     expect(activityResult?.dailyActivity).toHaveLength(1)
     expect(activityResult?.participantCourseAnalytics).toHaveLength(1)
-    expect(queryStatements[0]).toContain('analyticsLastComputedAt')
-    expect(queryStatements[0]).toContain('learningAnalyticsIncludedFrom')
     expect(queryStatements[0]).toContain(
-      'learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt'
+      'c."analyticsLastComputedAt" > p."learningAnalyticsChoiceAt"'
     )
 
     await getCoursePerformanceAnalytics(
       { courseId: '10000000-0000-4000-8000-000000000001' },
       ctx
     )
-    const performanceCall = courseFindUnique.mock.calls[1]?.[0]
-    if (!performanceCall?.include.participantPerformances) {
-      throw new Error('missing performance analytics query')
-    }
-    const performanceWhere =
-      performanceCall.include.participantPerformances.where
-    expect(performanceWhere.participantId.in).toEqual([participantId])
-    expect(performanceWhere).not.toHaveProperty('participant')
-    expect(queryStatements[1]).toContain('ParticipantPerformance')
-    expect(queryStatements[1]).toContain('ParticipantActivityPerformance')
     expect(queryStatements[1]).toContain(
-      'learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt'
+      'c."analyticsLastComputedAt" > p."learningAnalyticsChoiceAt"'
     )
   })
 

--- a/packages/graphql/test/participantDataUse.test.ts
+++ b/packages/graphql/test/participantDataUse.test.ts
@@ -1,0 +1,493 @@
+import { UserLoginScope, UserRole } from '@klicker-uzh/prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { schema } from '../src/index.js'
+import type { ContextWithUser } from '../src/lib/context.js'
+import {
+  PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+  type ParticipantDataUseFields,
+} from '../src/lib/learningAnalytics.js'
+import {
+  getCourseActivityAnalytics,
+  getCoursePerformanceAnalytics,
+} from '../src/services/analytics.js'
+import {
+  getParticipantDataUse,
+  setLearningAnalyticsConsent,
+  setResearchConsent,
+} from '../src/services/participants.js'
+
+const participantId = '00000000-0000-4000-8000-000000000001'
+const initialTime = new Date('2026-08-26T18:00:00.000Z')
+const nextTime = new Date('2026-08-26T18:01:00.000Z')
+
+function participantState(
+  overrides: Partial<ParticipantDataUseFields> = {}
+): ParticipantDataUseFields {
+  return {
+    researchConsent: false,
+    researchConsentChoiceAt: null,
+    researchConsentDisclosureVersion: null,
+    learningAnalyticsConsent: false,
+    learningAnalyticsChoiceAt: null,
+    learningAnalyticsDisclosureVersion: null,
+    learningAnalyticsIncludedFrom: null,
+    ...overrides,
+  }
+}
+
+function participantContext({
+  state = participantState(),
+  databaseTime = nextTime,
+  role = UserRole.PARTICIPANT,
+  lockError = false,
+}: {
+  state?: ParticipantDataUseFields
+  databaseTime?: Date
+  role?: UserRole
+  lockError?: boolean
+} = {}) {
+  const current = { ...state }
+  const queryStatements: string[] = []
+  const executeStatements: string[] = []
+  const queryRaw = vi.fn(
+    async (strings: TemplateStringsArray): Promise<Array<{ now?: Date }>> => {
+      const sql = strings.join(' ')
+      queryStatements.push(sql)
+      if (sql.includes('clock_timestamp')) return [{ now: databaseTime }]
+      return []
+    }
+  )
+  const executeRaw = vi.fn(async (strings: TemplateStringsArray) => {
+    const sql = strings.join(' ')
+    executeStatements.push(sql)
+    if (lockError && sql.includes('pg_advisory_xact_lock')) {
+      throw {
+        code: 'P2010',
+        meta: { code: '55P03' },
+        message: 'Raw query failed. Code: 55P03. Message: lock timeout',
+      }
+    }
+    return 0
+  })
+  const participant = {
+    findUnique: vi.fn(async () => ({ ...current })),
+    update: vi.fn(
+      async ({ data }: { data: Partial<ParticipantDataUseFields> }) => {
+        Object.assign(current, data)
+        return { ...current }
+      }
+    ),
+  }
+  const transaction = {
+    participant,
+    $queryRaw: queryRaw,
+    $executeRaw: executeRaw,
+  }
+  const prisma = {
+    participant,
+    $queryRaw: queryRaw,
+    $executeRaw: executeRaw,
+    $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) =>
+      callback(transaction)
+    ),
+  }
+  const ctx = {
+    prisma,
+    user: {
+      sub: participantId,
+      role,
+      scope: UserLoginScope.FULL_ACCESS,
+      catalystIndividual: false,
+      catalystInstitutional: false,
+    },
+  } as unknown as ContextWithUser
+
+  return {
+    ctx,
+    current,
+    participant,
+    prisma,
+    queryStatements,
+    executeStatements,
+  }
+}
+
+type ParticipantAnalyticsFilter = {
+  participantId: { in: string[] }
+  participant: Record<string, unknown>
+}
+
+type CourseFindUniqueArgs = {
+  include: {
+    participantCourseAnalytics?: { where: ParticipantAnalyticsFilter }
+    participantPerformances?: { where: ParticipantAnalyticsFilter }
+  }
+}
+
+describe('participant data-use API', () => {
+  it('returns only the seven current-state fields and keeps them out of Participant', () => {
+    const dataUseType = schema.getType('ParticipantDataUse')
+    expect(dataUseType).toBeDefined()
+    if (!dataUseType) return
+    const dataUseFields = Object.keys(
+      (dataUseType as { getFields: () => Record<string, unknown> }).getFields()
+    ).sort()
+    expect(dataUseFields).toEqual([
+      'learningAnalyticsChoiceAt',
+      'learningAnalyticsConsent',
+      'learningAnalyticsDisclosureVersion',
+      'learningAnalyticsIncludedFrom',
+      'researchConsent',
+      'researchConsentChoiceAt',
+      'researchConsentDisclosureVersion',
+    ])
+
+    const participantType = schema.getType('Participant')
+    expect(participantType).toBeDefined()
+    if (!participantType) return
+    const participantFields = (
+      participantType as { getFields: () => Record<string, unknown> }
+    ).getFields()
+    expect(participantFields).not.toHaveProperty('researchConsent')
+    expect(participantFields).not.toHaveProperty('learningAnalyticsConsent')
+
+    const queryField = schema.getQueryType()!.getFields().selfDataUse
+    expect(queryField).toBeDefined()
+    if (!queryField) return
+    expect(queryField.type.toString()).toBe('ParticipantDataUse')
+    expect(queryField.args).toHaveLength(0)
+  })
+
+  it('defends self-only access in the service layer', async () => {
+    const userContext = participantContext({ role: UserRole.USER })
+    await expect(getParticipantDataUse(userContext.ctx)).resolves.toBeNull()
+    await expect(
+      setResearchConsent({ consent: true }, userContext.ctx)
+    ).resolves.toBeNull()
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, userContext.ctx)
+    ).resolves.toBeNull()
+    expect(userContext.prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('records the initial explicit no with database time and v1', async () => {
+    const fixture = participantContext()
+    const result = await setResearchConsent({ consent: false }, fixture.ctx)
+
+    expect(result).toMatchObject({
+      researchConsent: false,
+      researchConsentChoiceAt: nextTime,
+      researchConsentDisclosureVersion: PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+    })
+    expect(fixture.current.researchConsentChoiceAt).toEqual(nextTime)
+    expect(fixture.current.learningAnalyticsIncludedFrom).toBeNull()
+    expect(fixture.queryStatements).toEqual([
+      expect.stringContaining('clock_timestamp'),
+    ])
+    expect(fixture.executeStatements).toHaveLength(0)
+
+    const learningAnalyticsFixture = participantContext()
+    const learningAnalyticsResult = await setLearningAnalyticsConsent(
+      { consent: false },
+      learningAnalyticsFixture.ctx
+    )
+    expect(learningAnalyticsResult).toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      learningAnalyticsIncludedFrom: null,
+    })
+    expect(learningAnalyticsFixture.executeStatements[0]).toContain(
+      'lock_timeout'
+    )
+  })
+
+  it('keeps a same-state recorded choice idempotent', async () => {
+    const boundary = new Date('2026-08-01T00:00:00.000Z')
+    const choiceAt = new Date('2026-08-02T00:00:00.000Z')
+    const fixture = participantContext({
+      state: participantState({
+        researchConsent: true,
+        researchConsentChoiceAt: choiceAt,
+        researchConsentDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: choiceAt,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: boundary,
+      }),
+    })
+
+    await expect(
+      setResearchConsent({ consent: true }, fixture.ctx)
+    ).resolves.toEqual(fixture.current)
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).resolves.toEqual(fixture.current)
+    expect(fixture.participant.update).not.toHaveBeenCalled()
+    expect(fixture.executeStatements).toEqual([
+      expect.stringContaining('lock_timeout'),
+      expect.stringContaining('pg_advisory_xact_lock'),
+    ])
+    expect(fixture.queryStatements).not.toContain(
+      expect.stringContaining('clock_timestamp')
+    )
+    expect(fixture.current.learningAnalyticsIncludedFrom).toEqual(boundary)
+  })
+
+  it('refreshes disclosure metadata without moving the learning boundary', async () => {
+    const boundary = new Date('2026-08-01T00:00:00.000Z')
+    const fixture = participantContext({
+      state: participantState({
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: initialTime,
+        learningAnalyticsDisclosureVersion: 'previous-v1',
+        learningAnalyticsIncludedFrom: boundary,
+      }),
+    })
+    expect(boundary.getTime()).toBeLessThan(initialTime.getTime())
+
+    const result = await setLearningAnalyticsConsent(
+      { consent: true },
+      fixture.ctx
+    )
+
+    expect(result).toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      learningAnalyticsIncludedFrom: boundary,
+    })
+    expect(fixture.participant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          learningAnalyticsIncludedFrom: expect.anything(),
+        }),
+      })
+    )
+  })
+
+  it('fails closed on an enabled boundary after its recorded choice and repairs on withdrawal', async () => {
+    const choiceAt = new Date('2026-08-02T00:00:00.000Z')
+    const impossibleBoundary = new Date('2026-08-03T00:00:00.000Z')
+    const fixture = participantContext({
+      state: participantState({
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: choiceAt,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: impossibleBoundary,
+      }),
+    })
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).rejects.toMatchObject({
+      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
+    })
+    expect(fixture.participant.update).not.toHaveBeenCalled()
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: false }, fixture.ctx)
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      learningAnalyticsIncludedFrom: null,
+    })
+  })
+
+  it('uses one database timestamp for a false-to-true boundary and clears it on withdrawal', async () => {
+    const fixture = participantContext()
+    const included = await setLearningAnalyticsConsent(
+      { consent: true },
+      fixture.ctx
+    )
+    expect(included).toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsIncludedFrom: nextTime,
+    })
+
+    const withdrawn = await setLearningAnalyticsConsent(
+      { consent: false },
+      fixture.ctx
+    )
+    expect(withdrawn).toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsIncludedFrom: null,
+    })
+    expect(fixture.executeStatements).toHaveLength(4)
+    expect(fixture.executeStatements[0]).toContain('lock_timeout')
+    expect(
+      fixture.queryStatements.filter((sql) => sql.includes('clock_timestamp'))
+    ).toHaveLength(2)
+  })
+
+  it('fails closed on malformed enablement and normalizes withdrawal', async () => {
+    const fixture = participantContext({
+      state: participantState({
+        learningAnalyticsConsent: true,
+        learningAnalyticsChoiceAt: null,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: null,
+      }),
+    })
+
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).rejects.toMatchObject({
+      extensions: { code: 'PARTICIPANT_DATA_USE_MALFORMED_STATE' },
+    })
+    expect(fixture.participant.update).not.toHaveBeenCalled()
+    expect(fixture.queryStatements).not.toContain(
+      expect.stringContaining('clock_timestamp')
+    )
+
+    const contradictoryWithdrawal = participantContext({
+      state: participantState({
+        learningAnalyticsConsent: false,
+        learningAnalyticsChoiceAt: initialTime,
+        learningAnalyticsDisclosureVersion:
+          PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+        learningAnalyticsIncludedFrom: initialTime,
+      }),
+    })
+    await expect(
+      setLearningAnalyticsConsent(
+        { consent: false },
+        contradictoryWithdrawal.ctx
+      )
+    ).resolves.toMatchObject({
+      learningAnalyticsConsent: false,
+      learningAnalyticsChoiceAt: nextTime,
+      learningAnalyticsDisclosureVersion:
+        PARTICIPANT_DATA_USE_DISCLOSURE_VERSION,
+      learningAnalyticsIncludedFrom: null,
+    })
+    expect(contradictoryWithdrawal.participant.update).toHaveBeenCalledOnce()
+  })
+
+  it('uses a bounded global lock and maps lock timeout without changing state', async () => {
+    const fixture = participantContext({ lockError: true })
+    await expect(
+      setLearningAnalyticsConsent({ consent: true }, fixture.ctx)
+    ).rejects.toMatchObject({
+      extensions: { code: 'PARTICIPANT_DATA_USE_LOCK_TIMEOUT' },
+    })
+    expect(fixture.executeStatements[0]).toContain(
+      "SET LOCAL lock_timeout = '5s'"
+    )
+    expect(fixture.executeStatements[1]).toContain('pg_advisory_xact_lock')
+    expect(fixture.participant.findUnique).not.toHaveBeenCalled()
+    expect(fixture.participant.update).not.toHaveBeenCalled()
+  })
+
+  it('does not take the learning-analytics lock for research changes', async () => {
+    const fixture = participantContext()
+    await setResearchConsent({ consent: true }, fixture.ctx)
+    expect(fixture.executeStatements).toHaveLength(0)
+    expect(fixture.queryStatements).not.toContain(
+      expect.stringContaining('pg_advisory_xact_lock')
+    )
+  })
+
+  it('filters individual analytics at the source while preserving aggregate output', async () => {
+    const queryStatements: string[] = []
+    const courseFindUnique = vi.fn(async (args: CourseFindUniqueArgs) => {
+      if (args.include.participantCourseAnalytics) {
+        return {
+          name: 'course',
+          startDate: initialTime,
+          endDate: nextTime,
+          participations: [{ id: 'participation' }],
+          aggregatedAnalytics: [
+            { type: 'DAILY', timestamp: initialTime, participantCount: 2 },
+          ],
+          aggregatedCourseAnalytics: null,
+          participantCourseAnalytics: [
+            {
+              activeWeeks: 1,
+              activeDaysPerWeek: 1,
+              meanElementsPerDay: 1,
+              activityLevel: 'HIGH',
+            },
+          ],
+        }
+      }
+
+      return {
+        name: 'course',
+        _count: { participations: 1 },
+        practiceQuizzes: [],
+        microLearnings: [],
+        participantPerformances: [],
+      }
+    })
+    const transactionClient = {
+      $queryRaw: vi.fn(async (strings: TemplateStringsArray) => {
+        queryStatements.push(strings.join(' '))
+        return [{ participantId }]
+      }),
+      course: { findUnique: courseFindUnique },
+    }
+    const prisma = {
+      $transaction: vi.fn(
+        async (callback: (tx: typeof transactionClient) => unknown) =>
+          callback(transactionClient)
+      ),
+    }
+    const ctx = { prisma } as unknown as ContextWithUser
+
+    const activityResult = await getCourseActivityAnalytics(
+      { courseId: '10000000-0000-4000-8000-000000000001' },
+      ctx
+    )
+    const activityCall = courseFindUnique.mock.calls[0]?.[0]
+    if (!activityCall?.include.participantCourseAnalytics) {
+      throw new Error('missing activity analytics query')
+    }
+    const activityWhere = activityCall.include.participantCourseAnalytics.where
+    expect(activityWhere.participantId.in).toEqual([participantId])
+    expect(activityWhere.participant).toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsChoiceAt: { not: null },
+      learningAnalyticsDisclosureVersion: { not: '' },
+      learningAnalyticsIncludedFrom: { not: null },
+    })
+    expect(activityResult?.dailyActivity).toHaveLength(1)
+    expect(activityResult?.participantCourseAnalytics).toHaveLength(1)
+    expect(queryStatements[0]).toContain('analyticsLastComputedAt')
+    expect(queryStatements[0]).toContain('learningAnalyticsIncludedFrom')
+    expect(queryStatements[0]).toContain(
+      'learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt'
+    )
+
+    await getCoursePerformanceAnalytics(
+      { courseId: '10000000-0000-4000-8000-000000000001' },
+      ctx
+    )
+    const performanceCall = courseFindUnique.mock.calls[1]?.[0]
+    if (!performanceCall?.include.participantPerformances) {
+      throw new Error('missing performance analytics query')
+    }
+    const performanceWhere =
+      performanceCall.include.participantPerformances.where
+    expect(performanceWhere.participantId.in).toEqual([participantId])
+    expect(performanceWhere.participant).toMatchObject({
+      learningAnalyticsConsent: true,
+      learningAnalyticsIncludedFrom: { not: null },
+    })
+    expect(queryStatements[1]).toContain('ParticipantPerformance')
+    expect(queryStatements[1]).toContain('ParticipantActivityPerformance')
+    expect(queryStatements[1]).toContain(
+      'learningAnalyticsIncludedFrom" <= p."learningAnalyticsChoiceAt'
+    )
+  })
+})


### PR DESCRIPTION
## What This Changes

This stacked draft adds the participant-only API and read-time privacy boundary for the global research and learning-analytics choices introduced by PR #5569.

- Adds `selfDataUse`, `setResearchConsent`, and `setLearningAnalyticsConsent`; the generic `Participant` type remains unchanged.
- Stores only the current Boolean choice, database choice time, and server-owned disclosure version `v1` for each purpose.
- Serializes learning-analytics changes through the shared global advisory gate with a five-second database lock timeout. Research changes remain independent.
- Treats current learning-analytics `yes` as permission to use all eligible stored canonical history and current `no` as permission to use none.
- Filters individual analytics at read time using current consent, complete nonblank metadata, a valid course, an existing computation watermark, and strict freshness: `Course.analyticsLastComputedAt > Participant.learningAnalyticsChoiceAt`.
- Leaves aggregate and canonical outputs unchanged.

No new database model, history table, Hatchet dispatch, worker activation, UI, deployment, or source-PR closure is included.

## Contract Details

- Access is self-only and restricted to authenticated participant accounts.
- The API exposes exactly six data-use fields through the dedicated object.
- An already recorded current choice with valid `v1` metadata is idempotent.
- Each actual transition records its database `choiceAt`; this timestamp is a revision and recomputation watermark, never an activity cutoff.
- Impossible enabled ordering and contradictory metadata fail closed on reads. Withdrawal remains available to normalize malformed state.
- Individual reads use a repeatable database snapshot and stay hidden until cleanup-first recomputation advances the course watermark strictly past the latest learning-analytics choice.
- Re-enabling does not maintain an opted-out interval. After the next valid recomputation, all eligible stored canonical history may contribute again.

## Branch Coverage

- Base: `rs/participant-data-use-schema` at `93344b11c0c03aa28e26611cc84ca2f752aabb0e` (draft PR #5569)
- Head: `1e0153b91aca10a8220b777e86316bf4de5445c2`
- Delta from the current base: six commits; 16 changed paths; +1,531/-146 lines, including generated GraphQL output
- Substantive handwritten delta excluding generated GraphQL schema and project artifacts: +1,519/-146 lines

The branch includes the corrected PC-P1 parent through an explicit merge commit, so the stack retains its full published history.

## Review Focus

- Confirm the six-field self-only boundary cannot leak through generic participant queries.
- Confirm current-state transitions, disclosure refresh, and strict recomputation freshness semantics.
- Confirm the global advisory gate and timeout preserve lock compatibility with the private Catalyst worker.
- Confirm `yes` never acts as an activity cutoff, `no` hides individual rows immediately, and aggregate output remains unchanged.
- Confirm incomplete or malformed metadata fails closed and can be repaired without exposing stale rows.

## Verification

- Focused Vitest files: 18 passed, including six real PostgreSQL integration tests.
- The integration tests cover idempotence, transition timestamps, strict watermark freshness, advisory locking, malformed metadata repair, immediate withdrawal filtering, and aggregate preservation.
- Prisma package check, GraphQL code generation, committed-schema diff, and GraphQL TypeScript check pass.
- Prettier on the changed Markdown and `git diff --check` pass.
- Required simplification review passes with no finding. The privacy and data-integrity review reports no code finding after confirming the corrected parent migrations have never landed or been officially deployed.

The host commit and pre-push hooks selected Node 22 and attempted a non-interactive pnpm reinstall. Equivalent package checks ran in the repository's required Node 24 devcontainer, so publication used `HUSKY=0`; hosted CI remains authoritative.

Hosted exact-head CodeQL, GitGuardian, and OpenCodeReview checks pass. The separate `trusted_policy` job is failing under the already active workflow investigation.

## Security and Privacy

- No participant identifier, choice value, or analytics content is logged.
- Tests use only synthetic records and remove their fixtures.
- No credentials, real participant data, export data, or live-service output is included.

## Blocking Before Merge

- [ ] GitHub recomputes a clean stacked merge result; the remote compare proves the current base is an ancestor with zero commits behind, while the PR API still reports a conflicting cached merge state.
- [ ] Exact-head required GitHub checks pass, including the separately investigated `trusted_policy` workflow.
- [ ] PC-P3 participant settings, Catalyst cleanup, and the remaining public learning-analytics integration stack pass cross-repository proof.

## Follow-Up

- Surface the two independent global choices in participant settings.
- Dispatch consent changes through the public Hatchet integration without adding consent history or a new database model.
- Keep the analytics worker disabled until the complete public/private stack is reviewed and deployment is separately authorized.
