### PR TITLE
enhance(playwright): improve ARM64 runner throughput

### DIFF
--- a/.github/workflows/public-pr-playwright-shards.yml
+++ b/.github/workflows/public-pr-playwright-shards.yml
@@ -210,8 +210,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/public-pr-playwright-shards.yml
+++ b/.github/workflows/public-pr-playwright-shards.yml
@@ -127,7 +127,7 @@ jobs:
         run: pnpm install
 
       - name: Build all packages and apps
-        run: pnpm run --filter @klicker-uzh/prisma build:test && pnpm run build:test
+        run: pnpm run --filter @klicker-uzh/prisma build:test && pnpm run build:test --concurrency=2
         env:
           APP_SECRET: abcd
           DATABASE_URL: postgres://klicker-prod:klicker@localhost:5432/klicker-prod

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -422,9 +422,9 @@ jobs:
         build-and-compile-hosted,
         test-playwright-hosted,
         test-playwright-public-pr,
-      ]
+    ]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.test-playwright-public-pr.result != 'skipped' && 'public-pr-arm64' || 'ubuntu-latest' }}
     steps:
       - name: Check result
         run: |

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -411,7 +411,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-public-pr-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
-    uses: uzh-bf/klicker-uzh/.github/workflows/public-pr-playwright-shards.yml@v3
+    uses: uzh-bf/klicker-uzh/.github/workflows/public-pr-playwright-shards.yml@rs/arm64-runner-canary
 
   # Always reports a status even when the tests are skipped by the path filter,
   # so this job can be used as a required check in branch protection.

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -10,7 +10,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Canary-only touch: selecting this workflow path exercises the full route.
+  # Canary-only touch: exercise the complete public PR ARM64 route.
   # The hosted and public-PR predicates are intentional complements. Only the
   # exact lowercase value "true" or an exact canary PR number enables the
   # self-hosted path; every other value fails closed to GitHub-hosted runners.

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -10,6 +10,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # Canary-only touch: selecting this workflow path exercises the full route.
   # The hosted and public-PR predicates are intentional complements. Only the
   # exact lowercase value "true" or an exact canary PR number enables the
   # self-hosted path; every other value fails closed to GitHub-hosted runners.

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -10,7 +10,6 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Canary-only touch: exercise the complete public PR ARM64 route.
   # The hosted and public-PR predicates are intentional complements. Only the
   # exact lowercase value "true" or an exact canary PR number enables the
   # self-hosted path; every other value fails closed to GitHub-hosted runners.
@@ -411,7 +410,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-public-pr-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
-    uses: uzh-bf/klicker-uzh/.github/workflows/public-pr-playwright-shards.yml@rs/arm64-runner-canary
+    uses: uzh-bf/klicker-uzh/.github/workflows/public-pr-playwright-shards.yml@v3
 
   # Always reports a status even when the tests are skipped by the path filter,
   # so this job can be used as a required check in branch protection.
@@ -422,7 +421,7 @@ jobs:
         build-and-compile-hosted,
         test-playwright-hosted,
         test-playwright-public-pr,
-    ]
+      ]
     if: always()
     runs-on: ${{ needs.test-playwright-public-pr.result != 'skipped' && 'public-pr-arm64' || 'ubuntu-latest' }}
     steps:


### PR DESCRIPTION
## What This Fixes

The public same-repository PR Playwright route now matches the capacity of the three-runner ARM64 pool:

- Limits the shared ARM64 build to Turbo concurrency 2, avoiding the CAX21 8 GB memory failure seen with unrestricted concurrency.
- Runs three Playwright shards, one per public ARM64 runner, instead of sending eight shards through three sequential waves.
- Runs the final public-route status job on the public ARM64 pool, avoiding a second GitHub-hosted queue after the tests finish.
- Keeps GitHub-hosted execution as the fail-closed path for forks, bots, drafts, private repositories, and disabled rollout.

## How It Works

The existing eligibility predicates and reusable `@v3` workflow boundary remain unchanged. Only the public ARM64 route's build concurrency, shard count, and final status runner selection change.

## Branch Coverage

- Base: `v3`
- Head: `e1ea1e388`
- Reviewed: 5 commits; 2 workflow files; 4 additions and 4 deletions
- Packaging: 8 substantive lines, below the normal package floor; this is a complete, floor-exempt CI capacity and reliability fix.
- Covered: temporary canary triggering, ARM64 build memory limit, shard-to-runner capacity matching, self-hosted status routing, and restoration of the merged `@v3` reusable-workflow reference.

The two initial canary-only commits leave no temporary comment or branch reference in the final diff. `v3` advanced by four unrelated commits during the canary; this branch was not rebased, and the PR diff remains limited to the two workflow files.

## Review Focus

- Confirm the three-shard matrix matches the three public ARM64 runners.
- Confirm the dynamic status runner uses `public-pr-arm64` only when the public reusable job was selected.
- Confirm all ineligible public PRs retain the GitHub-hosted fallback.

## Verification

### Current head

- `prettier --check .github/workflows/test-playwright.yml .github/workflows/public-pr-playwright-shards.yml`: passed.
- `git diff --check`: passed.
- Staged Gitleaks scan: passed with no leaks.
- Exact-head hosted checks: running on [PR #5592](https://github.com/uzh-bf/klicker-uzh/pull/5592).

### Earlier branch verification

- [Run 33023233335](https://github.com/uzh-bf/klicker-uzh/actions/runs/33023233335): all eight ARM64 shards and artifacts passed across `public-pr-arm64-01`, `-02`, and `-03`; this proved the runner, Docker, Playwright, build, shard, artifact, and status path.
- [Run 33047403336](https://github.com/uzh-bf/klicker-uzh/actions/runs/33047403336): the optimized route started without queueing, built in 7m34s, assigned all three shards simultaneously to the three runners, and started the final status job immediately on `public-pr-arm64-01`. Total duration was 47m24s.
- The same-day GitHub-hosted comparison runs took about 70–103 minutes end-to-end because build, shard, and status jobs queued: [33017627811](https://github.com/uzh-bf/klicker-uzh/actions/runs/33017627811), [33015462171](https://github.com/uzh-bf/klicker-uzh/actions/runs/33015462171), and [33012795278](https://github.com/uzh-bf/klicker-uzh/actions/runs/33012795278).

### Failed / Warning

- Optimized run 33047403336 ended red because `P-pagination-show-all.spec.ts` could not find an element within 10 seconds on both attempts. The runner remained online, completed 320 other tests in that shard, uploaded diagnostics, and cleaned up normally; the other two shards passed.
- The repository-wide local pre-commit typecheck was attempted but failed because the fresh host worktree lacked generated internal package outputs and used Node 26 instead of the pinned Node 24. The workflow-specific formatting and secret checks above passed; exact-head CI remains the merge gate.

## Security / Privacy

- The existing same-repository, non-bot, non-draft eligibility boundary remains in place. Fork PRs do not execute on the persistent public runners.
- The public reusable workflow keeps read-only contents permission and receives no repository secrets.
- No credentials, personal data, or generated test artifacts are committed.

## Blocking Before Merge

- [ ] Required checks pass on exact head `e1ea1e388`.

## Follow-Up After Merge

- [ ] Set `PUBLIC_PR_ARM64_PLAYWRIGHT_ENABLED=true` to enable the public ARM64 route globally.
- [ ] Compare the first real PR runs against the 47-minute canary and keep GitHub-hosted as the fallback.

## Local Session Artifacts

- Machine: local host
- Worktree: `trees/rs/arm64-runner-canary` in repository `klicker-uzh`
