### PR TITLE
fix(chat): restore disclaimer accept button contrast

### DIFF
--- a/apps/chat/src/components/disclaimer-modal.tsx
+++ b/apps/chat/src/components/disclaimer-modal.tsx
@@ -189,10 +189,12 @@ export const DisclaimerModal = ({
           </Button>
           <Button
             ref={acceptButtonRef}
-            primary
             data-cy="chat-disclaimer-accept"
             onClick={handleAccept}
             disabled={isLoading}
+            className={{
+              root: 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground disabled:hover:bg-primary border-transparent font-semibold',
+            }}
           >
             {isLoading
               ? t('chat.disclaimer.saving')


### PR DESCRIPTION
## What This Fixes

The chatbot disclaimer's primary action is visible again. The “Accept and continue” button now uses the Chat app's semantic blue background and contrasting foreground instead of the design-system `primary` token that resolves to an undefined Chat color.

## How It Works

- Replaces the incompatible `primary` prop with the semantic `bg-primary` and `text-primary-foreground` classes already used by Chat.
- Preserves the existing modal flow, loading state, focus behavior, geometry, callbacks, and test selector.

## Branch Coverage

- Base: `v3`; branch fork `1e7308d67ced9645ed9f93dc0a0f37bce9fa0463`
- Head: `e488cf1a4`
- Reviewed: 1 commit; 1 changed path; 3 additions and 1 deletion
- Packaging: 4 substantive lines, below the normal package floor; this is a floor-exempt isolated user-blocking UI regression fix.

The current `v3` remote advanced by one unrelated staging deployment-values commit after the branch fork. This branch was not rebased; the three-way PR diff contains only the disclaimer component.

## Screenshots

The final after screenshot is available as a machine-local session artifact and must be uploaded before this draft is marked ready.

## Verification

### Current head

- Combined final review of `1e7308d67ced9645ed9f93dc0a0f37bce9fa0463..e488cf1a4`: passed with no package findings.
- `pnpm --filter @klicker-uzh/chat check`: passed in the exact DevPod.
- `pnpm exec biome check apps/chat/src/components/disclaimer-modal.tsx`: passed with one pre-existing raw-image warning outside the changed region.
- `pnpm run build`: 23 of 23 tasks passed in the exact DevPod; the Chat production build passed.
- `git diff --check`: passed.
- Staged Gitleaks scan: no leaks found.
- `agent-browser@0.32.2`: the primary action initially receives focus; its rendered foreground is `[250, 250, 250]`, its background is `[0, 40, 165]`, and the contrast ratio is `10.89:1`. Hover, focus-ring, and disabled styles remain visible. Accepting closes the modal and exposes the message composer.
- Runtime shutdown: DevPod `rs-fix-chat-disclaimer-accept-bu` is stopped and has zero matching routes.

### Warnings and incomplete checks

- `pnpm run check:all` was attempted in the exact DevPod. The scoped Chat check passed, but the repository-wide run failed in untouched `apps/analytics` because Python 3.14 attempted to compile pandas 2.2.2 without `cc`, `gcc`, or `clang` in the container.
- Hosted required checks start after this draft opens.

## Security / Privacy

- Bounded code-level review covers the executable frontend change.
- The change adds no authentication, authorization, API, data-flow, external-provider, secret, credential, or personal-data behavior.

## Blocking Before Merge

- [ ] Upload the final after screenshot and mark the PR ready.
- [ ] Hosted required checks pass on the exact head.

## Local Session Artifacts

- Machine: local host
- Worktree: `trees/fix-chat-disclaimer-accept-button` in repository `klicker-uzh`
- Review reports: `project/_local/reviews/`
- Screenshot: `project/_local/screenshots/chat-disclaimer-accept-button-after.png`
- Environment: DevPod `rs-fix-chat-disclaimer-accept-bu` is stopped and its routes are released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the disclaimer modal’s Accept button styling to preserve its primary appearance, including hover states and emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->