### PR TITLE
chore(deploy): promote d96cf502a04b to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -27,7 +27,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+        rollout.klicker.uzh.ch/release: 'd96cf502a04b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -52,7 +52,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+        rollout.klicker.uzh.ch/release: 'd96cf502a04b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -74,7 +74,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+        rollout.klicker.uzh.ch/release: 'd96cf502a04b'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -108,7 +108,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -162,7 +162,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -346,7 +346,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -398,7 +398,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -451,7 +451,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -503,7 +503,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -571,7 +571,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -623,7 +623,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
   replicaCount: 1
 
   affinity:
@@ -672,7 +672,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+    rollout.klicker.uzh.ch/release: 'd96cf502a04b'
 
   replicaCount: 1
 
@@ -725,7 +725,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+      rollout.klicker.uzh.ch/release: 'd96cf502a04b'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -788,7 +788,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+      rollout.klicker.uzh.ch/release: 'd96cf502a04b'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -865,7 +865,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'cf03ce72d1b6'
+      rollout.klicker.uzh.ch/release: 'd96cf502a04b'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `d96cf502a04bff1e16e6ffba4c43af3ea5ec9163`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.
