### PR TITLE
fix(deploy): align staging promotion source

### DIFF
--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -671,7 +671,6 @@ function validatePromotionContract(input) {
     pull,
     permission,
     repository,
-    defaultBranch,
     sourceBranch,
     commits,
     files,
@@ -685,7 +684,7 @@ function validatePromotionContract(input) {
     return invalidPromotion('promotion PR must be open and ready')
   }
   if (
-    pull.baseRef !== defaultBranch ||
+    pull.baseRef !== sourceBranch ||
     pull.baseRepo !== repository ||
     pull.headRepo !== repository
   ) {
@@ -752,7 +751,7 @@ function validatePromotionContract(input) {
     shortSha,
     sourceBranch
   )
-  if (expected.releaseCount !== 15 || expected.tagCount !== 15) {
+  if (expected.releaseCount === 0 || expected.tagCount === 0) {
     return invalidPromotion('base promotion file has unexpected structure')
   }
   if (headContent !== expected.content) {
@@ -1275,7 +1274,6 @@ async function inspectPromotion({
     },
     permission,
     repository: `${context.repo.owner}/${context.repo.repo}`,
-    defaultBranch: context.payload.repository.default_branch,
     sourceBranch,
     commits: commits.map((commit) => ({
       message: commit.commit.message,

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -1987,15 +1987,20 @@ test('rejects duplicate disposition markers as ambiguous', () => {
   assert.equal(parseDispositionRecord(`${marker}\n${marker}`), null)
 })
 
-function promotionFile(release, tag = 'v3') {
-  return Array.from(
-    { length: 15 },
+function promotionFile(release, tag = 'v3-ai') {
+  const tags = Array.from(
+    { length: 17 },
+    (_, index) => `service${index}:\n  tag: ${tag}`
+  )
+  const annotations = Array.from(
+    { length: 16 },
     (_, index) =>
-      `service${index}:\n  tag: ${tag}\n  podAnnotations:\n    rollout.klicker.uzh.ch/release: '${release}'`
-  ).join('\n')
+      `rollout${index}:\n  podAnnotations:\n    rollout.klicker.uzh.ch/release: '${release}'`
+  )
+  return [...tags, ...annotations].join('\n')
 }
 
-function validPromotionInput(sourceBranch = 'v3') {
+function validPromotionInput(sourceBranch = 'v3-ai') {
   const targetSha = '123456789abc'.padEnd(40, 'd')
   const shortSha = targetSha.slice(0, 12)
   const baseContent = promotionFile('aaaaaaaaaaaa')
@@ -2009,7 +2014,7 @@ function validPromotionInput(sourceBranch = 'v3') {
     pull: {
       state: 'open',
       draft: false,
-      baseRef: 'v3',
+      baseRef: sourceBranch,
       baseSha: 'b'.repeat(40),
       baseRepo: 'uzh-bf/klicker-uzh',
       headRef: `chore/promote-stg-${shortSha}`,
@@ -2045,6 +2050,46 @@ test('accepts current and source-switch generated promotions', () => {
     validatePromotionContract(validPromotionInput('release-candidate')).valid,
     true
   )
+})
+
+test('requires non-empty dynamic promotion inventories', () => {
+  const noTags = validPromotionInput()
+  noTags.baseContent = noTags.baseContent.replace(/^([ \t]+tag: ).*$/gm, '')
+  noTags.headContent = buildExpectedPromotionContent(
+    noTags.baseContent,
+    noTags.buildEvidence.targetSha.slice(0, 12),
+    noTags.sourceBranch
+  ).content
+  assert.equal(validatePromotionContract(noTags).valid, false)
+
+  const noAnnotations = validPromotionInput()
+  noAnnotations.baseContent = noAnnotations.baseContent.replace(
+    /^([ \t]*rollout\.klicker\.uzh\.ch\/release: ).*$/gm,
+    ''
+  )
+  noAnnotations.headContent = buildExpectedPromotionContent(
+    noAnnotations.baseContent,
+    noAnnotations.buildEvidence.targetSha.slice(0, 12),
+    noAnnotations.sourceBranch
+  ).content
+  assert.equal(validatePromotionContract(noAnnotations).valid, false)
+})
+
+test('staging promoter targets the selected source without fixed value counts', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '../workflows/deploy-stg-promote.yml'),
+    'utf8'
+  )
+
+  assert.match(workflow, /Build Docker image for mcp-lecturer \(stg\)/)
+  assert.match(workflow, /Build Docker image for mcp-student \(stg\)/)
+  assert.match(
+    workflow,
+    /ref: \$\{\{ steps\.target\.outputs\.source_branch \}\}/
+  )
+  assert.ok(workflow.includes('--base "$SOURCE_BRANCH"'))
+  assert.ok(workflow.includes('Verified generated staging promotion'))
+  assert.doesNotMatch(workflow, /expected 15/)
 })
 
 test('requires every trusted exact-SHA staging build run for a promotion', async () => {
@@ -2230,7 +2275,7 @@ test('verifies the generated-promotion no-report status through the repository v
   const workflow = {
     conclusion: 'success',
     event: 'push',
-    head_branch: 'v3',
+    head_branch: input.sourceBranch,
     head_sha: input.buildEvidence.targetSha,
     path: workflowPath,
     repository: { full_name: input.repository },
@@ -2331,7 +2376,7 @@ test('verifies the generated-promotion no-report status through the repository v
       github,
       context: reviewContext(),
       pull,
-      sourceBranch: 'v3',
+      sourceBranch: input.sourceBranch,
       trustedSha,
     }),
     true
@@ -2348,6 +2393,9 @@ test('rejects every material promotion-contract deviation', () => {
     },
     (input) => {
       input.pull.headRepo = 'attacker/fork'
+    },
+    (input) => {
+      input.pull.baseRef = 'v3'
     },
     (input) => {
       input.pull.title = 'chore(deploy): bypass review'

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -2024,7 +2024,6 @@ function validPromotionInput(sourceBranch = 'v3-ai') {
     },
     permission: 'write',
     repository: 'uzh-bf/klicker-uzh',
-    defaultBranch: 'v3',
     sourceBranch,
     commits: [
       {

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -38,6 +38,8 @@ on:
       - 'Build Docker image for hatchet-worker-general (stg)'
       - 'Build Docker image for hatchet-worker-response-processor (stg)'
       - 'Build Docker image for lti (stg)'
+      - 'Build Docker image for mcp-lecturer (stg)'
+      - 'Build Docker image for mcp-student (stg)'
       - 'Build Docker image for olat-api (stg)'
       - 'Build Docker image for response-api (stg)'
     types: [completed]
@@ -54,7 +56,7 @@ on:
 # Must stay `false`: cancelling a promoter mid-publish could leave a branch pushed
 # with no PR. Keep workflow-run groups separate by source branch, so an unrelated
 # `v3*` branch cannot occupy the selected branch's pending slot. Within one branch
-# group, the 13 build completions collapse to the latest queued one.
+# group, repeated build completions collapse to the latest queued one.
 concurrency:
   group: promote-stg-${{ github.event.workflow_run.head_branch || 'manual' }}
   cancel-in-progress: false
@@ -110,14 +112,16 @@ jobs:
           # Must be the BUILD's head SHA, never the current tip of the source branch:
           # the tip may have advanced past the commit whose images are actually green.
           SHA="${WR_SHA:-$IN_SHA}"
-          [ -n "$SHA" ] || { echo "::error::no target SHA"; exit 1; }
+          [[ "$SHA" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "::error::target SHA must be 40 lowercase hexadecimal characters"; exit 1; }
           echo "sha=$SHA" >>"$GITHUB_OUTPUT"
+          echo "source_branch=$SOURCE_BRANCH" >>"$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
-          # Deployment values remain on v3; this workflow promotes images built from
-          # the selected source branch into that GitOps configuration.
-          ref: v3
+          # ArgoCD reads the selected source branch, so the promotion must update the
+          # values on that same branch.
+          ref: ${{ steps.target.outputs.source_branch }}
           fetch-depth: 0 # merge-base needs full history
           token: ${{ secrets.STG_PROMOTE_TOKEN }}
 
@@ -126,11 +130,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
+          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
         run: |
           set -euo pipefail
-          # Matched per workflow *file* via `.path`. Check-runs cannot be used: all 13
-          # stg workflows name their jobs `build-arm`/`build-amd`, so the names collide.
+          # Matched per workflow *file* via `.path`. Check-runs cannot be used: the stg
+          # workflows name their jobs `build-arm`/`build-amd`, so the names collide.
           # Re-poll rather than giving up on the first look. This job is only ever
           # triggered by a build completing, so if the API has not yet indexed the
           # last run when the surviving promoter evaluates, there is no later trigger
@@ -142,8 +146,8 @@ jobs:
                 '[.[].workflow_runs[] | select(.head_branch == $source)]' > runs.json
 
             missing=(); notgreen=()
-            # Required set derived from the checkout, so adding a 14th stg app needs no
-            # edit here -- only the trigger list above.
+            # Required set derived from the checkout, so changing the stg build set
+            # needs no count update here -- only the trigger list above.
             for wf in .github/workflows/v3_*-stg.yml; do
               run=$(jq -c --arg p "$wf" \
                 '[.[] | select(.path == $p)] | sort_by(.id) | last // empty' runs.json)
@@ -177,7 +181,7 @@ jobs:
         if: steps.gate.outputs.go == 'true'
         env:
           SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
+          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
         run: |
           set -euo pipefail
           F=deploy/env-uzh-stg/values.yaml
@@ -187,7 +191,9 @@ jobs:
           TOTAL_TAGS=$(awk '$1 == "tag:" { count++ } END { print count + 0 }' "$F")
           SOURCE_TAGS=$(awk -v source="$SOURCE_BRANCH" \
             '$1 == "tag:" && $2 == source { count++ } END { print count + 0 }' "$F")
-          if [ "$TOTAL_TAGS" -ne 15 ] || [ "$SOURCE_TAGS" -ne "$TOTAL_TAGS" ]; then
+          [ "$TOTAL_TAGS" -gt 0 ] \
+            || { echo "::error::staging values contain no image tags"; exit 1; }
+          if [ "$SOURCE_TAGS" -ne "$TOTAL_TAGS" ]; then
             echo "::notice::staging source tag is changing to ${SOURCE_BRANCH}"
             echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
           fi
@@ -197,14 +203,27 @@ jobs:
           # depends on the repository's `squash_merge_commit_title` setting, which lives
           # outside this repo and is not recorded anywhere as load-bearing. This check
           # does not depend on it, and without it a flipped setting yields a runaway loop
-          # that burns 13 image builds and a full stg rollout per iteration.
+          # that burns every image build and a full stg rollout per iteration.
           if git log -1 --format='%s' "$SHA" | grep -q '^chore(deploy): promote '; then
             echo "::notice::${SHA} is itself a promotion commit"
             echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
           fi
 
-          CUR=$(sed -n "s/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release: '\(.*\)'$/\1/p" "$F" | head -1)
-          # Stale-promotion guard, and the idempotence check for the 13 re-fires:
+          RELEASE_COUNT=$(awk \
+            '/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release:/ { count++ } END { print count + 0 }' "$F")
+          [ "$RELEASE_COUNT" -gt 0 ] \
+            || { echo "::error::staging values contain no rollout annotations"; exit 1; }
+          mapfile -t RELEASES < <(sed -n \
+            "s/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release: '\(.*\)'$/\1/p" "$F")
+          [ "${#RELEASES[@]}" -eq "$RELEASE_COUNT" ] \
+            || { echo "::error::rollout annotations must contain quoted string values"; exit 1; }
+          mapfile -t UNIQUE_RELEASES < <(printf '%s\n' "${RELEASES[@]}" | sort -u)
+          if [ "${#UNIQUE_RELEASES[@]}" -ne 1 ]; then
+            echo "::notice::staging rollout annotations are not uniform"
+            echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
+          fi
+          CUR="${UNIQUE_RELEASES[0]}"
+          # Stale-promotion guard, and the idempotence check for repeated build events:
           # `--is-ancestor` is true for equal commits. Restricted to hex so a legacy
           # release-tag value is not silently resolved as a commit -- `v3.4.0-alpha.64`
           # IS a tag in this repo, and comparing against a tag newer than the target
@@ -223,27 +242,32 @@ jobs:
         if: steps.gate.outputs.go == 'true' && steps.guard.outputs.go == 'true'
         env:
           SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
+          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
         run: |
           set -euo pipefail
           F=deploy/env-uzh-stg/values.yaml
           SHORT=$(git rev-parse --short=12 "$SHA")
 
-          TAGS_BEFORE=$(grep -cE "^[[:space:]]+tag: [^[:space:]]+$" "$F")
-          [ "$TAGS_BEFORE" -eq 15 ] || { echo "::error::expected 15 image tags, found $TAGS_BEFORE"; exit 1; }
+          TAGS_BEFORE=$(awk '$1 == "tag:" { count++ } END { print count + 0 }' "$F")
+          [ "$TAGS_BEFORE" -gt 0 ] \
+            || { echo "::error::staging values contain no image tags"; exit 1; }
           sed -i -E "s|^([[:space:]]+tag: ).*$|\1${SOURCE_BRANCH}|" "$F"
-          TAGS_AFTER=$(grep -c "tag: ${SOURCE_BRANCH}" "$F")
+          TAGS_AFTER=$(awk -v source="$SOURCE_BRANCH" \
+            '$1 == "tag:" && $2 == source { count++ } END { print count + 0 }' "$F")
           [ "$TAGS_AFTER" -eq "$TAGS_BEFORE" ] || { echo "::error::rewrote $TAGS_AFTER of $TAGS_BEFORE image tags"; exit 1; }
 
-          BEFORE=$(grep -c "rollout\.klicker\.uzh\.ch/release:" "$F")
-          [ "$BEFORE" -eq 15 ] || { echo "::error::expected 15 annotations, found $BEFORE"; exit 1; }
+          BEFORE=$(awk \
+            '/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release:/ { count++ } END { print count + 0 }' "$F")
+          [ "$BEFORE" -gt 0 ] \
+            || { echo "::error::staging values contain no rollout annotations"; exit 1; }
 
           # sed, not yq: the file carries comments and hand-chosen quote styles that a
           # yq round-trip reflows. The value MUST stay quoted -- an unquoted all-digit
           # short SHA parses as a YAML integer and Kubernetes rejects the annotation.
           sed -i -E "s|^([[:space:]]*rollout\.klicker\.uzh\.ch/release:).*|\1 '${SHORT}'|" "$F"
 
-          AFTER=$(grep -c "rollout\.klicker\.uzh\.ch/release: '${SHORT}'" "$F")
+          AFTER=$(awk -v release="'${SHORT}'" \
+            '$1 == "rollout.klicker.uzh.ch/release:" && $2 == release { count++ } END { print count + 0 }' "$F")
           [ "$AFTER" -eq "$BEFORE" ] || { echo "::error::rewrote $AFTER of $BEFORE"; exit 1; }
 
           git diff -- "$F"
@@ -255,6 +279,7 @@ jobs:
           GH_TOKEN: ${{ secrets.STG_PROMOTE_TOKEN }}
           SHA: ${{ steps.target.outputs.sha }}
           SHORT: ${{ steps.write.outputs.short }}
+          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
         run: |
           set -euo pipefail
           BRANCH="chore/promote-stg-${SHORT}"
@@ -279,7 +304,7 @@ jobs:
           git push origin "$BRANCH"
 
           # `[skip ci]` in the title becomes the squash commit message, which stops the
-          # merge from re-running all 13 builds and re-firing this workflow. The PR
+          # merge from re-running every image build and re-firing this workflow. The PR
           # touches only `deploy/**`, so `Build Fallback` supplies build-amd/build-arm.
           # The YAML block scalar strips this common indentation, so the heredoc body
           # and its EOF terminator both land at column 0 in the generated script.
@@ -292,10 +317,30 @@ jobs:
           commit. See ADR-0003.
           EOF
 
-          gh pr create \
-            --base v3 --head "$BRANCH" \
+          PR_URL=$(gh pr create \
+            --base "$SOURCE_BRANCH" --head "$BRANCH" \
             --title "chore(deploy): promote ${SHORT} to stg [skip ci]" \
-            --body-file /tmp/pr-body.md
+            --body-file /tmp/pr-body.md)
+
+          # The selected source branch may not require the generated-promotion
+          # verifier. Wait for its exact success status before allowing an immediate
+          # merge on an unprotected branch.
+          PROMOTION_HEAD=$(git rev-parse HEAD)
+          VERIFIED='false'
+          for attempt in 1 2 3 4 5 6; do
+            STATUS=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${PROMOTION_HEAD}/statuses" \
+              --jq '[.[] | select(.context == "final-ai-review")] | first | [.state, .description] | @tsv')
+            case "$STATUS" in
+              $'success\tVerified generated staging promotion')
+                VERIFIED='true'; break ;;
+              $'failure\t'* | $'error\t'*)
+                echo "::error::generated promotion verification failed: ${STATUS}"; exit 1 ;;
+            esac
+            echo "attempt ${attempt}: waiting for generated promotion verification on ${PR_URL}"
+            [ "$attempt" -eq 6 ] || sleep 20
+          done
+          [ "$VERIFIED" = 'true' ] \
+            || { echo "::error::generated promotion verification did not succeed for ${PR_URL}"; exit 1; }
 
           gh pr merge "$BRANCH" --squash --auto --delete-branch
 

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -8,41 +8,43 @@
 
 Staging pulls the floating image tag selected by the `STG_SOURCE_BRANCH` repository variable (the committed values currently use `v3-ai`; unset defaults to `v3`). A rebuild therefore leaves the rendered manifest byte-identical, ArgoCD detects no drift, and the new image sits in the registry until somebody restarts the pods by hand. Staging is the canary for everything merged since the prd-pinned tag, so "merged but not running" is the failure mode that matters most: [PR #5303](https://github.com/uzh-bf/klicker-uzh/pull/5303) was a regression that only production's tag pin had shielded, and it stayed unrolled on stg after merge with nothing signalling that.
 
-The deployment values and promotion PR remain on `v3`; the promotion workflow follows successful image builds from the selected source branch and updates the values' image tags automatically.
+The deployment values and promotion pull request must remain on the branch selected by `STG_SOURCE_BRANCH`. The external ArgoCD application currently tracks `v3-ai`, so writing the promotion to `v3` is invisible to staging even when the image builds and pull request succeed.
 
 The same blind spot already bit the PreSync migration hook of [ADR-0001](./0001-automate-db-migrations-via-argocd-presync-hook.md): ArgoCD excludes hook manifests from the OutOfSync comparison, so the hook only ran after a manual sync.
 
-`deploy/env-uzh-stg/values.yaml` already carried a `rollout.klicker.uzh.ch/release` pod annotation, 15 times, with no automation and a value (`v3.4.0-alpha.64`) that had drifted far behind the code actually running. It is absent from prd, which needs no trigger because its pinned tags change on every release.
+`deploy/env-uzh-stg/values.yaml` already carried `rollout.klicker.uzh.ch/release` pod annotations with no automation and a value (`v3.4.0-alpha.64`) that had drifted far behind the code actually running. The annotation is absent from prd, which needs no trigger because its pinned tags change on every release.
 
 ## Decision
 
-Automate that annotation. `.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into all 15 occurrences, which changes the pod template and so produces a genuine ArgoCD sync: PreSync migration hook first, then the pods roll.
+Automate that annotation. `.github/workflows/deploy-stg-promote.yml` writes the built commit's short SHA into every discovered occurrence on the selected source branch, which changes the pod template and so produces a genuine ArgoCD sync: PreSync migration hook first, then the pods roll.
 
 Promotion is gated on **every** `v3_*-stg.yml` image build succeeding for the selected source commit, with the required set derived from the workflow files present in the checkout rather than a hardcoded list. `skipped` is not treated as success. A rollout therefore cannot start against a half-published or stale source tag, and cannot run migrations from a stale migrator image.
 
-The workflow publishes as an **auto-merging pull request**, not a direct push.
+The workflow publishes as an **auto-merging pull request** to the selected source branch, not a direct push. It requires both image-tag and rollout-annotation inventories to be non-empty, replaces every discovered entry, and proves the independent before/after counts. Before requesting auto-merge it waits for the exact generated-promotion verification status so an unprotected source branch cannot merge the pull request before verification.
 
 ## Considered options
 
-**Publish mechanism — direct push vs pull request.** `v3` restricts pushes (an empty user/team/app allowlist) and requires 6 status checks, and the repository has no ruleset bypass actor. Granting the Actions bot a bypass would weaken the branch's protection for every workflow holding `contents: write`, not just this one. The PR route works within the existing protection: the promotion touches only `deploy/**`, so `Build Fallback` reports `build-amd`/`build-arm` in seconds and the remaining checks are the fast unconditional ones. The cost is a bot PR per merge and a dependency on `secrets.STG_PROMOTE_TOKEN`, because a PR opened with the default `GITHUB_TOKEN` does not trigger workflows and would never satisfy its own required checks.
+**Publish mechanism — direct push vs pull request.** The pull request route preserves review and generated-content verification across both protected and unprotected source branches. The cost is a bot pull request per merge and a dependency on `secrets.STG_PROMOTE_TOKEN`, because a pull request opened with the default `GITHUB_TOKEN` does not trigger workflows and would never receive its generated-promotion status.
 
-**Trigger — `workflow_run` fan-in vs restructuring the 13 builds into one workflow.** Chose `workflow_run` with a gate that re-evaluates on every build completion, so the last build to finish is the one that proceeds. Idempotent, and it leaves the 13 existing workflows untouched.
+**Trigger — `workflow_run` fan-in vs restructuring the builds into one workflow.** Chose `workflow_run` with a gate that re-evaluates on every declared build completion, so the last build to finish is the one that proceeds. The verification inventory is derived from `v3_*-stg.yml`; the trigger names remain explicit because GitHub Actions requires workflow names in the event declaration. Adding a staging build therefore requires adding its workflow name to the trigger list, but no workload-count assertion.
 
 **Write mechanism — `sed` vs `yq`.** Chose `sed` with a before/after count assertion. The values file carries comments and hand-chosen quote styles that a `yq` round-trip reflows. The annotation values were pre-quoted in the same change: an unquoted all-digit short SHA parses as a YAML integer and Kubernetes rejects a non-string annotation value.
 
-**Rejected — ArgoCD Image Updater.** Purpose-built and digest-aware, so it would solve provenance too, but it adds a cluster component plus repository write credentials to watch 15 images for a single environment whose trigger mechanism already existed.
+**Rejected — ArgoCD Image Updater.** Purpose-built and digest-aware, so it would solve provenance too, but it adds a cluster component plus repository write credentials for a single environment whose trigger mechanism already existed.
 
 **Rejected — CI calling the ArgoCD API directly.** Not GitOps, and it would require cluster credentials in CI plus network reachability the cluster does not offer.
 
 ## Consequences
 
-Each merge now produces a **second** commit on `v3` (the promotion). Because `v3` sets `required_status_checks.strict: true`, every other open PR is knocked out of date again by that second commit — with 20+ PRs typically open, that roughly doubles the branch-update churn. A promotion PR that is itself overtaken becomes un-mergeable and self-heals only when the next merge supersedes it.
+Each promoted source commit produces a **second** commit on the selected source branch. When that branch uses strict required status checks, every other open pull request is knocked out of date again by the promotion commit. A promotion pull request that is itself overtaken becomes unmergeable and self-heals only when the next promotion supersedes it.
 
-The required set is derived from the `v3_*-stg.yml` files, which includes `v3_analytics-stg.yml` — and `analytics` has **no** Deployment in the chart. A failed analytics image build therefore blocks the staging rollout of 15 components that do not depend on it. Accepted deliberately: a hardcoded exception would rot the moment a 14th stg app appears, and the failure is visible in the promoter's run log.
+The required set is derived from the `v3_*-stg.yml` files, which includes `v3_analytics-stg.yml` — and `analytics` has **no** Deployment in the chart. A failed analytics image build therefore blocks the staging rollout of components that do not depend on it. Accepted deliberately: a hardcoded exception would rot when the staging build inventory changes, and the failure is visible in the promoter's run log.
 
 Two repository settings are load-bearing and recorded nowhere else: `squash_merge_commit_title` must remain `PR_TITLE` so the `[skip ci]` marker reaches the squash commit, and auto-merge must stay enabled. The guard additionally refuses any commit whose subject starts with `chore(deploy): promote `, so a flipped setting degrades to wasted rebuilds rather than an unbounded promotion loop.
 
-All 15 components roll on every promoted commit from the selected source branch, including the Hatchet workers. The workers' SDK drains in-flight tasks on `SIGTERM` and their tasks declare retries, but the chart sets no `terminationGracePeriodSeconds` and no `preStop`, and both worker Dockerfiles use shell-form `CMD`, so signal delivery is not guaranteed. This is pre-existing and applies equally to every manual sync today; automation only changes how often it happens. Hardening it is tracked separately.
+Every workload carrying the rollout annotation rolls on each promoted commit from the selected source branch, including the Hatchet workers. The workers' SDK drains in-flight tasks on `SIGTERM` and their tasks declare retries, but the chart sets no `terminationGracePeriodSeconds` and no `preStop`, and both worker Dockerfiles use shell-form `CMD`, so signal delivery is not guaranteed. This is pre-existing and applies equally to every manual sync today; automation only changes how often it happens. Hardening it is tracked separately.
+
+GitHub loads `workflow_run` from the default branch. A correction merged only to a non-default selected source is available for a branch-selected manual dispatch but does not alter automatic fan-in until the executable correction also reaches default branch `v3`. Existing build runs keep the promoter definition they started with and need a separately authorized post-build promotion after the correction is active.
 
 A failed migration now blocks the entire staging rollout automatically rather than only when someone syncs by hand. That is the intended behaviour from ADR-0001, but it makes a bad migration a stop-the-world event on stg.
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -2,7 +2,7 @@
 type: Operations
 title: CI & Deployment
 description: PR gates, image builds, the standard-version release flow, Helm deployment reality, and what is NOT in this repo.
-timestamp: '2026-08-26'
+timestamp: '2026-08-27'
 tags:
   - ci
   - deployment
@@ -45,8 +45,8 @@ neither Node nor pnpm.
 
 ## Image builds
 
-15 stg + 15 prd image workflows (`v3_<app>-{stg,prd}.yml`) publish 16 ARM64
-images — the PWA has both an ordinary and an assessment pair, and
+Per-app stg and prd image workflows (`v3_<app>-{stg,prd}.yml`) publish the
+ARM64 images. The PWA has both an ordinary and an assessment pair, and
 `v3_backend-docker-{stg,prd}.yml` additionally builds
 `backend-docker-migrator` (see [Deployment migrations](#deployment-migrations)).
 This includes `mcp-lecturer` and `mcp-student`, which also have full chart
@@ -90,7 +90,7 @@ Version bumps are **local and manual** via standard-version: `pnpm run release[:
 
 ## Deployment values (facts, not procedures)
 
-- **stg** (`*.klicker.stg.df-app.ch`): everything rides the floating image tag selected by the `STG_SOURCE_BRANCH` repository variable (the committed values and unset default use `v3`), so the rendered manifest never changes on a rebuild and ArgoCD would never sync on its own. The promotion workflow aligns the image tags with the selected branch. The `rollout.klicker.uzh.ch/release` pod annotation is what makes it move — see [Staging promotion](#staging-promotion) below.
+- **stg** (`*.klicker.stg.df-app.ch`): everything rides the floating image tag selected by the `STG_SOURCE_BRANCH` repository variable (the current value and committed values use `v3-ai`; an unset variable defaults to `v3`), so the rendered manifest never changes on a rebuild and ArgoCD would never sync on its own. The promotion workflow aligns the image tags and promotion pull request with the selected branch. The `rollout.klicker.uzh.ch/release` pod annotation is what makes it move — see [Staging promotion](#staging-promotion) below.
 - **prd** (`*.klicker.uzh.ch`): pinned version tags, `replicaCount: 2` for web/API services.
 - **Secrets are external**: deployments reference `envFrom.secretRef` names, but the chart defines no `Secret` manifests — provision them out-of-band with matching names. GrowthBook-ready Node workloads also reference the optional shared `<rendered-chart-fullname>-secret-growthbook`, which supplies only `GROWTHBOOK_API_HOST` and the server SDK `GROWTHBOOK_CLIENT_KEY`; `GROWTHBOOK_ENV` comes from the global ConfigMap. Separately, only the primary GraphQL backend references optional `<rendered-chart-fullname>-secret-growthbook-management`, containing `GROWTHBOOK_MANAGEMENT_API_URL` and `GROWTHBOOK_MANAGEMENT_API_KEY`, which back the lecturer beta opt-in; its non-secret `GROWTHBOOK_BETA_SAVED_GROUP_ID` comes from the backend ConfigMap instead. The optional references preserve startup before provisioning. Do not place the write-capable management key in the shared evaluator Secret.
 - **Hatchet endpoint pair**: `hatchet.client.apiUrl` in the environment values renders `HATCHET_API_URL`, while the external secret supplies `HATCHET_CLIENT_HOST_PORT`. They must resolve to the same Hatchet installation; worker health alone does not validate programmatic schedule creation over the HTTP API. Staging uses `app-hatchet-svc-api.stg-hatchet-svc.svc.cluster.local:8080`, and production uses `app-hatchet-svc-api.prd-hatchet-svc.svc.cluster.local:8080` (see [Async & Workers](./async-and-workers.md)).
@@ -111,19 +111,21 @@ Why this shape (ArgoCD-native hook, dedicated migrator image, manual demoted to 
 
 **ArgoCD auto-syncs on git change** (prune + selfHeal, app `app-klicker`), but only when the _rendered manifest_ differs. Two things therefore do **not** trigger a sync, and both have bitten us:
 
-- **A rebuilt floating tag.** stg pulls the selected source tag (the committed values and unset default use `:v3`), so a new image leaves the Deployment spec byte-identical. `pullPolicy: Always` means a restart _would_ pick it up, but nothing asks for a restart.
+- **A rebuilt floating tag.** stg pulls the selected source tag (currently `:v3-ai`), so a new image leaves the Deployment spec byte-identical. `pullPolicy: Always` means a restart _would_ pick it up, but nothing asks for a restart.
 - **A hook-only change.** ArgoCD excludes hook manifests from the OutOfSync comparison, so a commit touching only the PreSync migration Job shows as "Synced" at the new revision with the hook never executed (this is why the hook in [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md) needed one manual sync to fire the first time).
 
-The `rollout.klicker.uzh.ch/release` annotation exists to break that tie: it lands in the **pod template**, so changing it is a real manifest change. It appears 15 times in `deploy/env-uzh-stg/values.yaml` and zero times in prd, which needs no such trigger because its pinned tags change on every release.
+The `rollout.klicker.uzh.ch/release` annotation exists to break that tie: it lands in the **pod template**, so changing it is a real manifest change. The promoter discovers every occurrence in `deploy/env-uzh-stg/values.yaml`; prd has no such annotation because its pinned tags change on every release.
 
-`.github/workflows/deploy-stg-promote.yml` reads `STG_SOURCE_BRANCH`, aligns all 15 image tags with that branch, and writes the built commit's short SHA once **every** `v3_*-stg.yml` image build for the selected commit has succeeded — so a rollout can never start against a half-published source tag, and the PreSync migration hook always runs before the new pods. It publishes as an auto-merging PR rather than a direct push, because `v3` restricts pushes and requires 6 status checks with no bypass actor; the PR touches only `deploy/**`, so `Build Fallback` supplies `build-amd`/`build-arm` in seconds. `[skip ci]` in the PR title keeps the squash-merge from re-running the 13 builds and re-firing the promoter.
+`.github/workflows/deploy-stg-promote.yml` resolves `STG_SOURCE_BRANCH` once, checks out that branch, aligns every discovered image tag, and writes the built commit's short SHA into every discovered rollout annotation once **every** `v3_*-stg.yml` image build for the selected commit has succeeded. Both inventories must be non-empty, but their sizes are intentionally independent. A rollout can therefore never start against a half-published source tag, and the PreSync migration hook runs before the new pods. The workflow publishes a pull request to the selected source branch rather than pushing directly. Before enabling auto-merge it waits for the exact `Verified generated staging promotion` status, which also protects an unprotected source branch from merging before the generated-content and exact-build checks finish. `[skip ci]` in the title prevents the squash commit from rebuilding every image and re-firing the promoter.
 
 Operational notes.
 
-- Set the repository variable `STG_SOURCE_BRANCH` to select the active supported `v3*` branch; it falls back to `v3` when unset. Set it explicitly to `v3-ai` for the current staging source. A new successful image build on that branch triggers reconciliation. If the selected commit is already built and no new push will occur, also dispatch this promoter with that commit SHA and `dry_run=false`. The branch name must be a Docker-safe image tag because the build workflows publish branch-name tags.
-- **Direct-source caveat:** the promoter always checks out and writes `v3`. If the external ArgoCD `Application` temporarily targets `v3-ai` directly, promotion commits on `v3` do not change the live manifests. Before changing `targetRevision`, render the staging chart from the branch ArgoCD will track and verify all workload image tags use that branch. After the sync, require both `Synced` and `Healthy`; a successful sync alone can still leave workloads in `ImagePullBackOff` or `OOMKilled`.
-- It needs `secrets.STG_PROMOTE_TOKEN`, an **admin-owned PAT** with `contents: write` + `pull-requests: write`. Two independent reasons it cannot be the default `GITHUB_TOKEN` or a plain App token: a PR opened with `GITHUB_TOKEN` does not trigger workflows, so its required checks never report and auto-merge never fires; and `v3`'s push restrictions carry an _empty_ user/team/app allowlist, which only repository admins bypass.
-- Two settings outside this repo are load-bearing. `squash_merge_commit_title` must stay `PR_TITLE`, or the `[skip ci]` marker never reaches the squash commit and every promotion rebuilds all 13 images. The workflow does not rely on it alone — the guard also refuses to promote any commit whose subject starts with `chore(deploy): promote ` — but the belt is worth keeping. Auto-merge must be enabled on the repository.
+- Set the repository variable `STG_SOURCE_BRANCH` to select the active supported `v3*` branch; it falls back to `v3` when unset. Set it explicitly to `v3-ai` for the current staging source. The branch name must be a Docker-safe image tag because the build workflows publish branch-name tags.
+- **Default-branch activation:** GitHub evaluates `workflow_run` from the repository default branch. A promoter correction merged only to `v3-ai` is available for a branch-selected manual dispatch but does not change automatic fan-in until the same executable correction reaches default branch `v3`. Activate it with a focused pull request; do not repeat a broad `v3` to `v3-ai` merge for that purpose.
+- **Already-built commits:** a build set started before a promoter correction keeps the old behavior. After the correction is active, first require every exact-head staging image build to succeed, inspect and resolve any stale wrong-base promotion pull request, then dispatch `Promote to stg` on the selected source ref with the full commit SHA and `dry_run=false`. Dispatch and rollout remain separate authorized actions. Merging the correction alone does not redeploy an existing image set.
+- Before changing ArgoCD `targetRevision`, render the staging chart from the branch ArgoCD will track and verify every workload image tag uses that branch. After an authorized sync, require both `Synced` and `Healthy`; a successful sync alone can still leave workloads in `ImagePullBackOff` or `OOMKilled`.
+- It needs `secrets.STG_PROMOTE_TOKEN`, a repository-owned PAT with `contents: write` and `pull-requests: write`, plus permission to merge into the selected source branch. A pull request opened with the default `GITHUB_TOKEN` does not trigger workflows, so the generated verifier would never report and the promoter would fail closed.
+- Two settings outside this repo are load-bearing. `squash_merge_commit_title` must stay `PR_TITLE`, or the `[skip ci]` marker never reaches the squash commit and every promotion rebuilds all staging images. The workflow does not rely on it alone — the guard also refuses to promote any commit whose subject starts with `chore(deploy): promote ` — but the belt is worth keeping. Auto-merge must be enabled on the repository.
 - The annotation records which commit _triggered_ the rollout, not which bits are in the image: two merges minutes apart cancel the first build (`cancel-in-progress: true`) and the selected source tag then holds the later images. Immutable per-commit tags are the fix if that ever matters.
 
 Rationale and rejected alternatives: [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).

--- a/docs/solutions/runtime-error/staging-source-branch-image-tag-drift.md
+++ b/docs/solutions/runtime-error/staging-source-branch-image-tag-drift.md
@@ -75,9 +75,22 @@ import failure. That fix and its build-time regression check are recorded in
 
 ## Prevention
 
-The staging promoter currently checks out and writes `v3`. While ArgoCD tracks
-`v3-ai` directly, those promotion commits cannot update the active manifests.
-Before any direct-source switch, follow the render and runtime checks in
+The staging promoter now resolves `STG_SOURCE_BRANCH` once and checks out,
+updates, and opens its generated pull request against that same branch. It
+discovers the image tags and rollout annotations in the selected values file,
+requires both inventories to be non-empty, and proves every discovered entry was
+rewritten. This avoids a workload-count constant becoming stale when the chart
+adds or removes workloads.
+
+The `workflow_run` definition still activates from default branch `v3`. A
+correction merged only to `v3-ai` must therefore reach `v3` through a focused
+activation change before automatic build fan-in uses it. Build runs already in
+progress retain their old promoter behavior; after every exact-head image build
+passes, use a separately authorized branch-selected promoter dispatch or one
+bounded equivalent promotion commit. Merging the correction alone does not
+redeploy that existing image set.
+
+Before any source switch, follow the render and runtime checks in
 [CI & Deployment](../../ci-and-deployment.md#staging-promotion). The testing
 procedure also requires image-tag inspection and independent ArgoCD health
 verification.


### PR DESCRIPTION
## What This Fixes

This PR makes the staging promoter write to the branch selected by
`STG_SOURCE_BRANCH`. Staging currently uses `v3-ai`, so the workflow now checks
out that branch, updates its values, and opens the generated promotion PR with
`v3-ai` as its base instead of writing an invisible promotion to `v3`.

- Adds the missing MCP lecturer and MCP student staging-image triggers.
- Replaces fixed workload counts with independent, non-empty discovery of image
  tags and rollout annotations, with exact rewrite checks.
- Requires the generated-promotion verifier to report success before auto-merge.
- Aligns the verifier, regression tests, deployment guide, ADR-0003, and the
  existing source-drift solution with the new branch contract.

## Branch Coverage

- Base: `v3-ai`
- Head: `ef6caa404b70294d84d4bd3fa529a62455860f6f`
- Reviewed: 3 commits, 6 files, 235 substantive changed lines
- Covered: promoter branch targeting, generated-promotion verifier and tests,
  build-trigger parity, and deployment guidance.

## Review Focus

- Confirm every Git write now follows the one resolved `STG_SOURCE_BRANCH`.
- Confirm empty inventories fail closed while workload additions or removals do
  not require count updates.
- Confirm the generated promotion cannot auto-merge until its exact verifier
  status succeeds.

## Verification

Current head:

- `node --test .github/scripts/final-ai-review.test.js` -> 33/33 passed.
- YAML parse and shellcheck of every workflow `run` block -> passed.
- Biome and Prettier for changed files, `git diff --check`, and staged gitleaks
  -> passed.
- Normal pre-commit hooks -> gitleaks, formatting, type checks, lint, syncpack,
  AGENTS, removed-doc checks, and Prisma sync passed.
- Normal pre-push build -> 26/26 tasks passed.
- Simplification, slice-risk, and integrated final reviews -> no remaining
  findings.

Failed/Warning:

- The host reports Node 26 while the repository pins Node 24; all configured
  checks completed successfully.
- Wiki-bundle validation retains pre-existing frontmatter and link errors across
  the documentation tree; this PR adds none.
- GitHub's `trusted_policy` job failed in `Resolve trusted default-branch commit`,
  so its dependent Final AI review jobs were skipped. This is recorded as a
  merge blocker, not attributed to this workflow change.

Not run:

- No workflow dispatch, promotion commit, ArgoCD sync, cluster access, or live
  staging check was performed.

## Security / Privacy

- No credentials or personal data are included.
- The existing `STG_PROMOTE_TOKEN` remains required only to create and merge the
  generated promotion PR; the workflow now fails closed if verification is absent.

## Blocking Before Merge

- [ ] Exact-head GitHub CI is terminal and has no actionable failure.
- [ ] Resolve or rerun the failed `trusted_policy` job before requesting review.

## Follow-Up After Merge

- [ ] With separate approval, land the focused default-branch (`v3`) activation
  change. GitHub loads `workflow_run` definitions from the default branch, so
  this PR alone does not activate automatic fan-in.
- [ ] After all exact-head staging image builds for `d96cf502a04bff1e16e6ffba4c43af3ea5ec9163`
  pass, separately authorize stale wrong-base promotion cleanup and a `v3-ai`
  dispatch or bounded equivalent marker promotion.
- [ ] Verify ArgoCD sync, health, and workload images only under separate
  deployment authority.

## Local Session Artifacts

- Machine: Local
- Worktree: `trees/stg-promotion-source` in `klicker-uzh`
- Review reports: `project/_local/reviews/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staging promotions now follow the configured source branch consistently.
  * Promotion workflows dynamically discover image tags and rollout annotations instead of relying on fixed counts.
  * Added support for additional staging image build workflows.
  * Promotions now require complete, consistent updates and successful generated-promotion verification before merging.

* **Bug Fixes**
  * Improved validation for invalid branches, empty inventories, and malformed commit identifiers.

* **Documentation**
  * Updated deployment guidance and troubleshooting notes for branch-based staging promotions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->