### PR TITLE
fix(playwright): enforce host-only local execution

### DIFF
--- a/.agents/skills/klicker-playwright-e2e/SKILL.md
+++ b/.agents/skills/klicker-playwright-e2e/SKILL.md
@@ -29,42 +29,41 @@ Use this skill for Klicker-specific Playwright work. Combine it with `playwright
 Useful check:
 
 ```bash
-volta run pnpm --filter @klicker-uzh/playwright exec playwright test --list --project=chromium
+pnpm playwright:host -- --list --project=chromium
 rg -n "test\\(" playwright/tests
 ```
 
 ## Local Test Setup
 
-Run from repo root. Use Volta when Node/pnpm versions are confusing.
-
-```bash
-docker compose down -v
-./_run_app_dependencies.sh
-pnpm run dev:playwright
-```
-
-Run Playwright:
+Run every local Playwright command from a **host shell** at the repository root.
+The host launcher reconciles the exact devrouter workspace, maps all app URLs
+and the worktree database, installs host-only Playwright dependencies and
+browsers when missing, and then runs the browser on the host. The applications,
+workers, and data services remain inside the devcontainer.
 
 ```bash
 # list active Chromium tests without executing them
-volta run pnpm --filter @klicker-uzh/playwright exec playwright test --list --project=chromium
+pnpm playwright:host -- --list --project=chromium
 
 # focused specs
-volta run pnpm --filter @klicker-uzh/playwright exec playwright test --project=chromium tests/O-live-quiz.spec.ts
+pnpm playwright:host -- --project=chromium tests/O-live-quiz.spec.ts
 
 # full active Chromium suite
-volta run pnpm --filter @klicker-uzh/playwright test -- --project=chromium
+pnpm playwright:host -- --project=chromium
+
+# inspect the resolved workspace without exposing credentials
+pnpm playwright:host -- --print-env
 ```
 
-For live quiz answer submission, response processing, scheduled microlearnings, or Hatchet workflow failures, start the missing services explicitly:
+Do not run `playwright test`, package-local raw scripts, browser installation,
+or the host launcher through `devrouter exec` or a DevPod shell. The Playwright
+config rejects direct local invocations before global setup, and the
+devcontainer cannot store Playwright browser binaries. GitHub Actions is the
+explicit exception and keeps running in the official Playwright container.
 
-```bash
-pnpm --filter @klicker-uzh/response-api dev
-pnpm --filter @klicker-uzh/hatchet-worker-response-processor dev
-./util/_run_with_infisical.sh --env dev-playwright pnpm --filter @klicker-uzh/hatchet-worker-general dev
-```
-
-Ensure the response processor is not running with `ASSESSMENT_MODE=true` when validating live quiz mode.
+The launcher starts the full devrouter profile, including response-api and both
+Hatchet workers. Ensure the response processor is not running with
+`ASSESSMENT_MODE=true` when validating live quiz mode.
 
 For `apps/chat` app-router recovery, authenticate the browser with a seeded
 participant before exercising `/<chatbotId>` routes. Both a malformed ID and a
@@ -93,7 +92,7 @@ render of the starter grid.
 
 ## Fast Failure Triage
 
-- `net::ERR_CONNECTION_REFUSED http://127.0.0.1:3002/`: the app server is down, not a selector issue. Check `pnpm run dev:playwright` and service readiness first.
+- `net::ERR_CONNECTION_REFUSED`: the routed app is down, not a selector issue. Run `pnpm playwright:host -- --print-env` and inspect `devrouter exec . -- tail -f /tmp/dev.log` first.
 - `ECONNREFUSED 127.0.0.1:7078`: `response-api` is not running.
 - Hatchet `workflow not found`: the relevant Hatchet worker is not registered/running, often `hatchet-worker-general` for scheduled tasks.
 - Sudden Firefox/WebKit execution: Playwright is running all configured projects. Pass `--project=chromium` or keep non-Chromium projects commented in config if Chromium-only is desired.
@@ -103,10 +102,8 @@ render of the starter grid.
 Before blaming a test, probe the apps:
 
 ```bash
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/healthz
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3001
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3002
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3010
+pnpm playwright:host -- --print-env
+devrouter exec . -- tail -n 100 /tmp/dev.log
 ```
 
 ## Klicker Helper Patterns
@@ -173,7 +170,9 @@ For refactors, run:
 ```bash
 volta run pnpm exec prettier --check playwright/util/actions.ts playwright/tests/<changed-spec>.spec.ts
 volta run pnpm --filter @klicker-uzh/playwright exec tsc --noEmit --project tsconfig.json
-volta run pnpm --filter @klicker-uzh/playwright exec playwright test --list --project=chromium
+pnpm playwright:host -- --list --project=chromium
 ```
 
-Only run browser specs when the local stack is up. If endpoints are down, report that runtime validation was not possible instead of producing noisy connection-refused failures.
+The type and format checks can run in the devcontainer; the Playwright command
+cannot. If the host launcher cannot prove the routed stack, report that runtime
+validation was not possible instead of bypassing the boundary.

--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -86,8 +86,9 @@ The Playwright build job must tar the five `.next` trees before artifact upload 
 
 CI runs Playwright (8-way shard) on almost every code PR — CI is the real e2e gate. Run e2e locally only when your change plausibly breaks a flow (new UI, changed selectors/`data-cy`, auth/redirect changes, activity lifecycle). If you do:
 
-- You are **authorized to start the required servers for this purpose** — test stack via the e2e skills' setup instructions, plus the Hatchet general worker for publish/schedule/end flows and response-api + response processor for live-answer flows (exact triage in the e2e skills).
-- Tear down afterwards (`./_down.sh`); leave the machine as you found it.
+- Run `pnpm playwright:host -- <args>` from the host. Never invoke Playwright or install browsers through `devrouter exec`, a DevPod shell, or another local container.
+- You are **authorized to start the required servers for this purpose** through the host launcher. It reconciles the full devrouter profile, including the Hatchet workers, response-api, and response processor.
+- If the launcher started a runtime for your task, tear it down afterwards with `devrouter stop .`; leave the machine as you found it.
 - On environment failure, switch to `klicker-environment-doctor` before blaming the test.
 
 For Chat model-picker or LiteLLM routing changes, treat the local proxy as a

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -66,6 +66,19 @@ Open the Manage URL printed by `ensure` and log in as **`lecturer` / `abcd`**
 (accept the terms checkbox). The dev servers run in the background; inspect
 `/tmp/dev.log` through `devrouter exec` or an exact DevPod shell.
 
+## Playwright runs on the host
+
+Run `pnpm playwright:host -- <args>` from a host shell. The launcher reconciles
+this exact checkout, uses its namespaced HTTPS routes, and discovers the
+workspace Postgres container's random loopback port for test cleanup and
+seeding. The Playwright process, Node dependencies, and browser binaries stay
+on the host; applications and services stay in this devcontainer.
+
+Direct local Playwright commands fail before global setup, and this container
+sets its Playwright browser path to a non-directory target. Do not run Playwright
+or install browsers through `devrouter exec` or a DevPod shell. GitHub Actions
+continues to run directly in the official Playwright container.
+
 ## How routing works
 
 The monorepo runs **all apps in one container** via `turbo dev`;
@@ -129,7 +142,7 @@ the hardcoded defaults only know `klicker.com`.
 Environment lives in `devcontainer.env` (committed, dev-only). Lifecycle:
 host-side `initialize.sh` creates the persistent machine-local pnpm store,
 `post-create.sh` links dependencies into the worktree-specific `node_modules`
-volume and builds/seeds the workspace, then `devrouter ensure` delivers its
+volumes and builds/seeds the workspace, then `devrouter ensure` delivers its
 matching process helper and invokes `post-start.sh`. Runtime state is
 `/tmp/devrouter-process-klicker-dev.state` for the app stack and
 `/tmp/devrouter-process-klicker-local-mcp.state` for the seeded local MCP
@@ -162,9 +175,11 @@ analytics image and lint CI so the root quality gate runs inside the container.
 
 ## Notes
 
-- `node_modules` is a named volume (pnpm hoists natives into the root
-  `node_modules/.pnpm`, so one root volume covers the monorepo). Its dependency
-  stamp prevents reuse after lockfile or workspace-manifest changes.
+- The root `node_modules` is a named volume because pnpm hoists native packages
+  into `node_modules/.pnpm`. Playwright, Prisma, and shared types also have
+  package-level volumes. Those prevent the Linux install from overwriting the
+  host Playwright runner's Darwin dependency links. The dependency stamp
+  prevents reuse after lockfile or workspace-manifest changes.
 - `/pnpm/.pnpm-store` is the only machine-shared cache. The external Docker
   volume `klicker-uzh-pnpm-store-v1` is created idempotently before Compose and
   survives individual DevPod deletion. `node_modules`, `.next`, and PostgreSQL

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -19,6 +19,12 @@
 # Next apps anyway; this also covers the backend node process.) ---
 NODE_ENV=development
 
+# --- Playwright stays on the host. The config guard blocks local container
+# execution; these values also prevent browser downloads into the DevPod. ---
+KLICKER_DEVCONTAINER=1
+PLAYWRIGHT_BROWSERS_PATH=/dev/null
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 # --- Database (postgres service) ---
 DATABASE_URL=postgres://klicker-prod:klicker@postgres:5432/klicker-prod
 SHADOW_DATABASE_URL=postgres://klicker-prod:klicker@postgres:5432/shadow

--- a/.devcontainer/docker-compose.devrouter.yml
+++ b/.devcontainer/docker-compose.devrouter.yml
@@ -2,6 +2,10 @@
 
 services:
   postgres:
+    # Playwright runs on the host. A random loopback port gives the host Prisma
+    # setup code a portable direct connection without colliding across worktrees.
+    ports:
+      - '127.0.0.1::5432'
     networks:
       devnet:
         aliases:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -98,10 +98,15 @@ services:
     volumes:
       - ..:/workspaces/klicker-uzh:cached
       # Named volume shadows host node_modules so Linux-native binaries (Prisma
-      # engines, esbuild, sharp) aren't clobbered. pnpm hoists natives into the
-      # ROOT node_modules/.pnpm, so the single root volume covers the monorepo.
-      # (GOTCHAS #6)
+      # engines, esbuild, sharp) aren't clobbered. pnpm hoists native packages
+      # into the root node_modules/.pnpm. (GOTCHAS #6)
       - node_modules_root:/workspaces/klicker-uzh/node_modules
+      # These package-level links are host-visible unless they are masked too.
+      # Keep the host Playwright runner and its workspace dependencies on Darwin
+      # while the devcontainer retains independent Linux dependency links.
+      - node_modules_playwright:/workspaces/klicker-uzh/playwright/node_modules
+      - node_modules_prisma:/workspaces/klicker-uzh/packages/prisma/node_modules
+      - node_modules_types:/workspaces/klicker-uzh/packages/types/node_modules
       # Machine-local, content-addressed package cache shared by every worktree.
       # node_modules remains isolated in the project-scoped volume above.
       - pnpm_store:/pnpm/.pnpm-store
@@ -146,6 +151,9 @@ services:
 volumes:
   pgdata:
   node_modules_root:
+  node_modules_playwright:
+  node_modules_prisma:
+  node_modules_types:
   pnpm_store:
     external: true
     name: klicker-uzh-pnpm-store-v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ See [Domain Model](docs/domain-model.md) for the canonical explanation.
 
 ### Self-contained devcontainer (recommended)
 
-Clone-and-run via a self-contained devcontainer — no Infisical/Doppler, no EduID, no `/etc/hosts` edits. The container owns the whole stack (Node 24 + pnpm toolchain, Postgres, 3× Redis, MailHog, Hatchet) and runs **all core apps in ONE container** via `turbo dev`. Run pnpm/prisma/tests **inside the container**, never on the host.
+Clone-and-run via a self-contained devcontainer — no Infisical/Doppler, no EduID, no `/etc/hosts` edits. The container owns the whole stack (Node 24 + pnpm toolchain, Postgres, 3× Redis, MailHog, Hatchet) and runs **all core apps in ONE container** via `turbo dev`. Run pnpm, Prisma, and unit tests **inside the container**. Playwright is the exception: always run `pnpm playwright:host -- <args>` from the host against the routed container stack. Never invoke Playwright or install its browsers through `devrouter exec`, a DevPod shell, or another local container; CI keeps its existing official Playwright container path.
 
 ```bash
 devrouter ensure .

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 type: Guide
 title: Getting Started
 description: Toolchain, first-time setup, infrastructure bring-up, dev-server paths, and the exact failure signatures a fresh clone produces.
-timestamp: '2026-08-25'
+timestamp: '2026-08-27'
 tags:
   - environment
   - onboarding
@@ -56,6 +56,14 @@ Clone-and-run via a self-contained devcontainer — no Infisical, no external Ed
         Use `devrouter workspace up <branch-name>` from the main repository to create a new worktree. Do not use bare `devpod up` or manual route-token loops; `ensure` owns the persisted identity, Git mount, overlay, aliases, runtime proof, and routes together.
      3. Those namespaced hosts only work because `allowedDevOrigins` in `packages/next-config/index.js` is `['**.localhost']` in development (and `undefined` in production) — Next's implicit `*.localhost` matches a single label only. If that glob ever stops covering a worktree host, the symptom is an app that serves HTML but never hydrates, with no obvious error.
 3. **Logs:** The dev servers auto-start inside the container. View logs via `devrouter exec . -- tail -f /tmp/dev.log`.
+
+Playwright is the deliberate toolchain exception. Run
+`pnpm playwright:host -- <args>` from the host; the launcher calls
+`devrouter ensure`, resolves the exact worktree routes, and connects the host
+Prisma setup to that workspace's random loopback PostgreSQL port. The browser
+and Playwright process never enter the devcontainer. Direct local Playwright
+commands fail before database cleanup, and the devcontainer blocks browser
+downloads. GitHub Actions keeps its existing official Playwright container.
 
 For OpenRouter-backed Chat, follow the host-side `rs-infisical-operator`
 workflow in [AGENTS.md](../AGENTS.md). Use only seeded or synthetic content;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 type: Testing Guide
 title: Testing
 description: Which test level to use when, what runs safely without services, the Playwright e2e stack and its seeds, and the CI test matrix.
-timestamp: '2026-08-26'
+timestamp: '2026-08-27'
 tags:
   - testing
   - ci
@@ -20,7 +20,7 @@ tags:
 | React/browser feature-flag behavior                                               | browser verification; use e2e when a user flow covers it                                   | `npx agent-browser@0.32.2` against the adopting app                                                                 |
 | GraphQL services/resolvers                                                        | `packages/graphql` vitest — needs REAL Postgres + Redis + Hatchet + `HATCHET_CLIENT_TOKEN` | `pnpm --filter @klicker-uzh/graphql test:local` (one-command bootstrap: `test/run-tests-local.sh`)                  |
 | Auth adapter against shared Prisma client                                         | disposable local PostgreSQL through the guarded Auth round-trip                            | `pnpm --filter @klicker-uzh/auth test:prisma-adapter`                                                               |
-| UI / user flows                                                                   | Playwright e2e                                                                             | see routing below                                                                                                   |
+| UI / user flows                                                                   | Playwright e2e                                                                             | `pnpm playwright:host -- <args>` from the host; see routing below                                                   |
 | Office Add-in URL validation                                                      | Node's built-in test runner — safe without services                                        | `pnpm --filter @klicker-uzh/office-addin test`                                                                      |
 
 For server-paginated manage lists, browser coverage must exercise finite page
@@ -72,11 +72,21 @@ The Office Add-in has a separate host boundary. Its pure URL contract runs under
 
 **Playwright is the sole e2e test suite.** All e2e specs live under `playwright/`.
 
+Local Playwright has a strict host/container boundary. The canonical command is
+`pnpm playwright:host -- <args>` from a host shell. It reconciles the exact
+devrouter workspace, maps every browser origin, discovers the workspace's
+random loopback PostgreSQL port, and runs Playwright with host dependencies and
+browser binaries. Package scripts route to the same launcher, while
+`playwright.config.ts` rejects direct local commands and every local container
+before global setup can reset data. The devcontainer also sets a non-directory
+browser path so browser installation fails there. GitHub Actions is explicitly
+allowed and retains the direct official-container workflow.
+
 Specs click `data-cy` attributes ([Frontend Conventions](./frontend-conventions.md)). Specs are letter-prefixed for run order (`A-login-workflow` … `Z-credential-verification`).
 
 |               | Playwright (`playwright/`)                                 |
 | ------------- | ---------------------------------------------------------- |
-| Stack scripts | `dev:playwright` / `start:playwright`                      |
+| Local command | `pnpm playwright:host -- <args>`                           |
 | Infisical env | `dev-playwright`                                           |
 | Seed          | own `seedDatabase()` in `global-setup.ts` (once, wipes DB) |
 | CI            | official Playwright container, 8-way shard, all PRs        |

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
     "build:test": "bash ./util/_with_local_test_origins.sh cross-env NODE_ENV=test turbo run build:test --cache-dir=.turbo",
     "check": "turbo run check --parallel --continue",
     "check:agents-md": "node ./util/check-agents-md.mjs",
-    "check:all": "run-p --npm-path pnpm check check:format check:lint check:syncpack check:agents-md check:removed-doc-artifacts check:prisma-sync",
+    "check:all": "run-p --npm-path pnpm check check:format check:lint check:syncpack check:agents-md check:removed-doc-artifacts check:prisma-sync check:playwright-host",
     "check:format": "lint-staged",
     "check:lint": "turbo run lint --parallel --continue",
+    "check:playwright-host": "node --test ./util/run-playwright-host.test.mjs",
     "check:prisma-sync": "bash ./util/check-prisma-sync.sh",
     "check:removed-doc-artifacts": "node ./util/check-removed-doc-artifacts.mjs",
     "check:syncpack": "syncpack lint",
@@ -70,6 +71,7 @@
     "knip": "knip",
     "lint": "turbo run lint --parallel --continue",
     "lint:biome": "biome lint .",
+    "playwright:host": "node ./util/run-playwright-host.mjs",
     "prepare": "husky",
     "prisma:deploy": "pnpm run --filter @klicker-uzh/prisma prisma:deploy",
     "prisma:migrate": "pnpm run --filter @klicker-uzh/prisma prisma:migrate",
@@ -103,7 +105,7 @@
     "syncpack:update": "syncpack update",
     "test:dev-runtime": "bash ./util/test-dev-runtime.sh",
     "test:run": "turbo run test:run",
-    "test:run:playwright": "pnpm --filter @klicker-uzh/playwright test:run",
+    "test:run:playwright": "pnpm playwright:host",
     "test:watch": "run-p --npm-path pnpm test dev:playwright"
   },
   "engines": {

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -19,26 +19,33 @@ playwright/
 
 ## Local run
 
-1. Start dependencies: `./_run_app_dependencies.sh` (from repo root)
-2. Start Playwright app stack: `pnpm run dev:playwright`
-3. Run all tests:
+Run from a host shell at the repository root. The launcher starts or reconciles
+the exact devrouter workspace, resolves its namespaced routes and database, and
+keeps the Playwright process and browser binaries on the host.
 
 ```bash
-# with Infisical secrets (recommended)
-pnpm --filter @klicker-uzh/playwright test:run
+# run all Chromium tests
+pnpm playwright:host -- --project=chromium
 
-# without Infisical (env vars already exported)
-pnpm --filter @klicker-uzh/playwright test:run:raw
+# run one spec
+pnpm playwright:host -- --project=chromium tests/A-login.spec.ts
+
+# inspect the resolved workspace without printing credentials
+pnpm playwright:host -- --print-env
 ```
+
+Direct local `playwright test` calls fail before database cleanup. Never run
+Playwright or install its browsers inside the devcontainer. GitHub Actions keeps
+using the official Playwright container directly.
 
 ## Useful commands
 
 ```bash
 # UI / interactive mode
-pnpm --filter @klicker-uzh/playwright test:ui
+pnpm playwright:host -- --ui
 
 # Headed Chromium only
-pnpm --filter @klicker-uzh/playwright test:headed
+pnpm playwright:host -- --headed --project=chromium
 
 # Show last HTML report
 pnpm --filter @klicker-uzh/playwright show-report

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -13,15 +13,16 @@
   },
   "scripts": {
     "check": "tsc --noEmit -p tsconfig.json",
-    "show-report": "playwright show-report",
-    "test": "../util/_run_with_infisical.sh --env dev-playwright playwright test",
-    "test:headed": "../util/_run_with_infisical.sh --env dev-playwright playwright test --headed --project=chromium",
-    "test:headed:raw": "playwright test --headed --project=chromium",
-    "test:raw": "playwright test",
-    "test:run": "../util/_run_with_infisical.sh --env dev-playwright playwright test",
-    "test:run:raw": "playwright test",
-    "test:ui": "../util/_run_with_infisical.sh --env dev-playwright playwright test --ui",
-    "test:ui:raw": "playwright test --ui"
+    "show-report": "node ../util/run-playwright-host.mjs --show-report",
+    "test": "node ../util/run-playwright-host.mjs",
+    "test:headed": "node ../util/run-playwright-host.mjs --headed --project=chromium",
+    "test:headed:raw": "node ../util/run-playwright-host.mjs --headed --project=chromium",
+    "test:host": "node ../util/run-playwright-host.mjs",
+    "test:raw": "node ../util/run-playwright-host.mjs",
+    "test:run": "node ../util/run-playwright-host.mjs",
+    "test:run:raw": "node ../util/run-playwright-host.mjs",
+    "test:ui": "node ../util/run-playwright-host.mjs --ui",
+    "test:ui:raw": "node ../util/run-playwright-host.mjs --ui"
   },
   "engines": {
     "node": "=24"

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
+import { assertPlaywrightHostBoundary } from '../util/playwright-host-policy.mjs'
+
+assertPlaywrightHostBoundary()
 
 const isCI = !!process.env.CI
 

--- a/util/playwright-host-policy.d.mts
+++ b/util/playwright-host-policy.d.mts
@@ -1,0 +1,13 @@
+export const HOST_RUNNER_ENV: 'KLICKER_PLAYWRIGHT_HOST_RUNNER'
+
+interface HostBoundaryOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  pathExists?: (path: string) => boolean
+}
+
+export function isContainerRuntime(options?: HostBoundaryOptions): boolean
+
+export function assertPlaywrightHostBoundary(
+  options?: HostBoundaryOptions
+): void

--- a/util/playwright-host-policy.mjs
+++ b/util/playwright-host-policy.mjs
@@ -1,0 +1,37 @@
+import { existsSync } from 'node:fs'
+
+export const HOST_RUNNER_ENV = 'KLICKER_PLAYWRIGHT_HOST_RUNNER'
+
+export function isContainerRuntime({
+  cwd = process.cwd(),
+  env = process.env,
+  pathExists = existsSync,
+} = {}) {
+  return (
+    env.KLICKER_DEVCONTAINER === '1' ||
+    env.REMOTE_CONTAINERS === 'true' ||
+    cwd.startsWith('/workspaces/') ||
+    pathExists('/.dockerenv') ||
+    pathExists('/run/.containerenv')
+  )
+}
+
+export function assertPlaywrightHostBoundary(options = {}) {
+  const env = options.env ?? process.env
+
+  // The existing GitHub Actions jobs intentionally run in the official
+  // Playwright container. Local containers are the boundary being rejected.
+  if (env.GITHUB_ACTIONS === 'true' && env.CI === 'true') return
+
+  if (isContainerRuntime({ ...options, env })) {
+    throw new Error(
+      'Local Playwright execution is host-only. Exit the devcontainer and run `pnpm playwright:host -- <args>` from the host.'
+    )
+  }
+
+  if (env[HOST_RUNNER_ENV] !== '1') {
+    throw new Error(
+      'Local Playwright must use the host launcher so it targets the exact devrouter workspace. Run `pnpm playwright:host -- <args>`.'
+    )
+  }
+}

--- a/util/run-playwright-host.mjs
+++ b/util/run-playwright-host.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { delimiter, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  assertPlaywrightHostBoundary,
+  HOST_RUNNER_ENV,
+} from './playwright-host-policy.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function fail(message) {
+  throw new Error(`[playwright:host] ${message}`)
+}
+
+function run(command, args, { capture = false, env = process.env } = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+    stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  })
+
+  if (result.error) fail(`${command} could not start: ${result.error.message}`)
+  if (result.status !== 0) {
+    const detail = capture ? result.stderr.trim() : ''
+    fail(
+      `${command} exited with ${result.status}${detail ? `: ${detail}` : ''}`
+    )
+  }
+
+  return capture ? result.stdout.trim() : ''
+}
+
+function commandExists(command) {
+  const result = spawnSync(command, ['--version'], { stdio: 'ignore' })
+  return result.status === 0
+}
+
+function runPnpm(args, env = process.env) {
+  if (commandExists('volta')) {
+    const nodeBinary = run('volta', ['which', 'node'], { capture: true })
+    const toolchainDirectory = dirname(nodeBinary)
+    const toolchainEnvironment = {
+      ...env,
+      PATH: `${toolchainDirectory}${delimiter}${env.PATH ?? ''}`,
+    }
+
+    return run(join(toolchainDirectory, 'corepack'), ['pnpm', ...args], {
+      env: toolchainEnvironment,
+    })
+  }
+
+  return run('pnpm', args, { env })
+}
+
+export function readCommittedEnvironment(contents) {
+  const values = new Map()
+
+  for (const line of contents.split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/)
+    if (match) values.set(match[1], match[2])
+  }
+
+  return values
+}
+
+export function parsePublishedPort(output) {
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.trim().match(/:(\d+)$/)
+    if (match) return Number(match[1])
+  }
+
+  fail('the workspace Postgres container has no loopback host port')
+}
+
+export function resolvePlaywrightEnvironment({
+  appSecret,
+  databaseTemplate,
+  databasePort,
+  workspace,
+}) {
+  const namespace = workspace ? `.${workspace}` : ''
+  const appUrl = (app) => `https://${app}.klicker${namespace}.localhost`
+  const databaseUrl = new URL(databaseTemplate)
+
+  databaseUrl.hostname = '127.0.0.1'
+  databaseUrl.port = String(databasePort)
+
+  const studentUrl = appUrl('pwa')
+
+  return {
+    APP_ORIGIN_AUTH: appUrl('auth'),
+    APP_SECRET: appSecret,
+    COOKIE_DOMAIN: `klicker${namespace}.localhost`,
+    DATABASE_URL: databaseUrl.toString(),
+    [HOST_RUNNER_ENV]: '1',
+    PLAYWRIGHT_BASE_URL: studentUrl,
+    URL_AUTH: appUrl('auth'),
+    URL_CHAT: appUrl('chat'),
+    URL_CONTROL: appUrl('control'),
+    URL_MANAGE: appUrl('manage'),
+    URL_STUDENT: studentUrl,
+    URL_STUDENT_LOGIN: `${studentUrl}/login`,
+  }
+}
+
+function resolveWorkspace() {
+  const gitDir = run(
+    'git',
+    ['-C', repoRoot, 'rev-parse', '--path-format=absolute', '--git-dir'],
+    { capture: true }
+  )
+  const commonDir = run(
+    'git',
+    ['-C', repoRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+    { capture: true }
+  )
+
+  if (gitDir === commonDir) return ''
+
+  const workspaceFile = join(gitDir, 'devrouter-workspace')
+  if (!existsSync(workspaceFile)) {
+    fail('devrouter did not persist a workspace token for this worktree')
+  }
+
+  return readFileSync(workspaceFile, 'utf8').trim()
+}
+
+function resolveDatabasePort() {
+  const workingDirectory = join(repoRoot, '.devcontainer')
+  const containerIds = run(
+    'docker',
+    [
+      'ps',
+      '--filter',
+      `label=com.docker.compose.project.working_dir=${workingDirectory}`,
+      '--filter',
+      'label=com.docker.compose.service=postgres',
+      '--format',
+      '{{.ID}}',
+    ],
+    { capture: true }
+  )
+    .split(/\r?\n/)
+    .filter(Boolean)
+
+  if (containerIds.length !== 1) {
+    fail(
+      `expected one Postgres container for ${workingDirectory}, found ${containerIds.length}`
+    )
+  }
+
+  const publishedPort = run('docker', ['port', containerIds[0], '5432/tcp'], {
+    capture: true,
+  })
+
+  return parsePublishedPort(publishedPort)
+}
+
+function ensureHostDependencies(playwrightArgs) {
+  const playwrightCli = join(
+    repoRoot,
+    'playwright',
+    'node_modules',
+    '@playwright',
+    'test',
+    'cli.js'
+  )
+
+  if (!existsSync(playwrightCli)) {
+    console.log('[playwright:host] Installing host Playwright dependencies')
+    runPnpm([
+      'install',
+      '--filter',
+      '@klicker-uzh/playwright...',
+      '--frozen-lockfile',
+    ])
+  }
+
+  if (!existsSync(join(repoRoot, 'packages', 'prisma', 'dist', 'index.js'))) {
+    console.log('[playwright:host] Building host Prisma test dependency')
+    runPnpm(['--filter', '@klicker-uzh/prisma', 'build'])
+  }
+
+  if (!existsSync(join(repoRoot, 'packages', 'types', 'dist', 'index.js'))) {
+    console.log('[playwright:host] Building host shared test types')
+    runPnpm(['--filter', '@klicker-uzh/types', 'build'])
+  }
+
+  if (playwrightArgs.includes('--list')) return
+
+  const headed =
+    playwrightArgs.includes('--headed') || playwrightArgs.includes('--ui')
+  const installArgs = headed ? ['chromium'] : ['--only-shell', 'chromium']
+
+  console.log('[playwright:host] Ensuring the host Chromium binary')
+  runPnpm([
+    '--filter',
+    '@klicker-uzh/playwright',
+    'exec',
+    'playwright',
+    'install',
+    ...installArgs,
+  ])
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const hostEnvironment = { ...process.env, [HOST_RUNNER_ENV]: '1' }
+  assertPlaywrightHostBoundary({ env: hostEnvironment })
+
+  const args = argv[0] === '--' ? argv.slice(1) : [...argv]
+  const showReport = args[0] === '--show-report'
+  if (showReport) args.shift()
+
+  if (showReport) {
+    ensureHostDependencies(['--list'])
+    runPnpm(
+      [
+        '--filter',
+        '@klicker-uzh/playwright',
+        'exec',
+        'playwright',
+        'show-report',
+        ...args,
+      ],
+      hostEnvironment
+    )
+    return
+  }
+
+  const printEnvironment = args[0] === '--print-env'
+  if (printEnvironment) args.shift()
+
+  console.log('[playwright:host] Reconciling the devcontainer runtime')
+  run('devrouter', ['ensure', repoRoot])
+
+  const workspace = resolveWorkspace()
+  const databasePort = resolveDatabasePort()
+  const committedEnvironment = readCommittedEnvironment(
+    readFileSync(join(repoRoot, '.devcontainer', 'devcontainer.env'), 'utf8')
+  )
+  const databaseTemplate = committedEnvironment.get('DATABASE_URL')
+  const appSecret = committedEnvironment.get('APP_SECRET')
+
+  if (!databaseTemplate || !appSecret) {
+    fail('devcontainer.env must define DATABASE_URL and APP_SECRET')
+  }
+
+  const resolvedEnvironment = resolvePlaywrightEnvironment({
+    appSecret,
+    databaseTemplate,
+    databasePort,
+    workspace,
+  })
+
+  if (printEnvironment) {
+    console.log(
+      JSON.stringify(
+        {
+          databaseHost: `127.0.0.1:${databasePort}`,
+          manageUrl: resolvedEnvironment.URL_MANAGE,
+          studentUrl: resolvedEnvironment.URL_STUDENT,
+          workspace: workspace || null,
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  ensureHostDependencies(args)
+  console.log(
+    `[playwright:host] Running on the host against ${resolvedEnvironment.URL_MANAGE}`
+  )
+  runPnpm(
+    [
+      '--filter',
+      '@klicker-uzh/playwright',
+      'exec',
+      'playwright',
+      'test',
+      ...args,
+    ],
+    { ...process.env, ...resolvedEnvironment }
+  )
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/util/run-playwright-host.test.mjs
+++ b/util/run-playwright-host.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  assertPlaywrightHostBoundary,
+  HOST_RUNNER_ENV,
+} from './playwright-host-policy.mjs'
+import {
+  parsePublishedPort,
+  resolvePlaywrightEnvironment,
+} from './run-playwright-host.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const simulatedHostCwd = '/Users/test/klicker-uzh'
+
+const noContainerPaths = () => false
+
+test('local Playwright rejects direct host execution', () => {
+  assert.throws(
+    () =>
+      assertPlaywrightHostBoundary({
+        cwd: simulatedHostCwd,
+        env: {},
+        pathExists: noContainerPaths,
+      }),
+    /must use the host launcher/
+  )
+})
+
+test('local Playwright accepts the host launcher marker', () => {
+  assert.doesNotThrow(() =>
+    assertPlaywrightHostBoundary({
+      cwd: simulatedHostCwd,
+      env: { [HOST_RUNNER_ENV]: '1' },
+      pathExists: noContainerPaths,
+    })
+  )
+})
+
+test('local containers are rejected even with the host marker', () => {
+  assert.throws(
+    () =>
+      assertPlaywrightHostBoundary({
+        cwd: '/workspaces/klicker-uzh',
+        env: {
+          KLICKER_DEVCONTAINER: '1',
+          [HOST_RUNNER_ENV]: '1',
+        },
+        pathExists: noContainerPaths,
+      }),
+    /host-only/
+  )
+})
+
+test('the existing GitHub Actions container remains allowed', () => {
+  assert.doesNotThrow(() =>
+    assertPlaywrightHostBoundary({
+      cwd: '/__w/klicker-uzh/klicker-uzh',
+      env: { CI: 'true', GITHUB_ACTIONS: 'true' },
+      pathExists: () => true,
+    })
+  )
+})
+
+test('a local container cannot use an incomplete GitHub Actions marker', () => {
+  assert.throws(
+    () =>
+      assertPlaywrightHostBoundary({
+        cwd: '/workspaces/klicker-uzh',
+        env: { GITHUB_ACTIONS: 'true' },
+        pathExists: noContainerPaths,
+      }),
+    /host-only/
+  )
+})
+
+test('workspace URLs and the loopback database port resolve together', () => {
+  const environment = resolvePlaywrightEnvironment({
+    appSecret: 'synthetic-test-value',
+    databaseTemplate: 'postgres://user:password@postgres:5432/database',
+    databasePort: 49153,
+    workspace: 'rs-host-playwright',
+  })
+
+  assert.equal(
+    environment.URL_MANAGE,
+    'https://manage.klicker.rs-host-playwright.localhost'
+  )
+  assert.equal(
+    environment.DATABASE_URL,
+    'postgres://user:password@127.0.0.1:49153/database'
+  )
+})
+
+test('Docker port output resolves IPv4 and IPv6 bindings', () => {
+  assert.equal(parsePublishedPort('127.0.0.1:49153'), 49153)
+  assert.equal(parsePublishedPort('[::1]:49154'), 49154)
+})
+
+test('every local Playwright package script routes through the host launcher', () => {
+  const packageJson = JSON.parse(
+    readFileSync(join(repoRoot, 'playwright', 'package.json'), 'utf8')
+  )
+  const localScripts = [
+    'show-report',
+    'test',
+    'test:headed',
+    'test:headed:raw',
+    'test:host',
+    'test:raw',
+    'test:run',
+    'test:run:raw',
+    'test:ui',
+    'test:ui:raw',
+  ]
+
+  for (const script of localScripts) {
+    assert.match(
+      packageJson.scripts[script],
+      /run-playwright-host\.mjs/,
+      `${script} bypasses the host launcher`
+    )
+  }
+})
+
+test('devcontainer dependency mounts cannot overwrite the host runner links', () => {
+  const compose = readFileSync(
+    join(repoRoot, '.devcontainer', 'docker-compose.yml'),
+    'utf8'
+  )
+
+  for (const dependencyPath of [
+    'playwright/node_modules',
+    'packages/prisma/node_modules',
+    'packages/types/node_modules',
+  ]) {
+    assert.ok(
+      compose.includes(`:/workspaces/klicker-uzh/${dependencyPath}`),
+      `${dependencyPath} is not isolated from the host`
+    )
+  }
+})


### PR DESCRIPTION
## What This Fixes

This PR makes local Playwright execution host-only while leaving GitHub Actions on its existing official Playwright container path.

- Adds one host launcher that reconciles the exact devrouter workspace, maps its namespaced HTTPS origins, and connects Prisma setup through that workspace's loopback-only PostgreSQL port.
- Routes every Playwright package script through the launcher.
- Rejects direct local host and devcontainer invocations before global setup can reset data or launch a browser.
- Prevents browser downloads in the devcontainer and separates its Linux Playwright dependency links from the host's Darwin links.
- Updates the repository instructions, testing guide, Playwright guide, and agent skills to use `pnpm playwright:host -- <args>`.

## How It Works

- `util/run-playwright-host.mjs` calls `devrouter ensure`, reads the persisted worktree namespace, resolves the exact Compose PostgreSQL container by labels, and injects only the local test URLs and committed development credentials required by Playwright.
- `playwright/playwright.config.ts` fails closed unless it is launched through the host runner. The only container exception requires both `CI=true` and `GITHUB_ACTIONS=true`.
- Linked worktrees publish PostgreSQL on a random loopback port, so concurrent worktrees do not compete for a fixed host port.
- GitHub workflows remain unchanged and continue to invoke `pnpm --filter @klicker-uzh/playwright exec playwright test` inside the official Playwright image.

## Branch Coverage

- Base: `v3` at `31cbbb36a3fca6d50371975bad982f51424e2abc`
- Head: `b4de1df45bfcb8ea9ab95430bba21e0d78ed1e54`
- Reviewed: 1 commit, 17 files, 681 substantive added or deleted lines
- No lockfile, generated artifact, CI workflow, database schema, or migration changed.

## Review Focus

- Confirm the GitHub Actions exception preserves the current containerized CI path without allowing ordinary local containers.
- Check the exact-worktree URL and PostgreSQL-port resolution in the host launcher.
- Check that the package-level volumes prevent Linux pnpm links from replacing the host runner's Darwin links.
- Confirm every supported local script reaches the same launcher and no documented bypass remains.

## Verification

Current head:

- `node --test ./util/run-playwright-host.test.mjs` -> 9/9 passed.
- Focused Biome and Prettier checks plus `git diff --check` -> passed.
- `gitleaks git --staged --redact --no-banner --config .gitleaks.toml` -> no leaks found.
- Docker Compose merged-config validation -> passed.

Hosted exact-head CI at PR creation:

- ARM and AMD build canaries plus workflow filters -> passed.
- Codebase check, hosted build/compile, Gitleaks, GraphQL, CodeQL, and review jobs -> pending.

Earlier branch verification, still applicable after the final CI-marker tightening and documentation-only cleanup:

- `pnpm playwright:host -- --list --project=chromium` -> host launcher resolved the `rs-host-playwright-enforcement` workspace and listed 886 tests in 31 files.
- `pnpm playwright:host -- tests/A-login.spec.ts --grep 'Sign in to student account$' --project=chromium --workers=1` -> 1/1 passed with Chromium running on the host against the devcontainer apps.
- Direct host Playwright CLI -> rejected before global setup with the host-launcher instruction.
- Direct `devrouter exec` Playwright CLI -> rejected before global setup with the host-only instruction.
- `pnpm --filter @klicker-uzh/playwright check` inside the devcontainer -> passed.

Failed/Warning:

- `trusted_policy` -> failed before branch review because the workflow definition commit `v3@31cbbb36` could not be verified. This is the same default-branch workflow-trust failure visible on other current PRs, not a Playwright test result.
- `pnpm run check:all` reached the task-specific checks, which passed, but the unrelated Analytics lint task selected Python 3.14 and could not build pandas 2.2.2 because the devcontainer has no compiler. The parallel gate then stopped.
- `pnpm run build` completed 21 tasks, then `frontend-manage` was killed with exit 137 during static-page generation. No changed Playwright file produced a build error.
- The existing wiki validator reports 25 baseline conformance errors outside the two changed guide pages.

## Security / Privacy

- Manual diff and staged-content review found no credentials, personal data, or production content.
- The launcher reads only the committed development `DATABASE_URL` and `APP_SECRET`; `--print-env` reports sanitized origins and the loopback database endpoint without values.
- The PostgreSQL host binding is loopback-only.

## Blocking Before Merge

- [ ] Exact-head GitHub checks must be terminal and green.
- [ ] Move the PR out of draft only after CI and human review are satisfactory.
- [ ] Merge requires separate explicit authorization.

## Follow-Up After Merge

None.

## Local Session Artifacts

- Machine: `MacBook-Pro.local`
- Worktree: `trees/host-playwright-enforcement` in `klicker-uzh`
- Environment: the task DevPod is stopped and has no active routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a host-based Playwright launcher for local end-to-end testing.
  * Automatically configures workspace routes, database connectivity, dependencies, and test environments.
  * Added support for listing tests, printing resolved environments, and viewing reports.

* **Bug Fixes**
  * Prevented unsupported Playwright execution and browser installation inside local containers.

* **Documentation**
  * Updated development, testing, and onboarding guidance with the new local Playwright workflow.
  * Clarified that CI continues using its existing Playwright container setup.

* **Tests**
  * Added coverage for host execution, environment resolution, routing, and dependency isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->