### PR TITLE
deploy(stg): enable knowledge graph generation

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -27,7 +27,7 @@ hatchet:
     sourceGatewayUrl: 'http://klicker-backend.stg-klicker.svc.cluster.local:3000'
     workerDisabled: false
   kbGraph:
-    disabled: true
+    disabled: false
     hostPort: 'hatchet-grpc.stg-hatchet-svc.svc.cluster.local:7070'
     apiUrl: 'http://app-hatchet-svc-api.stg-hatchet-svc.svc.cluster.local:8080'
     tlsStrategy: 'none'
@@ -634,7 +634,7 @@ backendGraphql:
   appControlDomain: control.klicker.stg.df-app.ch
   cookieDomain: .klicker.stg.df-app.ch
   kbIngestionDisabled: false
-  kbGraphDisabled: true
+  kbGraphDisabled: false
 
   knowledgeGraph:
     host: 'stg-falkordb-aigeneric-falkordb-falkordb.stg-kb-falkordb-aigeneric.svc.cluster.local'


### PR DESCRIPTION
## What This Changes

Enables staging knowledge-graph generation by opening the backend and general-worker kill switches together. Existing staging Hatchet, FalkorDB, GPT-5.6 Luna, artifact, and canary cost settings remain unchanged.

## Branch Coverage

- Base: `v3-ai`
- Head: `681c1d064`
- Reviewed: 1 commit, 1 file, 4 substantive changed lines
- Floor exemption: isolated staging demo unblock

## Verification

Current head:

- `helm template klicker-stg deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-stg/values.yaml --show-only templates/cm-backend-graphql.yaml` -> rendered with graph cost and FalkorDB settings and without `KB_GRAPH_DISABLED`.
- `helm template klicker-stg deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-stg/values.yaml --show-only templates/cm-hatchet-workers.yaml` -> rendered the external graph workflow and model settings without `KB_GRAPH_DISABLED`.
- `git diff --check origin/v3-ai...HEAD` -> passed.

## Security / Privacy

- No credentials or personal data are included.
- Current df-cloud staging source projects `KB_GRAPH_HATCHET_CLIENT_TOKEN` into the general-worker Secret; the token value was not read.

## Blocking Before Merge

- [ ] Exact-head GitHub CI is acceptable.
- [ ] Confirm the staging ExternalSecret is Ready and contains the graph-token key before allowing the shared general worker to roll.

## Follow-Up After Merge

- [ ] Verify ArgoCD sync and new backend/general-worker revisions.
- [ ] Enable the prepared staging Knowledge Base and run one synthetic graph canary.

## Local Session Artifacts

- Machine: Local
- Worktree: `trees/rs/enable-staging-kb-graph` in `klicker-uzh`
