### PR TITLE
fix(kb): route ingestion through live backend service

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -24,7 +24,7 @@ hatchet:
     apiUrl: 'http://app-hatchet-svc-api.stg-hatchet-svc.svc.cluster.local:8080'
   kbIngestion:
     apiUrl: 'http://ingestion-resource-api.stg-ingestion.svc.cluster.local:8000'
-    sourceGatewayUrl: 'http://klicker-backend.stg-klicker.svc.cluster.local:3000'
+    sourceGatewayUrl: 'http://app-klicker-klicker-uzh-v2-backend-graphql.stg-klicker.svc.cluster.local:3000'
     workerDisabled: false
   kbGraph:
     disabled: false

--- a/util/check-kb-ingestion-stg.mjs
+++ b/util/check-kb-ingestion-stg.mjs
@@ -9,7 +9,7 @@ const expectedWorkerData = {
     'http://ingestion-resource-api.stg-ingestion.svc.cluster.local:8000',
   KB_INGESTION_PROJECT_ID: 'klicker-course-materials',
   KB_SOURCE_GATEWAY_URL:
-    'http://klicker-backend.stg-klicker.svc.cluster.local:3000',
+    'http://app-klicker-klicker-uzh-v2-backend-graphql.stg-klicker.svc.cluster.local:3000',
 }
 const expectedBackendData = {
   KB_GRAPH_DISABLED: 'true',


### PR DESCRIPTION
## What This Fixes

Document ingestion reached the ingestion service but remained queued because Klicker's general worker advertised a non-existent `klicker-backend` source-gateway Service. This points `KB_SOURCE_GATEWAY_URL` at the backend Service actually rendered by the staging Argo release and keeps the staging render expectation aligned.

## Branch Coverage

- Base: `v3-ai`
- Head: `f053eaf0c`
- Reviewed: 1 commit, 2 files, 2 insertions and 2 deletions

## Review Focus

- The hostname intentionally couples this staging value to Argo release `app-klicker`, chart name `klicker-uzh-v2`, and namespace `stg-klicker`.
- The paired ingestion deployment MR must use the same origin for source fetches and callbacks.

## Verification

Current head:

- `helm lint deploy/charts/klicker-uzh-v3 --values deploy/env-uzh-stg/values.yaml` -> passed.
- `helm template app-klicker ... --show-only templates/service-app.yaml` -> rendered `app-klicker-klicker-uzh-v2-backend-graphql`.
- `helm template app-klicker ... --show-only templates/cm-hatchet-workers.yaml` -> rendered the matching `KB_SOURCE_GATEWAY_URL`.
- `prettier --check deploy/env-uzh-stg/values.yaml util/check-kb-ingestion-stg.mjs` -> passed.
- `git diff --check origin/v3-ai...HEAD` -> passed.

Failed/Warning:

- `check:kb-ingestion-stg` currently stops on a pre-existing stale assertion that expects `KB_GRAPH_DISABLED=true`, while `v3-ai` enables graph processing. The URL-specific Helm render was verified independently.

## Security / Privacy

- No credentials, personal data, public ingress, or permission changes are included.

## Blocking Before Merge

- [ ] Exact-head GitHub CI is acceptable.
- [ ] Pair with the ingestion deployment MR that updates the producer origin and callback URL.

## Follow-Up After Merge

- [ ] Verify ArgoCD reconciliation and the general-worker rollout.
- [ ] Retry or re-ingest the two failed staging PDFs and confirm completion callbacks update Klicker.
