### PR TITLE
fix(deploy): align KB STG render check with open graph gates

### DIFF
--- a/util/check-kb-ingestion-stg.mjs
+++ b/util/check-kb-ingestion-stg.mjs
@@ -4,15 +4,11 @@ import { parseAllDocuments } from 'yaml'
 const chartPath = 'deploy/charts/klicker-uzh-v3'
 const stagingValuesPath = 'deploy/env-uzh-stg/values.yaml'
 const expectedWorkerData = {
-  KB_GRAPH_DISABLED: 'true',
   KB_INGESTION_API_URL:
     'http://ingestion-resource-api.stg-ingestion.svc.cluster.local:8000',
   KB_INGESTION_PROJECT_ID: 'klicker-course-materials',
   KB_SOURCE_GATEWAY_URL:
     'http://app-klicker-klicker-uzh-v2-backend-graphql.stg-klicker.svc.cluster.local:3000',
-}
-const expectedBackendData = {
-  KB_GRAPH_DISABLED: 'true',
 }
 const workerOnlyKeys = [
   ...Object.keys(expectedWorkerData),
@@ -96,7 +92,10 @@ const responseProcessors = configMaps.filter((value) =>
   value.metadata?.name?.includes('-config-hatchet-worker-response-processor')
 )
 
-requireData(backend, expectedBackendData)
+// KB_GRAPH_DISABLED is intentionally absent on staging since #5612 enabled
+// graph generation; an open gate must not render the kill-switch key.
+requireAbsent(backend, ['KB_GRAPH_DISABLED'])
+requireAbsent(generalWorker, ['KB_GRAPH_DISABLED'])
 requireData(generalWorker, expectedWorkerData)
 requireAbsent(backend, ['KB_INGESTION_DISABLED'])
 requireAbsent(generalWorker, ['KB_INGESTION_WORKER_DISABLED'])


### PR DESCRIPTION
# Fix KB STG render check for open graph gates

## Summary

#5612 intentionally enabled KB graph generation in staging (`hatchet.kbGraph.disabled: false`, `kbGraphDisabled: false`). The W8-era validator in `util/check-kb-ingestion-stg.mjs` still asserted the `KB_GRAPH_DISABLED: "true"` kill-switch key on the backend-graphql and hatchet-worker ConfigMaps, so the Check codebase step has been failing with `expected KB_GRAPH_DISABLED="true", received undefined`.

This change:
- removes the stale graph-gate key from the expected worker data
- asserts instead that `KB_GRAPH_DISABLED` is absent from both backend-graphql and general-worker ConfigMaps
- keeps all ingestion-gate expectations (open gates) unchanged

## Context

- Follows the intentional staging behavior change in #5612 (KG enabled).
- Complements #5615 (source-gateway hostname fix on the same validator), which did not touch graph-gate expectations.
- Local verification: `node util/check-kb-ingestion-stg.mjs` passes at the rendered staging values (no `KB_GRAPH_DISABLED` keys rendered at tip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staging configuration validation to reflect the current Knowledge Base graph settings.
  * Removed outdated expectations for the graph-disabled setting from backend and worker configuration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->