### PR TITLE
enhance: improve knowledge element generation

### DIFF
--- a/apps/chat/test/account-usage-route.test.ts
+++ b/apps/chat/test/account-usage-route.test.ts
@@ -469,7 +469,10 @@ describe('account usage chat route', () => {
         ],
       })
     )
-    mocks.getAggregatedMCPTools.mockResolvedValueOnce({ KB_doc_query: {} })
+    mocks.getAggregatedMCPTools.mockResolvedValueOnce({
+      tools: { KB_doc_query: {} },
+      close: mocks.closeMCPTools,
+    })
 
     const response = await POST(createRequest({ selectedMode: 'quizzer' }), {
       params: Promise.resolve({ chatbotId: 'chatbot-1' }),

--- a/apps/chat/test/chatbot-published-gate.test.ts
+++ b/apps/chat/test/chatbot-published-gate.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   findUnique: vi.fn(),
@@ -32,9 +32,12 @@ const VALID_ID = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
 describe('getChatbotOr404 publication gate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubEnv('APP_SECRET', 'test-secret')
     mocks.jwtVerify.mockResolvedValue({ payload: { sub: 'participant-1' } })
-    mocks.participationFindUnique.mockResolvedValue({ isActive: false })
+    mocks.participationFindUnique.mockResolvedValue({ id: 'participation-1' })
   })
+
+  afterEach(() => vi.unstubAllEnvs())
 
   test('returns the chatbot when it is PUBLISHED', async () => {
     mocks.findUnique.mockResolvedValue({

--- a/apps/chat/test/required-mcp-route.test.ts
+++ b/apps/chat/test/required-mcp-route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   findUnique: vi.fn(),
   findThread: vi.fn(),
   getAggregatedMCPTools: vi.fn(),
+  closeMCPTools: vi.fn(),
   createThread: vi.fn(),
   findFailedTurnThreadId: vi.fn(),
   deleteThread: vi.fn(),
@@ -319,7 +320,10 @@ describe('required MCP chat preflight', () => {
     mocks.findUnique.mockResolvedValueOnce(
       createChatbot({ course: { displayName } })
     )
-    mocks.getAggregatedMCPTools.mockResolvedValueOnce({})
+    mocks.getAggregatedMCPTools.mockResolvedValueOnce({
+      tools: {},
+      close: mocks.closeMCPTools,
+    })
     mocks.compileSystemPrompt.mockImplementationOnce(() => {
       throw new Error('stop after prompt compilation')
     })
@@ -337,6 +341,11 @@ describe('required MCP chat preflight', () => {
         mcpConfigurations: {
           include: { mcpServer: true },
           orderBy: { priority: 'asc' },
+        },
+        knowledgeBases: {
+          where: { isEnabled: true },
+          select: { kbId: true },
+          take: 1,
         },
       },
     })
@@ -399,7 +408,13 @@ describe('required MCP chat preflight', () => {
           }),
         }),
       ],
-      'chatbot-1'
+      {
+        chatbotId: 'chatbot-1',
+        participantId: 'participant-1',
+        authMode: 'account',
+        kbId: undefined,
+        sessionId: 'thread-1',
+      }
     )
   })
 
@@ -415,7 +430,10 @@ describe('required MCP chat preflight', () => {
         ],
       })
     )
-    mocks.getAggregatedMCPTools.mockResolvedValueOnce({})
+    mocks.getAggregatedMCPTools.mockResolvedValueOnce({
+      tools: {},
+      close: mocks.closeMCPTools,
+    })
 
     const response = await POST(createRequest('quizzer'), {
       params: Promise.resolve({ chatbotId: 'chatbot-1' }),
@@ -492,7 +510,13 @@ describe('required MCP chat preflight', () => {
           server: expect.objectContaining({ id: 'server-1' }),
         }),
       ],
-      'chatbot-1'
+      {
+        chatbotId: 'chatbot-1',
+        participantId: 'participant-1',
+        authMode: 'account',
+        kbId: undefined,
+        sessionId: 'thread-1',
+      }
     )
   })
 })

--- a/apps/frontend-manage/src/components/elements/generation/ElementGenerationBuild.tsx
+++ b/apps/frontend-manage/src/components/elements/generation/ElementGenerationBuild.tsx
@@ -3,7 +3,7 @@ import {
   ElementGenerationBuildDocument,
   ElementGenerationBuildStatus,
   ElementGenerationCapabilitiesDocument,
-  type ElementGenerationReviewDecision,
+  ElementGenerationReviewDecision,
   PublishIncompleteElementGenerationDocument,
   RetryElementGenerationDocument,
   ReviewElementGenerationDocument,
@@ -13,6 +13,7 @@ import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { Button, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
+import { GENERATION_STARTED_EVENT } from '../../generation/GenerationStatusProvider'
 import ElementGenerationReviewGatePanel from './ElementGenerationReviewGate'
 import {
   elementGenerationErrorCode,
@@ -100,16 +101,32 @@ export default function ElementGenerationBuild({
   const mutationLoading =
     reviewState.loading || retryState.loading || publishState.loading
   const currentBuildId = build.id
+  const currentElementType = build.elementType
 
   async function refresh() {
     await query.refetch()
   }
 
-  async function runAction(action: () => Promise<unknown>) {
+  async function runAction(
+    action: () => Promise<unknown>,
+    resumeInBackground = false
+  ) {
     setActionError(undefined)
     try {
       await action()
       await refresh()
+      if (resumeInBackground) {
+        window.dispatchEvent(
+          new CustomEvent(GENERATION_STARTED_EVENT, {
+            detail: {
+              kind: 'element',
+              id: currentBuildId,
+              label: t(`elementTypes.${currentElementType}.label`),
+              startedAt: Date.now(),
+            },
+          })
+        )
+      }
     } catch (error) {
       const code = elementGenerationErrorCode(error)
       setActionError(code ? t('errors.withCode', { code }) : t('errors.action'))
@@ -121,17 +138,19 @@ export default function ElementGenerationBuild({
     decision: ElementGenerationReviewDecision,
     acknowledged: boolean
   ) {
-    await runAction(() =>
-      reviewGeneration({
-        variables: {
-          input: {
-            buildId: currentBuildId,
-            gate,
-            decision,
-            warningsAcknowledged: acknowledged,
+    await runAction(
+      () =>
+        reviewGeneration({
+          variables: {
+            input: {
+              buildId: currentBuildId,
+              gate,
+              decision,
+              warningsAcknowledged: acknowledged,
+            },
           },
-        },
-      })
+        }),
+      decision === ElementGenerationReviewDecision.Approve
     )
   }
 
@@ -262,10 +281,12 @@ export default function ElementGenerationBuild({
               type="button"
               disabled={mutationLoading}
               onClick={() =>
-                runAction(() =>
-                  retryGeneration({
-                    variables: { input: { buildId: build.id } },
-                  })
+                runAction(
+                  () =>
+                    retryGeneration({
+                      variables: { input: { buildId: build.id } },
+                    }),
+                  true
                 )
               }
               className={{ root: 'mt-4' }}
@@ -307,10 +328,12 @@ export default function ElementGenerationBuild({
                 type="button"
                 disabled={mutationLoading}
                 onClick={() =>
-                  runAction(() =>
-                    retryGeneration({
-                      variables: { input: { buildId: build.id } },
-                    })
+                  runAction(
+                    () =>
+                      retryGeneration({
+                        variables: { input: { buildId: build.id } },
+                      }),
+                    true
                   )
                 }
                 data={{ cy: 'element-generation-retry-incomplete' }}

--- a/apps/frontend-manage/src/components/elements/generation/ElementGenerationBuild.tsx
+++ b/apps/frontend-manage/src/components/elements/generation/ElementGenerationBuild.tsx
@@ -114,19 +114,27 @@ export default function ElementGenerationBuild({
     setActionError(undefined)
     try {
       await action()
+    } catch (error) {
+      const code = elementGenerationErrorCode(error)
+      setActionError(code ? t('errors.withCode', { code }) : t('errors.action'))
+      return
+    }
+
+    if (resumeInBackground) {
+      window.dispatchEvent(
+        new CustomEvent(GENERATION_STARTED_EVENT, {
+          detail: {
+            kind: 'element',
+            id: currentBuildId,
+            label: t(`elementTypes.${currentElementType}.label`),
+            startedAt: Date.now(),
+          },
+        })
+      )
+    }
+
+    try {
       await refresh()
-      if (resumeInBackground) {
-        window.dispatchEvent(
-          new CustomEvent(GENERATION_STARTED_EVENT, {
-            detail: {
-              kind: 'element',
-              id: currentBuildId,
-              label: t(`elementTypes.${currentElementType}.label`),
-              startedAt: Date.now(),
-            },
-          })
-        )
-      }
     } catch (error) {
       const code = elementGenerationErrorCode(error)
       setActionError(code ? t('errors.withCode', { code }) : t('errors.action'))
@@ -347,15 +355,17 @@ export default function ElementGenerationBuild({
                 type="button"
                 disabled={mutationLoading || !warningsAcknowledged}
                 onClick={() =>
-                  runAction(() =>
-                    publishIncomplete({
-                      variables: {
-                        input: {
-                          buildId: build.id,
-                          warningsAcknowledged,
+                  runAction(
+                    () =>
+                      publishIncomplete({
+                        variables: {
+                          input: {
+                            buildId: build.id,
+                            warningsAcknowledged,
+                          },
                         },
-                      },
-                    })
+                      }),
+                    true
                   )
                 }
                 data={{ cy: 'element-generation-publish-incomplete' }}

--- a/apps/frontend-manage/src/components/elements/generation/ElementGenerationConfigure.tsx
+++ b/apps/frontend-manage/src/components/elements/generation/ElementGenerationConfigure.tsx
@@ -13,6 +13,7 @@ import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { Button, UserNotification } from '@uzh-bf/design-system'
 import { useFormatter, useTranslations } from 'next-intl'
 import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { GENERATION_STARTED_EVENT } from '../../generation/GenerationStatusProvider'
 import {
   ELEMENT_TYPE_ORDER,
   elementGenerationErrorCode,
@@ -28,6 +29,40 @@ const DEFAULT_BLOOM_LEVELS = [
   ElementGenerationBloomLevel.Understand,
   ElementGenerationBloomLevel.Apply,
 ]
+const DIFFICULTY_LEVELS = [
+  ElementGenerationDifficultyPreset.D1,
+  ElementGenerationDifficultyPreset.D2,
+  ElementGenerationDifficultyPreset.D3,
+  ElementGenerationDifficultyPreset.D4,
+  ElementGenerationDifficultyPreset.D5,
+] as const
+const BLOOM_LEVEL_STYLES = {
+  [ElementGenerationBloomLevel.Remember]: {
+    badge: 'bg-sky-100 text-sky-900',
+    selected: 'border-sky-500 bg-sky-50 text-sky-950',
+    stripe: 'bg-sky-500',
+  },
+  [ElementGenerationBloomLevel.Understand]: {
+    badge: 'bg-cyan-100 text-cyan-900',
+    selected: 'border-cyan-600 bg-cyan-50 text-cyan-950',
+    stripe: 'bg-cyan-600',
+  },
+  [ElementGenerationBloomLevel.Apply]: {
+    badge: 'bg-emerald-100 text-emerald-900',
+    selected: 'border-emerald-600 bg-emerald-50 text-emerald-950',
+    stripe: 'bg-emerald-600',
+  },
+  [ElementGenerationBloomLevel.Analyze]: {
+    badge: 'bg-amber-100 text-amber-950',
+    selected: 'border-amber-500 bg-amber-50 text-amber-950',
+    stripe: 'bg-amber-500',
+  },
+  [ElementGenerationBloomLevel.Evaluate]: {
+    badge: 'bg-orange-100 text-orange-950',
+    selected: 'border-orange-600 bg-orange-50 text-orange-950',
+    stripe: 'bg-orange-600',
+  },
+} as const
 
 function scopeValues(
   sources: Array<{ resourceId: string }>
@@ -68,7 +103,7 @@ export default function ElementGenerationConfigure({
   const [elementCount, setElementCount] = useState(6)
   const [difficulty, setDifficulty] =
     useState<ElementGenerationDifficultyPreset>(
-      ElementGenerationDifficultyPreset.Mixed
+      ElementGenerationDifficultyPreset.D3
     )
   const [bloomLevels, setBloomLevels] =
     useState<ElementGenerationBloomLevel[]>(DEFAULT_BLOOM_LEVELS)
@@ -262,6 +297,16 @@ export default function ElementGenerationConfigure({
       })
       const buildId = result.data?.startElementGeneration.id
       if (!buildId) throw new Error('Element generation did not return a build')
+      window.dispatchEvent(
+        new CustomEvent(GENERATION_STARTED_EVENT, {
+          detail: {
+            kind: 'element',
+            id: buildId,
+            label: t(`elementTypes.${elementType}.label`),
+            startedAt: Date.now(),
+          },
+        })
+      )
       await onStarted(buildId)
     } catch (error) {
       const code = elementGenerationErrorCode(error)
@@ -407,6 +452,10 @@ export default function ElementGenerationConfigure({
                               />
                             </label>
                           </div>
+                        ) : scope.selected ? (
+                          <p className="ml-7 mt-2 text-xs text-slate-500">
+                            {t('configure.completeSource')}
+                          </p>
                         ) : null}
                       </div>
                     )
@@ -466,18 +515,23 @@ export default function ElementGenerationConfigure({
               <p className="mt-1 text-sm text-slate-600">
                 {t('configure.bloomHelp')}
               </p>
-              <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
-                {capabilities.bloomLevels.map((level) => {
+              <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+                {capabilities.bloomLevels.map((level, index) => {
                   const checked = bloomLevels.includes(level)
+                  const styles = BLOOM_LEVEL_STYLES[level]
                   return (
                     <label
                       key={level}
-                      className={`cursor-pointer rounded-lg border-2 px-3 py-4 text-center text-sm font-semibold ${
+                      className={`focus-within:ring-primary-80 relative min-h-40 cursor-pointer overflow-hidden rounded-xl border-2 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-offset-2 ${
                         checked
-                          ? 'border-orange-500 bg-orange-50 text-orange-900'
-                          : 'border-slate-200 text-slate-700'
+                          ? styles.selected
+                          : 'border-slate-200 bg-white text-slate-700'
                       }`}
                     >
+                      <span
+                        aria-hidden="true"
+                        className={`absolute inset-x-0 top-0 h-1.5 ${styles.stripe}`}
+                      />
                       <input
                         type="checkbox"
                         checked={checked}
@@ -491,7 +545,27 @@ export default function ElementGenerationConfigure({
                         className="sr-only"
                         data-cy={`element-generation-bloom-${level}`}
                       />
-                      {t(`bloom.${level}`)}
+                      <span className="flex items-center justify-between gap-2">
+                        <span
+                          className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold ${styles.badge}`}
+                        >
+                          {index + 1}
+                        </span>
+                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          {t('configure.bloomLevel', { level: index + 1 })}
+                        </span>
+                      </span>
+                      <span className="mt-4 block text-base font-bold">
+                        {t(`bloom.${level}`)}
+                      </span>
+                      <span className="mt-1 block text-xs font-normal leading-relaxed text-slate-600">
+                        {t(`bloomExamples.${level}`)}
+                      </span>
+                      <span className="mt-3 block text-xs font-semibold">
+                        {checked
+                          ? t('configure.bloomSelected')
+                          : t('configure.bloomSelect')}
+                      </span>
                     </label>
                   )
                 })}
@@ -540,29 +614,35 @@ export default function ElementGenerationConfigure({
                   <legend className="text-sm font-semibold text-slate-700">
                     {t('configure.difficulty')}
                   </legend>
-                  <div className="mt-2 grid max-w-xl grid-cols-3 gap-2">
-                    {Object.values(ElementGenerationDifficultyPreset).map(
-                      (value) => (
-                        <label
-                          key={value}
-                          className={`cursor-pointer rounded-md border px-3 py-2 text-center text-sm font-medium ${
-                            difficulty === value
-                              ? 'border-primary-100 bg-primary-20 text-primary-100'
-                              : 'border-slate-300 text-slate-700'
-                          }`}
-                        >
-                          <input
-                            type="radio"
-                            name="difficulty"
-                            checked={difficulty === value}
-                            onChange={() => setDifficulty(value)}
-                            className="sr-only"
-                            data-cy={`element-generation-difficulty-${value.toLowerCase()}`}
-                          />
-                          {t(`difficulty.${value}`)}
-                        </label>
-                      )
-                    )}
+                  <p className="mt-1 text-xs text-slate-500">
+                    {t('configure.difficultyHelp')}
+                  </p>
+                  <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+                    {DIFFICULTY_LEVELS.map((value, index) => (
+                      <label
+                        key={value}
+                        className={`focus-within:ring-primary-80 cursor-pointer rounded-lg border-2 px-3 py-3 text-left text-sm transition focus-within:ring-2 focus-within:ring-offset-2 ${
+                          difficulty === value
+                            ? 'border-primary-100 bg-primary-20 text-primary-100 shadow-sm'
+                            : 'border-slate-300 text-slate-700 hover:border-slate-400'
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="difficulty"
+                          checked={difficulty === value}
+                          onChange={() => setDifficulty(value)}
+                          className="sr-only"
+                          data-cy={`element-generation-difficulty-${value.toLowerCase()}`}
+                        />
+                        <span className="block font-bold">
+                          D{index + 1} · {t(`difficulty.${value}.label`)}
+                        </span>
+                        <span className="mt-1 block text-xs font-normal leading-snug text-slate-600">
+                          {t(`difficulty.${value}.description`)}
+                        </span>
+                      </label>
+                    ))}
                   </div>
                 </fieldset>
               ) : null}
@@ -591,12 +671,23 @@ export default function ElementGenerationConfigure({
                   <Button.Label>{t('configure.addObjective')}</Button.Label>
                 </Button>
               </div>
+              <div className="mt-3 rounded-lg border border-cyan-200 bg-cyan-50 p-3 text-sm text-cyan-950">
+                <p className="font-semibold">{t('configure.objectiveHint')}</p>
+                <p className="mt-1 text-xs leading-relaxed">
+                  {t('configure.objectiveFormula')}
+                </p>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
+                  <li>{t('configure.objectiveExampleOne')}</li>
+                  <li>{t('configure.objectiveExampleTwo')}</li>
+                </ul>
+              </div>
               <div className="mt-3 space-y-2">
                 {objectives.map((objective, index) => (
                   <div key={objective.id} className="flex gap-2">
                     <input
                       type="text"
                       value={objective.text}
+                      placeholder={t('configure.objectivePlaceholder')}
                       onChange={(event) =>
                         setObjectives((current) =>
                           current.map((item) =>

--- a/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
+++ b/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
@@ -267,7 +267,11 @@ export function GenerationStatusProvider({
 
   useEffect(() => {
     if (!storageReady) return
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs))
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs))
+    } catch {
+      // Keep in-memory generation tracking available when browser storage fails.
+    }
   }, [jobs, storageReady])
 
   useEffect(() => {

--- a/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
+++ b/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
@@ -1,0 +1,378 @@
+import { useQuery } from '@apollo/client'
+import {
+  faChevronUp,
+  faWandMagicSparkles,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  ElementGenerationBuildDocument,
+  ElementGenerationBuildStatus,
+  GetKbKnowledgeGraphConfigDocument,
+  KbGraphBuildStatus,
+} from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  toast,
+} from '@uzh-bf/design-system'
+import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+export const GENERATION_STARTED_EVENT = 'klicker:generation-started'
+
+type GraphGenerationJob = {
+  kind: 'graph'
+  id: string
+  kbId: string
+  label: string
+  startedAt: number
+}
+
+type ElementGenerationJob = {
+  kind: 'element'
+  id: string
+  label: string
+  startedAt: number
+}
+
+export type GenerationJob = GraphGenerationJob | ElementGenerationJob
+
+type GenerationJobProgress = {
+  label: string
+  status: string
+}
+
+const STORAGE_KEY = 'klicker-background-generation-jobs-v1'
+const POLL_INTERVAL_MS = 5000
+const UNMATCHED_GRAPH_JOB_TIMEOUT_MS = 120_000
+
+function isGenerationJob(value: unknown): value is GenerationJob {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Partial<GenerationJob>
+  if (
+    (candidate.kind !== 'graph' && candidate.kind !== 'element') ||
+    typeof candidate.id !== 'string' ||
+    typeof candidate.label !== 'string' ||
+    typeof candidate.startedAt !== 'number' ||
+    !Number.isFinite(candidate.startedAt)
+  ) {
+    return false
+  }
+  return candidate.kind !== 'graph' || typeof candidate.kbId === 'string'
+}
+
+function readJobs(): GenerationJob[] {
+  try {
+    const value = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+    return Array.isArray(value) ? value.filter(isGenerationJob) : []
+  } catch {
+    return []
+  }
+}
+
+function jobKey(job: GenerationJob): string {
+  return `${job.kind}:${job.id}`
+}
+
+function GraphJobTracker({
+  job,
+  onProgress,
+  onTerminal,
+}: Readonly<{
+  job: GraphGenerationJob
+  onProgress: (job: GenerationJob, progress: GenerationJobProgress) => void
+  onTerminal: (job: GenerationJob, succeeded: boolean) => void
+}>) {
+  const t = useTranslations('manage.generationStatus')
+  const query = useQuery(GetKbKnowledgeGraphConfigDocument, {
+    variables: { kbId: job.kbId },
+    fetchPolicy: 'network-only',
+    pollInterval: POLL_INTERVAL_MS,
+  })
+  const config = query.data?.getKbKnowledgeGraphConfig
+  const [checkedAt, setCheckedAt] = useState(0)
+
+  useEffect(() => {
+    setCheckedAt(Date.now())
+    const interval = window.setInterval(
+      () => setCheckedAt(Date.now()),
+      POLL_INTERVAL_MS
+    )
+    return () => window.clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (config?.publishedBuildId === job.id) {
+      onTerminal(job, true)
+      return
+    }
+    const matchesBuild =
+      config?.buildId === job.id || config?.activeBuildId === job.id
+    if (!config || !matchesBuild) {
+      if (checkedAt - job.startedAt >= UNMATCHED_GRAPH_JOB_TIMEOUT_MS) {
+        onTerminal(job, false)
+      }
+      return
+    }
+    if (config.status === KbGraphBuildStatus.Succeeded) {
+      onTerminal(job, true)
+      return
+    }
+    if (
+      config.status === KbGraphBuildStatus.Failed ||
+      config.status === KbGraphBuildStatus.Superseded
+    ) {
+      onTerminal(job, false)
+      return
+    }
+    onProgress(job, {
+      label: job.label,
+      status:
+        config.status === KbGraphBuildStatus.Processing
+          ? t('graphProcessing')
+          : t('graphQueued'),
+    })
+  }, [checkedAt, config, job, onProgress, onTerminal, t])
+
+  return null
+}
+
+function ElementJobTracker({
+  job,
+  onProgress,
+  onTerminal,
+}: Readonly<{
+  job: ElementGenerationJob
+  onProgress: (job: GenerationJob, progress: GenerationJobProgress) => void
+  onTerminal: (job: GenerationJob, succeeded: boolean) => void
+}>) {
+  const t = useTranslations('manage.generationStatus')
+  const query = useQuery(ElementGenerationBuildDocument, {
+    variables: { id: job.id },
+    fetchPolicy: 'network-only',
+    pollInterval: POLL_INTERVAL_MS,
+  })
+  const build = query.data?.elementGenerationBuild
+
+  useEffect(() => {
+    if (!build) return
+    if (
+      build.status === ElementGenerationBuildStatus.Completed ||
+      build.status === ElementGenerationBuildStatus.Incomplete ||
+      build.status === ElementGenerationBuildStatus.WaitingForDesignReview ||
+      build.status === ElementGenerationBuildStatus.WaitingForPlanReview ||
+      build.status ===
+        ElementGenerationBuildStatus.AwaitingIncompletePublication
+    ) {
+      onTerminal(job, true)
+      return
+    }
+    if (
+      build.status === ElementGenerationBuildStatus.Failed ||
+      build.status === ElementGenerationBuildStatus.Rejected
+    ) {
+      onTerminal(job, false)
+      return
+    }
+    onProgress(job, {
+      label: job.label,
+      status: t('elementProgress', {
+        generated: build.generatedElementCount,
+        requested: build.requestedElementCount,
+      }),
+    })
+  }, [build, job, onProgress, onTerminal, t])
+
+  return null
+}
+
+export function GenerationStatusProvider({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  const t = useTranslations('manage.generationStatus')
+  const router = useRouter()
+  const [jobs, setJobs] = useState<GenerationJob[]>([])
+  const [progressByKey, setProgressByKey] = useState<
+    Record<string, GenerationJobProgress>
+  >({})
+  const [storageReady, setStorageReady] = useState(false)
+  const handledRef = useRef(new Set<string>())
+
+  useEffect(() => {
+    setJobs(readJobs())
+    setStorageReady(true)
+  }, [])
+
+  useEffect(() => {
+    if (!storageReady) return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs))
+  }, [jobs, storageReady])
+
+  useEffect(() => {
+    const onStarted = (event: Event) => {
+      const job = (event as CustomEvent<unknown>).detail
+      if (!isGenerationJob(job)) return
+      handledRef.current.delete(jobKey(job))
+      setJobs((current) =>
+        current.some((candidate) => jobKey(candidate) === jobKey(job))
+          ? current
+          : [...current, job]
+      )
+    }
+    window.addEventListener(GENERATION_STARTED_EVENT, onStarted)
+    return () => window.removeEventListener(GENERATION_STARTED_EVENT, onStarted)
+  }, [])
+
+  const onProgress = useCallback(
+    (job: GenerationJob, progress: GenerationJobProgress) => {
+      const key = jobKey(job)
+      setProgressByKey((current) => {
+        const previous = current[key]
+        return previous?.label === progress.label &&
+          previous.status === progress.status
+          ? current
+          : { ...current, [key]: progress }
+      })
+    },
+    []
+  )
+
+  const onTerminal = useCallback(
+    (job: GenerationJob, succeeded: boolean) => {
+      const key = jobKey(job)
+      if (handledRef.current.has(key)) return
+      handledRef.current.add(key)
+      setJobs((current) =>
+        current.filter((candidate) => jobKey(candidate) !== key)
+      )
+      setProgressByKey((current) => {
+        const { [key]: _removed, ...remaining } = current
+        return remaining
+      })
+
+      const href =
+        job.kind === 'graph'
+          ? `/resources/knowledgeBases/${job.kbId}#knowledge-graph`
+          : `/elements/generate?buildId=${job.id}`
+      toast({
+        type: succeeded ? 'success' : 'error',
+        message: succeeded ? t('succeeded', { label: job.label }) : t('failed'),
+        options: {
+          duration: succeeded ? 30_000 : 8000,
+          ...(succeeded
+            ? {
+                action: {
+                  label: t('open'),
+                  onClick: () => void router.push(href),
+                },
+              }
+            : {}),
+        },
+      })
+    },
+    [router, t]
+  )
+
+  const rows = useMemo(
+    () =>
+      jobs.map((job) => ({
+        job,
+        progress: progressByKey[jobKey(job)] ?? {
+          label: job.label,
+          status: t('starting'),
+        },
+      })),
+    [jobs, progressByKey, t]
+  )
+
+  return (
+    <>
+      {children}
+      {jobs.map((job) =>
+        job.kind === 'graph' ? (
+          <GraphJobTracker
+            key={jobKey(job)}
+            job={job}
+            onProgress={onProgress}
+            onTerminal={onTerminal}
+          />
+        ) : (
+          <ElementJobTracker
+            key={jobKey(job)}
+            job={job}
+            onProgress={onProgress}
+            onTerminal={onTerminal}
+          />
+        )
+      )}
+      {rows.length > 0 ? (
+        <div
+          className="fixed right-4 bottom-20 z-30 max-w-[calc(100vw-2rem)]"
+          data-cy="generation-status"
+          role="status"
+        >
+          <Popover>
+            <PopoverTrigger className="focus:ring-primary-80 flex h-12 items-center gap-3 rounded-md border border-gray-200 bg-white px-4 text-left text-sm shadow-lg transition hover:border-primary-80 focus:outline-none focus:ring-2">
+              <Loader basic />
+              <span className="max-w-[14rem] truncate font-bold text-gray-900">
+                {t('title')}
+              </span>
+              <span className="rounded-full bg-primary-100 px-2 py-0.5 text-xs font-bold text-white">
+                {rows.length}
+              </span>
+              <FontAwesomeIcon
+                aria-hidden="true"
+                className="h-3 w-3 text-gray-600"
+                icon={faChevronUp}
+              />
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-[min(24rem,calc(100vw-2rem))] p-0"
+              side="top"
+            >
+              <div className="border-b border-gray-100 p-4">
+                <div className="flex items-center gap-2 font-bold text-gray-900">
+                  <FontAwesomeIcon
+                    icon={faWandMagicSparkles}
+                    className="h-4 w-4"
+                  />
+                  {t('title')}
+                </div>
+                <p className="mt-1 text-sm text-gray-600">{t('description')}</p>
+              </div>
+              <ul className="max-h-72 overflow-y-auto">
+                {rows.map(({ job, progress }) => (
+                  <li
+                    className="flex items-start gap-3 border-t border-gray-100 px-4 py-3 first:border-t-0"
+                    key={jobKey(job)}
+                  >
+                    <Loader basic />
+                    <div className="min-w-0">
+                      <div className="truncate font-bold text-gray-900">
+                        {progress.label}
+                      </div>
+                      <div className="truncate text-sm text-gray-600">
+                        {progress.status}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </PopoverContent>
+          </Popover>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
+++ b/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
@@ -94,12 +94,12 @@ function GraphJobTracker({
   onTerminal: (job: GenerationJob, succeeded: boolean) => void
 }>) {
   const t = useTranslations('manage.generationStatus')
-  const query = useQuery(GetKbKnowledgeGraphConfigDocument, {
+  const { data, error, loading } = useQuery(GetKbKnowledgeGraphConfigDocument, {
     variables: { kbId: job.kbId },
     fetchPolicy: 'network-only',
     pollInterval: POLL_INTERVAL_MS,
   })
-  const config = query.data?.getKbKnowledgeGraphConfig
+  const config = data?.getKbKnowledgeGraphConfig
   const [checkedAt, setCheckedAt] = useState(0)
 
   useEffect(() => {
@@ -119,6 +119,7 @@ function GraphJobTracker({
     const matchesBuild =
       config?.buildId === job.id || config?.activeBuildId === job.id
     if (!config || !matchesBuild) {
+      if (loading || error) return
       if (checkedAt - job.startedAt >= UNMATCHED_GRAPH_JOB_TIMEOUT_MS) {
         onTerminal(job, false)
       }
@@ -142,7 +143,7 @@ function GraphJobTracker({
           ? t('graphProcessing')
           : t('graphQueued'),
     })
-  }, [checkedAt, config, job, onProgress, onTerminal, t])
+  }, [checkedAt, config, error, job, loading, onProgress, onTerminal, t])
 
   return null
 }

--- a/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
+++ b/apps/frontend-manage/src/components/generation/GenerationStatusProvider.tsx
@@ -55,6 +55,12 @@ type GenerationJobProgress = {
 const STORAGE_KEY = 'klicker-background-generation-jobs-v1'
 const POLL_INTERVAL_MS = 5000
 const UNMATCHED_GRAPH_JOB_TIMEOUT_MS = 120_000
+const MAX_PERSISTED_JOB_AGE_MS = 24 * 60 * 60 * 1000
+const TERMINAL_QUERY_ERROR_CODES = new Set([
+  'AI_BETA_ACCESS_REQUIRED',
+  'FORBIDDEN',
+  'UNAUTHENTICATED',
+])
 
 function isGenerationJob(value: unknown): value is GenerationJob {
   if (typeof value !== 'object' || value === null) return false
@@ -73,11 +79,48 @@ function isGenerationJob(value: unknown): value is GenerationJob {
 
 function readJobs(): GenerationJob[] {
   try {
+    const now = Date.now()
     const value = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
-    return Array.isArray(value) ? value.filter(isGenerationJob) : []
+    return Array.isArray(value)
+      ? value.filter(
+          (job): job is GenerationJob =>
+            isGenerationJob(job) &&
+            job.startedAt <= now &&
+            now - job.startedAt <= MAX_PERSISTED_JOB_AGE_MS
+        )
+      : []
   } catch {
     return []
   }
+}
+
+function isTerminalGenerationQueryError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+
+  const graphQLErrors = Reflect.get(error, 'graphQLErrors')
+  const errors = Array.isArray(graphQLErrors) ? graphQLErrors : [error]
+
+  return errors.some((graphQLError) => {
+    if (typeof graphQLError !== 'object' || graphQLError === null) return false
+
+    const extensions = Reflect.get(graphQLError, 'extensions')
+    const code =
+      typeof extensions === 'object' && extensions !== null
+        ? Reflect.get(extensions, 'code')
+        : undefined
+    if (
+      typeof code === 'string' &&
+      (TERMINAL_QUERY_ERROR_CODES.has(code) || code.endsWith('_NOT_FOUND'))
+    ) {
+      return true
+    }
+
+    const message = Reflect.get(graphQLError, 'message')
+    return (
+      typeof message === 'string' &&
+      (message === 'Unauthorized' || /not found/i.test(message))
+    )
+  })
 }
 
 function jobKey(job: GenerationJob): string {
@@ -112,6 +155,10 @@ function GraphJobTracker({
   }, [])
 
   useEffect(() => {
+    if (isTerminalGenerationQueryError(error)) {
+      onTerminal(job, false)
+      return
+    }
     if (config?.publishedBuildId === job.id) {
       onTerminal(job, true)
       return
@@ -166,6 +213,10 @@ function ElementJobTracker({
   const build = query.data?.elementGenerationBuild
 
   useEffect(() => {
+    if (isTerminalGenerationQueryError(query.error)) {
+      onTerminal(job, false)
+      return
+    }
     if (!build) return
     if (
       build.status === ElementGenerationBuildStatus.Completed ||
@@ -192,7 +243,7 @@ function ElementJobTracker({
         requested: build.requestedElementCount,
       }),
     })
-  }, [build, job, onProgress, onTerminal, t])
+  }, [build, job, onProgress, onTerminal, query.error, t])
 
   return null
 }

--- a/apps/frontend-manage/src/pages/_app.tsx
+++ b/apps/frontend-manage/src/pages/_app.tsx
@@ -49,6 +49,24 @@ function App({ Component, pageProps }: AppProps) {
     ? (locale as (typeof routing.locales)[number])
     : routing.defaultLocale
 
+  const appContent = (
+    <>
+      <Toaster closeButton position="top-right" />
+      {pathname.startsWith('/analytics') ? (
+        <LearningAnalyticsRouteGuard>
+          <Component {...pageProps} />
+        </LearningAnalyticsRouteGuard>
+      ) : (
+        <Component {...pageProps} />
+      )}
+      {/* Mounted here rather than in Layout so that navigating between
+        authenticated Manage pages does not tear down the assistant
+        and reload its iframe mid-conversation. Public HMAC
+        evaluations must not issue the assistant's identity query. */}
+      {isPublicEvaluation ? null : <ManageAssistantWidget />}
+    </>
+  )
+
   return (
     <div
       id="__app"
@@ -65,21 +83,13 @@ function App({ Component, pageProps }: AppProps) {
           >
             <DndProvider backend={HTML5Backend}>
               <CourseDuplicationProvider>
-                <GenerationStatusProvider>
-                  <Toaster closeButton position="top-right" />
-                  {pathname.startsWith('/analytics') ? (
-                    <LearningAnalyticsRouteGuard>
-                      <Component {...pageProps} />
-                    </LearningAnalyticsRouteGuard>
-                  ) : (
-                    <Component {...pageProps} />
-                  )}
-                  {/* Mounted here rather than in Layout so that navigating between
-                    authenticated Manage pages does not tear down the assistant
-                    and reload its iframe mid-conversation. Public HMAC
-                    evaluations must not issue the assistant's identity query. */}
-                  {isPublicEvaluation ? null : <ManageAssistantWidget />}
-                </GenerationStatusProvider>
+                {isPublicEvaluation ? (
+                  appContent
+                ) : (
+                  <GenerationStatusProvider>
+                    {appContent}
+                  </GenerationStatusProvider>
+                )}
               </CourseDuplicationProvider>
             </DndProvider>
           </NextIntlClientProvider>

--- a/apps/frontend-manage/src/pages/_app.tsx
+++ b/apps/frontend-manage/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import LearningAnalyticsRouteGuard from '~/components/featureFlags/LearningAnaly
 import { ManageAssistantWidget } from '../components/assistant/ManageAssistantWidget'
 import { CourseDuplicationProvider } from '../components/courses/CourseDuplicationStatusProvider'
 import ManageFeatureFlagProvider from '../components/featureFlags/ManageFeatureFlagProvider'
+import { GenerationStatusProvider } from '../components/generation/GenerationStatusProvider'
 import '../globals.css'
 import { useApollo } from '../lib/apollo'
 import { isPublicLiveQuizEvaluationRoute } from '../lib/isPublicLiveQuizEvaluationRoute'
@@ -64,19 +65,21 @@ function App({ Component, pageProps }: AppProps) {
           >
             <DndProvider backend={HTML5Backend}>
               <CourseDuplicationProvider>
-                <Toaster closeButton position="top-right" />
-                {pathname.startsWith('/analytics') ? (
-                  <LearningAnalyticsRouteGuard>
+                <GenerationStatusProvider>
+                  <Toaster closeButton position="top-right" />
+                  {pathname.startsWith('/analytics') ? (
+                    <LearningAnalyticsRouteGuard>
+                      <Component {...pageProps} />
+                    </LearningAnalyticsRouteGuard>
+                  ) : (
                     <Component {...pageProps} />
-                  </LearningAnalyticsRouteGuard>
-                ) : (
-                  <Component {...pageProps} />
-                )}
-                {/* Mounted here rather than in Layout so that navigating between
+                  )}
+                  {/* Mounted here rather than in Layout so that navigating between
                     authenticated Manage pages does not tear down the assistant
                     and reload its iframe mid-conversation. Public HMAC
                     evaluations must not issue the assistant's identity query. */}
-                {isPublicEvaluation ? null : <ManageAssistantWidget />}
+                  {isPublicEvaluation ? null : <ManageAssistantWidget />}
+                </GenerationStatusProvider>
               </CourseDuplicationProvider>
             </DndProvider>
           </NextIntlClientProvider>

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -1412,6 +1412,11 @@ type ElementGenerationDifficultyCounts {
 }
 
 enum ElementGenerationDifficultyPreset {
+  D1
+  D2
+  D3
+  D4
+  D5
   EASY
   HARD
   MIXED

--- a/packages/graphql/src/schema/elementGeneration.ts
+++ b/packages/graphql/src/schema/elementGeneration.ts
@@ -24,7 +24,15 @@ type ElementGenerationBloomLevelValue =
   | 'apply'
   | 'analyze'
   | 'evaluate'
-type ElementGenerationDifficultyPresetValue = 'EASY' | 'MIXED' | 'HARD'
+type ElementGenerationDifficultyPresetValue =
+  | 'D1'
+  | 'D2'
+  | 'D3'
+  | 'D4'
+  | 'D5'
+  | 'EASY'
+  | 'MIXED'
+  | 'HARD'
 type GeneratedElementCardTypeValue = 'definition' | 'formula' | 'calculation'
 
 export const GeneratableElementType = builder.enumType(
@@ -43,7 +51,9 @@ export const ElementGenerationBloomLevel = builder.enumType(
 )
 export const ElementGenerationDifficultyPreset = builder.enumType(
   'ElementGenerationDifficultyPreset',
-  { values: ['EASY', 'MIXED', 'HARD'] as const }
+  {
+    values: ['D1', 'D2', 'D3', 'D4', 'D5', 'EASY', 'MIXED', 'HARD'] as const,
+  }
 )
 export const GeneratedElementCardType = builder.enumType(
   'GeneratedElementCardType',

--- a/packages/graphql/src/services/questionGenerationArtifacts.ts
+++ b/packages/graphql/src/services/questionGenerationArtifacts.ts
@@ -357,8 +357,8 @@ const designSchema = z
           .object({
             module_id: boundedText(100),
             source_file: boundedText(1024),
-            page_from: z.number().int().min(1),
-            page_to: z.number().int().min(1),
+            page_from: z.number().int().min(1).nullable(),
+            page_to: z.number().int().min(1).nullable(),
           })
           .passthrough()
       )
@@ -1700,13 +1700,13 @@ export function parseQuestionGenerationDesign(
             'Question-generation configuration references an unknown graph source'
           )
         }
-        const pageFrom = scope.pageFrom ?? 1
-        const pageTo = scope.pageTo ?? source.pageCount
-        if (pageTo === null) {
-          return artifactError(
-            'Question-generation source has no bounded registered page range'
-          )
-        }
+        const unbounded = scope.pageFrom === null && scope.pageTo === null
+        const pageFrom = unbounded
+          ? source.pageCount === null
+            ? null
+            : 1
+          : scope.pageFrom
+        const pageTo = unbounded ? source.pageCount : scope.pageTo
         return normalizeReviewSource(
           source.sourceFile,
           pageFrom,

--- a/packages/graphql/src/services/questionGenerationBlueprint.ts
+++ b/packages/graphql/src/services/questionGenerationBlueprint.ts
@@ -43,16 +43,15 @@ export async function createQuestionGenerationBlueprint(
     : configuration.sourceScopes.map((scope) => {
         const source = sourcesById.get(scope.resourceId)!
         const unbounded = scope.pageFrom === null && scope.pageTo === null
-        if (unbounded && source.pageCount === null) {
-          throw new Error(
-            'Selected question-generation source has no trustworthy page count'
-          )
-        }
 
         return {
           module_id: MODULE_ID,
           source_file: sourceBasename(source.sourceFile),
-          page_from: unbounded ? 1 : scope.pageFrom,
+          page_from: unbounded
+            ? source.pageCount === null
+              ? null
+              : 1
+            : scope.pageFrom,
           page_to: unbounded ? source.pageCount : scope.pageTo,
         }
       })

--- a/packages/graphql/src/services/questionGenerationConfiguration.ts
+++ b/packages/graphql/src/services/questionGenerationConfiguration.ts
@@ -85,7 +85,7 @@ function isBloomLevel(value: string): value is QuestionGenerationBloomLevel {
 function isDifficultyPreset(
   value: string
 ): value is QuestionGenerationDifficultyPreset {
-  return ['EASY', 'MIXED', 'HARD'].includes(value)
+  return ['D1', 'D2', 'D3', 'D4', 'D5', 'EASY', 'MIXED', 'HARD'].includes(value)
 }
 
 export function allocateDifficulty(

--- a/packages/graphql/test/manageChatbots.test.ts
+++ b/packages/graphql/test/manageChatbots.test.ts
@@ -47,6 +47,10 @@ describe('Integration tests for lecturer chatbot create/update', () => {
     )
     userOneCtx = ctx1
     userTwoCtx = ctx2
+    await prisma.user.updateMany({
+      where: { id: { in: [userOneCtx.user.sub, userTwoCtx.user.sub] } },
+      data: { aiFeaturesEnabled: true },
+    })
   })
 
   afterEach(async () => await testCleanup(prisma))

--- a/packages/graphql/test/questionGenerationArtifacts.test.ts
+++ b/packages/graphql/test/questionGenerationArtifacts.test.ts
@@ -736,6 +736,59 @@ describe('question-generation artifact normalization', () => {
     expect(JSON.stringify(summary)).not.toContain('private/worker')
   })
 
+  it.each([
+    ['SC', 'single_choice'],
+    ['MC', 'multiple_choice'],
+    ['KPRIM', 'kprim'],
+  ] as const)('accepts a complete named source without page metadata for %s', (itemType, itemFormat) => {
+    const artifact = design({
+      sources: [
+        {
+          ...design().sources[0],
+          page_from: null,
+          page_to: null,
+        },
+      ],
+      resolved_slots: [
+        {
+          ...design().resolved_slots[0],
+          item_format: itemFormat,
+        },
+      ],
+    })
+    const summary = parseQuestionGenerationDesign(bytes(artifact), {
+      buildId: BUILD_ID,
+      configuration: {
+        ...configuration,
+        itemType,
+        sourceScopes: [
+          {
+            resourceId: RESOURCE_ID,
+            pageFrom: null,
+            pageTo: null,
+          },
+        ],
+      },
+      sourceSnapshot: [
+        { ...sourceSnapshot[0]!, pageCount: null },
+        {
+          ...sourceSnapshot[0]!,
+          resourceId: '123e4567-e89b-42d3-a456-426614174001',
+          title: 'A second source',
+          sourceFile: 'second-source.pdf',
+        },
+      ],
+    })
+
+    expect(summary.sources).toEqual([
+      {
+        sourceFile: 'wine-chemistry.pdf',
+        pageFrom: null,
+        pageTo: null,
+      },
+    ])
+  })
+
   it('keeps worker-classified Bloom intent unresolved during Design review', () => {
     const artifact = design()
     artifact.resolved_slots[0]!.bloom_level = ''

--- a/packages/graphql/test/questionGenerationBlueprint.test.ts
+++ b/packages/graphql/test/questionGenerationBlueprint.test.ts
@@ -185,7 +185,7 @@ describe('question generation blueprint', () => {
     expect(parseBlueprint(bytes)).toMatchObject({ item_format: 'mc' })
   })
 
-  it('fails closed for unknown or unbounded selected sources', async () => {
+  it('fails closed for unknown selected sources', async () => {
     await expect(
       createQuestionGenerationBlueprint(
         {
@@ -197,12 +197,38 @@ describe('question generation blueprint', () => {
         sourceSnapshot
       )
     ).rejects.toThrow('absent from the graph snapshot')
+  })
 
-    await expect(
-      createQuestionGenerationBlueprint(configuration, [
-        sourceSnapshot[0]!,
-        { ...sourceSnapshot[1]!, pageCount: null },
-      ])
-    ).rejects.toThrow('page count')
+  it.each([
+    'SC',
+    'MC',
+    'KPRIM',
+  ] as const)('keeps an unbounded selected source for %s when page count is unknown', async (itemType) => {
+    const bytes = await createQuestionGenerationBlueprint(
+      {
+        ...configuration,
+        itemType,
+        sourceScopes: [
+          {
+            resourceId: sourceSnapshot[1]!.resourceId,
+            pageFrom: null,
+            pageTo: null,
+          },
+        ],
+      },
+      [sourceSnapshot[0]!, { ...sourceSnapshot[1]!, pageCount: null }]
+    )
+
+    expect(parseBlueprint(bytes)).toMatchObject({
+      item_format: itemType.toLocaleLowerCase('en'),
+      sources: [
+        {
+          module_id: 'M1',
+          source_file: 'fermentation-notes.pdf',
+          page_from: null,
+          page_to: null,
+        },
+      ],
+    })
   })
 })

--- a/packages/graphql/test/questionGenerationConfiguration.test.ts
+++ b/packages/graphql/test/questionGenerationConfiguration.test.ts
@@ -43,6 +43,11 @@ function configurationInput(
 
 describe('question generation configuration', () => {
   it.each([
+    'D1',
+    'D2',
+    'D3',
+    'D4',
+    'D5',
     'EASY',
     'MIXED',
     'HARD',
@@ -61,6 +66,10 @@ describe('question generation configuration', () => {
       if (preset === 'HARD') {
         expect(allocation.d1).toBe(0)
         expect(allocation.d2).toBe(0)
+      }
+      if (preset.startsWith('D')) {
+        expect(values.filter((value) => value > 0)).toEqual([count])
+        expect(values[Number(preset.slice(1)) - 1]).toBe(count)
       }
     }
   })

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2329,7 +2329,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       starting: 'Wird gestartet…',
       graphQueued: 'Wissensgraph ist eingereiht',
       graphProcessing: 'Wissensgraph wird generiert',
-      elementProgress: '{generated} von {requested} Elementen generiert',
+      elementProgress:
+        '{generated} von {requested, plural, one {# Element} other {# Elementen}} generiert',
       succeeded: '{label} ist bereit.',
       failed: 'Die Generierung im Hintergrund ist fehlgeschlagen.',
       open: 'Ergebnis öffnen',

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2322,6 +2322,18 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       tokenExpired:
         'Ihr Token ist leider abgelaufen, bitte generieren Sie einen neuen.',
     },
+    generationStatus: {
+      title: 'Generierung im Hintergrund',
+      description:
+        'Sie können weiterarbeiten, während diese Vorgänge im Hintergrund ausgeführt werden.',
+      starting: 'Wird gestartet…',
+      graphQueued: 'Wissensgraph ist eingereiht',
+      graphProcessing: 'Wissensgraph wird generiert',
+      elementProgress: '{generated} von {requested} Elementen generiert',
+      succeeded: '{label} ist bereit.',
+      failed: 'Die Generierung im Hintergrund ist fehlgeschlagen.',
+      open: 'Ergebnis öffnen',
+    },
     elementGeneration: {
       eyebrow: 'KI-unterstützte Erstellung',
       title: 'Elemente generieren',
@@ -2343,19 +2355,35 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         staleGraphHelp:
           'Dieser veröffentlichte Graph kann weiterhin verwendet werden, aber die Wissensbasis enthält neuere Änderungen. Erstellen Sie ihn zuerst neu, wenn diese Änderungen einbezogen werden sollen.',
         sourceDetails: 'Enthaltene Quellen',
+        completeSource: 'Die vollständige Quelle wird verwendet.',
         pageFrom: 'Von Seite',
         pageTo: 'Bis Seite',
         elementTypeTitle: 'Klicker-Elementtyp',
         elementTypeHelp:
           'Alle Typen werden als Klicker-Elemente generiert. Wählen Sie das Format passend zum Lernziel.',
         bloomTitle: 'Blooms Taxonomie',
-        bloomHelp: 'Wählen Sie die abzudeckenden kognitiven Stufen.',
+        bloomHelp:
+          'Wählen Sie eine oder mehrere kognitive Stufen. Die Schritte reichen vom Erinnern bis zum begründeten Bewerten.',
+        bloomLevel: 'Stufe {level}',
+        bloomSelected: 'Ausgewählt',
+        bloomSelect: 'Stufe auswählen',
         settingsTitle: 'Einstellungen der Generierung',
         elementCount: 'Anzahl Elemente',
         language: 'Sprache',
-        difficulty: 'Schwierigkeitsverteilung',
+        difficulty: 'Schwierigkeitsstufe',
+        difficultyHelp:
+          'Wählen Sie den Denkaufwand für alle generierten Elemente. Die Schwierigkeit entsteht durch die Aufgabe, nicht durch verwirrende Formulierungen.',
         objectives: 'Lernziele',
         objectivesHelp: 'Optionale Vorgaben für die generierten Elemente.',
+        objectiveHint: 'Formulieren Sie beobachtbare, konkrete Lernziele.',
+        objectiveFormula:
+          'Hilfreiches Muster: Handlungsverb + Lerngegenstand + Situation oder Bedingung.',
+        objectiveExampleOne:
+          'Erklären, warum Diversifikation das idiosynkratische Risiko reduziert.',
+        objectiveExampleTwo:
+          'Die Kapitalwertregel anwenden, um zwei Investitionsprojekte zu vergleichen.',
+        objectivePlaceholder:
+          'Z. B. Analysieren, wie ein Zinsanstieg Anleihenkurse beeinflusst.',
         addObjective: 'Lernziel hinzufügen',
         remove: 'Entfernen',
         start: 'Elemente generieren',
@@ -2395,7 +2423,36 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         analyze: 'Analysieren',
         evaluate: 'Bewerten',
       },
+      bloomExamples: {
+        remember: 'Nennen · definieren · wiedergeben',
+        understand: 'Erklären · zusammenfassen · einordnen',
+        apply: 'Berechnen · demonstrieren · anwenden',
+        analyze: 'Vergleichen · unterscheiden · verknüpfen',
+        evaluate: 'Beurteilen · begründen · empfehlen',
+      },
       difficulty: {
+        D1: {
+          label: 'Sehr leicht',
+          description: 'Direktes Erinnern oder Wiedererkennen.',
+        },
+        D2: {
+          label: 'Leicht',
+          description: 'Eine routinemässige Anwendung oder Interpretation.',
+        },
+        D3: {
+          label: 'Mittel',
+          description: 'Zwei verknüpfte Schritte oder eine relevante Auswahl.',
+        },
+        D4: {
+          label: 'Schwierig',
+          description:
+            'Mehrere abhängige Schritte oder eine Mehrkonzeptanalyse.',
+        },
+        D5: {
+          label: 'Sehr schwierig',
+          description:
+            'Nicht routinemässige Synthese oder Bewertung unter Bedingungen.',
+        },
         EASY: 'Leicht',
         MIXED: 'Gemischt',
         HARD: 'Schwer',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2305,7 +2305,8 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       starting: 'Starting…',
       graphQueued: 'Knowledge graph queued',
       graphProcessing: 'Knowledge graph is being generated',
-      elementProgress: '{generated} of {requested} elements generated',
+      elementProgress:
+        '{generated} of {requested, plural, one {# element} other {# elements}} generated',
       succeeded: '{label} is ready.',
       failed: 'Background generation failed.',
       open: 'Open result',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2298,6 +2298,18 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       tokenExpired:
         'Unfortunately, your token has expired, please generate a new one.',
     },
+    generationStatus: {
+      title: 'Background generation',
+      description:
+        'You can continue working while these operations run in the background.',
+      starting: 'Starting…',
+      graphQueued: 'Knowledge graph queued',
+      graphProcessing: 'Knowledge graph is being generated',
+      elementProgress: '{generated} of {requested} elements generated',
+      succeeded: '{label} is ready.',
+      failed: 'Background generation failed.',
+      open: 'Open result',
+    },
     elementGeneration: {
       eyebrow: 'AI-assisted creation',
       title: 'Generate elements',
@@ -2319,19 +2331,35 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
         staleGraphHelp:
           'This published graph is still usable, but the knowledge base has newer changes. Rebuild it first if those changes should be included.',
         sourceDetails: 'Included sources',
+        completeSource: 'The complete source will be used.',
         pageFrom: 'From page',
         pageTo: 'To page',
         elementTypeTitle: 'Klicker element type',
         elementTypeHelp:
           'All types are generated as Klicker elements. Choose the format that best matches your learning goal.',
         bloomTitle: "Bloom's taxonomy",
-        bloomHelp: 'Select the cognitive levels to cover.',
+        bloomHelp:
+          'Select one or more cognitive levels. The steps progress from recalling knowledge to making evidence-based judgments.',
+        bloomLevel: 'Level {level}',
+        bloomSelected: 'Selected',
+        bloomSelect: 'Select level',
         settingsTitle: 'Generation settings',
         elementCount: 'Number of elements',
         language: 'Language',
-        difficulty: 'Difficulty distribution',
+        difficulty: 'Difficulty level',
+        difficultyHelp:
+          'Choose the reasoning demand for all generated elements. Difficulty comes from the task, not from confusing wording.',
         objectives: 'Learning objectives',
         objectivesHelp: 'Optional guidance for the generated elements.',
+        objectiveHint: 'Write observable, specific learning objectives.',
+        objectiveFormula:
+          'Useful pattern: action verb + subject matter + situation or constraint.',
+        objectiveExampleOne:
+          'Explain why diversification reduces idiosyncratic risk.',
+        objectiveExampleTwo:
+          'Apply the net-present-value rule to compare two investment projects.',
+        objectivePlaceholder:
+          'E.g. Analyze how a rate increase affects bond prices.',
         addObjective: 'Add objective',
         remove: 'Remove',
         start: 'Generate elements',
@@ -2369,7 +2397,34 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
         analyze: 'Analyze',
         evaluate: 'Evaluate',
       },
+      bloomExamples: {
+        remember: 'Identify · define · recall',
+        understand: 'Explain · summarize · classify',
+        apply: 'Calculate · demonstrate · use',
+        analyze: 'Compare · distinguish · connect',
+        evaluate: 'Assess · justify · recommend',
+      },
       difficulty: {
+        D1: {
+          label: 'Very easy',
+          description: 'Direct recall or recognition.',
+        },
+        D2: {
+          label: 'Easy',
+          description: 'One routine application or interpretation.',
+        },
+        D3: {
+          label: 'Medium',
+          description: 'Two linked steps or a meaningful choice.',
+        },
+        D4: {
+          label: 'Difficult',
+          description: 'Several dependent steps or multi-concept analysis.',
+        },
+        D5: {
+          label: 'Very difficult',
+          description: 'Non-routine synthesis or evaluation under constraints.',
+        },
         EASY: 'Easy',
         MIXED: 'Mixed',
         HARD: 'Hard',

--- a/packages/kb-management/src/components/KnowledgeGraphPanel.tsx
+++ b/packages/kb-management/src/components/KnowledgeGraphPanel.tsx
@@ -232,6 +232,12 @@ function KnowledgeGraphPanel({ kbId }: { kbId: string }) {
     SetKbKnowledgeGraphEnabledDocument
   )
   const config = data?.getKbKnowledgeGraphConfig
+
+  useEffect(() => {
+    if (router.asPath.endsWith('#knowledge-graph')) {
+      setDetailsOpen(true)
+    }
+  }, [router.asPath])
   const formattedBillingLabel =
     config?.billingLabel === 'SEMESTER_QUOTA'
       ? t('kb.graphBillingSemesterQuota')
@@ -312,9 +318,23 @@ function KnowledgeGraphPanel({ kbId }: { kbId: string }) {
 
     setOperationError(null)
     try {
-      await rebuildGraph({
+      const result = await rebuildGraph({
         variables: { kbId, qualityTier: selectedTier },
       })
+      const buildId = result.data?.rebuildKbKnowledgeGraph.buildId
+      if (buildId) {
+        window.dispatchEvent(
+          new CustomEvent('klicker:generation-started', {
+            detail: {
+              kind: 'graph',
+              id: buildId,
+              kbId,
+              label: t('kb.graphTitle'),
+              startedAt: Date.now(),
+            },
+          })
+        )
+      }
       await refetch()
     } catch {
       console.error('Failed to rebuild KB knowledge graph', { kbId })
@@ -339,6 +359,8 @@ function KnowledgeGraphPanel({ kbId }: { kbId: string }) {
 
   return (
     <details
+      id="knowledge-graph"
+      open={detailsOpen}
       className="mt-4"
       data-cy="kb-graph-settings"
       onToggle={(event) => setDetailsOpen(event.currentTarget.open)}

--- a/packages/types/src/elementGeneration.ts
+++ b/packages/types/src/elementGeneration.ts
@@ -16,7 +16,15 @@ export type ElementGenerationBloomLevel =
   | 'apply'
   | 'analyze'
   | 'evaluate'
-export type ElementGenerationDifficultyPreset = 'EASY' | 'MIXED' | 'HARD'
+export type ElementGenerationDifficultyPreset =
+  | 'D1'
+  | 'D2'
+  | 'D3'
+  | 'D4'
+  | 'D5'
+  | 'EASY'
+  | 'MIXED'
+  | 'HARD'
 export type ElementGenerationDifficultyCounts = {
   d1: number
   d2: number
@@ -33,6 +41,11 @@ const ELEMENT_GENERATION_DIFFICULTY_KEYS = [
   'd5',
 ] as const
 const ELEMENT_GENERATION_DIFFICULTY_WEIGHTS = {
+  D1: [100, 0, 0, 0, 0],
+  D2: [0, 100, 0, 0, 0],
+  D3: [0, 0, 100, 0, 0],
+  D4: [0, 0, 0, 100, 0],
+  D5: [0, 0, 0, 0, 100],
   EASY: [40, 40, 20, 0, 0],
   MIXED: [10, 25, 30, 25, 10],
   HARD: [0, 0, 20, 40, 40],

--- a/packages/types/src/questionGeneration.ts
+++ b/packages/types/src/questionGeneration.ts
@@ -23,7 +23,15 @@ export type QuestionGenerationBloomLevel =
   | 'apply'
   | 'analyze'
   | 'evaluate'
-export type QuestionGenerationDifficultyPreset = 'EASY' | 'MIXED' | 'HARD'
+export type QuestionGenerationDifficultyPreset =
+  | 'D1'
+  | 'D2'
+  | 'D3'
+  | 'D4'
+  | 'D5'
+  | 'EASY'
+  | 'MIXED'
+  | 'HARD'
 export type QuestionGenerationDifficultyCounts = {
   d1: number
   d2: number
@@ -40,6 +48,11 @@ const QUESTION_GENERATION_DIFFICULTY_KEYS = [
   'd5',
 ] as const
 const QUESTION_GENERATION_DIFFICULTY_WEIGHTS = {
+  D1: [100, 0, 0, 0, 0],
+  D2: [0, 100, 0, 0, 0],
+  D3: [0, 0, 100, 0, 0],
+  D4: [0, 0, 0, 100, 0],
+  D5: [0, 0, 0, 0, 100],
   EASY: [40, 40, 20, 0, 0],
   MIXED: [10, 25, 30, 25, 10],
   HARD: [0, 0, 20, 40, 40],


### PR DESCRIPTION


## Latest Review Correction

- Commit 43b51350b guards the GenerationStatusProvider localStorage write so private-mode and quota failures do not crash the authenticated Manage tree.
- Frontend Manage type-check, Biome, and the full repository build pass; the build output retains existing Node 26 warnings.
- Browser runtime proof remains not run because the task DevPod is stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background generation tracking with progress indicators, completion notifications, and links to results.
  * Added D1–D5 difficulty levels, descriptions, and allocation options; D3 is now the default.
  * Improved Bloom’s taxonomy selection with level styling, examples, and guidance.
  * Added objective guidance and clearer messaging for complete sources.
  * Knowledge graph views can open directly from a URL.

* **Bug Fixes**
  * Generation now supports sources without known page counts.
  * Improved retry handling and generation status accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->