### PR TITLE
ci(final-review): pin OCR config path to runner temp

### DIFF
--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -3138,12 +3138,15 @@ async function verifyCurrentIndividualFinalReview({ repository, prNumber }) {
 function runCli() {
   const command = process.argv[2]
   if (command === 'configure-ocr') {
-    writeOCRConfig({ token: fs.readFileSync(0, 'utf8') })
+    writeOCRConfig({
+      token: fs.readFileSync(0, 'utf8'),
+      configPath: process.env.OCR_CONFIG_PATH || undefined,
+    })
     console.log('Ephemeral OCR configuration created')
     return
   }
   if (command === 'cleanup-ocr') {
-    removeOCRConfig()
+    removeOCRConfig(process.env.OCR_CONFIG_PATH || undefined)
     console.log('Ephemeral OCR configuration removed')
     return
   }

--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -367,10 +367,12 @@ jobs:
         if: needs.start.outputs.run_review == 'true'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-review-ocr-config.json
         run: |
           set -euo pipefail
           printf '%s' "${OPENROUTER_API_KEY}" |
             node .github/scripts/final-ai-review.js configure-ocr
+          test -s "${OCR_CONFIG_PATH}"
 
       - name: Run final review
         id: run_review
@@ -378,6 +380,7 @@ jobs:
         env:
           BACKGROUND: ${{ needs.start.outputs.background }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-review-ocr-config.json
           REVIEW_FROM: ${{ steps.range.outputs.review_from }}
           RESULT_PATH: ${{ runner.temp }}/final-ai-review-result.json
           STDERR_PATH: ${{ runner.temp }}/final-ai-review-stderr.log
@@ -421,6 +424,8 @@ jobs:
       - name: Remove ephemeral OpenRouter access
         id: cleanup
         if: always() && needs.start.outputs.run_review == 'true'
+        env:
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-review-ocr-config.json
         run: node .github/scripts/final-ai-review.js cleanup-ocr
 
       - name: Publish consolidated final review
@@ -802,10 +807,12 @@ jobs:
         if: needs.start_stack.outputs.run_review == 'true'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-stack-ocr-config.json
         run: |
           set -euo pipefail
           printf '%s' "${OPENROUTER_API_KEY}" |
             node .github/scripts/final-ai-review.js configure-ocr
+          test -s "${OCR_CONFIG_PATH}"
 
       - name: Run cumulative code review
         id: code_review
@@ -819,6 +826,7 @@ jobs:
           RESULT_PATH: ${{ runner.temp }}/final-ai-stack-code-result.json
           RANGE_DIR: ${{ runner.temp }}/final-ai-stack-code-ranges
           STDERR_PATH: ${{ runner.temp }}/final-ai-stack-code-stderr.log
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-stack-ocr-config.json
         run: |
           set -euo pipefail
           if [[ "${REVIEW_MODE}" == "incremental" ]]; then
@@ -876,6 +884,8 @@ jobs:
       - name: Remove ephemeral OpenRouter access after code review
         id: cleanup
         if: always() && needs.start_stack.outputs.run_review == 'true'
+        env:
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-stack-ocr-config.json
         run: node .github/scripts/final-ai-review.js cleanup-ocr
 
       - name: Run strict topology review


### PR DESCRIPTION
## Summary\n- Pass `OCR_CONFIG_PATH` explicitly through configure, review, and cleanup steps in `.github/workflows/check-ocr-final-review.yml` (single-PR and stack paths), eliminating `HOME`-relative resolution as a failure source.\n- Extend `configure-ocr`/`cleanup-ocr` in `.github/scripts/final-ai-review.js` to honor `OCR_CONFIG_PATH` (default unchanged); configure now verifies the file exists and is non-empty.\n\n## Evidence\n- Local reproduction with pinned CLI 1.9.10: explicit `OCR_CONFIG_PATH` (or loadable config under a writable HOME) resolves the LLM endpoint and starts reviews; default-path lookup failed identically to the CI failures (runs 33201401791, 33201392763, 33205905295).\n- Verification: YAML parse passed; `git diff --check` clean; helper tests 33/33 on exact head `a0c00b917`.