### PR TITLE
ci(final-review): echo captured CLI output into job log

### DIFF
--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -402,6 +402,15 @@ jobs:
           STDERR_PATH: ${{ runner.temp }}/final-ai-review-stderr.log
         run: |
           set -euo pipefail
+          echo '::group::Final review CLI failure output'
+          cat "${STDERR_PATH}" 2>/dev/null || echo 'stderr log was not created'
+          echo '::endgroup::'
+          if [[ -f "${RESULT_PATH}" ]]; then
+            echo '::group::Final review CLI result JSON'
+            cat "${RESULT_PATH}"
+            echo
+            echo '::endgroup::'
+          fi
           {
             echo '### Final review CLI failure'
             echo
@@ -862,6 +871,15 @@ jobs:
           STDERR_PATH: ${{ runner.temp }}/final-ai-stack-code-stderr.log
         run: |
           set -euo pipefail
+          echo '::group::Cumulative review CLI failure output'
+          cat "${STDERR_PATH}" 2>/dev/null || echo 'stderr log was not created'
+          echo '::endgroup::'
+          if [[ -f "${RESULT_PATH}" ]]; then
+            echo '::group::Cumulative review CLI result JSON'
+            cat "${RESULT_PATH}"
+            echo
+            echo '::endgroup::'
+          fi
           {
             echo '### Cumulative review CLI failure'
             echo


### PR DESCRIPTION
## Summary\n- The failure-capture steps now also print the captured stderr and result JSON into the job log via grouped output, so failures are readable through the Actions API and logs (the step-summary file is not API-readable).\n- Continuation of #5638/#5639; needed because the latest run (33208350521) still failed with its error only in the unreadable summary file.\n\n## Verification\n- Ruby YAML parse passed; Prettier check passed on exact head `ada997bb6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow failure reporting by displaying complete error logs and result details in grouped output.
  * Preserved concise summaries in the GitHub workflow step summary for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->