### PR TITLE
ci(final-review): provide LLM endpoint via OCR_* environment variables

### DIFF
--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -381,6 +381,9 @@ jobs:
           BACKGROUND: ${{ needs.start.outputs.background }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-review-ocr-config.json
+          OCR_LLM_URL: https://openrouter.ai/api/v1/chat/completions
+          OCR_LLM_TOKEN: ${{ secrets.OPENROUTER_API_KEY }}
+          OCR_LLM_MODEL: z-ai/glm-5.3-flash
           REVIEW_FROM: ${{ steps.range.outputs.review_from }}
           RESULT_PATH: ${{ runner.temp }}/final-ai-review-result.json
           STDERR_PATH: ${{ runner.temp }}/final-ai-review-stderr.log
@@ -836,6 +839,9 @@ jobs:
           RANGE_DIR: ${{ runner.temp }}/final-ai-stack-code-ranges
           STDERR_PATH: ${{ runner.temp }}/final-ai-stack-code-stderr.log
           OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-stack-ocr-config.json
+          OCR_LLM_URL: https://openrouter.ai/api/v1/chat/completions
+          OCR_LLM_TOKEN: ${{ secrets.OPENROUTER_API_KEY }}
+          OCR_LLM_MODEL: z-ai/glm-5.3-flash
         run: |
           set -euo pipefail
           if [[ "${REVIEW_MODE}" == "incremental" ]]; then


### PR DESCRIPTION
## Summary\n- Runs 33209424779/33209424835 captured the definitive root error: `resolve LLM endpoint: no valid LLM endpoint configured` even with the ephemeral config file present (verified via the new log-echo diagnostics from #5641).\n- The file-based handoff (both HOME-relative and explicit `OCR_CONFIG_PATH`) is broken in the runner environment; the environment-variable route (`OCR_LLM_URL`/`OCR_LLM_TOKEN`/`OCR_LLM_MODEL`) was verified locally against the same pinned CLI 1.9.10 and does resolve the endpoint.\n- This PR passes the three variables through to both review steps. The ephemeral config-file steps remain in place (harmless), keeping the diff minimal.\n\n## Verification\n- Ruby YAML parse passed; Prettier check passed on exact head `8d3698ccd`.