### PR TITLE
fix(chat): make Doc Query isolation proof source-specific

### DIFF
--- a/apps/chat/scripts/stg-doc-query-proof.mjs
+++ b/apps/chat/scripts/stg-doc-query-proof.mjs
@@ -57,6 +57,15 @@ const REJECTION_CLASSES = [
   'trusted_filter_override',
 ]
 
+const PRESERVATION_FIELDS = [
+  'databaseWrites',
+  'configurationChanges',
+  'bindingChanges',
+  'clusterChanges',
+  'productionActions',
+  'retries',
+]
+
 const FAILURE_CLASSES = new Set([
   'none',
   'manifest_refused',
@@ -111,6 +120,20 @@ function requireMarkerList(value) {
     throw new ProofFailure('manifest_refused')
   }
   return [...value]
+}
+
+function zeroPreservation() {
+  return Object.fromEntries(PRESERVATION_FIELDS.map((name) => [name, 0]))
+}
+
+function hasExactZeroPreservation(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === PRESERVATION_FIELDS.length &&
+    PRESERVATION_FIELDS.every((name) => value[name] === 0)
+  )
 }
 
 export function validateManifest(input) {
@@ -233,14 +256,7 @@ function emptyReceipt() {
     rejections: Object.fromEntries(
       REJECTION_CLASSES.map((name) => [name, 'not_run'])
     ),
-    preservation: {
-      databaseWrites: 0,
-      configurationChanges: 0,
-      bindingChanges: 0,
-      clusterChanges: 0,
-      productionActions: 0,
-      retries: 0,
-    },
+    preservation: zeroPreservation(),
   }
 }
 
@@ -696,7 +712,8 @@ function sanitizeReceipt(value) {
       value.counts?.positivePassed !== EXPECTED_CHATBOT_COUNT ||
       value.counts?.isolationPassed !== EXPECTED_CHATBOT_COUNT ||
       value.counts?.rejectionsPassed !== REJECTION_CLASSES.length ||
-      REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed'))
+      REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed') ||
+      !hasExactZeroPreservation(value.preservation))
   ) {
     return fixedFailureReceipt('protocol_failed')
   }
@@ -831,7 +848,10 @@ export async function superviseProof({
     else if (interrupted) receipt = fixedFailureReceipt('interrupted')
     else if (close.signal) receipt = fixedFailureReceipt('child_signaled')
     else if (close.code === 0) {
-      if (message?.result !== 'passed') {
+      if (
+        message?.result !== 'passed' &&
+        message?.failureClass !== 'protocol_failed'
+      ) {
         receipt = fixedFailureReceipt('child_failed')
       }
     } else if (message === null || message.result === 'passed') {

--- a/apps/chat/scripts/stg-doc-query-proof.mjs
+++ b/apps/chat/scripts/stg-doc-query-proof.mjs
@@ -1,0 +1,915 @@
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { open, readFile, unlink } from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { generateKeyPair, importPKCS8, SignJWT } from 'jose'
+
+const RECEIPT_VERSION = 1
+const MANIFEST_VERSION = 1
+const EXPECTED_KB_COUNT = 15
+const EXPECTED_CHATBOT_COUNT = 21
+const EXPECTED_EXCLUDED_CHATBOT_COUNT = 2
+const COLLECTION = 'klicker_course_materials_v1'
+const STG_ENDPOINT =
+  'http://mcp-doc-query.stg-doc-query.svc.cluster.local:1417/mcp/klicker'
+const TOOL_NAME = 'doc_query'
+const SCOPE_HEADER = 'X-Doc-Query-Scope-Token'
+const DEFAULT_DEADLINE_MS = 30 * 60 * 1000
+const TERMINATION_GRACE_MS = 2_000
+const WORKER_PATH = fileURLToPath(import.meta.url)
+const DEFAULT_LOCK_PATH = '/private/tmp/klicker-stg-doc-query-proof.lock'
+const ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const SECRET_ENV_NAMES = [
+  'DOC_QUERY_JWT_TOKEN_KLICKER',
+  'DOC_QUERY_SCOPE_PRIVATE_KEY',
+  'DOC_QUERY_SCOPE_KID',
+  'DOC_QUERY_SCOPE_ISSUER',
+  'DOC_QUERY_SCOPE_AUDIENCE',
+]
+
+// macOS adds this non-secret marker to spawned processes even with an explicit
+// environment allowlist. It is the only platform-added name accepted here.
+const PLATFORM_ENV_NAMES = new Set(['__CF_USER_TEXT_ENCODING'])
+const WORKER_CONTROL_ENV_NAMES = new Set([
+  'DOC_QUERY_PROOF_PARENT_PID',
+  'DOC_QUERY_PROOF_MANIFEST_PATH',
+])
+const ALLOWED_WORKER_ENV_NAMES = new Set([
+  ...SECRET_ENV_NAMES,
+  ...WORKER_CONTROL_ENV_NAMES,
+  ...PLATFORM_ENV_NAMES,
+])
+
+const REJECTION_CLASSES = [
+  'missing',
+  'expired',
+  'forged',
+  'wrong_issuer',
+  'wrong_audience',
+  'unknown_key',
+  'trusted_filter_override',
+]
+
+const FAILURE_CLASSES = new Set([
+  'none',
+  'manifest_refused',
+  'duplicate_refused',
+  'credential_missing',
+  'protocol_failed',
+  'canary_positive_failed',
+  'canary_isolation_failed',
+  'rejection_failed',
+  'positive_failed',
+  'isolation_failed',
+  'child_failed',
+  'child_signaled',
+  'timeout',
+  'interrupted',
+])
+
+class ProofFailure extends Error {
+  constructor(failureClass, caseId = null, rejectionClass = null) {
+    super(failureClass)
+    this.name = 'ProofFailure'
+    this.failureClass = failureClass
+    this.caseId = caseId
+    this.rejectionClass = rejectionClass
+  }
+}
+
+function requireString(value, _label, pattern) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ProofFailure('manifest_refused')
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new ProofFailure('manifest_refused')
+  }
+  return value
+}
+
+function requireMarkerList(value) {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > 8 ||
+    value.some(
+      (entry) =>
+        typeof entry !== 'string' || entry.length === 0 || entry.length > 160
+    )
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+  return [...value]
+}
+
+export function validateManifest(input) {
+  if (
+    !input ||
+    typeof input !== 'object' ||
+    Array.isArray(input) ||
+    input.version !== MANIFEST_VERSION ||
+    input.environment !== 'stg' ||
+    input.collection !== COLLECTION ||
+    !Array.isArray(input.cases) ||
+    input.cases.length !== EXPECTED_KB_COUNT ||
+    !Array.isArray(input.excludedChatbotIds) ||
+    input.excludedChatbotIds.length !== EXPECTED_EXCLUDED_CHATBOT_COUNT
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+
+  const caseIds = new Set()
+  const kbIds = new Set()
+  const chatbotIds = new Set()
+  const cases = input.cases.map((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const id = requireString(entry.id, 'case id', ID_PATTERN)
+    const kbId = requireString(entry.kbId, 'KB id', UUID_PATTERN)
+    if (caseIds.has(id) || kbIds.has(kbId)) {
+      throw new ProofFailure('manifest_refused')
+    }
+    caseIds.add(id)
+    kbIds.add(kbId)
+    if (!Array.isArray(entry.chatbotIds) || entry.chatbotIds.length === 0) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const entryChatbots = entry.chatbotIds.map((chatbotId) => {
+      const normalized = requireString(chatbotId, 'chatbot id', UUID_PATTERN)
+      if (chatbotIds.has(normalized)) {
+        throw new ProofFailure('manifest_refused')
+      }
+      chatbotIds.add(normalized)
+      return normalized
+    })
+    const positive = entry.positive
+    const foreign = entry.foreign
+    if (
+      !positive ||
+      typeof positive !== 'object' ||
+      !foreign ||
+      typeof foreign !== 'object'
+    ) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const minSources = positive.minSources ?? 1
+    if (!Number.isInteger(minSources) || minSources < 1 || minSources > 20) {
+      throw new ProofFailure('manifest_refused')
+    }
+    return {
+      id,
+      kbId,
+      chatbotIds: entryChatbots,
+      positive: {
+        question: requireString(positive.question, 'positive question'),
+        expectAny: requireMarkerList(positive.expectAny),
+        minSources,
+      },
+      foreign: {
+        question: requireString(foreign.question, 'foreign question'),
+        forbidReferences: requireMarkerList(foreign.forbidReferences),
+      },
+    }
+  })
+
+  if (chatbotIds.size !== EXPECTED_CHATBOT_COUNT) {
+    throw new ProofFailure('manifest_refused')
+  }
+  const excludedChatbotIds = input.excludedChatbotIds.map((chatbotId) =>
+    requireString(chatbotId, 'excluded chatbot id', UUID_PATTERN)
+  )
+  if (
+    new Set(excludedChatbotIds).size !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
+    excludedChatbotIds.some((chatbotId) => chatbotIds.has(chatbotId))
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+  const canaryCaseId = requireString(
+    input.singletonCanaryCaseId,
+    'canary case id',
+    ID_PATTERN
+  )
+  if (cases[0].id !== canaryCaseId || cases[0].chatbotIds.length !== 1) {
+    throw new ProofFailure('manifest_refused')
+  }
+
+  return {
+    version: MANIFEST_VERSION,
+    environment: 'stg',
+    collection: COLLECTION,
+    singletonCanaryCaseId: canaryCaseId,
+    cases,
+    excludedChatbotIds,
+  }
+}
+
+function emptyReceipt() {
+  return {
+    receiptVersion: RECEIPT_VERSION,
+    environment: 'stg',
+    collection: COLLECTION,
+    phase: 'preflight',
+    result: 'failed',
+    failureClass: 'none',
+    failedCaseId: null,
+    failedRejectionClass: null,
+    counts: {
+      kbExpected: EXPECTED_KB_COUNT,
+      kbPassed: 0,
+      chatbotsExpected: EXPECTED_CHATBOT_COUNT,
+      chatbotsPassed: 0,
+      excludedExpected: EXPECTED_EXCLUDED_CHATBOT_COUNT,
+      positivePassed: 0,
+      isolationPassed: 0,
+      rejectionsPassed: 0,
+    },
+    rejections: Object.fromEntries(
+      REJECTION_CLASSES.map((name) => [name, 'not_run'])
+    ),
+    preservation: {
+      databaseWrites: 0,
+      configurationChanges: 0,
+      bindingChanges: 0,
+      clusterChanges: 0,
+      productionActions: 0,
+      retries: 0,
+    },
+  }
+}
+
+function fixedFailureReceipt(
+  failureClass,
+  caseId = null,
+  rejectionClass = null
+) {
+  const receipt = emptyReceipt()
+  receipt.failureClass = FAILURE_CLASSES.has(failureClass)
+    ? failureClass
+    : 'protocol_failed'
+  receipt.failedCaseId = ID_PATTERN.test(caseId ?? '') ? caseId : null
+  receipt.failedRejectionClass = REJECTION_CLASSES.includes(rejectionClass)
+    ? rejectionClass
+    : null
+  return receipt
+}
+
+function extractDocuments(result) {
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    result.isError === true ||
+    !Array.isArray(result.content)
+  ) {
+    return null
+  }
+  for (const block of result.content) {
+    if (block?.type !== 'text' || typeof block.text !== 'string') {
+      continue
+    }
+    try {
+      const parsed = JSON.parse(block.text)
+      if (
+        parsed?.mode === 'documents' &&
+        Array.isArray(parsed.sources) &&
+        Number.isInteger(parsed?.summary?.sources_returned)
+      ) {
+        return parsed
+      }
+    } catch {
+      // A non-JSON block is not proof and is never surfaced.
+    }
+  }
+  return null
+}
+
+function documentHaystack(documents) {
+  return documents.sources
+    .flatMap((source) => [
+      typeof source?.reference === 'string' ? source.reference : '',
+      ...(Array.isArray(source?.chunks)
+        ? source.chunks.map((chunk) =>
+            typeof chunk?.content === 'string' ? chunk.content : ''
+          )
+        : []),
+    ])
+    .join('\n')
+    .toLocaleLowerCase('en')
+}
+
+function hasAnyDocumentMarker(documents, markers) {
+  const haystack = documentHaystack(documents)
+  return markers.some((marker) =>
+    haystack.includes(marker.toLocaleLowerCase('en'))
+  )
+}
+
+function hasAnyReferenceMarker(documents, markers) {
+  const references = documents.sources
+    .map((source) =>
+      typeof source?.reference === 'string'
+        ? source.reference.toLocaleLowerCase('en')
+        : ''
+    )
+    .filter(Boolean)
+  return markers.some((marker) => {
+    const normalized = marker.toLocaleLowerCase('en')
+    return references.some((reference) => reference.includes(normalized))
+  })
+}
+
+function isRejected(result) {
+  if (!result || typeof result !== 'object') return false
+  if (result.isError === true) return true
+  if (!Array.isArray(result.content)) return false
+  return result.content.some((block) => {
+    if (block?.type !== 'text' || typeof block.text !== 'string') {
+      return false
+    }
+    try {
+      const parsed = JSON.parse(block.text)
+      return Boolean(parsed?.error)
+    } catch {
+      return /unauthorized|invalid token|invalid arguments/i.test(block.text)
+    }
+  })
+}
+
+async function createScopeSigner(environment) {
+  let privateKey
+  try {
+    privateKey = await importPKCS8(
+      environment.DOC_QUERY_SCOPE_PRIVATE_KEY.replaceAll('\\n', '\n'),
+      'ES256'
+    )
+  } catch {
+    throw new ProofFailure('credential_missing')
+  }
+  const rogueKey = (await generateKeyPair('ES256')).privateKey
+
+  return async ({ kbId, chatbotId, variant = 'valid' }) => {
+    const now = Math.floor(Date.now() / 1000)
+    const issuer =
+      variant === 'wrong_issuer'
+        ? 'urn:klicker:doc-query-proof:rejected-issuer'
+        : environment.DOC_QUERY_SCOPE_ISSUER
+    const audience =
+      variant === 'wrong_audience'
+        ? 'urn:klicker:doc-query-proof:rejected-audience'
+        : environment.DOC_QUERY_SCOPE_AUDIENCE
+    const kid =
+      variant === 'unknown_key'
+        ? 'klicker-doc-query-proof-unknown-key'
+        : environment.DOC_QUERY_SCOPE_KID
+    const signingKey = variant === 'forged' ? rogueKey : privateKey
+    const issuedAt = variant === 'expired' ? now - 7_200 : now
+    const expiresAt = variant === 'expired' ? now - 3_600 : now + 300
+
+    return new SignJWT({ kb_id: kbId, chatbot_id: chatbotId })
+      .setProtectedHeader({ alg: 'ES256', typ: 'JWT', kid })
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setSubject(randomUUID())
+      .setJti(randomUUID())
+      .setIssuedAt(issuedAt)
+      .setExpirationTime(expiresAt)
+      .sign(signingKey)
+  }
+}
+
+async function invokeMcp({ bearer, scopeToken, question, override }) {
+  const headers = { authorization: `Bearer ${bearer}` }
+  if (scopeToken) headers[SCOPE_HEADER] = `Bearer ${scopeToken}`
+  const client = new Client({
+    name: 'klicker-stg-doc-query-proof',
+    version: '1',
+  })
+  const transport = new StreamableHTTPClientTransport(new URL(STG_ENDPOINT), {
+    requestInit: { headers, redirect: 'error' },
+  })
+  try {
+    await client.connect(transport)
+    return await client.callTool({
+      name: TOOL_NAME,
+      arguments: override
+        ? {
+            question,
+            metadata_filters: { resource_active: false, kb_id: override },
+          }
+        : { question },
+    })
+  } finally {
+    await client.close().catch(() => undefined)
+  }
+}
+
+async function provePositive(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId
+) {
+  const token = await signer({ kbId: proofCase.kbId, chatbotId })
+  const result = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: token,
+    question: proofCase.positive.question,
+  })
+  const documents = extractDocuments(result)
+  return Boolean(
+    documents &&
+      documents.summary.sources_returned >= proofCase.positive.minSources &&
+      hasAnyDocumentMarker(documents, proofCase.positive.expectAny)
+  )
+}
+
+async function proveIsolation(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId
+) {
+  const token = await signer({ kbId: proofCase.kbId, chatbotId })
+  const result = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: token,
+    question: proofCase.foreign.question,
+  })
+  const documents = extractDocuments(result)
+  return Boolean(
+    documents &&
+      !hasAnyReferenceMarker(documents, proofCase.foreign.forbidReferences)
+  )
+}
+
+async function proveRejections(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId,
+  foreignKbId,
+  receipt
+) {
+  const variants = [
+    ['missing', null],
+    ['expired', 'expired'],
+    ['forged', 'forged'],
+    ['wrong_issuer', 'wrong_issuer'],
+    ['wrong_audience', 'wrong_audience'],
+    ['unknown_key', 'unknown_key'],
+  ]
+
+  for (const [rejectionClass, variant] of variants) {
+    const scopeToken = variant
+      ? await signer({ kbId: proofCase.kbId, chatbotId, variant })
+      : undefined
+    const result = await invoke({
+      bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+      scopeToken,
+      question: proofCase.positive.question,
+    })
+    if (!isRejected(result)) {
+      throw new ProofFailure('rejection_failed', proofCase.id, rejectionClass)
+    }
+    receipt.rejections[rejectionClass] = 'passed'
+    receipt.counts.rejectionsPassed += 1
+  }
+
+  const validToken = await signer({ kbId: proofCase.kbId, chatbotId })
+  const overrideResult = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: validToken,
+    question: proofCase.positive.question,
+    override: foreignKbId,
+  })
+  if (!isRejected(overrideResult)) {
+    throw new ProofFailure(
+      'rejection_failed',
+      proofCase.id,
+      'trusted_filter_override'
+    )
+  }
+  receipt.rejections.trusted_filter_override = 'passed'
+  receipt.counts.rejectionsPassed += 1
+}
+
+export async function runProofMatrix({
+  manifest,
+  environment,
+  invoke = invokeMcp,
+}) {
+  const receipt = emptyReceipt()
+  try {
+    const signer = await createScopeSigner(environment)
+    const canary = manifest.cases[0]
+    const canaryChatbotId = canary.chatbotIds[0]
+    receipt.phase = 'canary'
+
+    if (
+      !(await provePositive(
+        invoke,
+        signer,
+        environment,
+        canary,
+        canaryChatbotId
+      ))
+    ) {
+      throw new ProofFailure('canary_positive_failed', canary.id)
+    }
+    receipt.counts.positivePassed += 1
+    if (
+      !(await proveIsolation(
+        invoke,
+        signer,
+        environment,
+        canary,
+        canaryChatbotId
+      ))
+    ) {
+      throw new ProofFailure('canary_isolation_failed', canary.id)
+    }
+    receipt.counts.isolationPassed += 1
+    receipt.counts.chatbotsPassed += 1
+
+    receipt.phase = 'rejections'
+    await proveRejections(
+      invoke,
+      signer,
+      environment,
+      canary,
+      canaryChatbotId,
+      manifest.cases[1].kbId,
+      receipt
+    )
+
+    receipt.phase = 'matrix'
+    for (const proofCase of manifest.cases) {
+      for (const chatbotId of proofCase.chatbotIds) {
+        if (proofCase === canary && chatbotId === canaryChatbotId) continue
+        if (
+          !(await provePositive(
+            invoke,
+            signer,
+            environment,
+            proofCase,
+            chatbotId
+          ))
+        ) {
+          throw new ProofFailure('positive_failed', proofCase.id)
+        }
+        receipt.counts.positivePassed += 1
+        if (
+          !(await proveIsolation(
+            invoke,
+            signer,
+            environment,
+            proofCase,
+            chatbotId
+          ))
+        ) {
+          throw new ProofFailure('isolation_failed', proofCase.id)
+        }
+        receipt.counts.isolationPassed += 1
+        receipt.counts.chatbotsPassed += 1
+      }
+      receipt.counts.kbPassed += 1
+    }
+
+    receipt.phase = 'complete'
+    receipt.result = 'passed'
+    receipt.failureClass = 'none'
+    return receipt
+  } catch (error) {
+    const failure =
+      error instanceof ProofFailure
+        ? error
+        : new ProofFailure('protocol_failed')
+    receipt.result = 'failed'
+    receipt.failureClass = failure.failureClass
+    receipt.failedCaseId = failure.caseId
+    receipt.failedRejectionClass = failure.rejectionClass
+    if (failure.rejectionClass) {
+      receipt.rejections[failure.rejectionClass] = 'failed'
+    }
+    return receipt
+  }
+}
+
+function requiredWorkerEnvironment(source) {
+  const environment = {}
+  for (const name of SECRET_ENV_NAMES) {
+    const value = source[name]
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new ProofFailure('credential_missing')
+    }
+    environment[name] = value
+  }
+  const manifestPath = source.DOC_QUERY_PROOF_MANIFEST_PATH
+  if (typeof manifestPath !== 'string' || !isAbsolute(manifestPath)) {
+    throw new ProofFailure('manifest_refused')
+  }
+  environment.DOC_QUERY_PROOF_MANIFEST_PATH = manifestPath
+  return environment
+}
+
+export function validateWorkerEnvironment(source) {
+  for (const name of Object.keys(source)) {
+    if (!ALLOWED_WORKER_ENV_NAMES.has(name)) {
+      throw new ProofFailure('protocol_failed')
+    }
+  }
+}
+
+export function minimalChildEnvironment(source, parentPid) {
+  return {
+    ...requiredWorkerEnvironment(source),
+    DOC_QUERY_PROOF_PARENT_PID: String(parentPid),
+  }
+}
+
+async function readManifest(path) {
+  let raw
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    throw new ProofFailure('manifest_refused')
+  }
+  try {
+    return validateManifest(JSON.parse(raw))
+  } catch (error) {
+    if (error instanceof ProofFailure) throw error
+    throw new ProofFailure('manifest_refused')
+  }
+}
+
+function sanitizeReceipt(value) {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    value.receiptVersion !== RECEIPT_VERSION ||
+    value.environment !== 'stg' ||
+    value.collection !== COLLECTION ||
+    !['preflight', 'canary', 'rejections', 'matrix', 'complete'].includes(
+      value.phase
+    ) ||
+    !['passed', 'failed'].includes(value.result) ||
+    !FAILURE_CLASSES.has(value.failureClass)
+  ) {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  if (value.result === 'failed' && value.failureClass === 'none') {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  if (
+    value.result === 'passed' &&
+    (value.phase !== 'complete' ||
+      value.failureClass !== 'none' ||
+      value.failedCaseId !== null ||
+      value.failedRejectionClass !== null ||
+      value.counts?.kbExpected !== EXPECTED_KB_COUNT ||
+      value.counts?.kbPassed !== EXPECTED_KB_COUNT ||
+      value.counts?.chatbotsExpected !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.chatbotsPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.excludedExpected !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
+      value.counts?.positivePassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.isolationPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.rejectionsPassed !== REJECTION_CLASSES.length ||
+      REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed'))
+  ) {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  const receipt = emptyReceipt()
+  receipt.phase = value.phase
+  receipt.result = value.result
+  receipt.failureClass = value.failureClass
+  receipt.failedCaseId = ID_PATTERN.test(value.failedCaseId ?? '')
+    ? value.failedCaseId
+    : null
+  receipt.failedRejectionClass = REJECTION_CLASSES.includes(
+    value.failedRejectionClass
+  )
+    ? value.failedRejectionClass
+    : null
+  for (const key of Object.keys(receipt.counts)) {
+    const count = value.counts?.[key]
+    receipt.counts[key] = Number.isInteger(count)
+      ? Math.max(0, Math.min(count, 100))
+      : receipt.counts[key]
+  }
+  for (const name of REJECTION_CLASSES) {
+    receipt.rejections[name] = ['not_run', 'passed', 'failed'].includes(
+      value.rejections?.[name]
+    )
+      ? value.rejections[name]
+      : 'not_run'
+  }
+  return receipt
+}
+
+function killProcessGroup(child, signal) {
+  if (!child.pid) return
+  try {
+    process.kill(-child.pid, signal)
+  } catch {
+    try {
+      child.kill(signal)
+    } catch {
+      // The process already exited.
+    }
+  }
+}
+
+async function acquireLock(path) {
+  try {
+    return await open(path, 'wx', 0o600)
+  } catch (error) {
+    if (error?.code === 'EEXIST') return null
+    throw error
+  }
+}
+
+export async function superviseProof({
+  sourceEnvironment = process.env,
+  childPath = WORKER_PATH,
+  childArgs = ['--worker'],
+  deadlineMs = DEFAULT_DEADLINE_MS,
+  lockPath = DEFAULT_LOCK_PATH,
+  installSignalHandlers = false,
+}) {
+  const startedAt = Date.now()
+  const lock = await acquireLock(lockPath)
+  if (!lock) {
+    return {
+      ...fixedFailureReceipt('duplicate_refused'),
+      exitCode: null,
+      signal: null,
+      elapsedMs: 0,
+    }
+  }
+
+  let child
+  let interrupted = false
+  let timedOut = false
+  let message = null
+  const signalHandlers = new Map()
+
+  try {
+    const environment = minimalChildEnvironment(sourceEnvironment, process.pid)
+    child = spawn(process.execPath, [resolve(childPath), ...childArgs], {
+      detached: true,
+      env: environment,
+      shell: false,
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+    })
+    child.on('message', (candidate) => {
+      if (message === null) message = sanitizeReceipt(candidate)
+    })
+
+    let forceTimer
+    const terminateChildGroup = () => {
+      killProcessGroup(child, 'SIGTERM')
+      if (forceTimer) return
+      forceTimer = setTimeout(
+        () => killProcessGroup(child, 'SIGKILL'),
+        TERMINATION_GRACE_MS
+      )
+    }
+
+    if (installSignalHandlers) {
+      for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
+        const handler = () => {
+          interrupted = true
+          terminateChildGroup()
+        }
+        signalHandlers.set(signal, handler)
+        process.once(signal, handler)
+      }
+    }
+
+    const deadlineTimer = setTimeout(() => {
+      timedOut = true
+      terminateChildGroup()
+    }, deadlineMs)
+    deadlineTimer.unref()
+
+    const close = await new Promise((resolveClose) => {
+      let settled = false
+      const settle = (code, signal) => {
+        if (settled) return
+        settled = true
+        resolveClose({ code, signal })
+      }
+      child.once('error', () => settle(null, null))
+      child.once('close', settle)
+    })
+    clearTimeout(deadlineTimer)
+
+    let receipt = message ?? fixedFailureReceipt('protocol_failed')
+    if (timedOut) receipt = fixedFailureReceipt('timeout')
+    else if (interrupted) receipt = fixedFailureReceipt('interrupted')
+    else if (close.signal) receipt = fixedFailureReceipt('child_signaled')
+    else if (close.code === 0) {
+      if (message?.result !== 'passed') {
+        receipt = fixedFailureReceipt('child_failed')
+      }
+    } else if (message === null || message.result === 'passed') {
+      receipt = fixedFailureReceipt('child_failed')
+    }
+
+    return {
+      ...receipt,
+      exitCode:
+        Number.isInteger(close.code) && close.code >= 0 && close.code <= 255
+          ? close.code
+          : null,
+      signal:
+        typeof close.signal === 'string' && close.signal.length <= 16
+          ? close.signal
+          : null,
+      elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
+    }
+  } catch (error) {
+    const failureClass =
+      error instanceof ProofFailure ? error.failureClass : 'child_failed'
+    return {
+      ...fixedFailureReceipt(failureClass),
+      exitCode: null,
+      signal: null,
+      elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
+    }
+  } finally {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler)
+    }
+    await lock.close().catch(() => undefined)
+    await unlink(lockPath).catch(() => undefined)
+  }
+}
+
+function sendWorkerReceipt(receipt, exitCode) {
+  if (typeof process.send !== 'function') process.exit(exitCode)
+  process.send(receipt, () => process.exit(exitCode))
+}
+
+async function workerMain() {
+  const expectedParentPid = Number(process.env.DOC_QUERY_PROOF_PARENT_PID)
+  const parentWatch = setInterval(() => {
+    if (
+      !Number.isInteger(expectedParentPid) ||
+      process.ppid !== expectedParentPid
+    ) {
+      process.exit(1)
+    }
+  }, 250)
+  parentWatch.unref()
+
+  for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
+    process.once(signal, () => process.exit(1))
+  }
+
+  try {
+    validateWorkerEnvironment(process.env)
+    const environment = requiredWorkerEnvironment(process.env)
+    const manifest = await readManifest(
+      environment.DOC_QUERY_PROOF_MANIFEST_PATH
+    )
+    const receipt = await runProofMatrix({ manifest, environment })
+    sendWorkerReceipt(receipt, receipt.result === 'passed' ? 0 : 1)
+  } catch (error) {
+    const receipt =
+      error instanceof ProofFailure
+        ? fixedFailureReceipt(
+            error.failureClass,
+            error.caseId,
+            error.rejectionClass
+          )
+        : fixedFailureReceipt('protocol_failed')
+    sendWorkerReceipt(receipt, 1)
+  }
+}
+
+async function launcherMain() {
+  const receipt = await superviseProof({ installSignalHandlers: true })
+  process.stdout.write(`${JSON.stringify(receipt)}\n`)
+  process.exitCode = receipt.result === 'passed' ? 0 : 1
+}
+
+const isMain =
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href ===
+    pathToFileURL(WORKER_PATH).href
+
+if (isMain) {
+  if (process.argv[2] === '--worker') await workerMain()
+  else await launcherMain()
+}

--- a/apps/chat/scripts/stg-doc-query-proof.mjs
+++ b/apps/chat/scripts/stg-doc-query-proof.mjs
@@ -84,7 +84,7 @@ class ProofFailure extends Error {
   }
 }
 
-function requireString(value, _label, pattern) {
+function requireString(value, pattern) {
   if (typeof value !== 'string' || value.length === 0) {
     throw new ProofFailure('manifest_refused')
   }
@@ -92,6 +92,10 @@ function requireString(value, _label, pattern) {
     throw new ProofFailure('manifest_refused')
   }
   return value
+}
+
+function requireUuid(value) {
+  return requireString(value, UUID_PATTERN).toLocaleLowerCase('en')
 }
 
 function requireMarkerList(value) {
@@ -132,8 +136,8 @@ export function validateManifest(input) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
       throw new ProofFailure('manifest_refused')
     }
-    const id = requireString(entry.id, 'case id', ID_PATTERN)
-    const kbId = requireString(entry.kbId, 'KB id', UUID_PATTERN)
+    const id = requireString(entry.id, ID_PATTERN)
+    const kbId = requireUuid(entry.kbId)
     if (caseIds.has(id) || kbIds.has(kbId)) {
       throw new ProofFailure('manifest_refused')
     }
@@ -143,7 +147,7 @@ export function validateManifest(input) {
       throw new ProofFailure('manifest_refused')
     }
     const entryChatbots = entry.chatbotIds.map((chatbotId) => {
-      const normalized = requireString(chatbotId, 'chatbot id', UUID_PATTERN)
+      const normalized = requireUuid(chatbotId)
       if (chatbotIds.has(normalized)) {
         throw new ProofFailure('manifest_refused')
       }
@@ -156,7 +160,8 @@ export function validateManifest(input) {
       !positive ||
       typeof positive !== 'object' ||
       !foreign ||
-      typeof foreign !== 'object'
+      typeof foreign !== 'object' ||
+      Object.hasOwn(foreign, 'forbidAny')
     ) {
       throw new ProofFailure('manifest_refused')
     }
@@ -169,12 +174,12 @@ export function validateManifest(input) {
       kbId,
       chatbotIds: entryChatbots,
       positive: {
-        question: requireString(positive.question, 'positive question'),
+        question: requireString(positive.question),
         expectAny: requireMarkerList(positive.expectAny),
         minSources,
       },
       foreign: {
-        question: requireString(foreign.question, 'foreign question'),
+        question: requireString(foreign.question),
         forbidReferences: requireMarkerList(foreign.forbidReferences),
       },
     }
@@ -183,20 +188,14 @@ export function validateManifest(input) {
   if (chatbotIds.size !== EXPECTED_CHATBOT_COUNT) {
     throw new ProofFailure('manifest_refused')
   }
-  const excludedChatbotIds = input.excludedChatbotIds.map((chatbotId) =>
-    requireString(chatbotId, 'excluded chatbot id', UUID_PATTERN)
-  )
+  const excludedChatbotIds = input.excludedChatbotIds.map(requireUuid)
   if (
     new Set(excludedChatbotIds).size !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
     excludedChatbotIds.some((chatbotId) => chatbotIds.has(chatbotId))
   ) {
     throw new ProofFailure('manifest_refused')
   }
-  const canaryCaseId = requireString(
-    input.singletonCanaryCaseId,
-    'canary case id',
-    ID_PATTERN
-  )
+  const canaryCaseId = requireString(input.singletonCanaryCaseId, ID_PATTERN)
   if (cases[0].id !== canaryCaseId || cases[0].chatbotIds.length !== 1) {
     throw new ProofFailure('manifest_refused')
   }
@@ -384,6 +383,21 @@ async function createScopeSigner(environment) {
   }
 }
 
+export function createMcpTransport(
+  headers,
+  Transport = StreamableHTTPClientTransport
+) {
+  return new Transport(new URL(STG_ENDPOINT), {
+    requestInit: { headers, redirect: 'error' },
+    reconnectionOptions: {
+      initialReconnectionDelay: 1_000,
+      maxReconnectionDelay: 30_000,
+      reconnectionDelayGrowFactor: 1.5,
+      maxRetries: 0,
+    },
+  })
+}
+
 async function invokeMcp({ bearer, scopeToken, question, override }) {
   const headers = { authorization: `Bearer ${bearer}` }
   if (scopeToken) headers[SCOPE_HEADER] = `Bearer ${scopeToken}`
@@ -391,9 +405,7 @@ async function invokeMcp({ bearer, scopeToken, question, override }) {
     name: 'klicker-stg-doc-query-proof',
     version: '1',
   })
-  const transport = new StreamableHTTPClientTransport(new URL(STG_ENDPOINT), {
-    requestInit: { headers, redirect: 'error' },
-  })
+  const transport = createMcpTransport(headers)
   try {
     await client.connect(transport)
     return await client.callTool({

--- a/apps/chat/scripts/stg-doc-query-proof.mjs
+++ b/apps/chat/scripts/stg-doc-query-proof.mjs
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { open, readFile, unlink } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { isAbsolute, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -21,7 +22,10 @@ const SCOPE_HEADER = 'X-Doc-Query-Scope-Token'
 const DEFAULT_DEADLINE_MS = 30 * 60 * 1000
 const TERMINATION_GRACE_MS = 2_000
 const WORKER_PATH = fileURLToPath(import.meta.url)
-const DEFAULT_LOCK_PATH = '/private/tmp/klicker-stg-doc-query-proof.lock'
+const DEFAULT_LOCK_PATH = resolve(
+  homedir(),
+  '.klicker-stg-doc-query-proof.lock'
+)
 const ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i

--- a/apps/chat/test/stg-doc-query-proof.test.ts
+++ b/apps/chat/test/stg-doc-query-proof.test.ts
@@ -190,7 +190,10 @@ describe('STG Doc Query proof transport', () => {
     }
 
     const headers = { authorization: 'Bearer dummy-transport-token' }
-    createMcpTransport(headers, RecordingTransport)
+    createMcpTransport(
+      headers,
+      RecordingTransport as unknown as Parameters<typeof createMcpTransport>[1]
+    )
 
     expect(capturedOptions).toMatchObject({
       requestInit: { headers, redirect: 'error' },

--- a/apps/chat/test/stg-doc-query-proof.test.ts
+++ b/apps/chat/test/stg-doc-query-proof.test.ts
@@ -1,0 +1,494 @@
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { exportPKCS8, generateKeyPair } from 'jose'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  minimalChildEnvironment,
+  runProofMatrix,
+  superviseProof,
+  validateManifest,
+  validateWorkerEnvironment,
+} from '../scripts/stg-doc-query-proof.mjs'
+
+const temporaryDirectories: string[] = []
+
+type MockToolResult = {
+  isError?: boolean
+  content: Array<{ type: 'text'; text: string }>
+  toolResult: unknown
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true }))
+  )
+})
+
+function uuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+}
+
+function manifest() {
+  let chatbotIndex = 100
+  const cases = Array.from({ length: 15 }, (_, index) => ({
+    id: `corpus_${index + 1}`,
+    kbId: uuid(index + 1),
+    chatbotIds: Array.from(
+      { length: index === 0 ? 1 : index <= 6 ? 2 : 1 },
+      () => uuid(chatbotIndex++)
+    ),
+    positive: {
+      question: `positive fixture ${index + 1}`,
+      expectAny: [`positive-marker-${index + 1}`],
+      minSources: 1,
+    },
+    foreign: {
+      question: `foreign fixture ${index + 1}`,
+      forbidReferences: [`foreign-reference-${index + 1}`],
+    },
+  }))
+  return {
+    version: 1,
+    environment: 'stg',
+    collection: 'klicker_course_materials_v1',
+    singletonCanaryCaseId: 'corpus_1',
+    cases,
+    excludedChatbotIds: [uuid(900), uuid(901)],
+  }
+}
+
+async function dummyEnvironment() {
+  const { privateKey } = await generateKeyPair('ES256')
+  return {
+    DOC_QUERY_JWT_TOKEN_KLICKER: 'dummy-transport-token',
+    DOC_QUERY_SCOPE_PRIVATE_KEY: await exportPKCS8(privateKey),
+    DOC_QUERY_SCOPE_KID: 'dummy-key',
+    DOC_QUERY_SCOPE_ISSUER: 'https://chat.klicker.test',
+    DOC_QUERY_SCOPE_AUDIENCE: 'klicker-doc-query-test',
+    DOC_QUERY_PROOF_MANIFEST_PATH: '/private/tmp/dummy-manifest.json',
+  }
+}
+
+function passedReceiptSource(extra = '') {
+  return `
+${extra}
+process.send({
+  receiptVersion: 1,
+  environment: 'stg',
+  collection: 'klicker_course_materials_v1',
+  phase: 'complete',
+  result: 'passed',
+  failureClass: 'none',
+  failedCaseId: null,
+  failedRejectionClass: null,
+  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:21,chatbotsPassed:21,excludedExpected:2,positivePassed:21,isolationPassed:21,rejectionsPassed:7},
+  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'}
+}, () => process.exit(0))
+`
+}
+
+function failedReceiptSource() {
+  return `
+process.send({
+  receiptVersion: 1,
+  environment: 'stg',
+  collection: 'klicker_course_materials_v1',
+  phase: 'canary',
+  result: 'failed',
+  failureClass: 'canary_positive_failed',
+  failedCaseId: 'corpus_1',
+  failedRejectionClass: null,
+  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:21,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0},
+  rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
+  secret: 'dummy-private-key'
+}, () => process.exit(1))
+`
+}
+
+async function writeDummy(source: string) {
+  const directory = await mkdtemp(
+    join(tmpdir(), 'klicker-doc-query-proof-test-')
+  )
+  temporaryDirectories.push(directory)
+  const path = join(directory, 'child.mjs')
+  await writeFile(path, source, { mode: 0o700 })
+  return { directory, path, lockPath: join(directory, 'proof.lock') }
+}
+
+describe('STG Doc Query proof manifest', () => {
+  test('accepts exactly 15 KBs, 21 target chatbots, and two exclusions', () => {
+    const validated = validateManifest(manifest())
+    expect(validated.cases).toHaveLength(15)
+    expect(
+      validated.cases.flatMap(
+        (entry: { chatbotIds: string[] }) => entry.chatbotIds
+      )
+    ).toHaveLength(21)
+    expect(validated.cases[0].chatbotIds).toHaveLength(1)
+    expect(validated.excludedChatbotIds).toHaveLength(2)
+  })
+
+  test('refuses duplicate target chatbots before any proof call', () => {
+    const duplicate = manifest()
+    duplicate.cases[1].chatbotIds[0] = duplicate.cases[0].chatbotIds[0]
+    expect(() => validateManifest(duplicate)).toThrow('manifest_refused')
+  })
+
+  test('requires source-reference isolation markers', () => {
+    const legacy = manifest()
+    const foreign = legacy.cases[0].foreign as {
+      question: string
+      forbidReferences?: string[]
+      forbidAny?: string[]
+    }
+    foreign.forbidAny = foreign.forbidReferences
+    delete foreign.forbidReferences
+    expect(() => validateManifest(legacy)).toThrow('manifest_refused')
+  })
+})
+
+describe('STG Doc Query proof matrix', () => {
+  test('runs the singleton canary, seven rejections, then the serial matrix', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let call = 0
+    const invoke = async ({
+      question,
+      override,
+    }: {
+      question: string
+      override?: string
+    }): Promise<MockToolResult> => {
+      call += 1
+      if ((call >= 3 && call <= 8) || override) {
+        return { isError: true, content: [], toolResult: undefined }
+      }
+      const positive = question.startsWith('positive')
+      const marker = question.replace(
+        positive ? 'positive fixture ' : 'foreign fixture ',
+        positive ? 'positive-marker-' : 'foreign-reference-'
+      )
+      return {
+        isError: false,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              mode: 'documents',
+              summary: { sources_returned: 1, chunks_returned: 1 },
+              sources: [
+                positive
+                  ? {
+                      reference: 'safe-positive-reference',
+                      chunks: [{ content: marker }],
+                    }
+                  : {
+                      reference: 'safe-foreign-reference',
+                      chunks: [{ content: marker }],
+                    },
+              ],
+            }),
+          },
+        ],
+        toolResult: undefined,
+      }
+    }
+
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke,
+    })
+
+    expect(call).toBe(49)
+    expect(receipt.result).toBe('passed')
+    expect(receipt.counts).toMatchObject({
+      kbPassed: 15,
+      chatbotsPassed: 21,
+      positivePassed: 21,
+      isolationPassed: 21,
+      rejectionsPassed: 7,
+    })
+  })
+
+  test('fails when a foreign source reference is returned', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let calls = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({ question }: { question: string }) => {
+        calls += 1
+        const positive = question.startsWith('positive')
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [
+                  {
+                    reference: positive
+                      ? 'safe-positive-reference'
+                      : 'foreign-reference-1',
+                    chunks: [
+                      {
+                        content: positive
+                          ? question.replace(
+                              'positive fixture ',
+                              'positive-marker-'
+                            )
+                          : 'overlapping subject terminology',
+                      },
+                    ],
+                  },
+                ],
+              }),
+            },
+          ],
+        }
+      },
+    })
+    expect(receipt.failureClass).toBe('canary_isolation_failed')
+    expect(calls).toBe(2)
+  })
+
+  test('stops on the first invariant failure without retrying', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let calls = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async () => {
+        calls += 1
+        return { isError: true, content: [] }
+      },
+    })
+    expect(receipt.failureClass).toBe('canary_positive_failed')
+    expect(calls).toBe(1)
+  })
+
+  test('sends both protected fields in the trusted-filter rejection case', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    const overrides: string[] = []
+    let call = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({
+        question,
+        override,
+      }: {
+        question: string
+        override?: string
+      }) => {
+        call += 1
+        if (override) overrides.push(override)
+        if ((call >= 3 && call <= 8) || override) {
+          return { isError: true, content: [] }
+        }
+        const positive = question.startsWith('positive')
+        const marker = question.replace(
+          positive ? 'positive fixture ' : 'foreign fixture ',
+          positive ? 'positive-marker-' : 'safe-marker-'
+        )
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [{ reference: marker, chunks: [] }],
+              }),
+            },
+          ],
+        }
+      },
+    })
+    expect(receipt.result).toBe('passed')
+    expect(overrides).toEqual([validated.cases[1].kbId])
+  })
+})
+
+describe('STG Doc Query proof supervisor', () => {
+  test('passes only the allowlisted environment', async () => {
+    const environment = await dummyEnvironment()
+    const childEnvironment = minimalChildEnvironment(
+      { ...environment, LEAK_ME: 'must-not-pass' },
+      123
+    )
+    expect(childEnvironment).not.toHaveProperty('LEAK_ME')
+    expect(childEnvironment).not.toHaveProperty('PATH')
+    expect(Object.keys(childEnvironment).sort()).toEqual(
+      [
+        'DOC_QUERY_JWT_TOKEN_KLICKER',
+        'DOC_QUERY_SCOPE_AUDIENCE',
+        'DOC_QUERY_SCOPE_ISSUER',
+        'DOC_QUERY_SCOPE_KID',
+        'DOC_QUERY_SCOPE_PRIVATE_KEY',
+        'DOC_QUERY_PROOF_PARENT_PID',
+        'DOC_QUERY_PROOF_MANIFEST_PATH',
+      ].sort()
+    )
+  })
+
+  test('rejects unexpected worker environment names while allowing the platform marker', async () => {
+    const environment = await dummyEnvironment()
+    expect(() =>
+      validateWorkerEnvironment({
+        ...environment,
+        DOC_QUERY_PROOF_PARENT_PID: '123',
+        __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0',
+      })
+    ).not.toThrow()
+    expect(() =>
+      validateWorkerEnvironment({
+        ...environment,
+        DOC_QUERY_PROOF_PARENT_PID: '123',
+        LEAK_ME: 'must-not-pass',
+      })
+    ).toThrow('protocol_failed')
+  })
+
+  test('suppresses noisy child output and returns only a fixed receipt', async () => {
+    const dummy = await writeDummy(
+      passedReceiptSource(
+        "process.stdout.write('dummy-transport-token'); process.stderr.write('dummy-private-key')"
+      )
+    )
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt.result).toBe('passed')
+    expect(JSON.stringify(receipt)).not.toContain('dummy-transport-token')
+    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+  })
+
+  test('rejects incomplete, exit-mismatched, and missing success receipts', async () => {
+    const sources = [
+      passedReceiptSource().replace("phase: 'complete'", "phase: 'matrix'"),
+      passedReceiptSource().replace('process.exit(0)', 'process.exit(1)'),
+      'process.exit(0)',
+    ]
+    for (const source of sources) {
+      const dummy = await writeDummy(source)
+      const receipt = await superviseProof({
+        sourceEnvironment:
+          (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: 2_000,
+      })
+      expect(receipt.result).toBe('failed')
+      expect(receipt.failureClass).toBe('child_failed')
+    }
+  })
+
+  test('passes no unrelated environment or file descriptor to the child', async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), 'klicker-doc-query-fd-test-')
+    )
+    temporaryDirectories.push(directory)
+    const unrelated = await open(join(directory, 'unrelated'), 'w')
+    const dummy = await writeDummy(
+      `
+import { fstatSync, readFileSync } from 'node:fs'
+const allowed = new Set(${JSON.stringify([
+        'DOC_QUERY_JWT_TOKEN_KLICKER',
+        'DOC_QUERY_SCOPE_AUDIENCE',
+        'DOC_QUERY_SCOPE_ISSUER',
+        'DOC_QUERY_SCOPE_KID',
+        'DOC_QUERY_SCOPE_PRIVATE_KEY',
+        'DOC_QUERY_PROOF_PARENT_PID',
+        'DOC_QUERY_PROOF_MANIFEST_PATH',
+        '__CF_USER_TEXT_ENCODING',
+      ])})
+if (Object.keys(process.env).some((name) => !allowed.has(name))) process.exit(8)
+if (readFileSync(0).length !== 0) process.exit(9)
+try {
+  fstatSync(${unrelated.fd})
+  process.exit(10)
+} catch (error) {
+  if (error?.code !== 'EBADF') process.exit(11)
+}
+${passedReceiptSource()}
+`
+    )
+    const receipt = await superviseProof({
+      sourceEnvironment: {
+        ...(await dummyEnvironment()),
+        LEAK_ME: 'must-not-pass',
+      } as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    await unrelated.close()
+    expect(receipt.result).toBe('passed')
+  })
+
+  test('preserves a values-free failure receipt from a failed child', async () => {
+    const dummy = await writeDummy(failedReceiptSource())
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt).toMatchObject({
+      result: 'failed',
+      failureClass: 'canary_positive_failed',
+      failedCaseId: 'corpus_1',
+      exitCode: 1,
+    })
+    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+  })
+
+  test.each([
+    ['exit', 'process.exit(7)', 'child_failed'],
+    ['signal', "process.kill(process.pid, 'SIGTERM')", 'child_signaled'],
+    ['timeout', 'setInterval(() => {}, 1000)', 'timeout'],
+  ])('classifies %s without retrying', async (_name, source, expected) => {
+    const dummy = await writeDummy(source)
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: expected === 'timeout' ? 50 : 2_000,
+    })
+    expect(receipt.failureClass).toBe(expected)
+  })
+
+  test('refuses a duplicate invocation before spawning', async () => {
+    const dummy = await writeDummy(passedReceiptSource())
+    await writeFile(dummy.lockPath, '')
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+    })
+    expect(receipt.failureClass).toBe('duplicate_refused')
+    expect(receipt.exitCode).toBeNull()
+  })
+})

--- a/apps/chat/test/stg-doc-query-proof.test.ts
+++ b/apps/chat/test/stg-doc-query-proof.test.ts
@@ -72,7 +72,10 @@ async function dummyEnvironment() {
   }
 }
 
-function passedReceiptSource(extra = '') {
+function passedReceiptSource(
+  extra = '',
+  preservation = '{databaseWrites:0,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+) {
   return `
 ${extra}
 process.send({
@@ -85,7 +88,8 @@ process.send({
   failedCaseId: null,
   failedRejectionClass: null,
   counts: {kbExpected:15,kbPassed:15,chatbotsExpected:21,chatbotsPassed:21,excludedExpected:2,positivePassed:21,isolationPassed:21,rejectionsPassed:7},
-  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'}
+  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
+  preservation: ${preservation}
 }, () => process.exit(0))
 `
 }
@@ -421,25 +425,43 @@ describe('STG Doc Query proof supervisor', () => {
     expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
   })
 
-  test('rejects incomplete, exit-mismatched, and missing success receipts', async () => {
-    const sources = [
+  test.each([
+    [
+      'an incomplete receipt',
       passedReceiptSource().replace("phase: 'complete'", "phase: 'matrix'"),
+      'protocol_failed',
+    ],
+    [
+      'missing preservation evidence',
+      passedReceiptSource('', 'undefined'),
+      'protocol_failed',
+    ],
+    [
+      'non-zero preservation evidence',
+      passedReceiptSource(
+        '',
+        '{databaseWrites:1,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+      ),
+      'protocol_failed',
+    ],
+    [
+      'an exit-mismatched receipt',
       passedReceiptSource().replace('process.exit(0)', 'process.exit(1)'),
-      'process.exit(0)',
-    ]
-    for (const source of sources) {
-      const dummy = await writeDummy(source)
-      const receipt = await superviseProof({
-        sourceEnvironment:
-          (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-        childPath: dummy.path,
-        childArgs: [],
-        lockPath: dummy.lockPath,
-        deadlineMs: 2_000,
-      })
-      expect(receipt.result).toBe('failed')
-      expect(receipt.failureClass).toBe('child_failed')
-    }
+      'child_failed',
+    ],
+    ['a missing receipt', 'process.exit(0)', 'child_failed'],
+  ])('rejects %s', async (_name, source, expectedFailure) => {
+    const dummy = await writeDummy(source)
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt.result).toBe('failed')
+    expect(receipt.failureClass).toBe(expectedFailure)
   })
 
   test('passes no unrelated environment or file descriptor to the child', async () => {

--- a/apps/chat/test/stg-doc-query-proof.test.ts
+++ b/apps/chat/test/stg-doc-query-proof.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { exportPKCS8, generateKeyPair } from 'jose'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
+  createMcpTransport,
   minimalChildEnvironment,
   runProofMatrix,
   superviseProof,
@@ -16,7 +17,6 @@ const temporaryDirectories: string[] = []
 type MockToolResult = {
   isError?: boolean
   content: Array<{ type: 'text'; text: string }>
-  toolResult: unknown
 }
 
 afterEach(async () => {
@@ -115,7 +115,7 @@ async function writeDummy(source: string) {
   temporaryDirectories.push(directory)
   const path = join(directory, 'child.mjs')
   await writeFile(path, source, { mode: 0o700 })
-  return { directory, path, lockPath: join(directory, 'proof.lock') }
+  return { path, lockPath: join(directory, 'proof.lock') }
 }
 
 describe('STG Doc Query proof manifest', () => {
@@ -133,8 +133,22 @@ describe('STG Doc Query proof manifest', () => {
 
   test('refuses duplicate target chatbots before any proof call', () => {
     const duplicate = manifest()
-    duplicate.cases[1].chatbotIds[0] = duplicate.cases[0].chatbotIds[0]
+    duplicate.cases[1].chatbotIds[0] =
+      duplicate.cases[0].chatbotIds[0].toUpperCase()
     expect(() => validateManifest(duplicate)).toThrow('manifest_refused')
+  })
+
+  test('canonicalizes UUIDs before every cardinality check', () => {
+    const duplicateKb = manifest()
+    duplicateKb.cases[1].kbId = duplicateKb.cases[0].kbId.toUpperCase()
+    expect(() => validateManifest(duplicateKb)).toThrow('manifest_refused')
+
+    const overlappingExclusion = manifest()
+    overlappingExclusion.excludedChatbotIds[0] =
+      overlappingExclusion.cases[0].chatbotIds[0].toUpperCase()
+    expect(() => validateManifest(overlappingExclusion)).toThrow(
+      'manifest_refused'
+    )
   })
 
   test('requires source-reference isolation markers', () => {
@@ -147,6 +161,37 @@ describe('STG Doc Query proof manifest', () => {
     foreign.forbidAny = foreign.forbidReferences
     delete foreign.forbidReferences
     expect(() => validateManifest(legacy)).toThrow('manifest_refused')
+
+    const mixed = manifest()
+    const mixedForeign = mixed.cases[0].foreign as {
+      question: string
+      forbidReferences: string[]
+      forbidAny?: string[]
+    }
+    mixedForeign.forbidAny = mixedForeign.forbidReferences
+    expect(() => validateManifest(mixed)).toThrow('manifest_refused')
+  })
+})
+
+describe('STG Doc Query proof transport', () => {
+  test('disables Streamable HTTP reconnection attempts', () => {
+    let capturedOptions: {
+      requestInit?: { headers?: Record<string, string>; redirect?: string }
+      reconnectionOptions?: { maxRetries?: number }
+    } = {}
+    class RecordingTransport {
+      constructor(_url: URL, options: typeof capturedOptions) {
+        capturedOptions = options
+      }
+    }
+
+    const headers = { authorization: 'Bearer dummy-transport-token' }
+    createMcpTransport(headers, RecordingTransport)
+
+    expect(capturedOptions).toMatchObject({
+      requestInit: { headers, redirect: 'error' },
+      reconnectionOptions: { maxRetries: 0 },
+    })
   })
 })
 
@@ -164,7 +209,7 @@ describe('STG Doc Query proof matrix', () => {
     }): Promise<MockToolResult> => {
       call += 1
       if ((call >= 3 && call <= 8) || override) {
-        return { isError: true, content: [], toolResult: undefined }
+        return { isError: true, content: [] }
       }
       const positive = question.startsWith('positive')
       const marker = question.replace(
@@ -193,7 +238,6 @@ describe('STG Doc Query proof matrix', () => {
             }),
           },
         ],
-        toolResult: undefined,
       }
     }
 

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -824,6 +824,13 @@ The chat route derives the enabled knowledge-base id from the authenticated chat
 
 `src/lib/server/docQueryScopeToken.ts:signDocQueryScopeToken` signs a five-minute ES256 token with `DOC_QUERY_SCOPE_PRIVATE_KEY`, `DOC_QUERY_SCOPE_KID`, `DOC_QUERY_SCOPE_ISSUER`, and `DOC_QUERY_SCOPE_AUDIENCE`. Claims bind `kb_id`, `chatbot_id`, session subject, and a unique `jti`; participant identity is intentionally absent. Scope-token requests carry the scoped bearer in `X-Doc-Query-Scope-Token` and retain `Authorization` only for transport authentication; they never use the legacy `Chatbot-ID` header for retrieval scope. Existing participant-JWT MCP authentication is unchanged.
 
+The staging isolation verifier keeps positive and negative evidence asymmetric:
+positive markers may appear in returned source references or chunk content, but
+each `foreign.forbidReferences` marker must identify a stable
+`source.reference` unique to the foreign corpus. Never use a shared subject
+term as negative evidence; related courses can legitimately retrieve the same
+terminology without crossing the signed knowledge-base boundary.
+
 The assistant UI registers the retrieval card through `src/components/tools-ui/rag-tool-ui.tsx:RAGToolUI`. Its registration uses `src/services/mcpScope.ts:DOC_QUERY_TOOL_NAME` (`KB_doc_query`), matching the namespaced runtime tool name. The card is localized through `pwa.chatbot.retrieval` and renders only a generic failure state; raw retrieval-service errors must never reach participants.
 
 ## Testing

--- a/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
@@ -121,8 +121,8 @@ branch integration, and final delivery are coupled on the critical path.
 
 ## Progress
 
-- Status: Source-reference-only correction implemented and accepted by the
-  slice reviewer.
+- Status: Source-reference-only correction implemented; the final review's
+  preservation-evidence finding is corrected locally.
 - Completed: False-positive classification, current-base worktree, continuity
   planning review, purpose-based naming, reviewed proof custody and lifecycle
   protections, asymmetric marker logic, regression coverage, and wiki
@@ -143,10 +143,17 @@ branch integration, and final delivery are coupled on the critical path.
   configured effort before reading the task. Trusted Luna continuity passes
   completed instead. The simplifier's safe reductions were applied; the risk
   reviewer accepted the correction after transport-retry, strict-manifest, and
-  UUID-canonicalization findings were resolved.
-- Remaining: Final review, target integration decision, explicit push, pull
-  request, exact-head CI, and ready state.
+  UUID-canonicalization findings were resolved. The final reviewer then found
+  that a passing parent receipt synthesized zero-mutation claims instead of
+  validating the child's evidence; the success gate now requires the exact
+  all-zero preservation object.
+- Fresh checks after the final-review correction: Focused Vitest passed 23/23
+  under pinned Node 24; Node syntax, Biome, Prettier, and `git diff --check`
+  passed.
+- Remaining: Final-review correction confirmation, target integration
+  decision, explicit push, pull request, exact-head CI, and ready state.
 - Required delivery layer: Ready pull request. Achieved layer: Verified local
   correction.
-- Next action: Obtain integrated final review, then request the one-time target
-  integration authority required by the deployment-only target drift.
+- Next action: Commit and confirm the final-review correction, then request the
+  one-time target integration authority required by the deployment-only target
+  drift.

--- a/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
@@ -72,25 +72,25 @@ against `v3-ai` without running another live proof or changing runtime state.
 
 ## Delegation map
 
-| Workstream | Owner | Dependency | Acceptance |
-| --- | --- | --- | --- |
-| Proof correction | main | Reviewed inherited helper | Focused and package checks pass |
-| Slice simplification | simplifier | Committed correction | No behavior-changing reduction |
-| Isolation and custody review | slice-reviewer | Committed correction | All findings resolved or rejected with evidence |
-| Integrated readiness | final-reviewer | Final committed range | Correctness, maintainability, security, and architecture pass |
+| Workstream                   | Owner          | Dependency                | Acceptance                                                    |
+| ---------------------------- | -------------- | ------------------------- | ------------------------------------------------------------- |
+| Proof correction             | main           | Reviewed inherited helper | Focused and package checks pass                               |
+| Slice simplification         | simplifier     | Committed correction      | No behavior-changing reduction                                |
+| Isolation and custody review | slice-reviewer | Committed correction      | All findings resolved or rejected with evidence               |
+| Integrated readiness         | final-reviewer | Final committed range     | Correctness, maintainability, security, and architecture pass |
 
 Execution-tier skip reason: The marker semantics, secret-custody invariants,
 branch integration, and final delivery are coupled on the critical path.
 
 ## Test portfolio
 
-| Contract | Obligation | Stable seam | Distinct failure |
-| --- | --- | --- | --- |
-| Positive evidence | Extend existing | `runProofMatrix` | Chunk-only positive marker is missed |
-| Overlapping topics | Extend existing | `runProofMatrix` | Shared chunk text falsely fails isolation |
-| Foreign source reference | Add regression | `runProofMatrix` | Foreign reference is not detected |
-| Manifest migration | Add regression | `validateManifest` | Legacy broad marker field is accepted |
-| Custody and lifecycle | Preserve existing | `superviseProof` | Output, environment, receipt, lock, signal, or timeout contract regresses |
+| Contract                 | Obligation        | Stable seam        | Distinct failure                                                          |
+| ------------------------ | ----------------- | ------------------ | ------------------------------------------------------------------------- |
+| Positive evidence        | Extend existing   | `runProofMatrix`   | Chunk-only positive marker is missed                                      |
+| Overlapping topics       | Extend existing   | `runProofMatrix`   | Shared chunk text falsely fails isolation                                 |
+| Foreign source reference | Add regression    | `runProofMatrix`   | Foreign reference is not detected                                         |
+| Manifest migration       | Add regression    | `validateManifest` | Legacy broad marker field is accepted                                     |
+| Custody and lifecycle    | Preserve existing | `superviseProof`   | Output, environment, receipt, lock, signal, or timeout contract regresses |
 
 ## Slice: make isolation evidence source-specific
 
@@ -121,14 +121,26 @@ branch integration, and final delivery are coupled on the critical path.
 
 ## Progress
 
-- Status: Plan approved; implementation is next.
-- Completed: False-positive classification, current-base worktree, and
-  continuity planning review.
-- Current branch: Recorded `origin/v3-ai@edae58628` baseline. The remote target
-  has since advanced by one deployment-annotation commit; no integration has
-  occurred.
-- Remaining: Implementation, local checks, slice gates, final review, explicit
-  push, pull request, exact-head CI, target integration decision if still
-  required, and ready state.
-- Required delivery layer: Ready pull request. Achieved layer: Reviewed plan.
-- Next action: Implement the source-specific isolation correction.
+- Status: Source-reference-only correction implemented; local review gates are
+  next.
+- Completed: False-positive classification, current-base worktree, continuity
+  planning review, purpose-based naming, reviewed proof custody and lifecycle
+  protections, asymmetric marker logic, regression coverage, and wiki
+  documentation.
+- Current branch: Plan commit over the recorded `origin/v3-ai@edae58628`
+  baseline. The remote target has since advanced by one deployment-annotation
+  commit; no integration has occurred.
+- Fresh checks: Node syntax passed; Biome passed for the helper and test;
+  Prettier passed for the plan and wiki; focused Vitest passed 17/17 under
+  pinned Node 24; `git diff --check` passed.
+- Environment gap: Exact-worktree `devrouter ensure` stopped before creating a
+  runtime because the current target's devcontainer defines
+  `postCreateCommand` without `waitFor`. The host fallback cannot build all
+  internal workspaces, so Chat TypeScript and full-suite collection remain for
+  exact-head CI rather than being claimed as local passes.
+- Remaining: Implementation commit, slice gates, final review, explicit push,
+  pull request, exact-head CI, target integration decision if still required,
+  and ready state.
+- Required delivery layer: Ready pull request. Achieved layer: Verified local
+  correction.
+- Next action: Commit the implementation and run the two required slice gates.

--- a/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
@@ -1,0 +1,134 @@
+# Doc Query isolation proof correction plan
+
+## Goal
+
+Correct the staging Doc Query isolation verifier so overlapping course topics do
+not produce false cross-knowledge-base failures. Publish a reviewed pull request
+against `v3-ai` without running another live proof or changing runtime state.
+
+## Non-goals
+
+- Do not change scope-token signing, MCP invocation, tenant filters, bindings,
+  configuration, secrets, cluster state, data, or production.
+- Do not include a live manifest, knowledge-base identifiers, chatbot
+  identifiers, retrieved content, or credential values in the repository.
+- Do not merge the pull request or rerun staging retrieval proof in this package.
+
+## Execution contract
+
+- Authority: Edit, test, review, commit, push the feature branch, create or
+  update its pull request, wait for exact-head CI, and mark it ready when green.
+- Withheld: Upstream integration, merge, deployment, secret access, runtime or
+  cluster action, data or configuration changes, live proof, cleanup, and PRD.
+- Execution owner: Current task.
+- Boundary owner: Current task.
+- Terminal: A ready pull request targeting `v3-ai`, with exact-head CI green and
+  the required independent reviews accepted.
+- Pause: Stop if the diff crosses the proof helper, its tests, this plan, or the
+  adjacent chat-platform documentation; if target drift requires integration;
+  or if a reviewer finds unresolved isolation or custody risk.
+
+## Plan identity
+
+- Branch: `fix/doc-query-isolation-proof`
+- Target: `v3-ai`
+- Plan: `project/2026-08-28-doc-query-isolation-proof-correction-plan.md`
+- The source package includes the previously reviewed proof custody and
+  lifecycle protections together with this source-specific isolation
+  correction.
+
+## Decisions
+
+- Problem: The verifier used one combined reference-and-content haystack for
+  both positive retrieval and negative isolation evidence. Banking and Finance
+  II legitimately discusses portfolio theory, so a shared topical phrase was
+  not proof of a foreign corpus result.
+- Evidence: The failed receipt identifies the first isolation failure only.
+  Static course descriptors show the supposedly foreign topic belongs to the
+  tested course. The reviewed service contract independently applies the signed
+  `kb_id` after caller filters and rejects trusted-filter overrides.
+- Decision: Positive evidence may match returned references or chunk content.
+  Negative isolation evidence may match only stable markers in returned
+  `source.reference` values.
+- Decision: Rename all work-package-coded script, test, environment, lock,
+  client, fixture, and description names to purpose-based Doc Query proof names.
+- Risk: Reference-marker uniqueness remains an operator-owned manifest
+  property. The manifest field name, documentation, and synthetic regressions
+  make that boundary explicit; a future live manifest still needs review.
+- ADR: Not required. This is a reversible regression correction to an
+  operational verifier, not a new architecture or product decision.
+- Primitive impact: None. No user-facing capability or lifecycle changes.
+
+## Planning review
+
+- Route: Native planner launch failed before work because its configured role
+  was routed to an unsupported GLM effort. A clean-context Sol continuity
+  planner completed with `DONE_WITH_CONCERNS`.
+- Accepted: Use `forbidReferences`, preserve positive reference-and-content
+  matching, add asymmetric regressions, rename every coded identifier, document
+  the manifest rule, and keep every custody and lifecycle path unchanged.
+- Accepted concern: Publish with an explicit feature-branch ref because the
+  local branch tracks the target branch; never use a bare push.
+
+## Delegation map
+
+| Workstream | Owner | Dependency | Acceptance |
+| --- | --- | --- | --- |
+| Proof correction | main | Reviewed inherited helper | Focused and package checks pass |
+| Slice simplification | simplifier | Committed correction | No behavior-changing reduction |
+| Isolation and custody review | slice-reviewer | Committed correction | All findings resolved or rejected with evidence |
+| Integrated readiness | final-reviewer | Final committed range | Correctness, maintainability, security, and architecture pass |
+
+Execution-tier skip reason: The marker semantics, secret-custody invariants,
+branch integration, and final delivery are coupled on the critical path.
+
+## Test portfolio
+
+| Contract | Obligation | Stable seam | Distinct failure |
+| --- | --- | --- | --- |
+| Positive evidence | Extend existing | `runProofMatrix` | Chunk-only positive marker is missed |
+| Overlapping topics | Extend existing | `runProofMatrix` | Shared chunk text falsely fails isolation |
+| Foreign source reference | Add regression | `runProofMatrix` | Foreign reference is not detected |
+| Manifest migration | Add regression | `validateManifest` | Legacy broad marker field is accepted |
+| Custody and lifecycle | Preserve existing | `superviseProof` | Output, environment, receipt, lock, signal, or timeout contract regresses |
+
+## Slice: make isolation evidence source-specific
+
+- Route: main.
+- Do: Rename the helper and test to purpose-based names and replace internal
+  coded identifiers with `DOC_QUERY_PROOF_*` names.
+- Do: Replace `foreign.forbidAny` with required
+  `foreign.forbidReferences`. Match those markers only against normalized
+  source references while preserving positive reference-and-content matching.
+- Do: Add the test obligations above and one concise documentation paragraph
+  under scoped knowledge-base retrieval.
+- Check: Focused Vitest, Chat typecheck, full Chat Vitest, formatter checks,
+  `git diff --check`, a scoped coded-name search, and staged data hygiene.
+- Commit: `fix(chat): make isolation proof source-specific`.
+
+## Delivery
+
+- Run the simplifier and the data-integrity slice reviewer on the immutable
+  correction commit, preserving existing proof-custody reviews where content is
+  unchanged.
+- Resolve findings, rerun affected checks, then run one integrated final review
+  over the complete branch range.
+- Fetch before publication. Stop rather than merge or rebase if target drift
+  requires integration.
+- Push explicitly to `fix/doc-query-isolation-proof`, open a draft pull request
+  against `v3-ai`, update the whole-branch evidence, and mark it ready only when
+  exact-head CI is terminal green.
+
+## Progress
+
+- Status: Plan approved; implementation is next.
+- Completed: False-positive classification, current-base worktree, and
+  continuity planning review.
+- Current branch: Recorded `origin/v3-ai@edae58628` baseline. The remote target
+  has since advanced by one deployment-annotation commit; no integration has
+  occurred.
+- Remaining: Implementation, local checks, slice gates, final review, explicit
+  push, pull request, exact-head CI, target integration decision if still
+  required, and ready state.
+- Required delivery layer: Ready pull request. Achieved layer: Reviewed plan.
+- Next action: Implement the source-specific isolation correction.

--- a/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
@@ -121,26 +121,28 @@ branch integration, and final delivery are coupled on the critical path.
 
 ## Progress
 
-- Status: Source-reference-only correction implemented; local review gates are
-  next.
+- Status: Source-reference-only correction implemented; slice-review
+  corrections are verified locally.
 - Completed: False-positive classification, current-base worktree, continuity
   planning review, purpose-based naming, reviewed proof custody and lifecycle
   protections, asymmetric marker logic, regression coverage, and wiki
-  documentation.
+  documentation, transport retry refusal, canonical UUID cardinality checks,
+  strict legacy-manifest refusal, and the accepted simplifier reductions.
 - Current branch: Plan commit over the recorded `origin/v3-ai@edae58628`
   baseline. The remote target has since advanced by one deployment-annotation
   commit; no integration has occurred.
 - Fresh checks: Node syntax passed; Biome passed for the helper and test;
-  Prettier passed for the plan and wiki; focused Vitest passed 17/17 under
+  Prettier passed for the plan and wiki; focused Vitest passed 19/19 under
   pinned Node 24; `git diff --check` passed.
 - Environment gap: Exact-worktree `devrouter ensure` stopped before creating a
   runtime because the current target's devcontainer defines
   `postCreateCommand` without `waitFor`. The host fallback cannot build all
   internal workspaces, so Chat TypeScript and full-suite collection remain for
   exact-head CI rather than being claimed as local passes.
-- Remaining: Implementation commit, slice gates, final review, explicit push,
-  pull request, exact-head CI, target integration decision if still required,
-  and ready state.
+- Remaining: Correction commit, slice-review confirmation, final review,
+  explicit push, pull request, exact-head CI, target integration decision if
+  still required, and ready state.
 - Required delivery layer: Ready pull request. Achieved layer: Verified local
   correction.
-- Next action: Commit the implementation and run the two required slice gates.
+- Next action: Commit the review corrections and obtain the slice-review
+  confirmation.

--- a/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-doc-query-isolation-proof-correction-plan.md
@@ -121,8 +121,8 @@ branch integration, and final delivery are coupled on the critical path.
 
 ## Progress
 
-- Status: Source-reference-only correction implemented; slice-review
-  corrections are verified locally.
+- Status: Source-reference-only correction implemented and accepted by the
+  slice reviewer.
 - Completed: False-positive classification, current-base worktree, continuity
   planning review, purpose-based naming, reviewed proof custody and lifecycle
   protections, asymmetric marker logic, regression coverage, and wiki
@@ -139,10 +139,14 @@ branch integration, and final delivery are coupled on the critical path.
   `postCreateCommand` without `waitFor`. The host fallback cannot build all
   internal workspaces, so Chat TypeScript and full-suite collection remain for
   exact-head CI rather than being claimed as local passes.
-- Remaining: Correction commit, slice-review confirmation, final review,
-  explicit push, pull request, exact-head CI, target integration decision if
-  still required, and ready state.
+- Review: The configured simplifier and slice-reviewer routes rejected their
+  configured effort before reading the task. Trusted Luna continuity passes
+  completed instead. The simplifier's safe reductions were applied; the risk
+  reviewer accepted the correction after transport-retry, strict-manifest, and
+  UUID-canonicalization findings were resolved.
+- Remaining: Final review, target integration decision, explicit push, pull
+  request, exact-head CI, and ready state.
 - Required delivery layer: Ready pull request. Achieved layer: Verified local
   correction.
-- Next action: Commit the review corrections and obtain the slice-review
-  confirmation.
+- Next action: Obtain integrated final review, then request the one-time target
+  integration authority required by the deployment-only target drift.

--- a/project/2026-08-28-pr-5645-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-pr-5645-doc-query-isolation-proof-correction-plan.md
@@ -122,7 +122,9 @@ branch integration, and final delivery are coupled on the critical path.
 ## Progress
 
 - Status: Source-reference-only correction implemented, reviewed, and
-  published as draft PR #5645; exact-head CI is pending.
+  published as ready PR #5645. The ready-state Sonar analysis exposed one
+  branch-owned unsafe-public-temporary-directory finding in the default lock
+  path; the lock now lives in the operator's home directory.
 - Completed: False-positive classification, current-base worktree, continuity
   planning review, purpose-based naming, reviewed proof custody and lifecycle
   protections, asymmetric marker logic, regression coverage, and wiki
@@ -150,12 +152,23 @@ branch integration, and final delivery are coupled on the critical path.
 - Fresh checks after the final-review correction: Focused Vitest passed 23/23
   under pinned Node 24; Node syntax, Biome, Prettier, and `git diff --check`
   passed.
+- Ready-state correction: The public `/private/tmp` lock location moved to the
+  operator-private home directory. Focused Vitest passed 23/23 on the host;
+  Node syntax, Biome, and `git diff --check` passed. Exact-head Node 24 CI and
+  Sonar re-analysis remain pending.
 - Integration: The one-time rebase onto `v3-ai@609000ea` preserved the complete
   reviewed source tree; the only upstream change was the known staging
   deployment annotation.
-- Published: Draft PR #5645 at exact head `d2b9fe6d7`.
-- Remaining: Exact-head CI and ready state.
-- Required delivery layer: Ready pull request. Achieved layer: Verified local
-  correction.
-- Next action: Commit the PR metadata, push it, monitor exact-head CI, and mark
-  the unchanged passing PR ready.
+- Published: Ready PR #5645 at exact pre-correction head `ce92d35f3`.
+- Review-policy limitation: The repository `/final-review` workflow accepts an
+  open ready PR only when it targets the default branch or belongs to a
+  verified native stack. PR #5645 targets `v3-ai`, so the approved trigger was
+  authorized but produced no review job. The prior native integrated review
+  remains the applicable full-branch evidence; the lock-path correction needs
+  its bounded correction review before publication.
+- Remaining: Commit and push the lock-path correction, obtain its bounded
+  review, then verify exact-head CI and Sonar re-analysis.
+- Required delivery layer: Ready pull request. Achieved layer: Ready pull
+  request with one locally corrected, not-yet-published Sonar finding.
+- Next action: Commit and review the lock-path correction, push it, and monitor
+  exact-head CI without merging.

--- a/project/2026-08-28-pr-5645-doc-query-isolation-proof-correction-plan.md
+++ b/project/2026-08-28-pr-5645-doc-query-isolation-proof-correction-plan.md
@@ -32,7 +32,7 @@ against `v3-ai` without running another live proof or changing runtime state.
 
 - Branch: `fix/doc-query-isolation-proof`
 - Target: `v3-ai`
-- Plan: `project/2026-08-28-doc-query-isolation-proof-correction-plan.md`
+- Plan: `project/2026-08-28-pr-5645-doc-query-isolation-proof-correction-plan.md`
 - The source package includes the previously reviewed proof custody and
   lifecycle protections together with this source-specific isolation
   correction.
@@ -121,8 +121,8 @@ branch integration, and final delivery are coupled on the critical path.
 
 ## Progress
 
-- Status: Source-reference-only correction implemented; the final review's
-  preservation-evidence finding is corrected locally.
+- Status: Source-reference-only correction implemented, reviewed, and
+  published as draft PR #5645; exact-head CI is pending.
 - Completed: False-positive classification, current-base worktree, continuity
   planning review, purpose-based naming, reviewed proof custody and lifecycle
   protections, asymmetric marker logic, regression coverage, and wiki
@@ -150,10 +150,12 @@ branch integration, and final delivery are coupled on the critical path.
 - Fresh checks after the final-review correction: Focused Vitest passed 23/23
   under pinned Node 24; Node syntax, Biome, Prettier, and `git diff --check`
   passed.
-- Remaining: Final-review correction confirmation, target integration
-  decision, explicit push, pull request, exact-head CI, and ready state.
+- Integration: The one-time rebase onto `v3-ai@609000ea` preserved the complete
+  reviewed source tree; the only upstream change was the known staging
+  deployment annotation.
+- Published: Draft PR #5645 at exact head `d2b9fe6d7`.
+- Remaining: Exact-head CI and ready state.
 - Required delivery layer: Ready pull request. Achieved layer: Verified local
   correction.
-- Next action: Commit and confirm the final-review correction, then request the
-  one-time target integration authority required by the deployment-only target
-  drift.
+- Next action: Commit the PR metadata, push it, monitor exact-head CI, and mark
+  the unchanged passing PR ready.


### PR DESCRIPTION
## What This Fixes

This PR adds the staging-only Doc Query isolation proof helper and corrects its negative-evidence contract:

1. Positive retrieval may be proven by expected markers in returned source references or chunk content.
2. Cross-knowledge-base isolation is checked only against stable foreign `source.reference` markers, so related courses may share terminology without producing a false leak verdict.
3. The helper validates exactly 15 knowledge bases and 21 chatbot bindings, runs a singleton canary and seven signed-scope rejection cases, and emits only values-free receipts.
4. Fail-closed supervision disables transport reconnection, rejects ambiguous manifests and duplicate UUID spellings, suppresses child output, prevents inherited environment or descriptor leakage, and validates zero-mutation evidence before accepting success.

## How It Works

- `apps/chat/scripts/stg-doc-query-proof.mjs` launches one isolated worker with an allowlisted environment, null standard streams, a process-group deadline, one local lock, and no retry path.
- Positive checks scan references and chunks. Negative checks scan only normalized references from `foreign.forbidReferences`; legacy `forbidAny` manifests are refused.
- The worker signs short-lived scope tokens for the fixed rejection matrix while retaining the separate transport bearer.
- The parent accepts a passing receipt only when cardinality, rejection results, exit status, and the exact all-zero preservation object agree.

## Important Details

- The helper is purpose-named; no roadmap or work-package identifier is part of its file, environment, lock, client, or fixture names.
- `foreign.forbidReferences` remains an operator-owned manifest property. A later live manifest must use reference markers unique to the foreign corpus, never shared subject terms.
- This PR does not contain a live manifest, knowledge-base identifiers, chatbot identifiers, credentials, retrieved content, deployment changes, or runtime configuration.

## Branch Coverage

- Base: `v3-ai@609000ea9`
- Head: `ce92d35f3`
- Reviewed: 7 commits; 1,517 substantive added lines excluding the committed execution plan
- Covered: execution plan, generic proof helper, marker-contract regressions, fail-closed lifecycle corrections, chat-platform documentation, review disposition, the metadata-only PR plan rename, and the test-only transport constructor type correction

## Review Focus

- Confirm positive chunk matching remains independent from negative source-reference matching.
- Confirm malformed or non-zero preservation evidence cannot produce a passing parent receipt.
- Confirm the fixed matrix, seven rejection cases, credential custody, output suppression, no-retry behavior, process-group cleanup, and purpose-based naming remain intact.

## Verification

Current head:

- The first exact-head CI run at `3b92eab52` found one branch-caused TypeScript error in the test transport seam. `ce92d35f3` adds only the required constructor type assertion; production helper behavior is unchanged.
- `vitest run test/stg-doc-query-proof.test.ts` under Node 24 -> 23/23 passed
- Node syntax check for the helper -> passed
- Biome for the helper and focused test -> passed
- Prettier for the documentation and execution plan -> passed
- `git diff --check` and staged data-hygiene review -> passed
- Slice data-integrity/security review -> passed after all findings were corrected
- Integrated final review -> passed after the zero-preservation evidence correction
- Exact-head `check`, hosted build/compile, gitleaks, GitGuardian, GraphQL status, lecturer-MCP status, and seven of eight hosted Playwright shards -> passed

Failed/Warning:

- The host pre-push build uses Node 26 and stopped in the transactional package because this checkout lacks the complete workspace dependency build. The branch was pushed without that host hook; exact-head GitHub CI remains required.
- Hosted Playwright shard 4 failed only in unchanged `playwright/tests/B-feature-access.spec.ts`: `page.goto` aborted on an analytics route on both attempts after 181 tests passed. This PR changes only the Chat proof helper, its focused test, documentation, and plan.
- OpenCodeReview timed out after ten minutes while reviewing the helper, reporting zero findings and one timed-out file. The separately completed native slice and final reviews remain recorded above.
- The trusted final-review policy initialized successfully, but its external `final-ai-review` status remains pending because authorization and review jobs were skipped.

Not run:

- Full Chat TypeScript and full-suite local collection: the exact worktree devcontainer cannot start because the current target defines `postCreateCommand` without `waitFor`, while the incomplete host workspace cannot resolve `apps/chat/node_modules/next`. Exact-head CI owns these broad checks.
- Live staging retrieval proof: separately gated after source review and merge.

## Security / Privacy

- Review: bounded data-integrity, secret-custody, lifecycle, and integrated final reviews completed.
- Result: no blocking source findings remain.
- Sensitive data: no secret values, personal data, production content, live identifiers, or live receipts are included.

## Blocking Before Merge

- [ ] Required exact-head GitHub checks pass.

## Follow-Up After Merge

- [ ] Review a values-free staging manifest that uses corpus-unique source-reference markers.
- [ ] Request separate authority for one staging proof run; no live proof is authorized by this PR.

## Local Session Artifacts

- Machine: `MacBook-Pro`
- Worktree: `trees/doc-query-isolation-proof` in repository `klicker-uzh`
