### PR TITLE
ci(final-review): fix OpenRouter provider preflight

### DIFF
--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -461,9 +461,6 @@ function buildOCRPolicy() {
       model: FINAL_REVIEW_MODEL,
       protocol: 'openai',
       extra_body: {
-        provider: {
-          require_parameters: true,
-        },
         reasoning: {
           effort: 'high',
         },

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -388,7 +388,6 @@ test('writes an exact high-reasoning OCR config with mode 0600', () => {
   assert.deepEqual(config, buildOCRConfig({ token }))
   assert.equal(config.llm.model, FINAL_REVIEW_MODEL)
   assert.deepEqual(config.llm.extra_body, {
-    provider: { require_parameters: true },
     reasoning: { effort: 'high' },
   })
   assert.equal(fs.statSync(configPath).mode & 0o777, 0o600)

--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -374,6 +374,19 @@ jobs:
             node .github/scripts/final-ai-review.js configure-ocr
           test -s "${OCR_CONFIG_PATH}"
 
+      - name: Verify OpenRouter review access
+        if: needs.start.outputs.run_review == 'true'
+        env:
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-review-ocr-config.json
+        run: |
+          set -euo pipefail
+          if ocr llm test >/dev/null; then
+            echo 'OpenRouter review preflight passed'
+            exit 0
+          fi
+          echo '::error::OpenRouter review preflight failed'
+          exit 1
+
       - name: Run final review
         id: run_review
         if: needs.start.outputs.run_review == 'true'
@@ -825,6 +838,19 @@ jobs:
           printf '%s' "${OPENROUTER_API_KEY}" |
             node .github/scripts/final-ai-review.js configure-ocr
           test -s "${OCR_CONFIG_PATH}"
+
+      - name: Verify OpenRouter review access
+        if: needs.start_stack.outputs.run_review == 'true'
+        env:
+          OCR_CONFIG_PATH: ${{ runner.temp }}/final-ai-stack-ocr-config.json
+        run: |
+          set -euo pipefail
+          if ocr llm test >/dev/null; then
+            echo 'OpenRouter review preflight passed'
+            exit 0
+          fi
+          echo '::error::OpenRouter review preflight failed'
+          exit 1
 
       - name: Run cumulative code review
         id: code_review


### PR DESCRIPTION
## What This Fixes

This PR restores the OpenRouter-backed final-review path by removing `provider.require_parameters`, which rejected every GLM endpoint when OpenCodeReview 1.9.10 sent `max_completion_tokens`.

It also runs `ocr llm test` before individual and stack reviews. Key, model, or provider failures now stop before the expensive review fan-out. Successful model output is suppressed while failure stderr remains available for diagnosis.

## Branch Coverage

- Base: `v3`
- Head: `2c6e05acd`
- Reviewed: 1 commit, 3 files, 26 insertions and 4 deletions
- Packaging: urgent CI-unblocking regression fix below the usual size floor

## Verification

Current head:

- `node --test .github/scripts/final-ai-review.test.js .github/scripts/final-ai-stack-review.test.js` -> 81 passed
- Workflow YAML parse through the repository `yaml` package -> passed
- `pnpm exec prettier --check .github/workflows/check-ocr-final-review.yml` -> passed
- `git show --check HEAD` -> passed

Not run:

- `actionlint` is unavailable on this host; exact-head GitHub workflow CI remains required.

## Security / Privacy

- The OpenRouter key remains a GitHub Actions secret and is written only to the existing mode-0600 temporary OCR configuration.
- The preflight suppresses successful model output and never prints the token.
- No secret values or personal data are included in this branch.

## Blocking Before Merge

- [ ] Required exact-head CI passes.

## Follow-Up After Merge

- [ ] Rerun `/final-review-stack` on PR #5619 and verify both final-review status contexts on its exact head.

## Local Session Artifacts

- Machine: `MacBook Pro`
- Worktree: `trees/rs/fix-final-review-stderr-visibility` in repository `klicker-uzh`
