### PR TITLE
test(playwright): avoid user-profile navigation race

### DIFF
--- a/playwright/package.json
+++ b/playwright/package.json
@@ -3,6 +3,7 @@
   "name": "@klicker-uzh/playwright",
   "devDependencies": {
     "@klicker-uzh/prisma": "workspace:*",
+    "@klicker-uzh/prisma-data": "workspace:*",
     "@klicker-uzh/types": "workspace:*",
     "@playwright/test": "~1.58.0",
     "@types/bcryptjs": "^2.4.6",

--- a/playwright/tests/B-feature-access.spec.ts
+++ b/playwright/tests/B-feature-access.spec.ts
@@ -298,6 +298,9 @@ test.describe('Tests the availability of standard activity creation formats', ()
     page,
     loginLecturer,
   }) => {
+    await loginLecturer()
+    await expect(page.getByTestId('homepage')).toBeVisible()
+
     await page.route('**/api/graphql*', async (route) => {
       if (getGraphqlOperationName(route.request()) === 'UserProfile') {
         await route.fulfill({
@@ -313,7 +316,6 @@ test.describe('Tests the availability of standard activity creation formats', ()
       await route.continue()
     })
 
-    await loginLecturer()
     const manageUrl = process.env.URL_MANAGE ?? URL_MANAGE
     await page.goto(`${manageUrl}/analytics/${COURSE_ID_TEST}/activity`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2760,6 +2760,9 @@ importers:
       '@klicker-uzh/prisma':
         specifier: workspace:*
         version: link:../packages/prisma
+      '@klicker-uzh/prisma-data':
+        specifier: workspace:*
+        version: link:../packages/prisma-data
       '@klicker-uzh/types':
         specifier: workspace:*
         version: link:../packages/types


### PR DESCRIPTION
## What This Fixes

This PR removes two independent sources of instability from the feature-access Playwright coverage:

- It waits for authenticated Manage navigation to finish before installing the synthetic `UserProfile` failure route, avoiding a competing `/login` redirect and `net::ERR_ABORTED` race.
- It declares Playwright's direct `@klicker-uzh/prisma-data` workspace dependency. Turbo can now infer the build edge through `prisma-data` to `@klicker-uzh/util` before Playwright type-checks the seed helper imported by `Y-response-examples.spec.ts`.

## Branch Coverage

- Base: `v3-ai@609000ea9`
- Head: `f94bad3a5`
- Reviewed: 2 commits and 3 files, with 7 additions and 1 deletion
- Substantive size: 5 changed lines outside the lockfile
- Packaging: complete isolated regression fix under the packaging floor

## Review Focus

- Confirm the authenticated homepage is stable before the synthetic profile failure is installed.
- Confirm the workspace dependency matches the existing direct source import and restores the required Turbo build order.

## Verification

Current head:

- Turbo dry-run graph includes `@klicker-uzh/prisma-data#build` and `@klicker-uzh/util#build` before Playwright checks.
- `pnpm exec turbo run check --filter='...[origin/v3-ai...HEAD]'` -> 6/6 tasks passed.
- Normal commit hook, including gitleaks, formatting, lint, syncpack, repository guards, and workspace checks -> passed.
- Normal pre-push `pnpm run build` -> 26/26 tasks passed.
- `git diff --check` and targeted Prettier checks -> passed.

Current exact-head CI:

- GitHub checks for `f94bad3a5` are running. The previous `@klicker-uzh/util/response-example-digest` failure belongs to superseded head `69fcde69b`.

## Blocking Before Merge

- [ ] Required exact-head GitHub checks pass, including hosted Playwright and its aggregate.

## Follow-Up After Merge

None.

## Local Session Artifacts

Machine-local pointer for resuming this branch; it is not review evidence.

- Machine: `MacBook-Pro.local`
- Worktree: `trees/playwright-user-profile-race` in repository `klicker-uzh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for the scenario where a user profile cannot be loaded.
  * Verified that the application displays the appropriate analytics-unavailable state while the rest of the homepage remains accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->