### PR TITLE
ci(final-review): prefer tool-capable GLM providers

### DIFF
--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -461,6 +461,10 @@ function buildOCRPolicy() {
       model: FINAL_REVIEW_MODEL,
       protocol: 'openai',
       extra_body: {
+        provider: {
+          order: ['deepinfra', 'fireworks'],
+          allow_fallbacks: true,
+        },
         reasoning: {
           effort: 'high',
         },

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -388,6 +388,10 @@ test('writes an exact high-reasoning OCR config with mode 0600', () => {
   assert.deepEqual(config, buildOCRConfig({ token }))
   assert.equal(config.llm.model, FINAL_REVIEW_MODEL)
   assert.deepEqual(config.llm.extra_body, {
+    provider: {
+      order: ['deepinfra', 'fireworks'],
+      allow_fallbacks: true,
+    },
     reasoning: { effort: 'high' },
   })
   assert.equal(fs.statSync(configPath).mode & 0o777, 0o600)


### PR DESCRIPTION
## Summary

- Prefer the DeepInfra endpoint for GLM 5.3 Flash final reviews.
- Fall back to Fireworks before returning to OpenRouter's normal provider pool.
- Keep the existing model, high-reasoning policy, and fallback behavior.

## Why

Run 33250961277 proved that the OpenRouter key and plain completion preflight work, but all 25 tool-bearing OpenCodeReview requests returned immediate HTTP 404 responses. OpenRouter advertises DeepInfra and Fireworks endpoints for this model with tool support, so this keeps the same model and cost class while avoiding the failing default tool route.

## Verification

- node --test .github/scripts/final-ai-review.test.js .github/scripts/final-ai-stack-review.test.js (81 passed)
- pnpm exec prettier --check .github/scripts/final-ai-review.js .github/scripts/final-ai-review.test.js
- git diff --cached --check

## Risk and rollback

This changes only OpenRouter provider preference for the existing final-review model. Normal fallbacks remain enabled. Reverting this commit restores automatic provider selection.

## Follow-up proof

After this PR reaches v3, rerun /final-review-stack on PR 5619 and require the exact-head provider preflight, cumulative code review, topology review, and finalization to pass.
