### PR TITLE
fix(chat): use the AI SDK MCP HTTP transport

### DIFF
--- a/apps/chat/scripts/prd-direct-chat-canary.ts
+++ b/apps/chat/scripts/prd-direct-chat-canary.ts
@@ -1002,7 +1002,7 @@ export async function runProof(
   } catch {
     return result
   } finally {
-    for (const handle of handles.reverse()) {
+    for (const handle of handles.toReversed()) {
       await suppressOutput(() => handle.close())
     }
   }

--- a/apps/chat/scripts/prd-direct-chat-canary.ts
+++ b/apps/chat/scripts/prd-direct-chat-canary.ts
@@ -18,7 +18,10 @@ import {
   MAX_TOOL_NAME_LENGTH,
   TOOL_NAME_SUFFIX_LENGTH,
 } from '../src/lib/config/toolNames.js'
-import { getAggregatedMCPTools } from '../src/services/mcpClients.js'
+import {
+  getAggregatedMCPTools,
+  type MCPToolsHandle,
+} from '../src/services/mcpClients.js'
 
 const SERVER_NAME = 'Klicker-compat' as const
 const CHAT_MODE = 'tutor' as const
@@ -881,7 +884,7 @@ function isSuccessfulToolResult(value: unknown): boolean {
   )
 }
 
-async function runProof(
+export async function runProof(
   proofUrl: string,
   candidateServer: any,
   chatbotId: string,
@@ -903,13 +906,16 @@ async function runProof(
     wrongTenant: 'failed',
     eduaiRoute: 'failed',
   }
+  const handles: MCPToolsHandle[] = []
 
   try {
-    const tools = await suppressOutput(() =>
+    const handle = await suppressOutput(() =>
       getAggregatedMCPTools([direct], chatbotId, {
         requestTimeoutMs: REQUEST_TIMEOUT_MS,
       })
     )
+    handles.push(handle)
+    const { tools } = handle
     const names = Object.keys(tools).sort((left, right) =>
       left.localeCompare(right)
     )
@@ -939,7 +945,7 @@ async function runProof(
     if (!isSuccessfulToolResult(retrieval)) return result
     result.retrieval = 'passed'
 
-    const wrong = await suppressOutput(() =>
+    const wrongHandle = await suppressOutput(() =>
       getAggregatedMCPTools(
         [
           {
@@ -954,25 +960,29 @@ async function runProof(
         { requestTimeoutMs: REQUEST_TIMEOUT_MS }
       )
     )
-    result.wrongBearer = Object.keys(wrong).length === 0 ? 'passed' : 'failed'
+    handles.push(wrongHandle)
+    result.wrongBearer =
+      Object.keys(wrongHandle.tools).length === 0 ? 'passed' : 'failed'
 
-    const missing = await suppressOutput(() =>
+    const missingHandle = await suppressOutput(() =>
       getAggregatedMCPTools(
         [{ ...direct, server: { ...direct.server, authSecret: undefined } }],
         chatbotId,
         { requestTimeoutMs: REQUEST_TIMEOUT_MS }
       )
     )
+    handles.push(missingHandle)
     result.missingBearer =
-      Object.keys(missing).length === 0 ? 'passed' : 'failed'
+      Object.keys(missingHandle.tools).length === 0 ? 'passed' : 'failed'
 
-    const wrongTenant = await suppressOutput(() =>
+    const wrongTenantHandle = await suppressOutput(() =>
       getAggregatedMCPTools([direct], randomUUID(), {
         requestTimeoutMs: REQUEST_TIMEOUT_MS,
       })
     )
+    handles.push(wrongTenantHandle)
     result.wrongTenant =
-      Object.keys(wrongTenant).length === 0 ? 'passed' : 'failed'
+      Object.keys(wrongTenantHandle.tools).length === 0 ? 'passed' : 'failed'
 
     const eduaiUrl = proofUrl.replace(/\/mcp\/klicker\/?$/, '/mcp/eduai')
     const eduaiStatus = await fixedRouteStatus(eduaiUrl)
@@ -991,6 +1001,10 @@ async function runProof(
     return result
   } catch {
     return result
+  } finally {
+    for (const handle of handles.reverse()) {
+      await suppressOutput(() => handle.close())
+    }
   }
 }
 

--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -46,6 +46,7 @@ import { DisclaimersService } from '@/src/services/disclaimers'
 import {
   getAggregatedMCPTools,
   type MCPServerWithConfig,
+  type MCPToolsHandle,
 } from '@/src/services/mcpClients'
 import { resolveMcpScopeSessionId } from '@/src/services/mcpScope'
 import {
@@ -1078,6 +1079,13 @@ export async function POST(
   }
 
   let providerStreamStarted = false
+  let mcpToolsHandle: MCPToolsHandle | undefined
+  const closeMcpTools = async () => {
+    const activeHandle = mcpToolsHandle
+    mcpToolsHandle = undefined
+    await activeHandle?.close()
+  }
+
   try {
     // Discover MCP tools only after read-only participant authorization.
     const mcpScopeSessionId = resolveMcpScopeSessionId({
@@ -1092,13 +1100,14 @@ export async function POST(
 
     let mcpTools: ToolSet
     try {
-      mcpTools = await getAggregatedMCPTools(mcpServersWithConfigs, {
+      mcpToolsHandle = await getAggregatedMCPTools(mcpServersWithConfigs, {
         chatbotId,
         participantId,
         authMode,
         kbId: enabledKnowledgeBaseId,
         sessionId: mcpScopeSessionId,
       })
+      mcpTools = mcpToolsHandle.tools
     } catch (error) {
       if (error instanceof RequiredMCPUnavailableError) {
         await failOrDiscardUnstartedClaim('mcp.discovery')
@@ -1723,6 +1732,7 @@ export async function POST(
         },
 
         onEnd: async (result) => {
+          await closeMcpTools()
           sawFinish = true
           // ai@7 still flushes onEnd after an abort once at least one step
           // completed. onAbort already persisted the partial answer and charged
@@ -1813,6 +1823,7 @@ export async function POST(
         },
 
         onAbort: async (steps) => {
+          await closeMcpTools()
           sawAbort = true
           let rawCreditsUsed: number | null = null
           if (steps && Array.isArray(steps.steps)) {
@@ -1906,6 +1917,7 @@ export async function POST(
         },
 
         onError: async (error) => {
+          await closeMcpTools()
           const serializedError = serializeStreamError(error)
           firstError = firstError ?? serializedError
           const classification = classifyStreamError(serializedError)
@@ -1954,6 +1966,7 @@ export async function POST(
       sendReasoning: true,
       consumeSseStream: consumeStream,
       onError: (error) => {
+        void closeMcpTools()
         const serializedError = serializeStreamError(error)
         const classification = classifyStreamError(serializedError)
 
@@ -1996,6 +2009,7 @@ export async function POST(
       },
     })
   } catch (error) {
+    await closeMcpTools()
     if (providerStreamStarted) await failAssistantClaim('request')
     else await failOrDiscardUnstartedClaim('request')
     throw error

--- a/apps/chat/src/services/mcpClients.ts
+++ b/apps/chat/src/services/mcpClients.ts
@@ -586,7 +586,7 @@ export async function getMCPTools(
   chatbotId: string,
   participantId: string,
   authMode: AuthMode
-) {
+): Promise<MCPToolsHandle> {
   console.log(' Using legacy MCP configuration from environment variables')
 
   const mcpKey = process.env.MCP_KEY
@@ -594,7 +594,7 @@ export async function getMCPTools(
 
   if (!mcpUrl) {
     console.log('No MCP_URL environment variable found, returning empty tools')
-    return {}
+    return { tools: {}, close: async () => {} }
   }
 
   // Create a legacy server configuration

--- a/apps/chat/src/services/mcpClients.ts
+++ b/apps/chat/src/services/mcpClients.ts
@@ -3,7 +3,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { experimental_createMCPClient as createSDKMCPClient } from '@ai-sdk/mcp'
 import { safeDecrypt } from '@klicker-uzh/util'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import {
   MAX_TOOL_NAME_LENGTH,
   TOOL_NAME_SUFFIX_LENGTH,
@@ -346,21 +345,16 @@ export async function createMCPClient(
   try {
     const headers = await createAuthHeaders(server, context)
 
-    const httpTransport = new StreamableHTTPClientTransport(
-      new URL(server.url),
-      {
-        requestInit: {
-          headers,
-          redirect: 'error',
-          ...(options.requestTimeoutMs !== undefined
-            ? { signal: AbortSignal.timeout(options.requestTimeoutMs) }
-            : {}),
-        },
-      }
-    )
-
     const client = await createSDKMCPClient({
-      transport: httpTransport,
+      transport: {
+        type: 'http',
+        url: server.url,
+        headers,
+        redirect: 'error',
+      },
+      ...(options.requestTimeoutMs !== undefined
+        ? { initializationOptions: { timeout: options.requestTimeoutMs } }
+        : {}),
     })
 
     console.log(`MCP Client for ${server.name} initialized successfully`)

--- a/apps/chat/src/services/mcpClients.ts
+++ b/apps/chat/src/services/mcpClients.ts
@@ -55,6 +55,11 @@ export interface MCPRequestOptions {
   requestTimeoutMs?: number
 }
 
+export interface MCPToolsHandle {
+  tools: Record<string, any>
+  close: () => Promise<void>
+}
+
 const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
 const DOC_QUERY_SCOPE_HEADER_PREFIX = 'x-doc-query-'
 const RESERVED_DOC_QUERY_SCOPE_HEADERS = new Set([
@@ -395,10 +400,26 @@ async function loadServerTools(
   serverWithConfig: MCPServerWithConfig,
   context: MCPRequestContext,
   options: MCPRequestOptions
-): Promise<Record<string, any>> {
+): Promise<MCPToolsHandle> {
   const { server, config } = serverWithConfig
   const runtimePolicy = parseMCPRuntimePolicy(config.parameters)
   let requiredRawToolName: string | undefined
+  let client: Awaited<ReturnType<typeof createMCPClient>> | undefined
+
+  const close = async () => {
+    const activeClient = client
+    client = undefined
+    if (!activeClient) return
+
+    try {
+      await activeClient.close()
+    } catch (error) {
+      console.warn('Failed to close MCP client', {
+        server: server.name,
+        errorType: error instanceof Error ? error.name : typeof error,
+      })
+    }
+  }
 
   if (runtimePolicy.required) {
     const configuredTool = config.allowedTools?.[0]
@@ -418,11 +439,11 @@ async function loadServerTools(
     if (runtimePolicy.required) {
       throw new RequiredMCPUnavailableError()
     }
-    return {}
+    return { tools: {}, close }
   }
 
   try {
-    const client = await createMCPClient(server, context, options)
+    client = await createMCPClient(server, context, options)
     const rawTools = await client.tools()
 
     if (runtimePolicy.required && requiredRawToolName) {
@@ -463,8 +484,9 @@ async function loadServerTools(
     console.log(
       `Loaded ${Object.keys(filteredTools).length} tools from ${server.name}`
     )
-    return filteredTools
+    return { tools: filteredTools, close }
   } catch (error) {
+    await close()
     if (
       error instanceof RequiredMCPUnavailableError ||
       runtimePolicy.required
@@ -475,7 +497,7 @@ async function loadServerTools(
 
     console.error('Optional MCP tools unavailable', { server: server.name })
     // Return empty object to allow other servers to continue loading
-    return {}
+    return { tools: {}, close }
   }
 }
 
@@ -487,7 +509,7 @@ export async function getAggregatedMCPTools(
   contextOrChatbotId: MCPRequestContext | string,
   participantIdOrOptions: string | MCPRequestOptions = '',
   authMode: AuthMode = 'account'
-): Promise<Record<string, any>> {
+): Promise<MCPToolsHandle> {
   console.log(`Loading MCP Tools from ${serversWithConfigs.length} servers...`)
 
   const { context, options } = normalizeMCPRequest(
@@ -498,7 +520,7 @@ export async function getAggregatedMCPTools(
 
   if (serversWithConfigs.length === 0) {
     console.log('No MCP servers configured')
-    return {}
+    return { tools: {}, close: async () => {} }
   }
 
   // Sort by priority (lower number = higher priority)
@@ -508,19 +530,29 @@ export async function getAggregatedMCPTools(
 
   const aggregatedTools: Record<string, any> = {}
   const requiredToolNames = new Set<string>()
+  const serverHandles: MCPToolsHandle[] = []
+
+  let closePromise: Promise<void> | undefined
+  const close = () => {
+    closePromise ??= Promise.all(
+      serverHandles.map((handle) => handle.close())
+    ).then(() => undefined)
+    return closePromise
+  }
 
   // Load tools from each server in priority order
   for (const serverWithConfig of sortedServers) {
     try {
-      const serverTools = await loadServerTools(
+      const serverHandle = await loadServerTools(
         serverWithConfig,
         context,
         options
       )
+      serverHandles.push(serverHandle)
       const runtimePolicy = parseMCPRuntimePolicy(
         serverWithConfig.config.parameters
       )
-      for (const [name, def] of Object.entries(serverTools)) {
+      for (const [name, def] of Object.entries(serverHandle.tools)) {
         if (!(name in aggregatedTools)) {
           aggregatedTools[name] = def
           if (runtimePolicy.required) requiredToolNames.add(name)
@@ -529,7 +561,10 @@ export async function getAggregatedMCPTools(
         }
       }
     } catch (error) {
-      if (error instanceof RequiredMCPUnavailableError) throw error
+      if (error instanceof RequiredMCPUnavailableError) {
+        await close()
+        throw error
+      }
 
       console.error(
         `Failed to load tools from ${serverWithConfig.server.name}, continuing with other servers`
@@ -540,7 +575,7 @@ export async function getAggregatedMCPTools(
   console.log(`Total aggregated tools: ${Object.keys(aggregatedTools).length}`)
   console.log('Available tools:', Object.keys(aggregatedTools))
 
-  return aggregatedTools
+  return { tools: aggregatedTools, close }
 }
 
 /**
@@ -577,14 +612,14 @@ export async function getMCPTools(
   }
 
   try {
-    const serverTools = await loadServerTools(
+    const serverHandle = await loadServerTools(
       { server: legacyServer, config: legacyConfig },
       { chatbotId, participantId, authMode },
       {}
     )
-    return serverTools
+    return serverHandle
   } catch (error) {
     console.error('Failed to load legacy MCP Tools:', error)
-    return {}
+    return { tools: {}, close: async () => {} }
   }
 }

--- a/apps/chat/test/account-usage-route.test.ts
+++ b/apps/chat/test/account-usage-route.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   threadUpdate: vi.fn(),
   transaction: vi.fn(),
   getAggregatedMCPTools: vi.fn(),
+  closeMCPTools: vi.fn(),
   createThread: vi.fn(),
   findFailedTurnThreadId: vi.fn(),
   deleteThread: vi.fn(),
@@ -234,7 +235,10 @@ describe('account usage chat route', () => {
       accepted: true,
     })
     mocks.chatbotFindUnique.mockResolvedValue(chatbot())
-    mocks.getAggregatedMCPTools.mockResolvedValue({})
+    mocks.getAggregatedMCPTools.mockResolvedValue({
+      tools: {},
+      close: mocks.closeMCPTools,
+    })
     mocks.claimChatTurn.mockResolvedValue({
       outcome: 'claimed',
       lifecycleAttemptId: '00000000-0000-4000-8000-000000000001',
@@ -523,6 +527,7 @@ describe('account usage chat route', () => {
     }
     await streamCallbacks().onEnd(result)
 
+    expect(mocks.closeMCPTools).toHaveBeenCalledOnce()
     expect(mocks.finalizeChatTurn).toHaveBeenCalledOnce()
     expect(mocks.finalizeChatTurn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -657,6 +662,7 @@ describe('account usage chat route', () => {
       })
     ).resolves.toBeUndefined()
 
+    expect(mocks.closeMCPTools).toHaveBeenCalledOnce()
     expect(mocks.finalizeChatTurn).toHaveBeenCalledWith(
       expect.objectContaining({ rawCreditsUsed: null })
     )
@@ -740,6 +746,7 @@ describe('account usage chat route', () => {
       steps,
     })
 
+    expect(mocks.closeMCPTools).toHaveBeenCalledOnce()
     expect(mocks.finalizeChatTurn).toHaveBeenCalledOnce()
     expect(mocks.finalizeChatTurn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -760,6 +767,7 @@ describe('account usage chat route', () => {
 
     await streamCallbacks().onError(new Error('synthetic provider failure'))
 
+    expect(mocks.closeMCPTools).toHaveBeenCalledOnce()
     expect(mocks.failChatTurn).toHaveBeenCalledWith({
       assistantMessageId: 'assistant-1',
       threadId: 'thread-1',

--- a/apps/chat/test/mcp-clients.test.ts
+++ b/apps/chat/test/mcp-clients.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const createSDKMCPClientMock = vi.hoisted(() => vi.fn())
+const signDocQueryScopeTokenMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@ai-sdk/mcp', () => ({
   experimental_createMCPClient: createSDKMCPClientMock,
+}))
+
+vi.mock('@/src/lib/server/docQueryScopeToken', () => ({
+  signDocQueryScopeToken: signDocQueryScopeTokenMock,
 }))
 
 vi.mock('@klicker-uzh/util', () => ({
@@ -49,6 +54,7 @@ function setTools(rawTools: Record<string, unknown>) {
 describe('MCP runtime policy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    signDocQueryScopeTokenMock.mockResolvedValue('scope-token')
   })
 
   test('keeps configs without reserved policy keys optional', () => {
@@ -74,6 +80,81 @@ describe('MCP runtime policy', () => {
         redirect: 'error',
       },
       initializationOptions: { timeout: 1_000 },
+    })
+  })
+
+  test('passes authentication headers through the AI SDK transport', async () => {
+    setTools({ search_docs: { description: 'search' } })
+
+    await getAggregatedMCPTools(
+      [
+        createServer({
+          authType: 'bearer',
+          authSecret: 'transport-token',
+        }),
+      ],
+      { chatbotId: 'chatbot-1', authMode: 'account' }
+    )
+    await getAggregatedMCPTools(
+      [
+        createServer({
+          authType: 'custom',
+          authSecret: JSON.stringify({
+            headers: { 'X-Custom-Auth': 'custom-token' },
+          }),
+        }),
+      ],
+      { chatbotId: 'chatbot-1', authMode: 'account' }
+    )
+    await getAggregatedMCPTools(
+      [
+        createServer({
+          name: 'KB',
+          authType: 'scope_token',
+          authSecret: 'transport-token',
+        }),
+      ],
+      {
+        chatbotId: 'chatbot-1',
+        authMode: 'account',
+        kbId: 'kb-1',
+        sessionId: 'session-1',
+      }
+    )
+
+    expect(createSDKMCPClientMock).toHaveBeenNthCalledWith(1, {
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.test',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer transport-token',
+        },
+        redirect: 'error',
+      },
+    })
+    expect(createSDKMCPClientMock).toHaveBeenNthCalledWith(2, {
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.test',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Custom-Auth': 'custom-token',
+        },
+        redirect: 'error',
+      },
+    })
+    expect(createSDKMCPClientMock).toHaveBeenNthCalledWith(3, {
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.test',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer transport-token',
+          'X-Doc-Query-Scope-Token': 'Bearer scope-token',
+        },
+        redirect: 'error',
+      },
     })
   })
 

--- a/apps/chat/test/mcp-clients.test.ts
+++ b/apps/chat/test/mcp-clients.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const createSDKMCPClientMock = vi.hoisted(() => vi.fn())
+const closeSDKMCPClientMock = vi.hoisted(() => vi.fn())
 const signDocQueryScopeTokenMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@ai-sdk/mcp', () => ({
@@ -21,9 +22,21 @@ import {
 } from '../src/lib/server/mcpRuntimePolicy'
 import { isDocQueryToolName } from '../src/lib/sources/normalizeSources'
 import {
-  getAggregatedMCPTools,
+  getAggregatedMCPTools as getAggregatedMCPToolsHandle,
   type MCPServerWithConfig,
 } from '../src/services/mcpClients'
+
+const openHandles: Array<
+  Awaited<ReturnType<typeof getAggregatedMCPToolsHandle>>
+> = []
+
+async function getAggregatedMCPTools(
+  ...args: Parameters<typeof getAggregatedMCPToolsHandle>
+) {
+  const handle = await getAggregatedMCPToolsHandle(...args)
+  openHandles.push(handle)
+  return handle.tools
+}
 
 function createServer(
   overrides: Partial<MCPServerWithConfig['server']> = {},
@@ -47,6 +60,7 @@ function createServer(
 
 function setTools(rawTools: Record<string, unknown>) {
   createSDKMCPClientMock.mockResolvedValue({
+    close: closeSDKMCPClientMock,
     tools: vi.fn().mockResolvedValue(rawTools),
   })
 }
@@ -55,6 +69,10 @@ describe('MCP runtime policy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     signDocQueryScopeTokenMock.mockResolvedValue('scope-token')
+  })
+
+  afterEach(async () => {
+    await Promise.all(openHandles.splice(0).map((handle) => handle.close()))
   })
 
   test('keeps configs without reserved policy keys optional', () => {
@@ -156,6 +174,41 @@ describe('MCP runtime policy', () => {
         redirect: 'error',
       },
     })
+  })
+
+  test('returns an idempotent cleanup handle for every created client', async () => {
+    setTools({ search_docs: { description: 'search' } })
+
+    const handle = await getAggregatedMCPToolsHandle(
+      [createServer(), createServer({ id: 'server-2', name: 'Second' })],
+      { chatbotId: 'chatbot-1', authMode: 'account' }
+    )
+
+    expect(Object.keys(handle.tools)).toEqual([
+      'IW_search_docs',
+      'Second_search_docs',
+    ])
+    await handle.close()
+    await handle.close()
+
+    expect(closeSDKMCPClientMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('closes a client when tool discovery fails', async () => {
+    createSDKMCPClientMock.mockResolvedValue({
+      close: closeSDKMCPClientMock,
+      tools: vi.fn().mockRejectedValue(new Error('discovery failed')),
+    })
+
+    const handle = await getAggregatedMCPToolsHandle([createServer()], {
+      chatbotId: 'chatbot-1',
+      authMode: 'account',
+    })
+
+    expect(handle.tools).toEqual({})
+    expect(closeSDKMCPClientMock).toHaveBeenCalledTimes(1)
+    await handle.close()
+    expect(closeSDKMCPClientMock).toHaveBeenCalledTimes(1)
   })
 
   test('requires one exact aliased tool for strict configs', async () => {
@@ -342,9 +395,11 @@ describe('MCP runtime policy', () => {
 
     createSDKMCPClientMock
       .mockResolvedValueOnce({
+        close: closeSDKMCPClientMock,
         tools: vi.fn().mockResolvedValue({ doc_query: {} }),
       })
       .mockResolvedValueOnce({
+        close: closeSDKMCPClientMock,
         tools: vi.fn().mockResolvedValue({ video_expert: {} }),
       })
     await expect(
@@ -359,9 +414,11 @@ describe('MCP runtime policy', () => {
     required.config.priority = 0
     createSDKMCPClientMock
       .mockResolvedValueOnce({
+        close: closeSDKMCPClientMock,
         tools: vi.fn().mockResolvedValue({ video_expert: {} }),
       })
       .mockResolvedValueOnce({
+        close: closeSDKMCPClientMock,
         tools: vi.fn().mockResolvedValue({ doc_query: {} }),
       })
     await expect(

--- a/apps/chat/test/mcp-clients.test.ts
+++ b/apps/chat/test/mcp-clients.test.ts
@@ -23,6 +23,7 @@ import {
 import { isDocQueryToolName } from '../src/lib/sources/normalizeSources'
 import {
   getAggregatedMCPTools as getAggregatedMCPToolsHandle,
+  getMCPTools,
   type MCPServerWithConfig,
 } from '../src/services/mcpClients'
 
@@ -73,12 +74,22 @@ describe('MCP runtime policy', () => {
 
   afterEach(async () => {
     await Promise.all(openHandles.splice(0).map((handle) => handle.close()))
+    vi.unstubAllEnvs()
   })
 
   test('keeps configs without reserved policy keys optional', () => {
     expect(parseMCPRuntimePolicy({ timeoutMs: 1000 })).toEqual({
       required: false,
     })
+  })
+
+  test('returns an empty cleanup handle when legacy MCP is not configured', async () => {
+    vi.stubEnv('MCP_URL', '')
+
+    const handle = await getMCPTools('chatbot-1', 'participant-1', 'account')
+
+    expect(handle.tools).toEqual({})
+    await expect(handle.close()).resolves.toBeUndefined()
   })
 
   test('uses the AI SDK HTTP transport configuration', async () => {

--- a/apps/chat/test/mcp-clients.test.ts
+++ b/apps/chat/test/mcp-clients.test.ts
@@ -10,15 +10,6 @@ vi.mock('@klicker-uzh/util', () => ({
   safeDecrypt: (value: string) => value,
 }))
 
-vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
-  StreamableHTTPClientTransport: class {
-    constructor(
-      readonly url: URL,
-      readonly options: { requestInit: { headers: Record<string, string> } }
-    ) {}
-  },
-}))
-
 import {
   parseMCPRuntimePolicy,
   REQUIRED_MCP_UNAVAILABLE_CODE,
@@ -63,6 +54,26 @@ describe('MCP runtime policy', () => {
   test('keeps configs without reserved policy keys optional', () => {
     expect(parseMCPRuntimePolicy({ timeoutMs: 1000 })).toEqual({
       required: false,
+    })
+  })
+
+  test('uses the AI SDK HTTP transport configuration', async () => {
+    setTools({ search_docs: { description: 'search' } })
+
+    await getAggregatedMCPTools(
+      [createServer()],
+      { chatbotId: 'chatbot-1', authMode: 'account' },
+      { requestTimeoutMs: 1_000 }
+    )
+
+    expect(createSDKMCPClientMock).toHaveBeenCalledWith({
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.test',
+        headers: { 'Content-Type': 'application/json' },
+        redirect: 'error',
+      },
+      initializationOptions: { timeout: 1_000 },
     })
   })
 

--- a/apps/chat/test/mcp-compat-canary.test.ts
+++ b/apps/chat/test/mcp-compat-canary.test.ts
@@ -509,6 +509,7 @@ function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
 describe('direct Prisma-shaped Chat MCP consumer', () => {
   let server: ReturnType<typeof createServer>
   let candidateUrl: string
+  let deleteRequestCount = 0
 
   beforeAll(async () => {
     process.env.APP_SECRET = APP_SECRET
@@ -526,6 +527,11 @@ describe('direct Prisma-shaped Chat MCP consumer', () => {
           return
         }
 
+        if (request.method === 'DELETE') {
+          deleteRequestCount += 1
+          response.writeHead(405).end()
+          return
+        }
         if (request.method === 'GET') {
           response.writeHead(405).end()
           return
@@ -620,23 +626,28 @@ describe('direct Prisma-shaped Chat MCP consumer', () => {
       },
     }
 
-    const tools = await getAggregatedMCPTools([directConfig], CHATBOT_ID)
-    expect(Object.keys(tools)).toEqual(['Klicker-compat_doc_query'])
-    const tool = tools['Klicker-compat_doc_query'] as {
-      execute?: (input: { query: string }) => Promise<unknown>
+    const handle = await getAggregatedMCPTools([directConfig], CHATBOT_ID)
+    try {
+      expect(Object.keys(handle.tools)).toEqual(['Klicker-compat_doc_query'])
+      const tool = handle.tools['Klicker-compat_doc_query'] as {
+        execute?: (input: { query: string }) => Promise<unknown>
+      }
+      await expect(
+        tool.execute?.({ query: 'synthetic query' })
+      ).resolves.toMatchObject({
+        content: [
+          {
+            type: 'text',
+            text: expect.stringContaining('Synthetic canary source'),
+          },
+        ],
+      })
+    } finally {
+      await handle.close()
     }
-    await expect(
-      tool.execute?.({ query: 'synthetic query' })
-    ).resolves.toMatchObject({
-      content: [
-        {
-          type: 'text',
-          text: expect.stringContaining('Synthetic canary source'),
-        },
-      ],
-    })
+    expect(deleteRequestCount).toBe(1)
 
-    const wrongBearer = await getAggregatedMCPTools(
+    const wrongBearerHandle = await getAggregatedMCPTools(
       [
         {
           ...directConfig,
@@ -648,9 +659,10 @@ describe('direct Prisma-shaped Chat MCP consumer', () => {
       ],
       CHATBOT_ID
     )
-    expect(wrongBearer).toEqual({})
+    expect(wrongBearerHandle.tools).toEqual({})
+    await wrongBearerHandle.close()
 
-    const missingBearer = await getAggregatedMCPTools(
+    const missingBearerHandle = await getAggregatedMCPTools(
       [
         {
           ...directConfig,
@@ -659,12 +671,14 @@ describe('direct Prisma-shaped Chat MCP consumer', () => {
       ],
       CHATBOT_ID
     )
-    expect(missingBearer).toEqual({})
+    expect(missingBearerHandle.tools).toEqual({})
+    await missingBearerHandle.close()
 
-    const wrongTenant = await getAggregatedMCPTools(
+    const wrongTenantHandle = await getAggregatedMCPTools(
       [directConfig],
       'wrong-chatbot'
     )
-    expect(wrongTenant).toEqual({})
+    expect(wrongTenantHandle.tools).toEqual({})
+    await wrongTenantHandle.close()
   })
 })

--- a/apps/chat/test/prd-direct-chat-canary.test.ts
+++ b/apps/chat/test/prd-direct-chat-canary.test.ts
@@ -3,11 +3,19 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 import { describe, expect, test, vi } from 'vitest'
+
+const getAggregatedMCPToolsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../src/services/mcpClients.js', () => ({
+  getAggregatedMCPTools: getAggregatedMCPToolsMock,
+}))
+
 import {
   classifyExpectedToolInventory,
   createReceiptStore,
   initialReceipt,
   probeFixedRoute,
+  runProof,
   runDirectChatCanaryTransaction,
   safeResult,
   suppressOutput,
@@ -96,6 +104,87 @@ test('counts the hashed long chunk-topic name as a chunk twin', () => {
     missingToolCount: 1,
     unexpectedToolCount: 1,
   })
+})
+
+test('uses and closes every aggregated MCP tools handle during proof', async () => {
+  const expertNames = [
+    'banking_expert',
+    'bf1_expert',
+    'cf1_expert',
+    'mat141_expert',
+    'mat182_expert',
+    'python_and_r_expert',
+    'fs26_intro_r_expert',
+    'bio144_expert',
+    'df_ap_expert',
+    'df_bf2_expert',
+    'df_cf2_expert',
+    'df_fineco_expert',
+    'df_qf_expert',
+    'mat183_expert',
+    'vorkurs_expert',
+    'informatik_und_wirtschaft_video_expert',
+    'radiosurfvet_expert',
+  ]
+  const names = [
+    ...expertNames.map((name) => `Klicker-compat_${name}`),
+    ...expertNames
+      .filter((name) => name !== 'informatik_und_wirtschaft_video_expert')
+      .map((name) => `Klicker-compat_${name}_chunk_topics`),
+    'Klicker-compat_informatik_und_wirtschaft_video_expert_c_246cf369',
+  ]
+  const tools = Object.fromEntries(
+    names.map((name) => [
+      name,
+      {
+        execute: vi.fn(async () => ({
+          content: [{ type: 'text', text: 'synthetic proof result' }],
+        })),
+      },
+    ])
+  )
+  const close = Array.from({ length: 4 }, () => vi.fn(async () => {}))
+  getAggregatedMCPToolsMock
+    .mockResolvedValueOnce({ tools, close: close[0] })
+    .mockResolvedValueOnce({ tools: {}, close: close[1] })
+    .mockResolvedValueOnce({ tools: {}, close: close[2] })
+    .mockResolvedValueOnce({ tools: {}, close: close[3] })
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(null, { status: 404 }))
+  )
+  vi.stubEnv('APP_SECRET', 'synthetic-app-secret-for-test')
+
+  try {
+    await expect(
+      runProof(
+        'http://127.0.0.1:1417/mcp/klicker',
+        {
+          id: 'candidate-server',
+          name: 'Klicker-compat',
+          authType: 'bearer',
+          authSecret: 'synthetic',
+          isActive: true,
+        },
+        'chatbot-id',
+        'synthetic'
+      )
+    ).resolves.toMatchObject({
+      status: 'passed',
+      toolCount: 34,
+      pairCount: 17,
+      retrieval: 'passed',
+      wrongBearer: 'passed',
+      missingBearer: 'passed',
+      wrongTenant: 'passed',
+      eduaiRoute: 'passed',
+    })
+    expect(getAggregatedMCPToolsMock).toHaveBeenCalledTimes(4)
+    close.forEach((closeClient) => expect(closeClient).toHaveBeenCalledOnce())
+  } finally {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  }
 })
 
 type FakeRow = Record<string, any>


### PR DESCRIPTION
## What This Fixes

The Chat service created a Model Context Protocol SDK `StreamableHTTPClientTransport` and passed that instance to `@ai-sdk/mcp`. The AI SDK expects its own transport configuration, so MCP initialization could complete without exposing the configured document-query tools.

This PR:

1. Uses the AI SDK-native HTTP transport configuration for every configured MCP server.
2. Preserves bearer, custom, and scoped Doc Query authentication headers.
3. Preserves the configured initialization timeout and rejects redirects so credentials are not forwarded to another origin.
4. Owns every created MCP client until stream completion, abort, or failure, then closes it exactly once.
5. Migrates the operational direct-chat canary and legacy fallback to the same explicit tools-handle contract.
6. Adds focused unit, route, operational-canary, and real-SDK regression coverage for transport, authentication, and lifecycle behavior.

## How It Works

`createMCPClient` now passes `{ type: 'http', url, headers, redirect: 'error' }` directly to `experimental_createMCPClient`. A configured request timeout is mapped to the AI SDK's `initializationOptions.timeout`.

Aggregation returns an explicit handle containing the generated tools and an idempotent cleanup function. The participant chat route closes that handle after normal completion, abort, provider failure, response-stream failure, or synchronous setup failure. Discovery and required-tool failures close any clients before they return.

The existing required-tool policy, aliases, and fail-closed behavior remain unchanged.

## Branch Coverage

- Base: `v3-ai@bedc6a855`
- Head: `c31745ac9`
- Reviewed: 5 commits and 7 changed files
- Substantive size: 474 changed lines across 7 source and test files (401 additions and 73 deletions); there are no lockfile, generated, or project-artifact changes
- Covered: AI SDK transport compatibility, initialization timeout, bearer/custom/scoped Doc Query authentication headers, redirect handling, explicit client ownership, terminal-stream cleanup, discovery-failure cleanup, operational-canary cleanup, legacy fallback compatibility, and focused regression tests
- Package boundary: one independently functional and reviewable Chat transport fix with no course provisioning, database, migration, dependency, deployment-configuration, or course-specific artifact change

## Review Focus

- Confirm the transport object matches the `@ai-sdk/mcp` HTTP transport contract.
- Confirm authentication headers remain scoped to the configured MCP URL and redirects fail closed.
- Confirm `requestTimeoutMs` retains its initialization-timeout behavior.
- Confirm every created client is closed once after normal, aborted, and failed turns without closing before tool execution completes.
- Confirm the branch contains generalized Chat behavior only and no course provisioning logic.

## Verification

Exact committed head:

- Five focused MCP, chat-route, and operational-canary suites under Node 24.16.0 and pnpm 11.5.0 -> 62/62 passed.
- The focused operational-canary suite after replacing mutating `reverse()` with `toReversed()` for Sonar rule `typescript:S4043` -> 14/14 passed.
- The real `@ai-sdk/mcp` 2.0.25 canary discovered and called an HTTP tool, then observed the session-close request.
- `pnpm --dir apps/chat run check` under Node 24.16.0 and pnpm 11.5.0 -> `next typegen && tsc --noEmit` passed.
- Commit hook -> all 29 configured tasks passed.
- Pre-push workspace build -> all 26 configured package builds passed.
- Staged gitleaks scan -> no leaks found.
- `git diff --check origin/v3-ai...HEAD` -> passed.
- GitHub exact-head CI -> code, unit, CodeQL, Sonar with zero new issues, gitleaks, Chat ARM image, all eight Playwright shards, and the Playwright aggregate passed.
- The `final-ai-review` context is inapplicable because `v3-ai` is neither the default branch nor a verified native stack member; its `trusted_policy` check passed.
- Integrated final review -> the initial lifecycle finding and correction-pass operational-canary and legacy-shape findings are corrected. The mechanical correction-pass follow-ups were closed by exhaustive caller inspection and exact-head tests under the workflow's one-correction-pass limit.

Not run:

- Live retrieval is pending the normal staging build, promotion, and Argo rollout after merge. The staging chatbot remains paused until the deployed revision is verified.

## Security / Privacy

- Authentication headers remain inside the AI SDK transport configuration, and `redirect: 'error'` prevents redirect-based credential forwarding.
- Focused tests cover bearer, custom, and scoped Doc Query header propagation.
- MCP clients are closed after terminal stream states and setup failures, preventing retained HTTP/SSE sessions.
- No secret values, personal data, production payloads, new provider, permission change, or course-specific content is included.

## Blocking Before Merge

- [x] Exact-head GitHub CI and applicable repository review checks passed.

## Follow-Up After Merge

- [ ] Verify the staging Chat workload runs the promoted revision.
- [ ] Republish the existing paused staging chatbot without rotating its join credential.
- [ ] Run one participant retrieval turn and require a document-query call plus visible source evidence; pause the chatbot again if retrieval fails.

## Local Session Artifacts

Machine-local pointer for resuming this branch; it is not review evidence.

- Machine: local development host (Codex desktop)
- Worktree: `trees/vorkurs2-chatbot-provisioner` in repository `klicker-uzh`
- Review receipt: `project/_local/reviews/2026-08-29-chat-mcp-http-final.md` in that worktree
