### PR TITLE
fix(devcontainer): use one validated workspace root

### DIFF
--- a/.agents/skills/devrouter/SKILL.md
+++ b/.agents/skills/devrouter/SKILL.md
@@ -322,6 +322,7 @@ For host/docker runtime apps only:
 ## Runtime behavior notes
 
 - Managed devcontainer images contain no devrouter package or helper. `devrouter ensure` delivers its matching process helper to the exact running container and invokes the repository-owned `.devcontainer/post-start.sh`; keep `.devrouter.yml` as the only consumer-side devrouter version pin.
+- Repository lifecycle hooks must canonicalize `KLICKER_DEVCONTAINER_ROOT` once and use that root for every repository-local path. Post-create must invalidate its completion marker before validating the configured root, and post-start must gate and start the same root.
 - `devrouter app run` auto-starts Docker dependencies and waits for health. Host app runs stop auto-started docker deps on exit; docker app runs leave target services running until explicit cleanup.
 - Host-runtime dependencies are NOT auto-started (v1).
 - `kind=dependency` entries do not create routes and cannot be direct targets for `devrouter app run`, `devrouter app exec`, or `devrouter open`.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,11 +2,13 @@
 # Runs once when the dev container is created. Installs deps, builds the
 # workspace packages the apps import, prepares the DB, and picks up the Hatchet
 # token. Every routed app plus the two Hatchet workers.
-ROOT="${KLICKER_DEVCONTAINER_ROOT:-/workspaces/klicker-uzh}"
-ROOT="$(cd "$ROOT" && pwd)" || exit 1
-HATCHET_TOKEN_FILE="${KLICKER_HATCHET_TOKEN_FILE:-/config/authdisabled-token}"
 set -euo pipefail
-bash "$ROOT/util/dev-runtime.sh" begin-bootstrap
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bash "$SCRIPT_ROOT/util/dev-runtime.sh" begin-bootstrap
+
+ROOT="${KLICKER_DEVCONTAINER_ROOT:-/workspaces/klicker-uzh}"
+ROOT="$(cd "$ROOT" && pwd)"
+HATCHET_TOKEN_FILE="${KLICKER_HATCHET_TOKEN_FILE:-/config/authdisabled-token}"
 cd "$ROOT"
 
 # DevPod truncates env_file values at '=' (a URL ...?schema=public arrives as

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -3,16 +3,18 @@
 # Invoked by host-side `devrouter ensure` after it validates the exact container.
 # Launches every routed app plus both workers through the delivered helper.
 set -euo pipefail
-bash /workspaces/klicker-uzh/util/dev-runtime.sh require-bootstrap
-cd /workspaces/klicker-uzh
+ROOT="${KLICKER_DEVCONTAINER_ROOT:-/workspaces/klicker-uzh}"
+ROOT="$(cd "$ROOT" && pwd)"
+bash "$ROOT/util/dev-runtime.sh" require-bootstrap
+cd "$ROOT"
 
 # Re-source the canonical env (DevPod truncates env_file values at '='), then the
 # runtime Hatchet token written by post-create (if any). (GOTCHAS #1)
 set -a
 # shellcheck source=/dev/null
-. /workspaces/klicker-uzh/.devcontainer/devcontainer.env
+. "$ROOT/.devcontainer/devcontainer.env"
 # shellcheck source=/dev/null
-[ -f /workspaces/klicker-uzh/.devcontainer/.hatchet.env ] && . /workspaces/klicker-uzh/.devcontainer/.hatchet.env
+[ -f "$ROOT/.devcontainer/.hatchet.env" ] && . "$ROOT/.devcontainer/.hatchet.env"
 set +a
 
 # Detect if devrouter routing is active (via mkcert CA mount) or fallback to plain localhost ports
@@ -116,7 +118,7 @@ fi
 # process starts, so close that race here after the managed Hatchet service is
 # running. Capability-only profiles do not wait for a token they never consume.
 if [ "$PROFILE_WANTS_DEV" = yes ] && [ -z "${HATCHET_CLIENT_TOKEN:-}" ]; then
-  HATCHET_ENV=/workspaces/klicker-uzh/.devcontainer/.hatchet.env
+  HATCHET_ENV="$ROOT/.devcontainer/.hatchet.env"
   for attempt in $(seq 1 60); do
     if [ -s /config/authdisabled-token ]; then
       HATCHET_CLIENT_TOKEN=$(tr -d '[:space:]' < /config/authdisabled-token)
@@ -264,7 +266,7 @@ worker_runtime_pid() {
   for proc in /proc/[0-9]*; do
     pid="${proc##*/}"
     cwd="$(readlink "$proc/cwd" 2>/dev/null || true)"
-    [ "$cwd" = "/workspaces/klicker-uzh/apps/$worker" ] || continue
+    [ "$cwd" = "$ROOT/apps/$worker" ] || continue
     state="$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]')"
     [ -n "$state" ] && [[ "$state" != Z* ]] || continue
     cmdline="$(tr '\0' ' ' <"$proc/cmdline" 2>/dev/null || true)"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 type: Guide
 title: Getting Started
 description: Toolchain, first-time setup, infrastructure bring-up, dev-server paths, and the exact failure signatures a fresh clone produces.
-timestamp: '2026-08-27'
+timestamp: '2026-08-29'
 tags:
   - environment
   - onboarding
@@ -103,7 +103,13 @@ destructive bootstrap and generated runtime inputs succeed; post-start checks
 that marker before it reads those inputs or starts a process. If the marker is
 missing or malformed, treat the workspace as incompletely bootstrapped and use
 the canonical stop/recovery path. A warm profile switch never manufactures the
-marker or reruns database bootstrap.
+marker or reruns database bootstrap. The `ROOT` contract in
+[post-create](../.devcontainer/post-create.sh) and
+[post-start](../.devcontainer/post-start.sh) canonicalizes
+`KLICKER_DEVCONTAINER_ROOT` once and uses that same checkout for every
+repository-local path. Post-create invalidates any earlier completion marker
+before it validates the configured root, so an invalid override cannot expose a
+stale successful bootstrap.
 
 Devrouter owns generic process lifecycle and route readiness. `ensure` verifies
 the selected routes and can spend one container recreate when an exact

--- a/util/test-dev-runtime.sh
+++ b/util/test-dev-runtime.sh
@@ -162,26 +162,35 @@ bash "$RUNTIME_SCRIPT" begin-bootstrap >/dev/null
 bash "$RUNTIME_SCRIPT" complete-bootstrap >/dev/null
 bash "$RUNTIME_SCRIPT" require-bootstrap
 
-first_after_strict_mode() {
-  awk '
-    /^set -euo pipefail$/ { strict = 1; next }
-    strict && $0 !~ /^[[:space:]]*($|#)/ { print; exit }
-  ' "$1"
+assert_before() {
+  local file="$1" earlier="$2" later="$3" earlier_line later_line
+
+  earlier_line="$(grep -nF -m1 "$earlier" "$file" | cut -d: -f1 || true)"
+  later_line="$(grep -nF -m1 "$later" "$file" | cut -d: -f1 || true)"
+  [ -n "$earlier_line" ] || fail "expected line in $file: $earlier"
+  [ -n "$later_line" ] || fail "expected line in $file: $later"
+  [ "$earlier_line" -lt "$later_line" ] || \
+    fail "expected '$earlier' before '$later' in $file"
 }
 
 last_semantic_line() {
   awk '$0 !~ /^[[:space:]]*($|#)/ { line = $0 } END { print line }' "$1"
 }
 
-assert_equal \
-  "$(first_after_strict_mode "$REPO_ROOT/.devcontainer/post-create.sh")" \
-  'bash "$ROOT/util/dev-runtime.sh" begin-bootstrap'
+assert_before \
+  "$REPO_ROOT/.devcontainer/post-create.sh" \
+  'bash "$SCRIPT_ROOT/util/dev-runtime.sh" begin-bootstrap' \
+  'ROOT="$(cd "$ROOT" && pwd)"'
 assert_equal \
   "$(last_semantic_line "$REPO_ROOT/.devcontainer/post-create.sh")" \
   'bash "$ROOT/util/dev-runtime.sh" complete-bootstrap'
+assert_before \
+  "$REPO_ROOT/.devcontainer/post-start.sh" \
+  'ROOT="$(cd "$ROOT" && pwd)"' \
+  'bash "$ROOT/util/dev-runtime.sh" require-bootstrap'
 assert_equal \
-  "$(first_after_strict_mode "$REPO_ROOT/.devcontainer/post-start.sh")" \
-  'bash /workspaces/klicker-uzh/util/dev-runtime.sh require-bootstrap'
+  "$(grep -Fc '/workspaces/klicker-uzh' "$REPO_ROOT/.devcontainer/post-start.sh")" \
+  '1'
 grep -Fq '"waitFor": "postCreateCommand"' \
   "$REPO_ROOT/.devcontainer/devcontainer.json" || \
   fail 'devcontainer does not wait for postCreateCommand'
@@ -195,6 +204,13 @@ mkdir -p \
   "$ROOT/util"
 write_file "$ROOT/.devcontainer/devcontainer.env" ''
 cp "$RUNTIME_SCRIPT" "$ROOT/util/dev-runtime.sh"
+bash "$RUNTIME_SCRIPT" complete-bootstrap >/dev/null
+if KLICKER_DEVCONTAINER_ROOT="$TEST_ROOT/missing-root" \
+  bash "$REPO_ROOT/.devcontainer/post-create.sh" >/dev/null 2>&1; then
+  fail 'post-create accepted a missing configured root'
+fi
+assert_absent "$KLICKER_DEV_RUNTIME_BOOTSTRAP_STATE_DIR/bootstrap-complete"
+
 bash "$RUNTIME_SCRIPT" complete-bootstrap >/dev/null
 if KLICKER_DEVCONTAINER_ROOT="$ROOT" \
   KLICKER_HATCHET_TOKEN_FILE="$TEST_ROOT/missing-hatchet-token" \
@@ -220,6 +236,17 @@ grep -Fq 'HATCHET_CLIENT_TOKEN=synthetic-test-token' \
 bash "$RUNTIME_SCRIPT" require-bootstrap >/dev/null
 : > "$INSTALL_LOG"
 rm -f "$ROOT/node_modules/.klicker-dependency-fingerprint"
+
+post_start_status=0
+post_start_output="$(
+  cd "$TEST_ROOT"
+  KLICKER_DEVCONTAINER_ROOT='repo' \
+    bash "$REPO_ROOT/.devcontainer/post-start.sh" 2>&1
+)" || post_start_status=$?
+[ "$post_start_status" -ne 0 ] || fail 'post-start bypassed the process-helper gate'
+process_helper_error='Run devrouter ensure to start this managed application process.'
+[[ "$post_start_output" == *"$process_helper_error"* ]] || \
+  fail 'post-start did not use the configured root before its process-helper gate'
 
 bash "$INIT_ROOT/initialize.sh"
 bash "$INIT_ROOT/initialize.sh"


### PR DESCRIPTION
## What This Fixes

This draft follows [PR #5646](https://github.com/uzh-bf/klicker-uzh/pull/5646), which introduced the managed bootstrap marker and configurable devcontainer root but left two startup paths inconsistent:

1. Post-create resolved the configured root before invalidating the previous completion marker, so an invalid root could fail while leaving a stale successful marker behind.
2. Post-start still used `/workspaces/klicker-uzh` for repository-local paths, even when post-create had bootstrapped a different configured root.

Post-create now invalidates the marker through its script-derived checkout before validating `KLICKER_DEVCONTAINER_ROOT`. Post-start canonicalizes that same configured root once and uses it for the marker gate, environment files, working directory, and process matching. Regression tests cover an invalid root with a stale marker and a relative configured root.

## Branch Coverage

- Base: `v3` at `05d379714`
- Head: `9f545e215`
- Reviewed locally: 1 commit; 5 files; 59 insertions and 21 deletions
- Substantive size: 80 changed lines; no lockfiles, generated output, or project-artifact documentation was excluded
- Packaging: direct regression follow-up to recently merged PR #5646

## Review Focus

- Confirm `begin-bootstrap` runs before configured-root canonicalization and still targets the checkout that owns the lifecycle script.
- Confirm post-start uses one canonical root for every repository-local path and retains only the default `/workspaces/klicker-uzh` fallback.
- Confirm the regression tests fail on the two former startup paths without coupling to a real container runtime.

## Verification

Current head:

- `bash util/test-dev-runtime.sh` -> pass
- `bash -n .devcontainer/post-create.sh .devcontainer/post-start.sh util/dev-runtime.sh util/test-dev-runtime.sh` -> pass
- `shellcheck -e SC1091,SC2034,SC2016 .devcontainer/post-create.sh .devcontainer/post-start.sh util/dev-runtime.sh util/test-dev-runtime.sh` -> pass
- `git diff --check origin/v3...HEAD` and `git show --check HEAD` -> pass
- `gitleaks git --redact --no-banner --config .gitleaks.toml --log-opts=origin/v3..HEAD` -> one commit scanned, no leaks

Earlier behavior-equivalent DevPod verification at `205229cd7` remains applicable because the rebase added only the unrelated `v3` final-review CI commit:

- Fresh `mcp` profile bootstrap completed, including the 13/13 workspace package build.
- The route-free profile selected only `klicker-local-mcp`; LiteLLM and the other optional capability services remained absent, with no runtime drift.
- Inside the container, the runtime regression test, shell syntax check, and changed-Markdown Prettier check passed.

Failed/Warning:

- Fresh Devsy startup on exact head `9f545e215` stopped before workspace registration after OrbStack stopped and three transient container IDs disappeared. The failed checkout's stale owner registration was removed, no Devsy or DevPod workspace remains for it, and OrbStack remains stopped as requested.
- The shared OKF wiki validator was not mounted in the fresh DevPod, so that validator did not execute.

Not run:

- `pnpm run check:all` on current head requires a managed container runtime and remains pending.
- Fresh Devsy `mcp` proof remains pending until OrbStack can run again.
- The armed combined final review remains pending until those delivery checks are complete.

## Security / Privacy

- The branch contains no credentials, secret files, personal data, or production data; the exact commit range passes Gitleaks.
- The executable shell-script security lens remains part of the pending combined final review.

## Blocking Before Merge

- [ ] Run `pnpm run check:all` in the managed container runtime.
- [ ] Prove the fresh Devsy `mcp` profile on exact head.
- [ ] Complete the combined final review and required exact-head GitHub checks.

## Follow-Up After Merge

- [ ] Reclaim the two retained validation worktrees only under separate destructive-cleanup approval.

## Local Session Artifacts

Machine-local pointers for resuming this draft; they are not review evidence.

- Machine: `MacBook-Pro`
- Task worktree: `trees/rs-devcontainer-bootstrap-root-safety`
- Detached Devsy validation checkout: `trees/rs-devcontainer-bootstrap-root-safety-devsy`
