### PR TITLE
feat(doc-query): add guarded production activation tooling

### DIFF
--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -14,6 +14,8 @@ const MANIFEST_VERSION = 1
 const EXPECTED_KB_COUNT = 15
 const EXPECTED_CHATBOT_COUNT = 22
 const EXPECTED_EXCLUDED_CHATBOT_COUNT = 2
+const EXPECTED_CORPUS_PROOF_COUNT = 15
+const EXPECTED_DIRECT_CALL_COUNT = 37
 const COLLECTION = 'klicker_course_materials_v1'
 const PRD_ENDPOINT =
   'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker'
@@ -256,6 +258,7 @@ function emptyReceipt() {
       positivePassed: 0,
       isolationPassed: 0,
       rejectionsPassed: 0,
+      directCallsAttempted: 0,
     },
     rejections: Object.fromEntries(
       REJECTION_CLASSES.map((name) => [name, 'not_run'])
@@ -550,6 +553,13 @@ export async function runProofMatrix({
 }) {
   const receipt = emptyReceipt()
   try {
+    const invokeWithCap = async (request) => {
+      receipt.counts.directCallsAttempted += 1
+      if (receipt.counts.directCallsAttempted > EXPECTED_DIRECT_CALL_COUNT) {
+        throw new ProofFailure('protocol_failed')
+      }
+      return invoke(request)
+    }
     const signer = await createScopeSigner(environment)
     const canary = manifest.cases[0]
     const canaryChatbotId = canary.chatbotIds[0]
@@ -557,7 +567,7 @@ export async function runProofMatrix({
 
     if (
       !(await provePositive(
-        invoke,
+        invokeWithCap,
         signer,
         environment,
         canary,
@@ -569,7 +579,7 @@ export async function runProofMatrix({
     receipt.counts.positivePassed += 1
     if (
       !(await proveIsolation(
-        invoke,
+        invokeWithCap,
         signer,
         environment,
         canary,
@@ -579,11 +589,12 @@ export async function runProofMatrix({
       throw new ProofFailure('canary_isolation_failed', canary.id)
     }
     receipt.counts.isolationPassed += 1
-    receipt.counts.chatbotsPassed += 1
+    receipt.counts.chatbotsPassed += canary.chatbotIds.length
+    receipt.counts.kbPassed += 1
 
     receipt.phase = 'rejections'
     await proveRejections(
-      invoke,
+      invokeWithCap,
       signer,
       environment,
       canary,
@@ -593,35 +604,33 @@ export async function runProofMatrix({
     )
 
     receipt.phase = 'matrix'
-    for (const proofCase of manifest.cases) {
-      for (const chatbotId of proofCase.chatbotIds) {
-        if (proofCase === canary && chatbotId === canaryChatbotId) continue
-        if (
-          !(await provePositive(
-            invoke,
-            signer,
-            environment,
-            proofCase,
-            chatbotId
-          ))
-        ) {
-          throw new ProofFailure('positive_failed', proofCase.id)
-        }
-        receipt.counts.positivePassed += 1
-        if (
-          !(await proveIsolation(
-            invoke,
-            signer,
-            environment,
-            proofCase,
-            chatbotId
-          ))
-        ) {
-          throw new ProofFailure('isolation_failed', proofCase.id)
-        }
-        receipt.counts.isolationPassed += 1
-        receipt.counts.chatbotsPassed += 1
+    for (const proofCase of manifest.cases.slice(1)) {
+      const representativeChatbotId = [...proofCase.chatbotIds].sort().at(-1)
+      if (
+        !(await provePositive(
+          invokeWithCap,
+          signer,
+          environment,
+          proofCase,
+          representativeChatbotId
+        ))
+      ) {
+        throw new ProofFailure('positive_failed', proofCase.id)
       }
+      receipt.counts.positivePassed += 1
+      if (
+        !(await proveIsolation(
+          invokeWithCap,
+          signer,
+          environment,
+          proofCase,
+          representativeChatbotId
+        ))
+      ) {
+        throw new ProofFailure('isolation_failed', proofCase.id)
+      }
+      receipt.counts.isolationPassed += 1
+      receipt.counts.chatbotsPassed += proofCase.chatbotIds.length
       receipt.counts.kbPassed += 1
     }
 
@@ -721,9 +730,10 @@ function sanitizeReceipt(value) {
       value.counts?.chatbotsExpected !== EXPECTED_CHATBOT_COUNT ||
       value.counts?.chatbotsPassed !== EXPECTED_CHATBOT_COUNT ||
       value.counts?.excludedExpected !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
-      value.counts?.positivePassed !== EXPECTED_CHATBOT_COUNT ||
-      value.counts?.isolationPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.positivePassed !== EXPECTED_CORPUS_PROOF_COUNT ||
+      value.counts?.isolationPassed !== EXPECTED_CORPUS_PROOF_COUNT ||
       value.counts?.rejectionsPassed !== REJECTION_CLASSES.length ||
+      value.counts?.directCallsAttempted !== EXPECTED_DIRECT_CALL_COUNT ||
       REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed') ||
       !hasExactZeroPreservation(value.preservation))
   ) {

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -802,6 +802,8 @@ async function acquireLock(path) {
 }
 
 async function releaseOwnedLock(path, identity) {
+  // Removing and replacing this lock while its launcher is still running is
+  // unsupported. Stale-lock recovery starts only after the owner has stopped.
   try {
     const current = await stat(path)
     if (current.dev !== identity.dev || current.ino !== identity.ino) return
@@ -818,9 +820,10 @@ export async function superviseProof({
   deadlineMs = DEFAULT_DEADLINE_MS,
   lockPath = DEFAULT_LOCK_PATH,
   installSignalHandlers = false,
+  acquireLockForProof = acquireLock,
 }) {
   const startedAt = Date.now()
-  const lock = await acquireLock(lockPath)
+  const lock = await acquireLockForProof(lockPath)
   if (!lock) {
     return {
       ...fixedFailureReceipt('duplicate_refused'),
@@ -829,8 +832,7 @@ export async function superviseProof({
       elapsedMs: 0,
     }
   }
-  const lockIdentity = await lock.stat()
-
+  let lockIdentity
   let child
   let interrupted = false
   let timedOut = false
@@ -839,6 +841,7 @@ export async function superviseProof({
   const signalHandlers = new Map()
 
   try {
+    lockIdentity = await lock.stat()
     const environment = minimalChildEnvironment(sourceEnvironment, process.pid)
     child = spawn(process.execPath, [resolve(childPath), ...childArgs], {
       detached: true,
@@ -930,7 +933,11 @@ export async function superviseProof({
     for (const [signal, handler] of signalHandlers) {
       process.removeListener(signal, handler)
     }
-    await releaseOwnedLock(lockPath, lockIdentity).catch(() => undefined)
+    if (lockIdentity) {
+      await releaseOwnedLock(lockPath, lockIdentity).catch(() => undefined)
+    } else {
+      await unlink(lockPath).catch(() => undefined)
+    }
     await lock.close().catch(() => undefined)
   }
 }

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -344,19 +344,24 @@ function hasAnyReferenceMarker(documents, markers) {
   })
 }
 
-function isRejected(result) {
-  if (!result || typeof result !== 'object') return false
-  if (result.isError === true) return true
+function isRejected(result, rejectionClass) {
+  if (!result || typeof result !== 'object' || result.isError !== true) {
+    return false
+  }
   if (!Array.isArray(result.content)) return false
+  const expected =
+    rejectionClass === 'trusted_filter_override'
+      ? /invalid arguments|validation error|extra inputs are not permitted/i
+      : /unauthorized:\s*(?:missing bearer token|invalid token)/i
   return result.content.some((block) => {
     if (block?.type !== 'text' || typeof block.text !== 'string') {
       return false
     }
     try {
       const parsed = JSON.parse(block.text)
-      return Boolean(parsed?.error)
+      return typeof parsed?.error === 'string' && expected.test(parsed.error)
     } catch {
-      return /unauthorized|invalid token|invalid arguments/i.test(block.text)
+      return expected.test(block.text)
     }
   })
 }
@@ -407,8 +412,11 @@ export function createMcpTransport(
   headers,
   Transport = StreamableHTTPClientTransport
 ) {
+  const noRedirectFetch = (input, init = {}) =>
+    fetch(input, { ...init, redirect: 'error' })
   return new Transport(new URL(PRD_ENDPOINT), {
     requestInit: { headers, redirect: 'error' },
+    fetch: noRedirectFetch,
     reconnectionOptions: {
       initialReconnectionDelay: 1_000,
       maxReconnectionDelay: 30_000,
@@ -510,7 +518,7 @@ async function proveRejections(
       scopeToken,
       question: proofCase.positive.question,
     })
-    if (!isRejected(result)) {
+    if (!isRejected(result, rejectionClass)) {
       throw new ProofFailure('rejection_failed', proofCase.id, rejectionClass)
     }
     receipt.rejections[rejectionClass] = 'passed'
@@ -524,7 +532,7 @@ async function proveRejections(
     question: proofCase.positive.question,
     override: foreignKbId,
   })
-  if (!isRejected(overrideResult)) {
+  if (!isRejected(overrideResult, 'trusted_filter_override')) {
     throw new ProofFailure(
       'rejection_failed',
       proofCase.id,

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { open, readFile, unlink } from 'node:fs/promises'
+import { open, readFile, stat, unlink } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, resolve } from 'node:path'
 import process from 'node:process'
@@ -801,6 +801,16 @@ async function acquireLock(path) {
   }
 }
 
+async function releaseOwnedLock(path, identity) {
+  try {
+    const current = await stat(path)
+    if (current.dev !== identity.dev || current.ino !== identity.ino) return
+    await unlink(path)
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+}
+
 export async function superviseProof({
   sourceEnvironment = process.env,
   childPath = WORKER_PATH,
@@ -819,6 +829,7 @@ export async function superviseProof({
       elapsedMs: 0,
     }
   }
+  const lockIdentity = await lock.stat()
 
   let child
   let interrupted = false
@@ -919,7 +930,7 @@ export async function superviseProof({
     for (const [signal, handler] of signalHandlers) {
       process.removeListener(signal, handler)
     }
-    await unlink(lockPath).catch(() => undefined)
+    await releaseOwnedLock(lockPath, lockIdentity).catch(() => undefined)
     await lock.close().catch(() => undefined)
   }
 }

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -32,6 +32,12 @@ const ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
+function compareUtf16Strings(left, right) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
 const SECRET_ENV_NAMES = [
   'DOC_QUERY_JWT_TOKEN_KLICKER',
   'DOC_QUERY_SCOPE_PRIVATE_KEY',
@@ -252,8 +258,9 @@ function emptyReceipt() {
     counts: {
       kbExpected: EXPECTED_KB_COUNT,
       kbPassed: 0,
-      chatbotsExpected: EXPECTED_CHATBOT_COUNT,
-      chatbotsPassed: 0,
+      chatbotsInScope: EXPECTED_CHATBOT_COUNT,
+      representativeChatbotsExpected: EXPECTED_CORPUS_PROOF_COUNT,
+      representativeChatbotsPassed: 0,
       excludedExpected: EXPECTED_EXCLUDED_CHATBOT_COUNT,
       positivePassed: 0,
       isolationPassed: 0,
@@ -589,7 +596,7 @@ export async function runProofMatrix({
       throw new ProofFailure('canary_isolation_failed', canary.id)
     }
     receipt.counts.isolationPassed += 1
-    receipt.counts.chatbotsPassed += canary.chatbotIds.length
+    receipt.counts.representativeChatbotsPassed += 1
     receipt.counts.kbPassed += 1
 
     receipt.phase = 'rejections'
@@ -605,7 +612,9 @@ export async function runProofMatrix({
 
     receipt.phase = 'matrix'
     for (const proofCase of manifest.cases.slice(1)) {
-      const representativeChatbotId = [...proofCase.chatbotIds].sort().at(-1)
+      const representativeChatbotId = [...proofCase.chatbotIds]
+        .sort(compareUtf16Strings)
+        .at(-1)
       if (
         !(await provePositive(
           invokeWithCap,
@@ -630,7 +639,7 @@ export async function runProofMatrix({
         throw new ProofFailure('isolation_failed', proofCase.id)
       }
       receipt.counts.isolationPassed += 1
-      receipt.counts.chatbotsPassed += proofCase.chatbotIds.length
+      receipt.counts.representativeChatbotsPassed += 1
       receipt.counts.kbPassed += 1
     }
 
@@ -727,8 +736,11 @@ function sanitizeReceipt(value) {
       value.failedRejectionClass !== null ||
       value.counts?.kbExpected !== EXPECTED_KB_COUNT ||
       value.counts?.kbPassed !== EXPECTED_KB_COUNT ||
-      value.counts?.chatbotsExpected !== EXPECTED_CHATBOT_COUNT ||
-      value.counts?.chatbotsPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.chatbotsInScope !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.representativeChatbotsExpected !==
+        EXPECTED_CORPUS_PROOF_COUNT ||
+      value.counts?.representativeChatbotsPassed !==
+        EXPECTED_CORPUS_PROOF_COUNT ||
       value.counts?.excludedExpected !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
       value.counts?.positivePassed !== EXPECTED_CORPUS_PROOF_COUNT ||
       value.counts?.isolationPassed !== EXPECTED_CORPUS_PROOF_COUNT ||
@@ -812,6 +824,7 @@ export async function superviseProof({
   let interrupted = false
   let timedOut = false
   let message = null
+  let forceTimer
   const signalHandlers = new Map()
 
   try {
@@ -826,7 +839,6 @@ export async function superviseProof({
       if (message === null) message = sanitizeReceipt(candidate)
     })
 
-    let forceTimer
     const terminateChildGroup = () => {
       killProcessGroup(child, 'SIGTERM')
       if (forceTimer) return
@@ -834,6 +846,7 @@ export async function superviseProof({
         () => killProcessGroup(child, 'SIGKILL'),
         TERMINATION_GRACE_MS
       )
+      forceTimer.unref()
     }
 
     if (installSignalHandlers) {
@@ -864,6 +877,7 @@ export async function superviseProof({
       child.once('close', settle)
     })
     clearTimeout(deadlineTimer)
+    if (forceTimer) clearTimeout(forceTimer)
 
     let receipt = message ?? fixedFailureReceipt('protocol_failed')
     if (timedOut) receipt = fixedFailureReceipt('timeout')
@@ -902,11 +916,12 @@ export async function superviseProof({
       elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
     }
   } finally {
+    if (forceTimer) clearTimeout(forceTimer)
     for (const [signal, handler] of signalHandlers) {
       process.removeListener(signal, handler)
     }
-    await lock.close().catch(() => undefined)
     await unlink(lockPath).catch(() => undefined)
+    await lock.close().catch(() => undefined)
   }
 }
 

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -1,9 +1,11 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { open, readFile, stat, unlink } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { open, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, resolve } from 'node:path'
 import process from 'node:process'
+import { DatabaseSync } from 'node:sqlite'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -790,24 +792,52 @@ function killProcessGroup(child, signal) {
   }
 }
 
-async function acquireLock(path) {
-  try {
-    return await open(path, 'wx', 0o600)
-  } catch (error) {
-    if (error?.code === 'EEXIST') return null
-    throw error
-  }
+function isDatabaseLockError(error) {
+  return (
+    typeof error?.message === 'string' &&
+    error.message.includes('database is locked')
+  )
 }
 
-async function releaseOwnedLock(path, identity) {
-  // Removing and replacing this lock while its launcher is still running is
-  // unsupported. Stale-lock recovery starts only after the owner has stopped.
+function lockGuardPath(path) {
+  return `${path}.guard.sqlite`
+}
+
+async function acquireLock(path) {
+  let database
+  const marker = await open(
+    path,
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_APPEND |
+      constants.O_NOFOLLOW,
+    0o600
+  )
   try {
-    const current = await stat(path)
-    if (current.dev !== identity.dev || current.ino !== identity.ino) return
-    await unlink(path)
+    database = new DatabaseSync(lockGuardPath(path), { timeout: 0 })
+    database.exec('BEGIN EXCLUSIVE')
+    return {
+      // Keep the exclusive transaction open for the complete supervised
+      // proof. The guard database and marker are persistent and never unlinked
+      // during cleanup, so an old owner cannot remove a replacement marker.
+      close: async () => {
+        try {
+          database.exec('ROLLBACK')
+        } finally {
+          database.close()
+        }
+      },
+    }
   } catch (error) {
-    if (error?.code !== 'ENOENT') throw error
+    try {
+      database?.close()
+    } catch {
+      // The connection may not have opened.
+    }
+    if (isDatabaseLockError(error)) return null
+    throw error
+  } finally {
+    await marker.close()
   }
 }
 
@@ -830,7 +860,6 @@ export async function superviseProof({
       elapsedMs: 0,
     }
   }
-  let lockIdentity
   let child
   let interrupted = false
   let timedOut = false
@@ -839,7 +868,6 @@ export async function superviseProof({
   const signalHandlers = new Map()
 
   try {
-    lockIdentity = await lock.stat()
     const environment = minimalChildEnvironment(sourceEnvironment, process.pid)
     child = spawn(process.execPath, [resolve(childPath), ...childArgs], {
       detached: true,
@@ -930,11 +958,6 @@ export async function superviseProof({
     if (forceTimer) clearTimeout(forceTimer)
     for (const [signal, handler] of signalHandlers) {
       process.removeListener(signal, handler)
-    }
-    if (lockIdentity) {
-      await releaseOwnedLock(lockPath, lockIdentity).catch(() => undefined)
-    } else {
-      await unlink(lockPath).catch(() => undefined)
     }
     await lock.close().catch(() => undefined)
   }

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -1,0 +1,951 @@
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { open, readFile, unlink } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { generateKeyPair, importPKCS8, SignJWT } from 'jose'
+
+const RECEIPT_VERSION = 1
+const MANIFEST_VERSION = 1
+const EXPECTED_KB_COUNT = 15
+const EXPECTED_CHATBOT_COUNT = 22
+const EXPECTED_EXCLUDED_CHATBOT_COUNT = 2
+const COLLECTION = 'klicker_course_materials_v1'
+const PRD_ENDPOINT =
+  'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker'
+const TOOL_NAME = 'doc_query'
+const SCOPE_HEADER = 'X-Doc-Query-Scope-Token'
+const DEFAULT_DEADLINE_MS = 30 * 60 * 1000
+const TERMINATION_GRACE_MS = 2_000
+const WORKER_PATH = fileURLToPath(import.meta.url)
+const DEFAULT_LOCK_PATH = resolve(
+  homedir(),
+  '.klicker-prd-doc-query-proof.lock'
+)
+const ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const SECRET_ENV_NAMES = [
+  'DOC_QUERY_JWT_TOKEN_KLICKER',
+  'DOC_QUERY_SCOPE_PRIVATE_KEY',
+  'DOC_QUERY_SCOPE_KID',
+  'DOC_QUERY_SCOPE_ISSUER',
+  'DOC_QUERY_SCOPE_AUDIENCE',
+]
+
+// macOS adds this non-secret marker to spawned processes even with an explicit
+// environment allowlist. It is the only platform-added name accepted here.
+const PLATFORM_ENV_NAMES = new Set(['__CF_USER_TEXT_ENCODING'])
+const WORKER_CONTROL_ENV_NAMES = new Set([
+  'DOC_QUERY_PROOF_PARENT_PID',
+  'DOC_QUERY_PROOF_MANIFEST_PATH',
+])
+const ALLOWED_WORKER_ENV_NAMES = new Set([
+  ...SECRET_ENV_NAMES,
+  ...WORKER_CONTROL_ENV_NAMES,
+  ...PLATFORM_ENV_NAMES,
+])
+
+const REJECTION_CLASSES = [
+  'missing',
+  'expired',
+  'forged',
+  'wrong_issuer',
+  'wrong_audience',
+  'unknown_key',
+  'trusted_filter_override',
+]
+
+const PRESERVATION_FIELDS = [
+  'databaseWrites',
+  'configurationChanges',
+  'bindingChanges',
+  'clusterChanges',
+  'productionActions',
+  'retries',
+]
+
+const FAILURE_CLASSES = new Set([
+  'none',
+  'manifest_refused',
+  'duplicate_refused',
+  'credential_missing',
+  'protocol_failed',
+  'canary_positive_failed',
+  'canary_isolation_failed',
+  'rejection_failed',
+  'positive_failed',
+  'isolation_failed',
+  'child_failed',
+  'child_signaled',
+  'timeout',
+  'interrupted',
+])
+
+class ProofFailure extends Error {
+  constructor(failureClass, caseId = null, rejectionClass = null) {
+    super(failureClass)
+    this.name = 'ProofFailure'
+    this.failureClass = failureClass
+    this.caseId = caseId
+    this.rejectionClass = rejectionClass
+  }
+}
+
+function requireString(value, pattern) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ProofFailure('manifest_refused')
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new ProofFailure('manifest_refused')
+  }
+  return value
+}
+
+function requireUuid(value) {
+  return requireString(value, UUID_PATTERN).toLocaleLowerCase('en')
+}
+
+function requireMarkerList(value) {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > 8 ||
+    value.some(
+      (entry) =>
+        typeof entry !== 'string' || entry.length === 0 || entry.length > 160
+    )
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+  return [...value]
+}
+
+function zeroPreservation() {
+  return Object.fromEntries(PRESERVATION_FIELDS.map((name) => [name, 0]))
+}
+
+function hasExactZeroPreservation(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === PRESERVATION_FIELDS.length &&
+    PRESERVATION_FIELDS.every((name) => value[name] === 0)
+  )
+}
+
+export function validateManifest(input) {
+  if (
+    !input ||
+    typeof input !== 'object' ||
+    Array.isArray(input) ||
+    input.version !== MANIFEST_VERSION ||
+    input.environment !== 'prd' ||
+    input.collection !== COLLECTION ||
+    !Array.isArray(input.cases) ||
+    input.cases.length !== EXPECTED_KB_COUNT ||
+    !Array.isArray(input.excludedChatbotIds) ||
+    input.excludedChatbotIds.length !== EXPECTED_EXCLUDED_CHATBOT_COUNT
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+
+  const caseIds = new Set()
+  const kbIds = new Set()
+  const chatbotIds = new Set()
+  const cases = input.cases.map((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const id = requireString(entry.id, ID_PATTERN)
+    const kbId = requireUuid(entry.kbId)
+    if (caseIds.has(id) || kbIds.has(kbId)) {
+      throw new ProofFailure('manifest_refused')
+    }
+    caseIds.add(id)
+    kbIds.add(kbId)
+    if (!Array.isArray(entry.chatbotIds) || entry.chatbotIds.length === 0) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const entryChatbots = entry.chatbotIds.map((chatbotId) => {
+      const normalized = requireUuid(chatbotId)
+      if (chatbotIds.has(normalized)) {
+        throw new ProofFailure('manifest_refused')
+      }
+      chatbotIds.add(normalized)
+      return normalized
+    })
+    const positive = entry.positive
+    const foreign = entry.foreign
+    if (
+      !positive ||
+      typeof positive !== 'object' ||
+      !foreign ||
+      typeof foreign !== 'object' ||
+      Object.hasOwn(foreign, 'forbidAny')
+    ) {
+      throw new ProofFailure('manifest_refused')
+    }
+    const minSources = positive.minSources ?? 1
+    if (!Number.isInteger(minSources) || minSources < 1 || minSources > 20) {
+      throw new ProofFailure('manifest_refused')
+    }
+    return {
+      id,
+      kbId,
+      chatbotIds: entryChatbots,
+      positive: {
+        question: requireString(positive.question),
+        expectAny: requireMarkerList(positive.expectAny),
+        minSources,
+      },
+      foreign: {
+        question: requireString(foreign.question),
+        forbidReferences: requireMarkerList(foreign.forbidReferences),
+      },
+    }
+  })
+
+  if (chatbotIds.size !== EXPECTED_CHATBOT_COUNT) {
+    throw new ProofFailure('manifest_refused')
+  }
+  const excludedChatbotIds = input.excludedChatbotIds.map(requireUuid)
+  if (
+    new Set(excludedChatbotIds).size !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
+    excludedChatbotIds.some((chatbotId) => chatbotIds.has(chatbotId))
+  ) {
+    throw new ProofFailure('manifest_refused')
+  }
+  const canaryCaseId = requireString(input.singletonCanaryCaseId, ID_PATTERN)
+  if (cases[0].id !== canaryCaseId || cases[0].chatbotIds.length !== 1) {
+    throw new ProofFailure('manifest_refused')
+  }
+
+  return {
+    version: MANIFEST_VERSION,
+    environment: 'prd',
+    collection: COLLECTION,
+    singletonCanaryCaseId: canaryCaseId,
+    cases,
+    excludedChatbotIds,
+  }
+}
+
+function emptyReceipt() {
+  return {
+    receiptVersion: RECEIPT_VERSION,
+    environment: 'prd',
+    collection: COLLECTION,
+    phase: 'preflight',
+    result: 'failed',
+    failureClass: 'none',
+    failedCaseId: null,
+    failedRejectionClass: null,
+    counts: {
+      kbExpected: EXPECTED_KB_COUNT,
+      kbPassed: 0,
+      chatbotsExpected: EXPECTED_CHATBOT_COUNT,
+      chatbotsPassed: 0,
+      excludedExpected: EXPECTED_EXCLUDED_CHATBOT_COUNT,
+      positivePassed: 0,
+      isolationPassed: 0,
+      rejectionsPassed: 0,
+    },
+    rejections: Object.fromEntries(
+      REJECTION_CLASSES.map((name) => [name, 'not_run'])
+    ),
+    preservation: zeroPreservation(),
+  }
+}
+
+function fixedFailureReceipt(
+  failureClass,
+  caseId = null,
+  rejectionClass = null
+) {
+  const receipt = emptyReceipt()
+  receipt.failureClass = FAILURE_CLASSES.has(failureClass)
+    ? failureClass
+    : 'protocol_failed'
+  receipt.failedCaseId = ID_PATTERN.test(caseId ?? '') ? caseId : null
+  receipt.failedRejectionClass = REJECTION_CLASSES.includes(rejectionClass)
+    ? rejectionClass
+    : null
+  return receipt
+}
+
+function extractDocuments(result) {
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    result.isError === true ||
+    !Array.isArray(result.content)
+  ) {
+    return null
+  }
+  for (const block of result.content) {
+    if (block?.type !== 'text' || typeof block.text !== 'string') {
+      continue
+    }
+    try {
+      const parsed = JSON.parse(block.text)
+      if (
+        parsed?.mode === 'documents' &&
+        Array.isArray(parsed.sources) &&
+        Number.isInteger(parsed?.summary?.sources_returned)
+      ) {
+        return parsed
+      }
+    } catch {
+      // A non-JSON block is not proof and is never surfaced.
+    }
+  }
+  return null
+}
+
+function documentHaystack(documents) {
+  return documents.sources
+    .flatMap((source) => [
+      typeof source?.reference === 'string' ? source.reference : '',
+      ...(Array.isArray(source?.chunks)
+        ? source.chunks.map((chunk) =>
+            typeof chunk?.content === 'string' ? chunk.content : ''
+          )
+        : []),
+    ])
+    .join('\n')
+    .toLocaleLowerCase('en')
+}
+
+function hasAnyDocumentMarker(documents, markers) {
+  const haystack = documentHaystack(documents)
+  return markers.some((marker) =>
+    haystack.includes(marker.toLocaleLowerCase('en'))
+  )
+}
+
+function hasAnyReferenceMarker(documents, markers) {
+  const references = documents.sources
+    .map((source) =>
+      typeof source?.reference === 'string'
+        ? source.reference.toLocaleLowerCase('en')
+        : ''
+    )
+    .filter(Boolean)
+  return markers.some((marker) => {
+    const normalized = marker.toLocaleLowerCase('en')
+    return references.some((reference) => reference.includes(normalized))
+  })
+}
+
+function isRejected(result) {
+  if (!result || typeof result !== 'object') return false
+  if (result.isError === true) return true
+  if (!Array.isArray(result.content)) return false
+  return result.content.some((block) => {
+    if (block?.type !== 'text' || typeof block.text !== 'string') {
+      return false
+    }
+    try {
+      const parsed = JSON.parse(block.text)
+      return Boolean(parsed?.error)
+    } catch {
+      return /unauthorized|invalid token|invalid arguments/i.test(block.text)
+    }
+  })
+}
+
+async function createScopeSigner(environment) {
+  let privateKey
+  try {
+    privateKey = await importPKCS8(
+      environment.DOC_QUERY_SCOPE_PRIVATE_KEY.replaceAll('\\n', '\n'),
+      'ES256'
+    )
+  } catch {
+    throw new ProofFailure('credential_missing')
+  }
+  const rogueKey = (await generateKeyPair('ES256')).privateKey
+
+  return async ({ kbId, chatbotId, variant = 'valid' }) => {
+    const now = Math.floor(Date.now() / 1000)
+    const issuer =
+      variant === 'wrong_issuer'
+        ? 'urn:klicker:doc-query-proof:rejected-issuer'
+        : environment.DOC_QUERY_SCOPE_ISSUER
+    const audience =
+      variant === 'wrong_audience'
+        ? 'urn:klicker:doc-query-proof:rejected-audience'
+        : environment.DOC_QUERY_SCOPE_AUDIENCE
+    const kid =
+      variant === 'unknown_key'
+        ? 'klicker-doc-query-proof-unknown-key'
+        : environment.DOC_QUERY_SCOPE_KID
+    const signingKey = variant === 'forged' ? rogueKey : privateKey
+    const issuedAt = variant === 'expired' ? now - 7_200 : now
+    const expiresAt = variant === 'expired' ? now - 3_600 : now + 300
+
+    return new SignJWT({ kb_id: kbId, chatbot_id: chatbotId })
+      .setProtectedHeader({ alg: 'ES256', typ: 'JWT', kid })
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setSubject(randomUUID())
+      .setJti(randomUUID())
+      .setIssuedAt(issuedAt)
+      .setExpirationTime(expiresAt)
+      .sign(signingKey)
+  }
+}
+
+export function createMcpTransport(
+  headers,
+  Transport = StreamableHTTPClientTransport
+) {
+  return new Transport(new URL(PRD_ENDPOINT), {
+    requestInit: { headers, redirect: 'error' },
+    reconnectionOptions: {
+      initialReconnectionDelay: 1_000,
+      maxReconnectionDelay: 30_000,
+      reconnectionDelayGrowFactor: 1.5,
+      maxRetries: 0,
+    },
+  })
+}
+
+async function invokeMcp({ bearer, scopeToken, question, override }) {
+  const headers = { authorization: `Bearer ${bearer}` }
+  if (scopeToken) headers[SCOPE_HEADER] = `Bearer ${scopeToken}`
+  const client = new Client({
+    name: 'klicker-prd-doc-query-proof',
+    version: '1',
+  })
+  const transport = createMcpTransport(headers)
+  try {
+    await client.connect(transport)
+    return await client.callTool({
+      name: TOOL_NAME,
+      arguments: override
+        ? {
+            question,
+            metadata_filters: { resource_active: false, kb_id: override },
+          }
+        : { question },
+    })
+  } finally {
+    await client.close().catch(() => undefined)
+  }
+}
+
+async function provePositive(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId
+) {
+  const token = await signer({ kbId: proofCase.kbId, chatbotId })
+  const result = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: token,
+    question: proofCase.positive.question,
+  })
+  const documents = extractDocuments(result)
+  return Boolean(
+    documents &&
+      documents.summary.sources_returned >= proofCase.positive.minSources &&
+      hasAnyDocumentMarker(documents, proofCase.positive.expectAny)
+  )
+}
+
+async function proveIsolation(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId
+) {
+  const token = await signer({ kbId: proofCase.kbId, chatbotId })
+  const result = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: token,
+    question: proofCase.foreign.question,
+  })
+  const documents = extractDocuments(result)
+  return Boolean(
+    documents &&
+      !hasAnyReferenceMarker(documents, proofCase.foreign.forbidReferences)
+  )
+}
+
+async function proveRejections(
+  invoke,
+  signer,
+  environment,
+  proofCase,
+  chatbotId,
+  foreignKbId,
+  receipt
+) {
+  const variants = [
+    ['missing', null],
+    ['expired', 'expired'],
+    ['forged', 'forged'],
+    ['wrong_issuer', 'wrong_issuer'],
+    ['wrong_audience', 'wrong_audience'],
+    ['unknown_key', 'unknown_key'],
+  ]
+
+  for (const [rejectionClass, variant] of variants) {
+    const scopeToken = variant
+      ? await signer({ kbId: proofCase.kbId, chatbotId, variant })
+      : undefined
+    const result = await invoke({
+      bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+      scopeToken,
+      question: proofCase.positive.question,
+    })
+    if (!isRejected(result)) {
+      throw new ProofFailure('rejection_failed', proofCase.id, rejectionClass)
+    }
+    receipt.rejections[rejectionClass] = 'passed'
+    receipt.counts.rejectionsPassed += 1
+  }
+
+  const validToken = await signer({ kbId: proofCase.kbId, chatbotId })
+  const overrideResult = await invoke({
+    bearer: environment.DOC_QUERY_JWT_TOKEN_KLICKER,
+    scopeToken: validToken,
+    question: proofCase.positive.question,
+    override: foreignKbId,
+  })
+  if (!isRejected(overrideResult)) {
+    throw new ProofFailure(
+      'rejection_failed',
+      proofCase.id,
+      'trusted_filter_override'
+    )
+  }
+  receipt.rejections.trusted_filter_override = 'passed'
+  receipt.counts.rejectionsPassed += 1
+}
+
+export async function runProofMatrix({
+  manifest,
+  environment,
+  invoke = invokeMcp,
+}) {
+  const receipt = emptyReceipt()
+  try {
+    const signer = await createScopeSigner(environment)
+    const canary = manifest.cases[0]
+    const canaryChatbotId = canary.chatbotIds[0]
+    receipt.phase = 'canary'
+
+    if (
+      !(await provePositive(
+        invoke,
+        signer,
+        environment,
+        canary,
+        canaryChatbotId
+      ))
+    ) {
+      throw new ProofFailure('canary_positive_failed', canary.id)
+    }
+    receipt.counts.positivePassed += 1
+    if (
+      !(await proveIsolation(
+        invoke,
+        signer,
+        environment,
+        canary,
+        canaryChatbotId
+      ))
+    ) {
+      throw new ProofFailure('canary_isolation_failed', canary.id)
+    }
+    receipt.counts.isolationPassed += 1
+    receipt.counts.chatbotsPassed += 1
+
+    receipt.phase = 'rejections'
+    await proveRejections(
+      invoke,
+      signer,
+      environment,
+      canary,
+      canaryChatbotId,
+      manifest.cases[1].kbId,
+      receipt
+    )
+
+    receipt.phase = 'matrix'
+    for (const proofCase of manifest.cases) {
+      for (const chatbotId of proofCase.chatbotIds) {
+        if (proofCase === canary && chatbotId === canaryChatbotId) continue
+        if (
+          !(await provePositive(
+            invoke,
+            signer,
+            environment,
+            proofCase,
+            chatbotId
+          ))
+        ) {
+          throw new ProofFailure('positive_failed', proofCase.id)
+        }
+        receipt.counts.positivePassed += 1
+        if (
+          !(await proveIsolation(
+            invoke,
+            signer,
+            environment,
+            proofCase,
+            chatbotId
+          ))
+        ) {
+          throw new ProofFailure('isolation_failed', proofCase.id)
+        }
+        receipt.counts.isolationPassed += 1
+        receipt.counts.chatbotsPassed += 1
+      }
+      receipt.counts.kbPassed += 1
+    }
+
+    receipt.phase = 'complete'
+    receipt.result = 'passed'
+    receipt.failureClass = 'none'
+    return receipt
+  } catch (error) {
+    const failure =
+      error instanceof ProofFailure
+        ? error
+        : new ProofFailure('protocol_failed')
+    receipt.result = 'failed'
+    receipt.failureClass = failure.failureClass
+    receipt.failedCaseId = failure.caseId
+    receipt.failedRejectionClass = failure.rejectionClass
+    if (failure.rejectionClass) {
+      receipt.rejections[failure.rejectionClass] = 'failed'
+    }
+    return receipt
+  }
+}
+
+function requiredWorkerEnvironment(source) {
+  const environment = {}
+  for (const name of SECRET_ENV_NAMES) {
+    const value = source[name]
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new ProofFailure('credential_missing')
+    }
+    environment[name] = value
+  }
+  const manifestPath = source.DOC_QUERY_PROOF_MANIFEST_PATH
+  if (typeof manifestPath !== 'string' || !isAbsolute(manifestPath)) {
+    throw new ProofFailure('manifest_refused')
+  }
+  environment.DOC_QUERY_PROOF_MANIFEST_PATH = manifestPath
+  return environment
+}
+
+export function validateWorkerEnvironment(source) {
+  for (const name of Object.keys(source)) {
+    if (!ALLOWED_WORKER_ENV_NAMES.has(name)) {
+      throw new ProofFailure('protocol_failed')
+    }
+  }
+}
+
+export function minimalChildEnvironment(source, parentPid) {
+  return {
+    ...requiredWorkerEnvironment(source),
+    DOC_QUERY_PROOF_PARENT_PID: String(parentPid),
+  }
+}
+
+async function readManifest(path) {
+  let raw
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    throw new ProofFailure('manifest_refused')
+  }
+  try {
+    return validateManifest(JSON.parse(raw))
+  } catch (error) {
+    if (error instanceof ProofFailure) throw error
+    throw new ProofFailure('manifest_refused')
+  }
+}
+
+function sanitizeReceipt(value) {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    value.receiptVersion !== RECEIPT_VERSION ||
+    value.environment !== 'prd' ||
+    value.collection !== COLLECTION ||
+    !['preflight', 'canary', 'rejections', 'matrix', 'complete'].includes(
+      value.phase
+    ) ||
+    !['passed', 'failed'].includes(value.result) ||
+    !FAILURE_CLASSES.has(value.failureClass)
+  ) {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  if (value.result === 'failed' && value.failureClass === 'none') {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  if (
+    value.result === 'passed' &&
+    (value.phase !== 'complete' ||
+      value.failureClass !== 'none' ||
+      value.failedCaseId !== null ||
+      value.failedRejectionClass !== null ||
+      value.counts?.kbExpected !== EXPECTED_KB_COUNT ||
+      value.counts?.kbPassed !== EXPECTED_KB_COUNT ||
+      value.counts?.chatbotsExpected !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.chatbotsPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.excludedExpected !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
+      value.counts?.positivePassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.isolationPassed !== EXPECTED_CHATBOT_COUNT ||
+      value.counts?.rejectionsPassed !== REJECTION_CLASSES.length ||
+      REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed') ||
+      !hasExactZeroPreservation(value.preservation))
+  ) {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  const receipt = emptyReceipt()
+  receipt.phase = value.phase
+  receipt.result = value.result
+  receipt.failureClass = value.failureClass
+  receipt.failedCaseId = ID_PATTERN.test(value.failedCaseId ?? '')
+    ? value.failedCaseId
+    : null
+  receipt.failedRejectionClass = REJECTION_CLASSES.includes(
+    value.failedRejectionClass
+  )
+    ? value.failedRejectionClass
+    : null
+  for (const key of Object.keys(receipt.counts)) {
+    const count = value.counts?.[key]
+    receipt.counts[key] = Number.isInteger(count)
+      ? Math.max(0, Math.min(count, 100))
+      : receipt.counts[key]
+  }
+  for (const name of REJECTION_CLASSES) {
+    receipt.rejections[name] = ['not_run', 'passed', 'failed'].includes(
+      value.rejections?.[name]
+    )
+      ? value.rejections[name]
+      : 'not_run'
+  }
+  return receipt
+}
+
+function killProcessGroup(child, signal) {
+  if (!child.pid) return
+  try {
+    process.kill(-child.pid, signal)
+  } catch {
+    try {
+      child.kill(signal)
+    } catch {
+      // The process already exited.
+    }
+  }
+}
+
+async function acquireLock(path) {
+  try {
+    return await open(path, 'wx', 0o600)
+  } catch (error) {
+    if (error?.code === 'EEXIST') return null
+    throw error
+  }
+}
+
+export async function superviseProof({
+  sourceEnvironment = process.env,
+  childPath = WORKER_PATH,
+  childArgs = ['--worker'],
+  deadlineMs = DEFAULT_DEADLINE_MS,
+  lockPath = DEFAULT_LOCK_PATH,
+  installSignalHandlers = false,
+}) {
+  const startedAt = Date.now()
+  const lock = await acquireLock(lockPath)
+  if (!lock) {
+    return {
+      ...fixedFailureReceipt('duplicate_refused'),
+      exitCode: null,
+      signal: null,
+      elapsedMs: 0,
+    }
+  }
+
+  let child
+  let interrupted = false
+  let timedOut = false
+  let message = null
+  const signalHandlers = new Map()
+
+  try {
+    const environment = minimalChildEnvironment(sourceEnvironment, process.pid)
+    child = spawn(process.execPath, [resolve(childPath), ...childArgs], {
+      detached: true,
+      env: environment,
+      shell: false,
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+    })
+    child.on('message', (candidate) => {
+      if (message === null) message = sanitizeReceipt(candidate)
+    })
+
+    let forceTimer
+    const terminateChildGroup = () => {
+      killProcessGroup(child, 'SIGTERM')
+      if (forceTimer) return
+      forceTimer = setTimeout(
+        () => killProcessGroup(child, 'SIGKILL'),
+        TERMINATION_GRACE_MS
+      )
+    }
+
+    if (installSignalHandlers) {
+      for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
+        const handler = () => {
+          interrupted = true
+          terminateChildGroup()
+        }
+        signalHandlers.set(signal, handler)
+        process.once(signal, handler)
+      }
+    }
+
+    const deadlineTimer = setTimeout(() => {
+      timedOut = true
+      terminateChildGroup()
+    }, deadlineMs)
+    deadlineTimer.unref()
+
+    const close = await new Promise((resolveClose) => {
+      let settled = false
+      const settle = (code, signal) => {
+        if (settled) return
+        settled = true
+        resolveClose({ code, signal })
+      }
+      child.once('error', () => settle(null, null))
+      child.once('close', settle)
+    })
+    clearTimeout(deadlineTimer)
+
+    let receipt = message ?? fixedFailureReceipt('protocol_failed')
+    if (timedOut) receipt = fixedFailureReceipt('timeout')
+    else if (interrupted) receipt = fixedFailureReceipt('interrupted')
+    else if (close.signal) receipt = fixedFailureReceipt('child_signaled')
+    else if (close.code === 0) {
+      if (
+        message?.result !== 'passed' &&
+        message?.failureClass !== 'protocol_failed'
+      ) {
+        receipt = fixedFailureReceipt('child_failed')
+      }
+    } else if (message === null || message.result === 'passed') {
+      receipt = fixedFailureReceipt('child_failed')
+    }
+
+    return {
+      ...receipt,
+      exitCode:
+        Number.isInteger(close.code) && close.code >= 0 && close.code <= 255
+          ? close.code
+          : null,
+      signal:
+        typeof close.signal === 'string' && close.signal.length <= 16
+          ? close.signal
+          : null,
+      elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
+    }
+  } catch (error) {
+    const failureClass =
+      error instanceof ProofFailure ? error.failureClass : 'child_failed'
+    return {
+      ...fixedFailureReceipt(failureClass),
+      exitCode: null,
+      signal: null,
+      elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
+    }
+  } finally {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler)
+    }
+    await lock.close().catch(() => undefined)
+    await unlink(lockPath).catch(() => undefined)
+  }
+}
+
+function sendWorkerReceipt(receipt, exitCode) {
+  if (typeof process.send !== 'function') process.exit(exitCode)
+  process.send(receipt, () => process.exit(exitCode))
+}
+
+async function workerMain() {
+  const expectedParentPid = Number(process.env.DOC_QUERY_PROOF_PARENT_PID)
+  const parentWatch = setInterval(() => {
+    if (
+      !Number.isInteger(expectedParentPid) ||
+      process.ppid !== expectedParentPid
+    ) {
+      process.exit(1)
+    }
+  }, 250)
+  parentWatch.unref()
+
+  for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
+    process.once(signal, () => process.exit(1))
+  }
+
+  try {
+    validateWorkerEnvironment(process.env)
+    const environment = requiredWorkerEnvironment(process.env)
+    const manifest = await readManifest(
+      environment.DOC_QUERY_PROOF_MANIFEST_PATH
+    )
+    const receipt = await runProofMatrix({ manifest, environment })
+    sendWorkerReceipt(receipt, receipt.result === 'passed' ? 0 : 1)
+  } catch (error) {
+    const receipt =
+      error instanceof ProofFailure
+        ? fixedFailureReceipt(
+            error.failureClass,
+            error.caseId,
+            error.rejectionClass
+          )
+        : fixedFailureReceipt('protocol_failed')
+    sendWorkerReceipt(receipt, 1)
+  }
+}
+
+async function launcherMain() {
+  const receipt = await superviseProof({ installSignalHandlers: true })
+  process.stdout.write(`${JSON.stringify(receipt)}\n`)
+  process.exitCode = receipt.result === 'passed' ? 0 : 1
+}
+
+const isMain =
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href ===
+    pathToFileURL(WORKER_PATH).href
+
+if (isMain) {
+  if (process.argv[2] === '--worker') await workerMain()
+  else await launcherMain()
+}

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -116,7 +116,7 @@ function requireString(value, pattern) {
 }
 
 function requireUuid(value) {
-  return requireString(value, UUID_PATTERN).toLocaleLowerCase('en')
+  return requireString(value, UUID_PATTERN).toLowerCase()
 }
 
 function requireMarkerList(value) {
@@ -330,26 +330,24 @@ function documentHaystack(documents) {
         : []),
     ])
     .join('\n')
-    .toLocaleLowerCase('en')
+    .toLowerCase()
 }
 
 function hasAnyDocumentMarker(documents, markers) {
   const haystack = documentHaystack(documents)
-  return markers.some((marker) =>
-    haystack.includes(marker.toLocaleLowerCase('en'))
-  )
+  return markers.some((marker) => haystack.includes(marker.toLowerCase()))
 }
 
 function hasAnyReferenceMarker(documents, markers) {
   const references = documents.sources
     .map((source) =>
       typeof source?.reference === 'string'
-        ? source.reference.toLocaleLowerCase('en')
+        ? source.reference.toLowerCase()
         : ''
     )
     .filter(Boolean)
   return markers.some((marker) => {
-    const normalized = marker.toLocaleLowerCase('en')
+    const normalized = marker.toLowerCase()
     return references.some((reference) => reference.includes(normalized))
   })
 }

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -877,7 +877,6 @@ export async function superviseProof({
       child.once('close', settle)
     })
     clearTimeout(deadlineTimer)
-    if (forceTimer) clearTimeout(forceTimer)
 
     let receipt = message ?? fixedFailureReceipt('protocol_failed')
     if (timedOut) receipt = fixedFailureReceipt('timeout')

--- a/apps/chat/test/doc-query-proof-test-support.ts
+++ b/apps/chat/test/doc-query-proof-test-support.ts
@@ -65,6 +65,11 @@ export function proofUuid(index: number): string {
   return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
 }
 
+function getChatbotCount(index: number, extraChatbotCases: number): number {
+  if (index > 0 && index <= extraChatbotCases) return 2
+  return 1
+}
+
 export function createTemporaryDirectoryRegistry() {
   const directories: string[] = []
   return {
@@ -95,7 +100,7 @@ export function createProofManifest({
     id: `corpus_${index + 1}`,
     kbId: proofUuid(index + 1),
     chatbotIds: Array.from(
-      { length: index === 0 ? 1 : index <= extraChatbotCases ? 2 : 1 },
+      { length: getChatbotCount(index, extraChatbotCases) },
       () => proofUuid(chatbotIndex++)
     ),
     positive: {
@@ -458,6 +463,7 @@ export function defineProofSupervisorSuite(
   config: {
     dummyEnvironment: () => Promise<Record<string, string>>
     writeDummy: (source: string) => Promise<{ path: string; lockPath: string }>
+    prepareDuplicateLock?: (lockPath: string) => Promise<() => Promise<void>>
     passedReceiptSource: (extra?: string, preservation?: string) => string
     failedReceiptSource: () => string
   }
@@ -657,16 +663,25 @@ export function defineProofSupervisorSuite(
 
     test('refuses a duplicate invocation before spawning', async () => {
       const dummy = await config.writeDummy(config.passedReceiptSource())
-      await writeFile(dummy.lockPath, '')
-      const receipt = await behaviors.superviseProof({
-        sourceEnvironment:
-          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-        childPath: dummy.path,
-        childArgs: [],
-        lockPath: dummy.lockPath,
-      })
-      expect(receipt.failureClass).toBe('duplicate_refused')
-      expect(receipt.exitCode).toBeNull()
+      let release = async () => {}
+      if (config.prepareDuplicateLock) {
+        release = await config.prepareDuplicateLock(dummy.lockPath)
+      } else {
+        await writeFile(dummy.lockPath, '')
+      }
+      try {
+        const receipt = await behaviors.superviseProof({
+          sourceEnvironment:
+            (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+          childPath: dummy.path,
+          childArgs: [],
+          lockPath: dummy.lockPath,
+        })
+        expect(receipt.failureClass).toBe('duplicate_refused')
+        expect(receipt.exitCode).toBeNull()
+      } finally {
+        await release()
+      }
     })
   })
 }

--- a/apps/chat/test/doc-query-proof-test-support.ts
+++ b/apps/chat/test/doc-query-proof-test-support.ts
@@ -1,0 +1,672 @@
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { exportPKCS8, generateKeyPair } from 'jose'
+import { afterEach, describe, expect, test } from 'vitest'
+
+export type MockToolResult = {
+  isError?: boolean
+  content: Array<{ type: 'text'; text: string }>
+}
+
+export type ProofInvokeArgs = {
+  question: string
+  override?: string
+}
+
+export type ProofInvoke = (args: ProofInvokeArgs) => Promise<MockToolResult>
+
+export type ProofReceipt = {
+  result: string
+  failureClass: string | null
+  failedCaseId: string | null
+  failedRejectionClass: string | null
+  exitCode: number | null
+  counts: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export type ValidatedProofManifest = {
+  cases: Array<{ kbId: string; chatbotIds: string[] }>
+  excludedChatbotIds: unknown[]
+  [key: string]: unknown
+}
+
+export type ValidateProofManifest = (
+  manifest: unknown
+) => ValidatedProofManifest
+
+export type RunProofMatrix = (options: {
+  manifest: unknown
+  environment: Record<string, string> | NodeJS.ProcessEnv
+  invoke: ProofInvoke
+}) => Promise<ProofReceipt>
+
+export type SuperviseProof = (options: {
+  sourceEnvironment: NodeJS.ProcessEnv
+  childPath: string
+  childArgs: string[]
+  lockPath: string
+  deadlineMs?: number
+  acquireLockForProof?: unknown
+}) => Promise<ProofReceipt>
+
+export function rejected(
+  message = 'unauthorized: invalid token'
+): MockToolResult {
+  return { isError: true, content: [{ type: 'text', text: message }] }
+}
+
+export function emptyRejection(): MockToolResult {
+  return { isError: true, content: [] }
+}
+
+export function proofUuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+}
+
+export function createTemporaryDirectoryRegistry() {
+  const directories: string[] = []
+  return {
+    register(directory: string) {
+      directories.push(directory)
+    },
+    cleanup() {
+      return Promise.all(
+        directories
+          .splice(0)
+          .map((directory) => rm(directory, { recursive: true, force: true }))
+      )
+    },
+  }
+}
+
+export function createProofManifest({
+  environment,
+  collection,
+  extraChatbotCases,
+}: {
+  environment: string
+  collection: string
+  extraChatbotCases: number
+}) {
+  let chatbotIndex = 100
+  const cases = Array.from({ length: 15 }, (_, index) => ({
+    id: `corpus_${index + 1}`,
+    kbId: proofUuid(index + 1),
+    chatbotIds: Array.from(
+      { length: index === 0 ? 1 : index <= extraChatbotCases ? 2 : 1 },
+      () => proofUuid(chatbotIndex++)
+    ),
+    positive: {
+      question: `positive fixture ${index + 1}`,
+      expectAny: [`positive-marker-${index + 1}`],
+      minSources: 1,
+    },
+    foreign: {
+      question: `foreign fixture ${index + 1}`,
+      forbidReferences: [`foreign-reference-${index + 1}`],
+    },
+  }))
+  return {
+    version: 1,
+    environment,
+    collection,
+    singletonCanaryCaseId: 'corpus_1',
+    cases,
+    excludedChatbotIds: [proofUuid(900), proofUuid(901)],
+  }
+}
+
+export async function proofDummyEnvironment(): Promise<Record<string, string>> {
+  const { privateKey } = await generateKeyPair('ES256')
+  return {
+    DOC_QUERY_JWT_TOKEN_KLICKER: 'dummy-transport-token',
+    DOC_QUERY_SCOPE_PRIVATE_KEY: await exportPKCS8(privateKey),
+    DOC_QUERY_SCOPE_KID: 'dummy-key',
+    DOC_QUERY_SCOPE_ISSUER: 'https://chat.klicker.test',
+    DOC_QUERY_SCOPE_AUDIENCE: 'klicker-doc-query-test',
+    DOC_QUERY_PROOF_MANIFEST_PATH: '/private/tmp/dummy-manifest.json',
+  }
+}
+export function createProofReceiptSources({
+  environment,
+  collection,
+  passedCounts,
+  failedCounts,
+}: {
+  environment: string
+  collection: string
+  passedCounts: string
+  failedCounts: string
+}) {
+  function passedReceiptSource(
+    extra = '',
+    preservation = '{databaseWrites:0,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+  ) {
+    return [
+      '',
+      extra,
+      'process.send({',
+      '  receiptVersion: 1,',
+      `  environment: '${environment}',`,
+      `  collection: '${collection}',`,
+      "  phase: 'complete',",
+      "  result: 'passed',",
+      "  failureClass: 'none',",
+      '  failedCaseId: null,',
+      '  failedRejectionClass: null,',
+      `  counts: ${passedCounts},`,
+      "  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},",
+      `  preservation: ${preservation}`,
+      '}, () => process.exit(0))',
+      '',
+    ].join('\n')
+  }
+
+  function failedReceiptSource() {
+    return [
+      '',
+      'process.send({',
+      '  receiptVersion: 1,',
+      `  environment: '${environment}',`,
+      `  collection: '${collection}',`,
+      "  phase: 'canary',",
+      "  result: 'failed',",
+      "  failureClass: 'canary_positive_failed',",
+      "  failedCaseId: 'corpus_1',",
+      '  failedRejectionClass: null,',
+      `  counts: ${failedCounts},`,
+      "  rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},",
+      "  secret: 'dummy-private-key'",
+      '}, () => process.exit(1))',
+      '',
+    ].join('\n')
+  }
+
+  return { passedReceiptSource, failedReceiptSource }
+}
+
+export function createProofChildWriter(registry: {
+  register: (directory: string) => void
+}) {
+  return async function writeDummy(source: string) {
+    const directory = await mkdtemp(
+      join(tmpdir(), 'klicker-doc-query-proof-test-')
+    )
+    registry.register(directory)
+    const path = join(directory, 'child.mjs')
+    await writeFile(path, source, { mode: 0o700 })
+    return { path, lockPath: join(directory, 'proof.lock') }
+  }
+}
+export function defineProofManifestSuite(
+  label: string,
+  behaviors: { validateManifest: ValidateProofManifest },
+  config: { manifest: () => unknown; expectedChatbotCount: number }
+) {
+  describe(`${label} Doc Query proof manifest`, () => {
+    test('accepts exactly 15 KBs, the configured chatbot targets, and two exclusions', () => {
+      const validated = behaviors.validateManifest(config.manifest())
+      expect(validated.cases).toHaveLength(15)
+      expect(validated.cases.flatMap((entry) => entry.chatbotIds)).toHaveLength(
+        config.expectedChatbotCount
+      )
+      expect(validated.cases[0].chatbotIds).toHaveLength(1)
+      expect(validated.excludedChatbotIds).toHaveLength(2)
+    })
+
+    test('refuses duplicate target chatbots before any proof call', () => {
+      const duplicate = config.manifest() as {
+        cases: Array<{ kbId: string; chatbotIds: string[] }>
+      }
+      duplicate.cases[1].chatbotIds[0] =
+        duplicate.cases[0].chatbotIds[0].toUpperCase()
+      expect(() => behaviors.validateManifest(duplicate)).toThrow(
+        'manifest_refused'
+      )
+    })
+
+    test('canonicalizes UUIDs before every cardinality check', () => {
+      const duplicateKb = config.manifest() as {
+        cases: Array<{ kbId: string; chatbotIds: string[] }>
+        excludedChatbotIds: string[]
+      }
+      duplicateKb.cases[1].kbId = duplicateKb.cases[0].kbId.toUpperCase()
+      expect(() => behaviors.validateManifest(duplicateKb)).toThrow(
+        'manifest_refused'
+      )
+
+      const overlappingExclusion = config.manifest() as typeof duplicateKb
+      overlappingExclusion.excludedChatbotIds[0] =
+        overlappingExclusion.cases[0].chatbotIds[0].toUpperCase()
+      expect(() => behaviors.validateManifest(overlappingExclusion)).toThrow(
+        'manifest_refused'
+      )
+    })
+
+    test('requires source-reference isolation markers', () => {
+      const legacy = config.manifest() as {
+        cases: Array<{
+          foreign: {
+            question: string
+            forbidReferences?: string[]
+            forbidAny?: string[]
+          }
+        }>
+      }
+      const foreign = legacy.cases[0].foreign
+      foreign.forbidAny = foreign.forbidReferences
+      delete foreign.forbidReferences
+      expect(() => behaviors.validateManifest(legacy)).toThrow(
+        'manifest_refused'
+      )
+
+      const mixed = config.manifest() as typeof legacy
+      const mixedForeign = mixed.cases[0].foreign as {
+        question: string
+        forbidReferences: string[]
+        forbidAny?: string[]
+      }
+      mixedForeign.forbidAny = mixedForeign.forbidReferences
+      expect(() => behaviors.validateManifest(mixed)).toThrow(
+        'manifest_refused'
+      )
+    })
+  })
+}
+
+export function defineProofMatrixSuite(
+  label: string,
+  behaviors: {
+    validateManifest: ValidateProofManifest
+    runProofMatrix: RunProofMatrix
+  },
+  config: {
+    manifest: () => unknown
+    environment: () => Promise<Record<string, string>>
+    rejection: (message?: string) => MockToolResult
+    rejectionWithArguments: () => MockToolResult
+    expectedDirectCalls: number
+    expectedCounts: Record<string, number>
+  }
+) {
+  describe(`${label} Doc Query proof matrix`, () => {
+    test('runs the singleton canary, seven rejections, then the serial matrix', async () => {
+      const validated = behaviors.validateManifest(config.manifest())
+      const environment = await config.environment()
+      let call = 0
+      const invoke: ProofInvoke = async ({ question, override }) => {
+        call += 1
+        if ((call >= 3 && call <= 8) || override) {
+          return override ? config.rejectionWithArguments() : config.rejection()
+        }
+        const positive = question.startsWith('positive')
+        const marker = question.replace(
+          positive ? 'positive fixture ' : 'foreign fixture ',
+          positive ? 'positive-marker-' : 'foreign-reference-'
+        )
+        return {
+          isError: false,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [
+                  positive
+                    ? {
+                        reference: 'safe-positive-reference',
+                        chunks: [{ content: marker }],
+                      }
+                    : {
+                        reference: 'safe-foreign-reference',
+                        chunks: [{ content: marker }],
+                      },
+                ],
+              }),
+            },
+          ],
+        }
+      }
+
+      const receipt = await behaviors.runProofMatrix({
+        manifest: validated,
+        environment,
+        invoke,
+      })
+
+      expect(call).toBe(config.expectedDirectCalls)
+      expect(receipt.result).toBe('passed')
+      expect(receipt.counts).toMatchObject(config.expectedCounts)
+    })
+
+    test('fails when a foreign source reference is returned', async () => {
+      const validated = behaviors.validateManifest(config.manifest())
+      const environment = await config.environment()
+      let calls = 0
+      const receipt = await behaviors.runProofMatrix({
+        manifest: validated,
+        environment,
+        invoke: async ({ question }) => {
+          calls += 1
+          const positive = question.startsWith('positive')
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  mode: 'documents',
+                  summary: { sources_returned: 1, chunks_returned: 1 },
+                  sources: [
+                    {
+                      reference: positive
+                        ? 'safe-positive-reference'
+                        : 'foreign-reference-1',
+                      chunks: [
+                        {
+                          content: positive
+                            ? question.replace(
+                                'positive fixture ',
+                                'positive-marker-'
+                              )
+                            : 'overlapping subject terminology',
+                        },
+                      ],
+                    },
+                  ],
+                }),
+              },
+            ],
+          }
+        },
+      })
+      expect(receipt.failureClass).toBe('canary_isolation_failed')
+      expect(calls).toBe(2)
+    })
+
+    test('stops on the first invariant failure without retrying', async () => {
+      const validated = behaviors.validateManifest(config.manifest())
+      const environment = await config.environment()
+      let calls = 0
+      const receipt = await behaviors.runProofMatrix({
+        manifest: validated,
+        environment,
+        invoke: async () => {
+          calls += 1
+          return config.rejection('backend unavailable')
+        },
+      })
+      expect(receipt.failureClass).toBe('canary_positive_failed')
+      expect(calls).toBe(1)
+    })
+
+    test('sends both protected fields in the trusted-filter rejection case', async () => {
+      const validated = behaviors.validateManifest(config.manifest())
+      const environment = await config.environment()
+      const overrides: string[] = []
+      let call = 0
+      const receipt = await behaviors.runProofMatrix({
+        manifest: validated,
+        environment,
+        invoke: async ({ question, override }) => {
+          call += 1
+          if (override) overrides.push(override)
+          if (override) {
+            return config.rejectionWithArguments()
+          }
+          if (call >= 3 && call <= 8) {
+            return config.rejection()
+          }
+          const positive = question.startsWith('positive')
+          const marker = question.replace(
+            positive ? 'positive fixture ' : 'foreign fixture ',
+            positive ? 'positive-marker-' : 'safe-marker-'
+          )
+          return {
+            isError: false,
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  mode: 'documents',
+                  summary: { sources_returned: 1, chunks_returned: 1 },
+                  sources: [{ reference: marker, chunks: [] }],
+                }),
+              },
+            ],
+          }
+        },
+      })
+      expect(receipt.result).toBe('passed')
+      expect(overrides).toEqual([validated.cases[1].kbId])
+    })
+  })
+}
+
+export function defineProofSupervisorSuite(
+  label: string,
+  behaviors: {
+    minimalChildEnvironment: (
+      environment: Record<string, string>,
+      parentPid: number
+    ) => Record<string, string>
+    validateWorkerEnvironment: (environment: Record<string, unknown>) => void
+    superviseProof: SuperviseProof
+  },
+  config: {
+    dummyEnvironment: () => Promise<Record<string, string>>
+    writeDummy: (source: string) => Promise<{ path: string; lockPath: string }>
+    passedReceiptSource: (extra?: string, preservation?: string) => string
+    failedReceiptSource: () => string
+  }
+) {
+  const suiteRegistry = createTemporaryDirectoryRegistry()
+  afterEach(suiteRegistry.cleanup)
+
+  describe(`${label} Doc Query proof supervisor`, () => {
+    test('passes only the allowlisted environment', async () => {
+      const environment = await config.dummyEnvironment()
+      const childEnvironment = behaviors.minimalChildEnvironment(
+        { ...environment, LEAK_ME: 'must-not-pass' },
+        123
+      )
+      expect(childEnvironment).not.toHaveProperty('LEAK_ME')
+      expect(childEnvironment).not.toHaveProperty('PATH')
+      expect(Object.keys(childEnvironment).sort()).toEqual(
+        [
+          'DOC_QUERY_JWT_TOKEN_KLICKER',
+          'DOC_QUERY_SCOPE_AUDIENCE',
+          'DOC_QUERY_SCOPE_ISSUER',
+          'DOC_QUERY_SCOPE_KID',
+          'DOC_QUERY_SCOPE_PRIVATE_KEY',
+          'DOC_QUERY_PROOF_PARENT_PID',
+          'DOC_QUERY_PROOF_MANIFEST_PATH',
+        ].sort()
+      )
+    })
+
+    test('rejects unexpected worker environment names while allowing the platform marker', async () => {
+      const environment = await config.dummyEnvironment()
+      expect(() =>
+        behaviors.validateWorkerEnvironment({
+          ...environment,
+          DOC_QUERY_PROOF_PARENT_PID: '123',
+          __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0',
+        })
+      ).not.toThrow()
+      expect(() =>
+        behaviors.validateWorkerEnvironment({
+          ...environment,
+          DOC_QUERY_PROOF_PARENT_PID: '123',
+          LEAK_ME: 'must-not-pass',
+        })
+      ).toThrow('protocol_failed')
+    })
+
+    test('suppresses noisy child output and returns only a fixed receipt', async () => {
+      const dummy = await config.writeDummy(
+        config.passedReceiptSource(
+          "process.stdout.write('dummy-transport-token'); process.stderr.write('dummy-private-key')"
+        )
+      )
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment:
+          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: 2_000,
+      })
+      expect(receipt.result).toBe('passed')
+      expect(JSON.stringify(receipt)).not.toContain('dummy-transport-token')
+      expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+    })
+
+    test.each([
+      [
+        'an incomplete receipt',
+        () =>
+          config
+            .passedReceiptSource()
+            .replace("phase: 'complete'", "phase: 'matrix'"),
+        'protocol_failed',
+      ],
+      [
+        'missing preservation evidence',
+        () => config.passedReceiptSource('', 'undefined'),
+        'protocol_failed',
+      ],
+      [
+        'non-zero preservation evidence',
+        () =>
+          config.passedReceiptSource(
+            '',
+            '{databaseWrites:1,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+          ),
+        'protocol_failed',
+      ],
+      [
+        'an exit-mismatched receipt',
+        () =>
+          config
+            .passedReceiptSource()
+            .replace('process.exit(0)', 'process.exit(1)'),
+        'child_failed',
+      ],
+      ['a missing receipt', () => 'process.exit(0)', 'child_failed'],
+    ] as Array<
+      [string, () => string, string]
+    >)('rejects %s', async (_name, source, expectedFailure) => {
+      const dummy = await config.writeDummy(source())
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment:
+          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: 2_000,
+      })
+      expect(receipt.result).toBe('failed')
+      expect(receipt.failureClass).toBe(expectedFailure)
+    })
+
+    test('passes no unrelated environment or file descriptor to the child', async () => {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'klicker-doc-query-fd-test-')
+      )
+      suiteRegistry.register(directory)
+      const unrelated = await open(join(directory, 'unrelated'), 'w')
+      const allowedEnvironmentNames = [
+        'DOC_QUERY_JWT_TOKEN_KLICKER',
+        'DOC_QUERY_SCOPE_AUDIENCE',
+        'DOC_QUERY_SCOPE_ISSUER',
+        'DOC_QUERY_SCOPE_KID',
+        'DOC_QUERY_SCOPE_PRIVATE_KEY',
+        'DOC_QUERY_PROOF_PARENT_PID',
+        'DOC_QUERY_PROOF_MANIFEST_PATH',
+        '__CF_USER_TEXT_ENCODING',
+      ]
+      const source = [
+        "import { fstatSync, readFileSync } from 'node:fs'",
+        'const allowed = new Set(' +
+          JSON.stringify(allowedEnvironmentNames) +
+          ')',
+        'if (Object.keys(process.env).some((name) => !allowed.has(name))) process.exit(8)',
+        'if (readFileSync(0).length !== 0) process.exit(9)',
+        'try {',
+        `  fstatSync(${unrelated.fd})`,
+        '  process.exit(10)',
+        '} catch (error) {',
+        "  if (error?.code !== 'EBADF') process.exit(11)",
+        '}',
+        config.passedReceiptSource(),
+        '',
+      ].join('\n')
+      const dummy = await config.writeDummy(source)
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment: {
+          ...(await config.dummyEnvironment()),
+          LEAK_ME: 'must-not-pass',
+        } as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: 2_000,
+      })
+      await unrelated.close()
+      expect(receipt.result).toBe('passed')
+    })
+
+    test('preserves a values-free failure receipt from a failed child', async () => {
+      const dummy = await config.writeDummy(config.failedReceiptSource())
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment:
+          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: 2_000,
+      })
+      expect(receipt).toMatchObject({
+        result: 'failed',
+        failureClass: 'canary_positive_failed',
+        failedCaseId: 'corpus_1',
+        exitCode: 1,
+      })
+      expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+    })
+
+    test.each([
+      ['exit', 'process.exit(7)', 'child_failed'],
+      ['signal', "process.kill(process.pid, 'SIGTERM')", 'child_signaled'],
+      ['timeout', 'setInterval(() => {}, 1000)', 'timeout'],
+    ])('classifies %s without retrying', async (_name, source, expected) => {
+      const dummy = await config.writeDummy(source)
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment:
+          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+        deadlineMs: expected === 'timeout' ? 50 : 2_000,
+      })
+      expect(receipt.failureClass).toBe(expected)
+    })
+
+    test('refuses a duplicate invocation before spawning', async () => {
+      const dummy = await config.writeDummy(config.passedReceiptSource())
+      await writeFile(dummy.lockPath, '')
+      const receipt = await behaviors.superviseProof({
+        sourceEnvironment:
+          (await config.dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        childPath: dummy.path,
+        childArgs: [],
+        lockPath: dummy.lockPath,
+      })
+      expect(receipt.failureClass).toBe('duplicate_refused')
+      expect(receipt.exitCode).toBeNull()
+    })
+  })
+}

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -1,4 +1,5 @@
-import { open, stat, unlink, writeFile } from 'node:fs/promises'
+import { stat, unlink, writeFile } from 'node:fs/promises'
+import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   createMcpTransport,
@@ -41,6 +42,18 @@ const receiptSources = createProofReceiptSources({
 const proofRegistry = createTemporaryDirectoryRegistry()
 const writeDummy = createProofChildWriter(proofRegistry)
 afterEach(() => proofRegistry.cleanup())
+
+async function prepareDuplicateLock(lockPath: string) {
+  const database = new DatabaseSync(`${lockPath}.guard.sqlite`, { timeout: 0 })
+  database.exec('BEGIN EXCLUSIVE')
+  return async () => {
+    try {
+      database.exec('ROLLBACK')
+    } finally {
+      database.close()
+    }
+  }
+}
 
 defineProofManifestSuite(
   'PRD',
@@ -186,12 +199,49 @@ defineProofSupervisorSuite(
   {
     dummyEnvironment: proofDummyEnvironment,
     writeDummy,
+    prepareDuplicateLock,
     passedReceiptSource: receiptSources.passedReceiptSource,
     failedReceiptSource: receiptSources.failedReceiptSource,
   }
 )
 
 describe('PRD Doc Query proof supervisor', () => {
+  test('refuses a concurrent proof while the advisory lock is held', async () => {
+    const dummy = await writeDummy(
+      receiptSources.passedReceiptSource(
+        'await new Promise((resolve) => setTimeout(resolve, 200))'
+      )
+    )
+    const first = superviseProof({
+      sourceEnvironment:
+        (await proofDummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      try {
+        await stat(`${dummy.lockPath}.guard.sqlite`)
+        break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    }
+
+    const second = await superviseProof({
+      sourceEnvironment:
+        (await proofDummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+
+    expect(second.failureClass).toBe('duplicate_refused')
+    expect((await first).result).toBe('passed')
+  })
+
   test('does not remove a replacement proof lock during cleanup', async () => {
     const dummy = await writeDummy(
       receiptSources.passedReceiptSource(
@@ -222,30 +272,24 @@ describe('PRD Doc Query proof supervisor', () => {
     expect((await stat(dummy.lockPath)).ino).toBe(replacement.ino)
   })
 
-  test('cleans up when reading the acquired proof lock identity fails', async () => {
+  test('closes the advisory proof lock when child setup fails', async () => {
     const dummy = await writeDummy(receiptSources.passedReceiptSource())
-    const handle = await open(dummy.lockPath, 'wx', 0o600)
     let closed = false
     const receipt = await superviseProof({
       sourceEnvironment:
         (await proofDummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
+      childPath: `${dummy.path}.missing`,
       childArgs: [],
       lockPath: dummy.lockPath,
       acquireLockForProof: async () =>
         ({
-          stat: async () => {
-            throw new Error('synthetic stat failure')
-          },
           close: async () => {
             closed = true
-            await handle.close()
           },
-        }) as unknown as typeof handle,
+        }) as unknown as { close: () => Promise<void> },
     })
 
     expect(receipt.failureClass).toBe('child_failed')
     expect(closed).toBe(true)
-    await expect(stat(dummy.lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, open, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { exportPKCS8, generateKeyPair } from 'jose'
@@ -642,5 +642,35 @@ ${passedReceiptSource()}
     })
     expect(receipt.failureClass).toBe('duplicate_refused')
     expect(receipt.exitCode).toBeNull()
+  })
+
+  test('does not remove a replacement proof lock during cleanup', async () => {
+    const dummy = await writeDummy(
+      passedReceiptSource(
+        'await new Promise((resolve) => setTimeout(resolve, 200))'
+      )
+    )
+    const proof = superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      try {
+        await stat(dummy.lockPath)
+        break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    }
+    await unlink(dummy.lockPath)
+    await writeFile(dummy.lockPath, 'replacement', { flag: 'wx', mode: 0o600 })
+    const replacement = await stat(dummy.lockPath)
+
+    expect((await proof).result).toBe('passed')
+    expect((await stat(dummy.lockPath)).ino).toBe(replacement.ino)
   })
 })

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -673,4 +673,31 @@ ${passedReceiptSource()}
     expect((await proof).result).toBe('passed')
     expect((await stat(dummy.lockPath)).ino).toBe(replacement.ino)
   })
+
+  test('cleans up when reading the acquired proof lock identity fails', async () => {
+    const dummy = await writeDummy(passedReceiptSource())
+    const handle = await open(dummy.lockPath, 'wx', 0o600)
+    let closed = false
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      acquireLockForProof: async () =>
+        ({
+          stat: async () => {
+            throw new Error('synthetic stat failure')
+          },
+          close: async () => {
+            closed = true
+            await handle.close()
+          },
+        }) as unknown as typeof handle,
+    })
+
+    expect(receipt.failureClass).toBe('child_failed')
+    expect(closed).toBe(true)
+    await expect(stat(dummy.lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
 })

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -1,7 +1,4 @@
-import { mkdtemp, open, rm, stat, unlink, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { exportPKCS8, generateKeyPair } from 'jose'
+import { open, stat, unlink, writeFile } from 'node:fs/promises'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   createMcpTransport,
@@ -11,175 +8,45 @@ import {
   validateManifest,
   validateWorkerEnvironment,
 } from '../scripts/prd-doc-query-proof.mjs'
+import type {
+  RunProofMatrix,
+  SuperviseProof,
+} from './doc-query-proof-test-support'
+import {
+  createProofChildWriter,
+  createProofManifest,
+  createProofReceiptSources,
+  createTemporaryDirectoryRegistry,
+  defineProofManifestSuite,
+  defineProofMatrixSuite,
+  defineProofSupervisorSuite,
+  proofDummyEnvironment,
+  rejected,
+} from './doc-query-proof-test-support'
 
-const temporaryDirectories: string[] = []
-
-type MockToolResult = {
-  isError?: boolean
-  content: Array<{ type: 'text'; text: string }>
-}
-
-function rejected(message = 'unauthorized: invalid token'): MockToolResult {
-  return { isError: true, content: [{ type: 'text', text: message }] }
-}
-
-afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((path) => rm(path, { recursive: true, force: true }))
-  )
-})
-
-function uuid(index: number): string {
-  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
-}
-
-function manifest() {
-  let chatbotIndex = 100
-  const cases = Array.from({ length: 15 }, (_, index) => ({
-    id: `corpus_${index + 1}`,
-    kbId: uuid(index + 1),
-    chatbotIds: Array.from(
-      { length: index === 0 ? 1 : index <= 7 ? 2 : 1 },
-      () => uuid(chatbotIndex++)
-    ),
-    positive: {
-      question: `positive fixture ${index + 1}`,
-      expectAny: [`positive-marker-${index + 1}`],
-      minSources: 1,
-    },
-    foreign: {
-      question: `foreign fixture ${index + 1}`,
-      forbidReferences: [`foreign-reference-${index + 1}`],
-    },
-  }))
-  return {
-    version: 1,
+const manifest = () =>
+  createProofManifest({
     environment: 'prd',
     collection: 'klicker_course_materials_v1',
-    singletonCanaryCaseId: 'corpus_1',
-    cases,
-    excludedChatbotIds: [uuid(900), uuid(901)],
-  }
-}
-
-async function dummyEnvironment() {
-  const { privateKey } = await generateKeyPair('ES256')
-  return {
-    DOC_QUERY_JWT_TOKEN_KLICKER: 'dummy-transport-token',
-    DOC_QUERY_SCOPE_PRIVATE_KEY: await exportPKCS8(privateKey),
-    DOC_QUERY_SCOPE_KID: 'dummy-key',
-    DOC_QUERY_SCOPE_ISSUER: 'https://chat.klicker.test',
-    DOC_QUERY_SCOPE_AUDIENCE: 'klicker-doc-query-test',
-    DOC_QUERY_PROOF_MANIFEST_PATH: '/private/tmp/dummy-manifest.json',
-  }
-}
-
-function passedReceiptSource(
-  extra = '',
-  preservation = '{databaseWrites:0,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
-) {
-  return `
-${extra}
-process.send({
-  receiptVersion: 1,
+    extraChatbotCases: 7,
+  })
+const receiptSources = createProofReceiptSources({
   environment: 'prd',
   collection: 'klicker_course_materials_v1',
-  phase: 'complete',
-  result: 'passed',
-  failureClass: 'none',
-  failedCaseId: null,
-  failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:15,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:15,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37},
-  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
-  preservation: ${preservation}
-}, () => process.exit(0))
-`
-}
-
-function failedReceiptSource() {
-  return `
-process.send({
-  receiptVersion: 1,
-  environment: 'prd',
-  collection: 'klicker_course_materials_v1',
-  phase: 'canary',
-  result: 'failed',
-  failureClass: 'canary_positive_failed',
-  failedCaseId: 'corpus_1',
-  failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:0,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0},
-  rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
-  secret: 'dummy-private-key'
-}, () => process.exit(1))
-`
-}
-
-async function writeDummy(source: string) {
-  const directory = await mkdtemp(
-    join(tmpdir(), 'klicker-doc-query-proof-test-')
-  )
-  temporaryDirectories.push(directory)
-  const path = join(directory, 'child.mjs')
-  await writeFile(path, source, { mode: 0o700 })
-  return { path, lockPath: join(directory, 'proof.lock') }
-}
-
-describe('PRD Doc Query proof manifest', () => {
-  test('accepts exactly 15 KBs, 22 target chatbots, and two exclusions', () => {
-    const validated = validateManifest(manifest())
-    expect(validated.cases).toHaveLength(15)
-    expect(
-      validated.cases.flatMap(
-        (entry: { chatbotIds: string[] }) => entry.chatbotIds
-      )
-    ).toHaveLength(22)
-    expect(validated.cases[0].chatbotIds).toHaveLength(1)
-    expect(validated.excludedChatbotIds).toHaveLength(2)
-  })
-
-  test('refuses duplicate target chatbots before any proof call', () => {
-    const duplicate = manifest()
-    duplicate.cases[1].chatbotIds[0] =
-      duplicate.cases[0].chatbotIds[0].toUpperCase()
-    expect(() => validateManifest(duplicate)).toThrow('manifest_refused')
-  })
-
-  test('canonicalizes UUIDs before every cardinality check', () => {
-    const duplicateKb = manifest()
-    duplicateKb.cases[1].kbId = duplicateKb.cases[0].kbId.toUpperCase()
-    expect(() => validateManifest(duplicateKb)).toThrow('manifest_refused')
-
-    const overlappingExclusion = manifest()
-    overlappingExclusion.excludedChatbotIds[0] =
-      overlappingExclusion.cases[0].chatbotIds[0].toUpperCase()
-    expect(() => validateManifest(overlappingExclusion)).toThrow(
-      'manifest_refused'
-    )
-  })
-
-  test('requires source-reference isolation markers', () => {
-    const legacy = manifest()
-    const foreign = legacy.cases[0].foreign as {
-      question: string
-      forbidReferences?: string[]
-      forbidAny?: string[]
-    }
-    foreign.forbidAny = foreign.forbidReferences
-    delete foreign.forbidReferences
-    expect(() => validateManifest(legacy)).toThrow('manifest_refused')
-
-    const mixed = manifest()
-    const mixedForeign = mixed.cases[0].foreign as {
-      question: string
-      forbidReferences: string[]
-      forbidAny?: string[]
-    }
-    mixedForeign.forbidAny = mixedForeign.forbidReferences
-    expect(() => validateManifest(mixed)).toThrow('manifest_refused')
-  })
+  passedCounts:
+    '{kbExpected:15,kbPassed:15,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:15,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37}',
+  failedCounts:
+    '{kbExpected:15,kbPassed:0,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0}',
 })
+const proofRegistry = createTemporaryDirectoryRegistry()
+const writeDummy = createProofChildWriter(proofRegistry)
+afterEach(() => proofRegistry.cleanup())
+
+defineProofManifestSuite(
+  'PRD',
+  { validateManifest },
+  { manifest, expectedChatbotCount: 22 }
+)
 
 describe('PRD Doc Query proof transport', () => {
   test('disables Streamable HTTP reconnection attempts', () => {
@@ -249,134 +116,9 @@ describe('PRD Doc Query proof transport', () => {
 })
 
 describe('PRD Doc Query proof matrix', () => {
-  test('runs the singleton canary, seven rejections, then the serial matrix', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let call = 0
-    const invoke = async ({
-      question,
-      override,
-    }: {
-      question: string
-      override?: string
-    }): Promise<MockToolResult> => {
-      call += 1
-      if ((call >= 3 && call <= 8) || override) {
-        return rejected(override ? 'invalid arguments' : undefined)
-      }
-      const positive = question.startsWith('positive')
-      const marker = question.replace(
-        positive ? 'positive fixture ' : 'foreign fixture ',
-        positive ? 'positive-marker-' : 'foreign-reference-'
-      )
-      return {
-        isError: false,
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              mode: 'documents',
-              summary: { sources_returned: 1, chunks_returned: 1 },
-              sources: [
-                positive
-                  ? {
-                      reference: 'safe-positive-reference',
-                      chunks: [{ content: marker }],
-                    }
-                  : {
-                      reference: 'safe-foreign-reference',
-                      chunks: [{ content: marker }],
-                    },
-              ],
-            }),
-          },
-        ],
-      }
-    }
-
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke,
-    })
-
-    expect(call).toBe(37)
-    expect(receipt.result).toBe('passed')
-    expect(receipt.counts).toMatchObject({
-      kbPassed: 15,
-      chatbotsInScope: 22,
-      representativeChatbotsExpected: 15,
-      representativeChatbotsPassed: 15,
-      positivePassed: 15,
-      isolationPassed: 15,
-      rejectionsPassed: 7,
-      directCallsAttempted: 37,
-    })
-  })
-
-  test('fails when a foreign source reference is returned', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let calls = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async ({ question }: { question: string }) => {
-        calls += 1
-        const positive = question.startsWith('positive')
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                mode: 'documents',
-                summary: { sources_returned: 1, chunks_returned: 1 },
-                sources: [
-                  {
-                    reference: positive
-                      ? 'safe-positive-reference'
-                      : 'foreign-reference-1',
-                    chunks: [
-                      {
-                        content: positive
-                          ? question.replace(
-                              'positive fixture ',
-                              'positive-marker-'
-                            )
-                          : 'overlapping subject terminology',
-                      },
-                    ],
-                  },
-                ],
-              }),
-            },
-          ],
-        }
-      },
-    })
-    expect(receipt.failureClass).toBe('canary_isolation_failed')
-    expect(calls).toBe(2)
-  })
-
-  test('stops on the first invariant failure without retrying', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let calls = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async () => {
-        calls += 1
-        return rejected('backend unavailable')
-      },
-    })
-    expect(receipt.failureClass).toBe('canary_positive_failed')
-    expect(calls).toBe(1)
-  })
-
   test('does not accept an unrelated tool error as an auth rejection', async () => {
     const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
+    const environment = await proofDummyEnvironment()
     let call = 0
     const receipt = await runProofMatrix({
       manifest: validated,
@@ -407,252 +149,58 @@ describe('PRD Doc Query proof matrix', () => {
     expect(receipt.failedRejectionClass).toBe('missing')
     expect(call).toBe(3)
   })
-
-  test('sends both protected fields in the trusted-filter rejection case', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    const overrides: string[] = []
-    let call = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async ({
-        question,
-        override,
-      }: {
-        question: string
-        override?: string
-      }) => {
-        call += 1
-        if (override) overrides.push(override)
-        if ((call >= 3 && call <= 8) || override) {
-          return rejected(override ? 'invalid arguments' : undefined)
-        }
-        const positive = question.startsWith('positive')
-        const marker = question.replace(
-          positive ? 'positive fixture ' : 'foreign fixture ',
-          positive ? 'positive-marker-' : 'safe-marker-'
-        )
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                mode: 'documents',
-                summary: { sources_returned: 1, chunks_returned: 1 },
-                sources: [{ reference: marker, chunks: [] }],
-              }),
-            },
-          ],
-        }
-      },
-    })
-    expect(receipt.result).toBe('passed')
-    expect(overrides).toEqual([validated.cases[1].kbId])
-  })
 })
 
+defineProofMatrixSuite(
+  'PRD',
+  {
+    validateManifest,
+    runProofMatrix: runProofMatrix as unknown as RunProofMatrix,
+  },
+  {
+    manifest,
+    environment: proofDummyEnvironment,
+    rejection: rejected,
+    rejectionWithArguments: () => rejected('invalid arguments'),
+    expectedDirectCalls: 37,
+    expectedCounts: {
+      kbPassed: 15,
+      chatbotsInScope: 22,
+      representativeChatbotsExpected: 15,
+      representativeChatbotsPassed: 15,
+      positivePassed: 15,
+      isolationPassed: 15,
+      rejectionsPassed: 7,
+      directCallsAttempted: 37,
+    },
+  }
+)
+
+defineProofSupervisorSuite(
+  'PRD',
+  {
+    minimalChildEnvironment,
+    validateWorkerEnvironment,
+    superviseProof: superviseProof as unknown as SuperviseProof,
+  },
+  {
+    dummyEnvironment: proofDummyEnvironment,
+    writeDummy,
+    passedReceiptSource: receiptSources.passedReceiptSource,
+    failedReceiptSource: receiptSources.failedReceiptSource,
+  }
+)
+
 describe('PRD Doc Query proof supervisor', () => {
-  test('passes only the allowlisted environment', async () => {
-    const environment = await dummyEnvironment()
-    const childEnvironment = minimalChildEnvironment(
-      { ...environment, LEAK_ME: 'must-not-pass' },
-      123
-    )
-    expect(childEnvironment).not.toHaveProperty('LEAK_ME')
-    expect(childEnvironment).not.toHaveProperty('PATH')
-    expect(Object.keys(childEnvironment).sort()).toEqual(
-      [
-        'DOC_QUERY_JWT_TOKEN_KLICKER',
-        'DOC_QUERY_SCOPE_AUDIENCE',
-        'DOC_QUERY_SCOPE_ISSUER',
-        'DOC_QUERY_SCOPE_KID',
-        'DOC_QUERY_SCOPE_PRIVATE_KEY',
-        'DOC_QUERY_PROOF_PARENT_PID',
-        'DOC_QUERY_PROOF_MANIFEST_PATH',
-      ].sort()
-    )
-  })
-
-  test('rejects unexpected worker environment names while allowing the platform marker', async () => {
-    const environment = await dummyEnvironment()
-    expect(() =>
-      validateWorkerEnvironment({
-        ...environment,
-        DOC_QUERY_PROOF_PARENT_PID: '123',
-        __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0',
-      })
-    ).not.toThrow()
-    expect(() =>
-      validateWorkerEnvironment({
-        ...environment,
-        DOC_QUERY_PROOF_PARENT_PID: '123',
-        LEAK_ME: 'must-not-pass',
-      })
-    ).toThrow('protocol_failed')
-  })
-
-  test('suppresses noisy child output and returns only a fixed receipt', async () => {
-    const dummy = await writeDummy(
-      passedReceiptSource(
-        "process.stdout.write('dummy-transport-token'); process.stderr.write('dummy-private-key')"
-      )
-    )
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt.result).toBe('passed')
-    expect(JSON.stringify(receipt)).not.toContain('dummy-transport-token')
-    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
-  })
-
-  test.each([
-    [
-      'an incomplete receipt',
-      passedReceiptSource().replace("phase: 'complete'", "phase: 'matrix'"),
-      'protocol_failed',
-    ],
-    [
-      'missing preservation evidence',
-      passedReceiptSource('', 'undefined'),
-      'protocol_failed',
-    ],
-    [
-      'non-zero preservation evidence',
-      passedReceiptSource(
-        '',
-        '{databaseWrites:1,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
-      ),
-      'protocol_failed',
-    ],
-    [
-      'an exit-mismatched receipt',
-      passedReceiptSource().replace('process.exit(0)', 'process.exit(1)'),
-      'child_failed',
-    ],
-    ['a missing receipt', 'process.exit(0)', 'child_failed'],
-  ])('rejects %s', async (_name, source, expectedFailure) => {
-    const dummy = await writeDummy(source)
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt.result).toBe('failed')
-    expect(receipt.failureClass).toBe(expectedFailure)
-  })
-
-  test('passes no unrelated environment or file descriptor to the child', async () => {
-    const directory = await mkdtemp(
-      join(tmpdir(), 'klicker-doc-query-fd-test-')
-    )
-    temporaryDirectories.push(directory)
-    const unrelated = await open(join(directory, 'unrelated'), 'w')
-    const dummy = await writeDummy(
-      `
-import { fstatSync, readFileSync } from 'node:fs'
-const allowed = new Set(${JSON.stringify([
-        'DOC_QUERY_JWT_TOKEN_KLICKER',
-        'DOC_QUERY_SCOPE_AUDIENCE',
-        'DOC_QUERY_SCOPE_ISSUER',
-        'DOC_QUERY_SCOPE_KID',
-        'DOC_QUERY_SCOPE_PRIVATE_KEY',
-        'DOC_QUERY_PROOF_PARENT_PID',
-        'DOC_QUERY_PROOF_MANIFEST_PATH',
-        '__CF_USER_TEXT_ENCODING',
-      ])})
-if (Object.keys(process.env).some((name) => !allowed.has(name))) process.exit(8)
-if (readFileSync(0).length !== 0) process.exit(9)
-try {
-  fstatSync(${unrelated.fd})
-  process.exit(10)
-} catch (error) {
-  if (error?.code !== 'EBADF') process.exit(11)
-}
-${passedReceiptSource()}
-`
-    )
-    const receipt = await superviseProof({
-      sourceEnvironment: {
-        ...(await dummyEnvironment()),
-        LEAK_ME: 'must-not-pass',
-      } as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    await unrelated.close()
-    expect(receipt.result).toBe('passed')
-  })
-
-  test('preserves a values-free failure receipt from a failed child', async () => {
-    const dummy = await writeDummy(failedReceiptSource())
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt).toMatchObject({
-      result: 'failed',
-      failureClass: 'canary_positive_failed',
-      failedCaseId: 'corpus_1',
-      exitCode: 1,
-    })
-    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
-  })
-
-  test.each([
-    ['exit', 'process.exit(7)', 'child_failed'],
-    ['signal', "process.kill(process.pid, 'SIGTERM')", 'child_signaled'],
-    ['timeout', 'setInterval(() => {}, 1000)', 'timeout'],
-  ])('classifies %s without retrying', async (_name, source, expected) => {
-    const dummy = await writeDummy(source)
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: expected === 'timeout' ? 50 : 2_000,
-    })
-    expect(receipt.failureClass).toBe(expected)
-  })
-
-  test('refuses a duplicate invocation before spawning', async () => {
-    const dummy = await writeDummy(passedReceiptSource())
-    await writeFile(dummy.lockPath, '')
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-    })
-    expect(receipt.failureClass).toBe('duplicate_refused')
-    expect(receipt.exitCode).toBeNull()
-  })
-
   test('does not remove a replacement proof lock during cleanup', async () => {
     const dummy = await writeDummy(
-      passedReceiptSource(
+      receiptSources.passedReceiptSource(
         'await new Promise((resolve) => setTimeout(resolve, 200))'
       )
     )
     const proof = superviseProof({
       sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        (await proofDummyEnvironment()) as unknown as NodeJS.ProcessEnv,
       childPath: dummy.path,
       childArgs: [],
       lockPath: dummy.lockPath,
@@ -675,12 +223,12 @@ ${passedReceiptSource()}
   })
 
   test('cleans up when reading the acquired proof lock identity fails', async () => {
-    const dummy = await writeDummy(passedReceiptSource())
+    const dummy = await writeDummy(receiptSources.passedReceiptSource())
     const handle = await open(dummy.lockPath, 'wx', 0o600)
     let closed = false
     const receipt = await superviseProof({
       sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+        (await proofDummyEnvironment()) as unknown as NodeJS.ProcessEnv,
       childPath: dummy.path,
       childArgs: [],
       lockPath: dummy.lockPath,

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -91,7 +91,7 @@ process.send({
   failureClass: 'none',
   failedCaseId: null,
   failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:22,chatbotsPassed:22,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37},
+  counts: {kbExpected:15,kbPassed:15,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:15,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37},
   rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
   preservation: ${preservation}
 }, () => process.exit(0))
@@ -109,7 +109,7 @@ process.send({
   failureClass: 'canary_positive_failed',
   failedCaseId: 'corpus_1',
   failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:22,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0},
+  counts: {kbExpected:15,kbPassed:0,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0},
   rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
   secret: 'dummy-private-key'
 }, () => process.exit(1))
@@ -304,7 +304,9 @@ describe('PRD Doc Query proof matrix', () => {
     expect(receipt.result).toBe('passed')
     expect(receipt.counts).toMatchObject({
       kbPassed: 15,
-      chatbotsPassed: 22,
+      chatbotsInScope: 22,
+      representativeChatbotsExpected: 15,
+      representativeChatbotsPassed: 15,
       positivePassed: 15,
       isolationPassed: 15,
       rejectionsPassed: 7,

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -19,6 +19,10 @@ type MockToolResult = {
   content: Array<{ type: 'text'; text: string }>
 }
 
+function rejected(message = 'unauthorized: invalid token'): MockToolResult {
+  return { isError: true, content: [{ type: 'text', text: message }] }
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
@@ -179,12 +183,15 @@ describe('PRD Doc Query proof manifest', () => {
 
 describe('PRD Doc Query proof transport', () => {
   test('disables Streamable HTTP reconnection attempts', () => {
+    let capturedUrl: URL | undefined
     let capturedOptions: {
       requestInit?: { headers?: Record<string, string>; redirect?: string }
+      fetch?: typeof fetch
       reconnectionOptions?: { maxRetries?: number }
     } = {}
     class RecordingTransport {
-      constructor(_url: URL, options: typeof capturedOptions) {
+      constructor(url: URL, options: typeof capturedOptions) {
+        capturedUrl = url
         capturedOptions = options
       }
     }
@@ -199,6 +206,45 @@ describe('PRD Doc Query proof transport', () => {
       requestInit: { headers, redirect: 'error' },
       reconnectionOptions: { maxRetries: 0 },
     })
+    expect(capturedUrl?.toString()).toBe(
+      'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker'
+    )
+    expect(capturedOptions.fetch).toBeTypeOf('function')
+  })
+
+  test('applies redirect refusal to the transport GET request', async () => {
+    const originalFetch = globalThis.fetch
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit
+    ) => {
+      capturedInit = init
+      return new Response(null, { status: 405 })
+    }) as typeof fetch
+    try {
+      let capturedOptions: { fetch?: typeof fetch } = {}
+      class RecordingTransport {
+        constructor(_url: URL, options: typeof capturedOptions) {
+          capturedOptions = options
+        }
+      }
+      createMcpTransport(
+        { authorization: 'Bearer dummy-transport-token' },
+        RecordingTransport as unknown as Parameters<
+          typeof createMcpTransport
+        >[1]
+      )
+      await capturedOptions.fetch?.('https://example.test/mcp', {
+        method: 'GET',
+      })
+      expect(capturedInit).toMatchObject({
+        method: 'GET',
+        redirect: 'error',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })
 
@@ -216,7 +262,7 @@ describe('PRD Doc Query proof matrix', () => {
     }): Promise<MockToolResult> => {
       call += 1
       if ((call >= 3 && call <= 8) || override) {
-        return { isError: true, content: [] }
+        return rejected(override ? 'invalid arguments' : undefined)
       }
       const positive = question.startsWith('positive')
       const marker = question.replace(
@@ -318,11 +364,45 @@ describe('PRD Doc Query proof matrix', () => {
       environment,
       invoke: async () => {
         calls += 1
-        return { isError: true, content: [] }
+        return rejected('backend unavailable')
       },
     })
     expect(receipt.failureClass).toBe('canary_positive_failed')
     expect(calls).toBe(1)
+  })
+
+  test('does not accept an unrelated tool error as an auth rejection', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let call = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({ question }: { question: string }) => {
+        call += 1
+        if (call === 3) return rejected('backend unavailable')
+        const positive = question.startsWith('positive')
+        const marker = question.replace(
+          positive ? 'positive fixture ' : 'foreign fixture ',
+          positive ? 'positive-marker-' : 'safe-marker-'
+        )
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [{ reference: marker, chunks: [] }],
+              }),
+            },
+          ],
+        }
+      },
+    })
+    expect(receipt.failureClass).toBe('rejection_failed')
+    expect(receipt.failedRejectionClass).toBe('missing')
+    expect(call).toBe(3)
   })
 
   test('sends both protected fields in the trusted-filter rejection case', async () => {
@@ -343,7 +423,7 @@ describe('PRD Doc Query proof matrix', () => {
         call += 1
         if (override) overrides.push(override)
         if ((call >= 3 && call <= 8) || override) {
-          return { isError: true, content: [] }
+          return rejected(override ? 'invalid arguments' : undefined)
         }
         const positive = question.startsWith('positive')
         const marker = question.replace(

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -1,0 +1,563 @@
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { exportPKCS8, generateKeyPair } from 'jose'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  createMcpTransport,
+  minimalChildEnvironment,
+  runProofMatrix,
+  superviseProof,
+  validateManifest,
+  validateWorkerEnvironment,
+} from '../scripts/prd-doc-query-proof.mjs'
+
+const temporaryDirectories: string[] = []
+
+type MockToolResult = {
+  isError?: boolean
+  content: Array<{ type: 'text'; text: string }>
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true }))
+  )
+})
+
+function uuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+}
+
+function manifest() {
+  let chatbotIndex = 100
+  const cases = Array.from({ length: 15 }, (_, index) => ({
+    id: `corpus_${index + 1}`,
+    kbId: uuid(index + 1),
+    chatbotIds: Array.from(
+      { length: index === 0 ? 1 : index <= 7 ? 2 : 1 },
+      () => uuid(chatbotIndex++)
+    ),
+    positive: {
+      question: `positive fixture ${index + 1}`,
+      expectAny: [`positive-marker-${index + 1}`],
+      minSources: 1,
+    },
+    foreign: {
+      question: `foreign fixture ${index + 1}`,
+      forbidReferences: [`foreign-reference-${index + 1}`],
+    },
+  }))
+  return {
+    version: 1,
+    environment: 'prd',
+    collection: 'klicker_course_materials_v1',
+    singletonCanaryCaseId: 'corpus_1',
+    cases,
+    excludedChatbotIds: [uuid(900), uuid(901)],
+  }
+}
+
+async function dummyEnvironment() {
+  const { privateKey } = await generateKeyPair('ES256')
+  return {
+    DOC_QUERY_JWT_TOKEN_KLICKER: 'dummy-transport-token',
+    DOC_QUERY_SCOPE_PRIVATE_KEY: await exportPKCS8(privateKey),
+    DOC_QUERY_SCOPE_KID: 'dummy-key',
+    DOC_QUERY_SCOPE_ISSUER: 'https://chat.klicker.test',
+    DOC_QUERY_SCOPE_AUDIENCE: 'klicker-doc-query-test',
+    DOC_QUERY_PROOF_MANIFEST_PATH: '/private/tmp/dummy-manifest.json',
+  }
+}
+
+function passedReceiptSource(
+  extra = '',
+  preservation = '{databaseWrites:0,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+) {
+  return `
+${extra}
+process.send({
+  receiptVersion: 1,
+  environment: 'prd',
+  collection: 'klicker_course_materials_v1',
+  phase: 'complete',
+  result: 'passed',
+  failureClass: 'none',
+  failedCaseId: null,
+  failedRejectionClass: null,
+  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:22,chatbotsPassed:22,excludedExpected:2,positivePassed:22,isolationPassed:22,rejectionsPassed:7},
+  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
+  preservation: ${preservation}
+}, () => process.exit(0))
+`
+}
+
+function failedReceiptSource() {
+  return `
+process.send({
+  receiptVersion: 1,
+  environment: 'prd',
+  collection: 'klicker_course_materials_v1',
+  phase: 'canary',
+  result: 'failed',
+  failureClass: 'canary_positive_failed',
+  failedCaseId: 'corpus_1',
+  failedRejectionClass: null,
+  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:22,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0},
+  rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
+  secret: 'dummy-private-key'
+}, () => process.exit(1))
+`
+}
+
+async function writeDummy(source: string) {
+  const directory = await mkdtemp(
+    join(tmpdir(), 'klicker-doc-query-proof-test-')
+  )
+  temporaryDirectories.push(directory)
+  const path = join(directory, 'child.mjs')
+  await writeFile(path, source, { mode: 0o700 })
+  return { path, lockPath: join(directory, 'proof.lock') }
+}
+
+describe('PRD Doc Query proof manifest', () => {
+  test('accepts exactly 15 KBs, 22 target chatbots, and two exclusions', () => {
+    const validated = validateManifest(manifest())
+    expect(validated.cases).toHaveLength(15)
+    expect(
+      validated.cases.flatMap(
+        (entry: { chatbotIds: string[] }) => entry.chatbotIds
+      )
+    ).toHaveLength(22)
+    expect(validated.cases[0].chatbotIds).toHaveLength(1)
+    expect(validated.excludedChatbotIds).toHaveLength(2)
+  })
+
+  test('refuses duplicate target chatbots before any proof call', () => {
+    const duplicate = manifest()
+    duplicate.cases[1].chatbotIds[0] =
+      duplicate.cases[0].chatbotIds[0].toUpperCase()
+    expect(() => validateManifest(duplicate)).toThrow('manifest_refused')
+  })
+
+  test('canonicalizes UUIDs before every cardinality check', () => {
+    const duplicateKb = manifest()
+    duplicateKb.cases[1].kbId = duplicateKb.cases[0].kbId.toUpperCase()
+    expect(() => validateManifest(duplicateKb)).toThrow('manifest_refused')
+
+    const overlappingExclusion = manifest()
+    overlappingExclusion.excludedChatbotIds[0] =
+      overlappingExclusion.cases[0].chatbotIds[0].toUpperCase()
+    expect(() => validateManifest(overlappingExclusion)).toThrow(
+      'manifest_refused'
+    )
+  })
+
+  test('requires source-reference isolation markers', () => {
+    const legacy = manifest()
+    const foreign = legacy.cases[0].foreign as {
+      question: string
+      forbidReferences?: string[]
+      forbidAny?: string[]
+    }
+    foreign.forbidAny = foreign.forbidReferences
+    delete foreign.forbidReferences
+    expect(() => validateManifest(legacy)).toThrow('manifest_refused')
+
+    const mixed = manifest()
+    const mixedForeign = mixed.cases[0].foreign as {
+      question: string
+      forbidReferences: string[]
+      forbidAny?: string[]
+    }
+    mixedForeign.forbidAny = mixedForeign.forbidReferences
+    expect(() => validateManifest(mixed)).toThrow('manifest_refused')
+  })
+})
+
+describe('PRD Doc Query proof transport', () => {
+  test('disables Streamable HTTP reconnection attempts', () => {
+    let capturedOptions: {
+      requestInit?: { headers?: Record<string, string>; redirect?: string }
+      reconnectionOptions?: { maxRetries?: number }
+    } = {}
+    class RecordingTransport {
+      constructor(_url: URL, options: typeof capturedOptions) {
+        capturedOptions = options
+      }
+    }
+
+    const headers = { authorization: 'Bearer dummy-transport-token' }
+    createMcpTransport(
+      headers,
+      RecordingTransport as unknown as Parameters<typeof createMcpTransport>[1]
+    )
+
+    expect(capturedOptions).toMatchObject({
+      requestInit: { headers, redirect: 'error' },
+      reconnectionOptions: { maxRetries: 0 },
+    })
+  })
+})
+
+describe('PRD Doc Query proof matrix', () => {
+  test('runs the singleton canary, seven rejections, then the serial matrix', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let call = 0
+    const invoke = async ({
+      question,
+      override,
+    }: {
+      question: string
+      override?: string
+    }): Promise<MockToolResult> => {
+      call += 1
+      if ((call >= 3 && call <= 8) || override) {
+        return { isError: true, content: [] }
+      }
+      const positive = question.startsWith('positive')
+      const marker = question.replace(
+        positive ? 'positive fixture ' : 'foreign fixture ',
+        positive ? 'positive-marker-' : 'foreign-reference-'
+      )
+      return {
+        isError: false,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              mode: 'documents',
+              summary: { sources_returned: 1, chunks_returned: 1 },
+              sources: [
+                positive
+                  ? {
+                      reference: 'safe-positive-reference',
+                      chunks: [{ content: marker }],
+                    }
+                  : {
+                      reference: 'safe-foreign-reference',
+                      chunks: [{ content: marker }],
+                    },
+              ],
+            }),
+          },
+        ],
+      }
+    }
+
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke,
+    })
+
+    expect(call).toBe(51)
+    expect(receipt.result).toBe('passed')
+    expect(receipt.counts).toMatchObject({
+      kbPassed: 15,
+      chatbotsPassed: 22,
+      positivePassed: 22,
+      isolationPassed: 22,
+      rejectionsPassed: 7,
+    })
+  })
+
+  test('fails when a foreign source reference is returned', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let calls = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({ question }: { question: string }) => {
+        calls += 1
+        const positive = question.startsWith('positive')
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [
+                  {
+                    reference: positive
+                      ? 'safe-positive-reference'
+                      : 'foreign-reference-1',
+                    chunks: [
+                      {
+                        content: positive
+                          ? question.replace(
+                              'positive fixture ',
+                              'positive-marker-'
+                            )
+                          : 'overlapping subject terminology',
+                      },
+                    ],
+                  },
+                ],
+              }),
+            },
+          ],
+        }
+      },
+    })
+    expect(receipt.failureClass).toBe('canary_isolation_failed')
+    expect(calls).toBe(2)
+  })
+
+  test('stops on the first invariant failure without retrying', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    let calls = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async () => {
+        calls += 1
+        return { isError: true, content: [] }
+      },
+    })
+    expect(receipt.failureClass).toBe('canary_positive_failed')
+    expect(calls).toBe(1)
+  })
+
+  test('sends both protected fields in the trusted-filter rejection case', async () => {
+    const validated = validateManifest(manifest())
+    const environment = await dummyEnvironment()
+    const overrides: string[] = []
+    let call = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({
+        question,
+        override,
+      }: {
+        question: string
+        override?: string
+      }) => {
+        call += 1
+        if (override) overrides.push(override)
+        if ((call >= 3 && call <= 8) || override) {
+          return { isError: true, content: [] }
+        }
+        const positive = question.startsWith('positive')
+        const marker = question.replace(
+          positive ? 'positive fixture ' : 'foreign fixture ',
+          positive ? 'positive-marker-' : 'safe-marker-'
+        )
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [{ reference: marker, chunks: [] }],
+              }),
+            },
+          ],
+        }
+      },
+    })
+    expect(receipt.result).toBe('passed')
+    expect(overrides).toEqual([validated.cases[1].kbId])
+  })
+})
+
+describe('PRD Doc Query proof supervisor', () => {
+  test('passes only the allowlisted environment', async () => {
+    const environment = await dummyEnvironment()
+    const childEnvironment = minimalChildEnvironment(
+      { ...environment, LEAK_ME: 'must-not-pass' },
+      123
+    )
+    expect(childEnvironment).not.toHaveProperty('LEAK_ME')
+    expect(childEnvironment).not.toHaveProperty('PATH')
+    expect(Object.keys(childEnvironment).sort()).toEqual(
+      [
+        'DOC_QUERY_JWT_TOKEN_KLICKER',
+        'DOC_QUERY_SCOPE_AUDIENCE',
+        'DOC_QUERY_SCOPE_ISSUER',
+        'DOC_QUERY_SCOPE_KID',
+        'DOC_QUERY_SCOPE_PRIVATE_KEY',
+        'DOC_QUERY_PROOF_PARENT_PID',
+        'DOC_QUERY_PROOF_MANIFEST_PATH',
+      ].sort()
+    )
+  })
+
+  test('rejects unexpected worker environment names while allowing the platform marker', async () => {
+    const environment = await dummyEnvironment()
+    expect(() =>
+      validateWorkerEnvironment({
+        ...environment,
+        DOC_QUERY_PROOF_PARENT_PID: '123',
+        __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0',
+      })
+    ).not.toThrow()
+    expect(() =>
+      validateWorkerEnvironment({
+        ...environment,
+        DOC_QUERY_PROOF_PARENT_PID: '123',
+        LEAK_ME: 'must-not-pass',
+      })
+    ).toThrow('protocol_failed')
+  })
+
+  test('suppresses noisy child output and returns only a fixed receipt', async () => {
+    const dummy = await writeDummy(
+      passedReceiptSource(
+        "process.stdout.write('dummy-transport-token'); process.stderr.write('dummy-private-key')"
+      )
+    )
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt.result).toBe('passed')
+    expect(JSON.stringify(receipt)).not.toContain('dummy-transport-token')
+    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+  })
+
+  test.each([
+    [
+      'an incomplete receipt',
+      passedReceiptSource().replace("phase: 'complete'", "phase: 'matrix'"),
+      'protocol_failed',
+    ],
+    [
+      'missing preservation evidence',
+      passedReceiptSource('', 'undefined'),
+      'protocol_failed',
+    ],
+    [
+      'non-zero preservation evidence',
+      passedReceiptSource(
+        '',
+        '{databaseWrites:1,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
+      ),
+      'protocol_failed',
+    ],
+    [
+      'an exit-mismatched receipt',
+      passedReceiptSource().replace('process.exit(0)', 'process.exit(1)'),
+      'child_failed',
+    ],
+    ['a missing receipt', 'process.exit(0)', 'child_failed'],
+  ])('rejects %s', async (_name, source, expectedFailure) => {
+    const dummy = await writeDummy(source)
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt.result).toBe('failed')
+    expect(receipt.failureClass).toBe(expectedFailure)
+  })
+
+  test('passes no unrelated environment or file descriptor to the child', async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), 'klicker-doc-query-fd-test-')
+    )
+    temporaryDirectories.push(directory)
+    const unrelated = await open(join(directory, 'unrelated'), 'w')
+    const dummy = await writeDummy(
+      `
+import { fstatSync, readFileSync } from 'node:fs'
+const allowed = new Set(${JSON.stringify([
+        'DOC_QUERY_JWT_TOKEN_KLICKER',
+        'DOC_QUERY_SCOPE_AUDIENCE',
+        'DOC_QUERY_SCOPE_ISSUER',
+        'DOC_QUERY_SCOPE_KID',
+        'DOC_QUERY_SCOPE_PRIVATE_KEY',
+        'DOC_QUERY_PROOF_PARENT_PID',
+        'DOC_QUERY_PROOF_MANIFEST_PATH',
+        '__CF_USER_TEXT_ENCODING',
+      ])})
+if (Object.keys(process.env).some((name) => !allowed.has(name))) process.exit(8)
+if (readFileSync(0).length !== 0) process.exit(9)
+try {
+  fstatSync(${unrelated.fd})
+  process.exit(10)
+} catch (error) {
+  if (error?.code !== 'EBADF') process.exit(11)
+}
+${passedReceiptSource()}
+`
+    )
+    const receipt = await superviseProof({
+      sourceEnvironment: {
+        ...(await dummyEnvironment()),
+        LEAK_ME: 'must-not-pass',
+      } as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    await unrelated.close()
+    expect(receipt.result).toBe('passed')
+  })
+
+  test('preserves a values-free failure receipt from a failed child', async () => {
+    const dummy = await writeDummy(failedReceiptSource())
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+    expect(receipt).toMatchObject({
+      result: 'failed',
+      failureClass: 'canary_positive_failed',
+      failedCaseId: 'corpus_1',
+      exitCode: 1,
+    })
+    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
+  })
+
+  test.each([
+    ['exit', 'process.exit(7)', 'child_failed'],
+    ['signal', "process.kill(process.pid, 'SIGTERM')", 'child_signaled'],
+    ['timeout', 'setInterval(() => {}, 1000)', 'timeout'],
+  ])('classifies %s without retrying', async (_name, source, expected) => {
+    const dummy = await writeDummy(source)
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: expected === 'timeout' ? 50 : 2_000,
+    })
+    expect(receipt.failureClass).toBe(expected)
+  })
+
+  test('refuses a duplicate invocation before spawning', async () => {
+    const dummy = await writeDummy(passedReceiptSource())
+    await writeFile(dummy.lockPath, '')
+    const receipt = await superviseProof({
+      sourceEnvironment:
+        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+    })
+    expect(receipt.failureClass).toBe('duplicate_refused')
+    expect(receipt.exitCode).toBeNull()
+  })
+})

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -91,7 +91,7 @@ process.send({
   failureClass: 'none',
   failedCaseId: null,
   failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:22,chatbotsPassed:22,excludedExpected:2,positivePassed:22,isolationPassed:22,rejectionsPassed:7},
+  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:22,chatbotsPassed:22,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37},
   rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
   preservation: ${preservation}
 }, () => process.exit(0))
@@ -109,7 +109,7 @@ process.send({
   failureClass: 'canary_positive_failed',
   failedCaseId: 'corpus_1',
   failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:22,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0},
+  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:22,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0},
   rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
   secret: 'dummy-private-key'
 }, () => process.exit(1))
@@ -300,14 +300,15 @@ describe('PRD Doc Query proof matrix', () => {
       invoke,
     })
 
-    expect(call).toBe(51)
+    expect(call).toBe(37)
     expect(receipt.result).toBe('passed')
     expect(receipt.counts).toMatchObject({
       kbPassed: 15,
       chatbotsPassed: 22,
-      positivePassed: 22,
-      isolationPassed: 22,
+      positivePassed: 15,
+      isolationPassed: 15,
       rejectionsPassed: 7,
+      directCallsAttempted: 37,
     })
   })
 

--- a/apps/chat/test/stg-doc-query-proof.test.ts
+++ b/apps/chat/test/stg-doc-query-proof.test.ts
@@ -1,7 +1,3 @@
-import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { exportPKCS8, generateKeyPair } from 'jose'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   createMcpTransport,
@@ -11,171 +7,41 @@ import {
   validateManifest,
   validateWorkerEnvironment,
 } from '../scripts/stg-doc-query-proof.mjs'
+import type { RunProofMatrix } from './doc-query-proof-test-support'
+import {
+  createProofChildWriter,
+  createProofManifest,
+  createProofReceiptSources,
+  createTemporaryDirectoryRegistry,
+  defineProofManifestSuite,
+  defineProofMatrixSuite,
+  defineProofSupervisorSuite,
+  emptyRejection,
+  proofDummyEnvironment,
+} from './doc-query-proof-test-support'
 
-const temporaryDirectories: string[] = []
-
-type MockToolResult = {
-  isError?: boolean
-  content: Array<{ type: 'text'; text: string }>
-}
-
-afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((path) => rm(path, { recursive: true, force: true }))
-  )
-})
-
-function uuid(index: number): string {
-  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
-}
-
-function manifest() {
-  let chatbotIndex = 100
-  const cases = Array.from({ length: 15 }, (_, index) => ({
-    id: `corpus_${index + 1}`,
-    kbId: uuid(index + 1),
-    chatbotIds: Array.from(
-      { length: index === 0 ? 1 : index <= 6 ? 2 : 1 },
-      () => uuid(chatbotIndex++)
-    ),
-    positive: {
-      question: `positive fixture ${index + 1}`,
-      expectAny: [`positive-marker-${index + 1}`],
-      minSources: 1,
-    },
-    foreign: {
-      question: `foreign fixture ${index + 1}`,
-      forbidReferences: [`foreign-reference-${index + 1}`],
-    },
-  }))
-  return {
-    version: 1,
+const manifest = () =>
+  createProofManifest({
     environment: 'stg',
     collection: 'klicker_course_materials_v1',
-    singletonCanaryCaseId: 'corpus_1',
-    cases,
-    excludedChatbotIds: [uuid(900), uuid(901)],
-  }
-}
-
-async function dummyEnvironment() {
-  const { privateKey } = await generateKeyPair('ES256')
-  return {
-    DOC_QUERY_JWT_TOKEN_KLICKER: 'dummy-transport-token',
-    DOC_QUERY_SCOPE_PRIVATE_KEY: await exportPKCS8(privateKey),
-    DOC_QUERY_SCOPE_KID: 'dummy-key',
-    DOC_QUERY_SCOPE_ISSUER: 'https://chat.klicker.test',
-    DOC_QUERY_SCOPE_AUDIENCE: 'klicker-doc-query-test',
-    DOC_QUERY_PROOF_MANIFEST_PATH: '/private/tmp/dummy-manifest.json',
-  }
-}
-
-function passedReceiptSource(
-  extra = '',
-  preservation = '{databaseWrites:0,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
-) {
-  return `
-${extra}
-process.send({
-  receiptVersion: 1,
+    extraChatbotCases: 6,
+  })
+const receiptSources = createProofReceiptSources({
   environment: 'stg',
   collection: 'klicker_course_materials_v1',
-  phase: 'complete',
-  result: 'passed',
-  failureClass: 'none',
-  failedCaseId: null,
-  failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:15,chatbotsExpected:21,chatbotsPassed:21,excludedExpected:2,positivePassed:21,isolationPassed:21,rejectionsPassed:7},
-  rejections: {missing:'passed',expired:'passed',forged:'passed',wrong_issuer:'passed',wrong_audience:'passed',unknown_key:'passed',trusted_filter_override:'passed'},
-  preservation: ${preservation}
-}, () => process.exit(0))
-`
-}
-
-function failedReceiptSource() {
-  return `
-process.send({
-  receiptVersion: 1,
-  environment: 'stg',
-  collection: 'klicker_course_materials_v1',
-  phase: 'canary',
-  result: 'failed',
-  failureClass: 'canary_positive_failed',
-  failedCaseId: 'corpus_1',
-  failedRejectionClass: null,
-  counts: {kbExpected:15,kbPassed:0,chatbotsExpected:21,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0},
-  rejections: {missing:'not_run',expired:'not_run',forged:'not_run',wrong_issuer:'not_run',wrong_audience:'not_run',unknown_key:'not_run',trusted_filter_override:'not_run'},
-  secret: 'dummy-private-key'
-}, () => process.exit(1))
-`
-}
-
-async function writeDummy(source: string) {
-  const directory = await mkdtemp(
-    join(tmpdir(), 'klicker-doc-query-proof-test-')
-  )
-  temporaryDirectories.push(directory)
-  const path = join(directory, 'child.mjs')
-  await writeFile(path, source, { mode: 0o700 })
-  return { path, lockPath: join(directory, 'proof.lock') }
-}
-
-describe('STG Doc Query proof manifest', () => {
-  test('accepts exactly 15 KBs, 21 target chatbots, and two exclusions', () => {
-    const validated = validateManifest(manifest())
-    expect(validated.cases).toHaveLength(15)
-    expect(
-      validated.cases.flatMap(
-        (entry: { chatbotIds: string[] }) => entry.chatbotIds
-      )
-    ).toHaveLength(21)
-    expect(validated.cases[0].chatbotIds).toHaveLength(1)
-    expect(validated.excludedChatbotIds).toHaveLength(2)
-  })
-
-  test('refuses duplicate target chatbots before any proof call', () => {
-    const duplicate = manifest()
-    duplicate.cases[1].chatbotIds[0] =
-      duplicate.cases[0].chatbotIds[0].toUpperCase()
-    expect(() => validateManifest(duplicate)).toThrow('manifest_refused')
-  })
-
-  test('canonicalizes UUIDs before every cardinality check', () => {
-    const duplicateKb = manifest()
-    duplicateKb.cases[1].kbId = duplicateKb.cases[0].kbId.toUpperCase()
-    expect(() => validateManifest(duplicateKb)).toThrow('manifest_refused')
-
-    const overlappingExclusion = manifest()
-    overlappingExclusion.excludedChatbotIds[0] =
-      overlappingExclusion.cases[0].chatbotIds[0].toUpperCase()
-    expect(() => validateManifest(overlappingExclusion)).toThrow(
-      'manifest_refused'
-    )
-  })
-
-  test('requires source-reference isolation markers', () => {
-    const legacy = manifest()
-    const foreign = legacy.cases[0].foreign as {
-      question: string
-      forbidReferences?: string[]
-      forbidAny?: string[]
-    }
-    foreign.forbidAny = foreign.forbidReferences
-    delete foreign.forbidReferences
-    expect(() => validateManifest(legacy)).toThrow('manifest_refused')
-
-    const mixed = manifest()
-    const mixedForeign = mixed.cases[0].foreign as {
-      question: string
-      forbidReferences: string[]
-      forbidAny?: string[]
-    }
-    mixedForeign.forbidAny = mixedForeign.forbidReferences
-    expect(() => validateManifest(mixed)).toThrow('manifest_refused')
-  })
+  passedCounts:
+    '{kbExpected:15,kbPassed:15,chatbotsExpected:21,chatbotsPassed:21,excludedExpected:2,positivePassed:21,isolationPassed:21,rejectionsPassed:7}',
+  failedCounts:
+    '{kbExpected:15,kbPassed:0,chatbotsExpected:21,chatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0}',
 })
+const proofRegistry = createTemporaryDirectoryRegistry()
+afterEach(() => proofRegistry.cleanup())
+
+defineProofManifestSuite(
+  'STG',
+  { validateManifest },
+  { manifest, expectedChatbotCount: 21 }
+)
 
 describe('STG Doc Query proof transport', () => {
   test('disables Streamable HTTP reconnection attempts', () => {
@@ -202,362 +68,35 @@ describe('STG Doc Query proof transport', () => {
   })
 })
 
-describe('STG Doc Query proof matrix', () => {
-  test('runs the singleton canary, seven rejections, then the serial matrix', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let call = 0
-    const invoke = async ({
-      question,
-      override,
-    }: {
-      question: string
-      override?: string
-    }): Promise<MockToolResult> => {
-      call += 1
-      if ((call >= 3 && call <= 8) || override) {
-        return { isError: true, content: [] }
-      }
-      const positive = question.startsWith('positive')
-      const marker = question.replace(
-        positive ? 'positive fixture ' : 'foreign fixture ',
-        positive ? 'positive-marker-' : 'foreign-reference-'
-      )
-      return {
-        isError: false,
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              mode: 'documents',
-              summary: { sources_returned: 1, chunks_returned: 1 },
-              sources: [
-                positive
-                  ? {
-                      reference: 'safe-positive-reference',
-                      chunks: [{ content: marker }],
-                    }
-                  : {
-                      reference: 'safe-foreign-reference',
-                      chunks: [{ content: marker }],
-                    },
-              ],
-            }),
-          },
-        ],
-      }
-    }
-
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke,
-    })
-
-    expect(call).toBe(49)
-    expect(receipt.result).toBe('passed')
-    expect(receipt.counts).toMatchObject({
+defineProofMatrixSuite(
+  'STG',
+  {
+    validateManifest,
+    runProofMatrix: runProofMatrix as unknown as RunProofMatrix,
+  },
+  {
+    manifest,
+    environment: proofDummyEnvironment,
+    rejection: emptyRejection,
+    rejectionWithArguments: emptyRejection,
+    expectedDirectCalls: 49,
+    expectedCounts: {
       kbPassed: 15,
       chatbotsPassed: 21,
       positivePassed: 21,
       isolationPassed: 21,
       rejectionsPassed: 7,
-    })
-  })
+    },
+  }
+)
 
-  test('fails when a foreign source reference is returned', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let calls = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async ({ question }: { question: string }) => {
-        calls += 1
-        const positive = question.startsWith('positive')
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                mode: 'documents',
-                summary: { sources_returned: 1, chunks_returned: 1 },
-                sources: [
-                  {
-                    reference: positive
-                      ? 'safe-positive-reference'
-                      : 'foreign-reference-1',
-                    chunks: [
-                      {
-                        content: positive
-                          ? question.replace(
-                              'positive fixture ',
-                              'positive-marker-'
-                            )
-                          : 'overlapping subject terminology',
-                      },
-                    ],
-                  },
-                ],
-              }),
-            },
-          ],
-        }
-      },
-    })
-    expect(receipt.failureClass).toBe('canary_isolation_failed')
-    expect(calls).toBe(2)
-  })
-
-  test('stops on the first invariant failure without retrying', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    let calls = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async () => {
-        calls += 1
-        return { isError: true, content: [] }
-      },
-    })
-    expect(receipt.failureClass).toBe('canary_positive_failed')
-    expect(calls).toBe(1)
-  })
-
-  test('sends both protected fields in the trusted-filter rejection case', async () => {
-    const validated = validateManifest(manifest())
-    const environment = await dummyEnvironment()
-    const overrides: string[] = []
-    let call = 0
-    const receipt = await runProofMatrix({
-      manifest: validated,
-      environment,
-      invoke: async ({
-        question,
-        override,
-      }: {
-        question: string
-        override?: string
-      }) => {
-        call += 1
-        if (override) overrides.push(override)
-        if ((call >= 3 && call <= 8) || override) {
-          return { isError: true, content: [] }
-        }
-        const positive = question.startsWith('positive')
-        const marker = question.replace(
-          positive ? 'positive fixture ' : 'foreign fixture ',
-          positive ? 'positive-marker-' : 'safe-marker-'
-        )
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                mode: 'documents',
-                summary: { sources_returned: 1, chunks_returned: 1 },
-                sources: [{ reference: marker, chunks: [] }],
-              }),
-            },
-          ],
-        }
-      },
-    })
-    expect(receipt.result).toBe('passed')
-    expect(overrides).toEqual([validated.cases[1].kbId])
-  })
-})
-
-describe('STG Doc Query proof supervisor', () => {
-  test('passes only the allowlisted environment', async () => {
-    const environment = await dummyEnvironment()
-    const childEnvironment = minimalChildEnvironment(
-      { ...environment, LEAK_ME: 'must-not-pass' },
-      123
-    )
-    expect(childEnvironment).not.toHaveProperty('LEAK_ME')
-    expect(childEnvironment).not.toHaveProperty('PATH')
-    expect(Object.keys(childEnvironment).sort()).toEqual(
-      [
-        'DOC_QUERY_JWT_TOKEN_KLICKER',
-        'DOC_QUERY_SCOPE_AUDIENCE',
-        'DOC_QUERY_SCOPE_ISSUER',
-        'DOC_QUERY_SCOPE_KID',
-        'DOC_QUERY_SCOPE_PRIVATE_KEY',
-        'DOC_QUERY_PROOF_PARENT_PID',
-        'DOC_QUERY_PROOF_MANIFEST_PATH',
-      ].sort()
-    )
-  })
-
-  test('rejects unexpected worker environment names while allowing the platform marker', async () => {
-    const environment = await dummyEnvironment()
-    expect(() =>
-      validateWorkerEnvironment({
-        ...environment,
-        DOC_QUERY_PROOF_PARENT_PID: '123',
-        __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0',
-      })
-    ).not.toThrow()
-    expect(() =>
-      validateWorkerEnvironment({
-        ...environment,
-        DOC_QUERY_PROOF_PARENT_PID: '123',
-        LEAK_ME: 'must-not-pass',
-      })
-    ).toThrow('protocol_failed')
-  })
-
-  test('suppresses noisy child output and returns only a fixed receipt', async () => {
-    const dummy = await writeDummy(
-      passedReceiptSource(
-        "process.stdout.write('dummy-transport-token'); process.stderr.write('dummy-private-key')"
-      )
-    )
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt.result).toBe('passed')
-    expect(JSON.stringify(receipt)).not.toContain('dummy-transport-token')
-    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
-  })
-
-  test.each([
-    [
-      'an incomplete receipt',
-      passedReceiptSource().replace("phase: 'complete'", "phase: 'matrix'"),
-      'protocol_failed',
-    ],
-    [
-      'missing preservation evidence',
-      passedReceiptSource('', 'undefined'),
-      'protocol_failed',
-    ],
-    [
-      'non-zero preservation evidence',
-      passedReceiptSource(
-        '',
-        '{databaseWrites:1,configurationChanges:0,bindingChanges:0,clusterChanges:0,productionActions:0,retries:0}'
-      ),
-      'protocol_failed',
-    ],
-    [
-      'an exit-mismatched receipt',
-      passedReceiptSource().replace('process.exit(0)', 'process.exit(1)'),
-      'child_failed',
-    ],
-    ['a missing receipt', 'process.exit(0)', 'child_failed'],
-  ])('rejects %s', async (_name, source, expectedFailure) => {
-    const dummy = await writeDummy(source)
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt.result).toBe('failed')
-    expect(receipt.failureClass).toBe(expectedFailure)
-  })
-
-  test('passes no unrelated environment or file descriptor to the child', async () => {
-    const directory = await mkdtemp(
-      join(tmpdir(), 'klicker-doc-query-fd-test-')
-    )
-    temporaryDirectories.push(directory)
-    const unrelated = await open(join(directory, 'unrelated'), 'w')
-    const dummy = await writeDummy(
-      `
-import { fstatSync, readFileSync } from 'node:fs'
-const allowed = new Set(${JSON.stringify([
-        'DOC_QUERY_JWT_TOKEN_KLICKER',
-        'DOC_QUERY_SCOPE_AUDIENCE',
-        'DOC_QUERY_SCOPE_ISSUER',
-        'DOC_QUERY_SCOPE_KID',
-        'DOC_QUERY_SCOPE_PRIVATE_KEY',
-        'DOC_QUERY_PROOF_PARENT_PID',
-        'DOC_QUERY_PROOF_MANIFEST_PATH',
-        '__CF_USER_TEXT_ENCODING',
-      ])})
-if (Object.keys(process.env).some((name) => !allowed.has(name))) process.exit(8)
-if (readFileSync(0).length !== 0) process.exit(9)
-try {
-  fstatSync(${unrelated.fd})
-  process.exit(10)
-} catch (error) {
-  if (error?.code !== 'EBADF') process.exit(11)
-}
-${passedReceiptSource()}
-`
-    )
-    const receipt = await superviseProof({
-      sourceEnvironment: {
-        ...(await dummyEnvironment()),
-        LEAK_ME: 'must-not-pass',
-      } as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    await unrelated.close()
-    expect(receipt.result).toBe('passed')
-  })
-
-  test('preserves a values-free failure receipt from a failed child', async () => {
-    const dummy = await writeDummy(failedReceiptSource())
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: 2_000,
-    })
-    expect(receipt).toMatchObject({
-      result: 'failed',
-      failureClass: 'canary_positive_failed',
-      failedCaseId: 'corpus_1',
-      exitCode: 1,
-    })
-    expect(JSON.stringify(receipt)).not.toContain('dummy-private-key')
-  })
-
-  test.each([
-    ['exit', 'process.exit(7)', 'child_failed'],
-    ['signal', "process.kill(process.pid, 'SIGTERM')", 'child_signaled'],
-    ['timeout', 'setInterval(() => {}, 1000)', 'timeout'],
-  ])('classifies %s without retrying', async (_name, source, expected) => {
-    const dummy = await writeDummy(source)
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-      deadlineMs: expected === 'timeout' ? 50 : 2_000,
-    })
-    expect(receipt.failureClass).toBe(expected)
-  })
-
-  test('refuses a duplicate invocation before spawning', async () => {
-    const dummy = await writeDummy(passedReceiptSource())
-    await writeFile(dummy.lockPath, '')
-    const receipt = await superviseProof({
-      sourceEnvironment:
-        (await dummyEnvironment()) as unknown as NodeJS.ProcessEnv,
-      childPath: dummy.path,
-      childArgs: [],
-      lockPath: dummy.lockPath,
-    })
-    expect(receipt.failureClass).toBe('duplicate_refused')
-    expect(receipt.exitCode).toBeNull()
-  })
-})
+defineProofSupervisorSuite(
+  'STG',
+  { minimalChildEnvironment, validateWorkerEnvironment, superviseProof },
+  {
+    dummyEnvironment: proofDummyEnvironment,
+    writeDummy: createProofChildWriter(proofRegistry),
+    passedReceiptSource: receiptSources.passedReceiptSource,
+    failedReceiptSource: receiptSources.failedReceiptSource,
+  }
+)

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -1,12 +1,14 @@
+import { createHash } from 'node:crypto'
 import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmdirSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { hostname, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
@@ -15,7 +17,9 @@ import {
   type ActivationConfigCreate,
   type ActivationConfigRecord,
   type ActivationKnowledgeBaseCreate,
+  type ActivationReceipt,
   type ActivationReceiptPayload,
+  type ActivationReceiptSession,
   type ActivationReceiptStore,
   type ActivationServerCreate,
   type ActivationServerRecord,
@@ -49,6 +53,50 @@ function uuid(number: number): string {
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
+}
+
+function canonicalReceipt(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalReceipt(item))
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonicalReceipt(record[key])])
+    )
+  }
+  return value
+}
+
+function receiptDigest(receipt: ActivationReceipt): string {
+  const { payloadDigest: _payloadDigest, ...withoutDigest } = receipt
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalReceipt(withoutDigest)))
+    .digest('hex')
+}
+
+function deadPid(): number {
+  for (let candidate = 2_000_000; candidate < 2_000_100; candidate += 1) {
+    try {
+      process.kill(candidate, 0)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') return candidate
+    }
+  }
+  throw new Error('no dead test pid found')
+}
+
+function writeLockOwner(lockPath: string, pid: number, host = hostname()) {
+  mkdirSync(lockPath)
+  writeFileSync(
+    join(lockPath, 'owner.json'),
+    `${JSON.stringify({
+      version: 1,
+      pid,
+      host,
+      token: uuid(9990),
+    })}\n`
+  )
 }
 
 function makeManifest(): FrozenCohortManifest {
@@ -167,7 +215,7 @@ class MemoryStore implements ActivationStore {
   private sequence = 20000
   private clock = 1
 
-  constructor(readonly manifest: FrozenCohortManifest) {
+  constructor(manifest: FrozenCohortManifest) {
     const chatbotIds = manifest.corpora.flatMap((corpus) => corpus.chatbotIds)
     for (const [index, chatbotId] of chatbotIds.entries()) {
       const corpus = manifest.corpora.find((entry) =>
@@ -334,7 +382,6 @@ class MemoryStore implements ActivationStore {
     const row = {
       id: this.nextId(),
       ...data,
-      description: data.description,
       updatedAt: this.nextDate(),
     }
     this.servers.set(row.id, row)
@@ -442,6 +489,13 @@ class MemoryStore implements ActivationStore {
 class MemoryReceiptStore {
   value: ActivationReceiptPayload | null = null
   writes = 0
+  private locked = false
+  private blockedExclusive: {
+    entered: Promise<void>
+    signalEntered: () => void
+    released: Promise<void>
+    release: () => void
+  } | null = null
 
   async read() {
     return this.value
@@ -456,6 +510,54 @@ class MemoryReceiptStore {
     }
     this.value = clone(receipt)
     this.writes += 1
+  }
+
+  async runExclusive<T>(
+    callback: (store: ActivationReceiptSession) => Promise<T>
+  ) {
+    if (this.locked) {
+      throw new CohortActivationError(
+        'RECEIPT_LOCKED',
+        'receipt is already being updated'
+      )
+    }
+    this.locked = true
+    const blocked = this.blockedExclusive
+    try {
+      if (blocked) {
+        blocked.signalEntered()
+        await blocked.released
+      }
+      return await callback(this)
+    } finally {
+      this.locked = false
+    }
+  }
+
+  blockNextExclusive() {
+    let resolveEntered!: () => void
+    let resolveRelease!: () => void
+    const entered = new Promise<void>((resolve) => {
+      resolveEntered = resolve
+    })
+    const released = new Promise<void>((resolve) => {
+      resolveRelease = resolve
+    })
+    this.blockedExclusive = {
+      entered,
+      signalEntered: resolveEntered,
+      released,
+      release: resolveRelease,
+    }
+  }
+
+  async waitForExclusive() {
+    await this.blockedExclusive?.entered
+  }
+
+  releaseExclusive() {
+    this.blockedExclusive?.release()
+    this.blockedExclusive = null
   }
 }
 
@@ -485,10 +587,12 @@ class ConcurrentReceiptStore implements ActivationReceiptStore {
   ) {
     return this.delegate.compareAndSwap(expectedDigest, receipt)
   }
-}
 
-function expectedFingerprint(value: FrozenCohortManifest): string {
-  return fingerprintManifest(value)
+  async runExclusive<T>(
+    callback: (store: ActivationReceiptSession) => Promise<T>
+  ) {
+    return this.delegate.runExclusive(callback)
+  }
 }
 
 function options(
@@ -496,7 +600,7 @@ function options(
   manifest: FrozenCohortManifest
 ) {
   return {
-    expectedManifestFingerprint: expectedFingerprint(manifest),
+    expectedManifestFingerprint: fingerprintManifest(manifest),
     receiptStore,
     target: TARGET,
   }
@@ -571,7 +675,7 @@ describe('cohort activation operator', () => {
           candidate,
           manifest,
           TARGET,
-          expectedFingerprint(manifest)
+          fingerprintManifest(manifest)
         )
       ).rejects.toThrowError(
         expect.objectContaining({ code: 'SOURCE_SERVER_MISMATCH' })
@@ -592,7 +696,7 @@ describe('cohort activation operator', () => {
         new MemoryStore(mismatchedManifest),
         mismatchedManifest,
         TARGET,
-        expectedFingerprint(mismatchedManifest)
+        fingerprintManifest(mismatchedManifest)
       )
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'SOURCE_SERVER_MISMATCH' })
@@ -606,7 +710,7 @@ describe('cohort activation operator', () => {
         store,
         manifest,
         TARGET,
-        expectedFingerprint(manifest)
+        fingerprintManifest(manifest)
       )
     ).rejects.toThrowError(expect.objectContaining({ code: 'COURSE_MISSING' }))
 
@@ -617,7 +721,7 @@ describe('cohort activation operator', () => {
         store,
         manifest,
         TARGET,
-        expectedFingerprint(manifest)
+        fingerprintManifest(manifest)
       )
     ).rejects.toThrowError(expect.objectContaining({ code: 'COURSE_DRIFT' }))
 
@@ -631,7 +735,7 @@ describe('cohort activation operator', () => {
         store,
         manifest,
         TARGET,
-        expectedFingerprint(manifest)
+        fingerprintManifest(manifest)
       )
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'COURSE_REFERENCE_MISSING' })
@@ -644,7 +748,7 @@ describe('cohort activation operator', () => {
         store,
         manifest,
         TARGET,
-        expectedFingerprint(manifest)
+        fingerprintManifest(manifest)
       )
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'EXCLUDED_CONFIG_DRIFT' })
@@ -658,7 +762,7 @@ describe('cohort activation operator', () => {
         store,
         manifest,
         TARGET,
-        expectedFingerprint(manifest)
+        fingerprintManifest(manifest)
       )
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'EXCLUDED_CONFIG_DRIFT' })
@@ -670,7 +774,7 @@ describe('cohort activation operator', () => {
       store,
       manifest,
       TARGET,
-      expectedFingerprint(manifest)
+      fingerprintManifest(manifest)
     )
     expect(result.status).toBe('dry-run')
     expect(result.writes).toEqual({
@@ -856,6 +960,29 @@ describe('cohort activation operator', () => {
     expect(receiptStore.writes).toBe(switchedReceipts)
   })
 
+  it('rejects concurrent switch and rollback under one receipt guard', async () => {
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
+    receiptStore.blockNextExclusive()
+    const switching = switchCohortChatbot(store, manifest, {
+      ...options(receiptStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    await receiptStore.waitForExclusive()
+    await expect(
+      rollbackCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_LOCKED' }))
+    receiptStore.releaseExclusive()
+    await expect(switching).resolves.toMatchObject({ status: 'switched' })
+    expect(receiptStore.value?.state).toBe('switched')
+  })
+
   it('refuses a mixed target group and keeps the durable receipt unchanged', async () => {
     await prepareCohortActivation(
       store,
@@ -875,6 +1002,68 @@ describe('cohort activation operator', () => {
       expect.objectContaining({ code: 'SNAPSHOT_MISMATCH' })
     )
     expect(receiptStore.value).toEqual(receiptBefore)
+  })
+
+  it('rejects semantically inconsistent receipts with otherwise valid digests', async () => {
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
+    const baseline = clone(receiptStore.value!) as ActivationReceipt
+
+    const wrongSwitchedAlias = clone(baseline)
+    wrongSwitchedAlias.switchedChatbotAliases = ['chatbot-999']
+    wrongSwitchedAlias.payloadDigest = receiptDigest(wrongSwitchedAlias)
+    receiptStore.value = wrongSwitchedAlias
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MISMATCH' })
+    )
+
+    const enabledMismatch = clone(baseline)
+    enabledMismatch.bindings[0]!.isEnabled = true
+    enabledMismatch.payloadDigest = receiptDigest(enabledMismatch)
+    receiptStore.value = enabledMismatch
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_STATE' }))
+
+    const invalidPending = clone(baseline)
+    invalidPending.pendingChatbotAlias = 'chatbot-001'
+    invalidPending.payloadDigest = receiptDigest(invalidPending)
+    receiptStore.value = invalidPending
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_STATE' }))
+
+    receiptStore.value = baseline
+    await switchCohortChatbot(store, manifest, {
+      ...options(receiptStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    const switched = clone(receiptStore.value!) as ActivationReceipt
+    const invalidRollback = clone(switched)
+    invalidRollback.state = 'rolling_back'
+    invalidRollback.pendingRollbackAliases = ['chatbot-002']
+    invalidRollback.payloadDigest = receiptDigest(invalidRollback)
+    receiptStore.value = invalidRollback
+    await expect(
+      rollbackCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_STATE' }))
   })
 
   it('refuses enabled alternative bindings during switch and rollback validation', async () => {
@@ -986,6 +1175,74 @@ describe('cohort activation operator', () => {
     expect(await fileStore.read()).toEqual(receipt)
   })
 
+  it('reclaims only a dead same-host lock owner for in-flight recovery', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-stale-'))
+    const path = join(directory, 'receipt.json')
+    writeLockOwner(`${path}.lock`, deadPid())
+    const fileStore = createFileActivationReceiptStore(path)
+    const result = await prepareCohortActivation(
+      store,
+      manifest,
+      options(fileStore, manifest)
+    )
+    expect(result.status).toBe('prepared')
+    expect(() => statSync(`${path}.lock`)).toThrow()
+  })
+
+  it('refuses live and unknown receipt lock owners without expiry', async () => {
+    const sourceDirectory = mkdtempSync(
+      join(tmpdir(), 'cohort-activation-lock-source-')
+    )
+    const sourcePath = join(sourceDirectory, 'receipt.json')
+    const sourceStore = createFileActivationReceiptStore(sourcePath)
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(sourceStore, manifest)
+    )
+    const receipt = await sourceStore.read()
+    for (const [index, owner] of [
+      { host: hostname(), pid: process.pid },
+      { host: 'unknown-host', pid: deadPid() },
+    ].entries()) {
+      const directory = mkdtempSync(
+        join(tmpdir(), `cohort-activation-locked-${index}-`)
+      )
+      const path = join(directory, 'receipt.json')
+      writeLockOwner(`${path}.lock`, owner.pid, owner.host)
+      const fileStore = createFileActivationReceiptStore(path)
+      await expect(
+        fileStore.compareAndSwap(null, receipt!)
+      ).rejects.toThrowError(
+        expect.objectContaining({ code: 'RECEIPT_LOCKED' })
+      )
+      expect(statSync(`${path}.lock`).isDirectory()).toBe(true)
+      rmSync(`${path}.lock`, { force: true, recursive: true })
+    }
+  })
+
+  it('preserves the primary failure when lock cleanup also fails', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-cleanup-'))
+    const path = join(directory, 'receipt.json')
+    const fileStore = createFileActivationReceiptStore(path)
+    const primary = new Error('synthetic operation failure')
+    const failure = await fileStore
+      .runExclusive(async () => {
+        rmSync(`${path}.lock`, { force: true, recursive: true })
+        throw primary
+      })
+      .catch((error: unknown) => error)
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toContain(primary)
+    expect(
+      (failure as AggregateError).errors.some(
+        (error) =>
+          error instanceof CohortActivationError &&
+          error.code === 'RECEIPT_LOCK_CLEANUP_FAILED'
+      )
+    ).toBe(true)
+  })
+
   it('does not let concurrent prepare calls overwrite receipt recovery evidence', async () => {
     const directory = mkdtempSync(
       join(tmpdir(), 'cohort-activation-concurrent-')
@@ -1012,6 +1269,27 @@ describe('cohort activation operator', () => {
       outcomes.find((outcome) => outcome.status === 'rejected')?.reason.code
     )
     expect((await fileStore.read())?.state).toBe('prepared')
+  })
+
+  it('leaves a durable in-flight receipt readable for rollback recovery', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-inflight-'))
+    const path = join(directory, 'receipt.json')
+    const fileStore = createFileActivationReceiptStore(path)
+    await prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    store.failTargetConfigUpdate = true
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(fileStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'CONCURRENT_EDIT' }))
+    expect((await fileStore.read())?.state).toBe('switching')
+    await expect(
+      rollbackCohortChatbot(store, manifest, {
+        ...options(fileStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).resolves.toMatchObject({ status: 'rolled_back' })
   })
 
   it('serializes receipt updates, rejects stale digests, and refuses tampered shape', async () => {

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -1,0 +1,660 @@
+import { mkdtempSync, readFileSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  type ActivationBindingCreate,
+  type ActivationBindingRecord,
+  type ActivationConfigCreate,
+  type ActivationConfigRecord,
+  type ActivationKnowledgeBaseCreate,
+  type ActivationReceiptPayload,
+  type ActivationServerCreate,
+  type ActivationServerRecord,
+  type ActivationStore,
+  type ActivationTransactionStore,
+  type ChatbotRecord,
+  CohortActivationError,
+  createFileActivationReceiptStore,
+  dryRunCohortActivation,
+  type FrozenCohortManifest,
+  fingerprintManifest,
+  type KnowledgeBaseRecord,
+  prepareCohortActivation,
+  readbackCohortActivation,
+  rollbackCohortChatbot,
+  switchCohortChatbot,
+  validateCohortManifest,
+} from './cohort-activation.js'
+
+const TARGET = {
+  description: 'Scoped document retrieval',
+  url: 'https://doc-query.synthetic.invalid/mcp',
+}
+const SOURCE_SERVER_ID = uuid(900)
+const SOURCE_CREDENTIAL = 'encrypted-transport-credential'
+const OWNER_ID = uuid(901)
+
+function uuid(number: number): string {
+  return `00000000-0000-4000-8000-${String(number).padStart(12, '0')}`
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function makeManifest(): FrozenCohortManifest {
+  const corpora: FrozenCohortManifest['corpora'] = []
+  let chatbotNumber = 1
+  let courseNumber = 1
+  let configNumber = 1
+  for (let corpusNumber = 0; corpusNumber < 15; corpusNumber += 1) {
+    const chatbotCount = corpusNumber < 12 ? 1 : corpusNumber === 12 ? 2 : 4
+    const courseCount = corpusNumber < 12 ? 1 : corpusNumber === 12 ? 2 : 1
+    const modes =
+      corpusNumber === 14
+        ? ['default', 'tutor', 'explainer', 'tutoradvanced']
+        : ['tutor', 'explainer']
+    const chatbotIds = Array.from({ length: chatbotCount }, () =>
+      uuid(1000 + chatbotNumber++)
+    )
+    const courseIds = Array.from({ length: courseCount }, () =>
+      uuid(2000 + courseNumber++)
+    )
+    const configurations = chatbotIds.flatMap((chatbotId) =>
+      modes
+        .slice(
+          0,
+          corpusNumber === 13 ? 1 : corpusNumber === 14 ? modes.length : 2
+        )
+        .map((chatMode) => ({
+          allowedTools: [`source_tool_${corpusNumber}`],
+          chatbotId,
+          chatMode,
+          configId: uuid(3000 + configNumber++),
+          parameters: { required: true, toolAlias: 'doc_query' },
+          priority: 0,
+          sourceServerId: SOURCE_SERVER_ID,
+        }))
+    )
+    corpora.push({
+      chatbotIds,
+      configurations,
+      courseIds,
+      kbId: uuid(4000 + corpusNumber),
+      kbName: `Synthetic KB ${String(corpusNumber + 1)}`,
+      ownerId: OWNER_ID,
+      sourceCollection: 'source_collection',
+      targetCollection: 'target_collection',
+      tool: `source_tool_${corpusNumber}`,
+    })
+  }
+  return {
+    collection: 'synthetic_collection',
+    corpora,
+    environment: 'test',
+    excluded: [
+      {
+        chatbotId: uuid(7001),
+        chatMode: 'tutor',
+        configId: uuid(7101),
+        serverId: SOURCE_SERVER_ID,
+        tool: 'bf1_expert',
+      },
+      {
+        chatbotId: uuid(7001),
+        chatMode: 'explainer',
+        configId: uuid(7102),
+        serverId: SOURCE_SERVER_ID,
+        tool: 'bf1_expert',
+      },
+      {
+        chatbotId: uuid(7002),
+        chatMode: 'tutor',
+        configId: uuid(7103),
+        serverId: SOURCE_SERVER_ID,
+        tool: 'vorkurs2_expert',
+      },
+      {
+        chatbotId: uuid(7002),
+        chatMode: 'explainer',
+        configId: uuid(7104),
+        serverId: SOURCE_SERVER_ID,
+        tool: 'vorkurs2_expert',
+      },
+    ],
+    singletonCanaryKbId: uuid(8000),
+    version: 1,
+  }
+}
+
+class MemoryStore implements ActivationStore {
+  readonly sourceServer: ActivationServerRecord = {
+    id: SOURCE_SERVER_ID,
+    name: 'Klicker-compat',
+    description: 'legacy transport',
+    url: 'https://legacy.synthetic.invalid/mcp',
+    authType: 'bearer',
+    authSecret: SOURCE_CREDENTIAL,
+    passChatbotId: true,
+    chatbotIdHeader: 'Chatbot-ID',
+    parameters: {},
+    isActive: true,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  }
+  readonly chatbots = new Map<string, ChatbotRecord>()
+  readonly knowledgeBases = new Map<string, KnowledgeBaseRecord>()
+  readonly sourceConfigs = new Map<string, ActivationConfigRecord>()
+  readonly targetConfigs = new Map<string, ActivationConfigRecord>()
+  readonly bindings = new Map<string, ActivationBindingRecord>()
+  readonly servers = new Map<string, ActivationServerRecord>()
+  writes = 0
+  transactions = 0
+  legacyUpdates = 0
+  failTargetConfigUpdate = false
+  private sequence = 20000
+  private clock = 1
+
+  constructor(readonly manifest: FrozenCohortManifest) {
+    const chatbotIds = manifest.corpora.flatMap((corpus) => corpus.chatbotIds)
+    for (const [index, chatbotId] of chatbotIds.entries()) {
+      const corpus = manifest.corpora.find((entry) =>
+        entry.chatbotIds.includes(chatbotId)
+      )!
+      this.chatbots.set(chatbotId, {
+        id: chatbotId,
+        courseId: corpus.courseIds[index % corpus.courseIds.length]!,
+        ownerId: corpus.ownerId,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    }
+    for (const corpus of manifest.corpora) {
+      for (const configuration of corpus.configurations) {
+        this.sourceConfigs.set(configuration.configId, {
+          id: configuration.configId,
+          chatbotId: configuration.chatbotId,
+          mcpServerId: configuration.sourceServerId,
+          chatMode: configuration.chatMode,
+          allowedTools: clone(configuration.allowedTools),
+          priority: configuration.priority,
+          isEnabled: true,
+          parameters: clone(configuration.parameters),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        })
+      }
+    }
+  }
+
+  private nextId(): string {
+    this.sequence += 1
+    return uuid(this.sequence)
+  }
+
+  private nextDate(): Date {
+    this.clock += 1
+    return new Date(Date.UTC(2026, 0, 1, 0, 0, 0, this.clock))
+  }
+
+  private copy<T extends { updatedAt: Date }>(record: T): T {
+    return {
+      ...record,
+      updatedAt: new Date(record.updatedAt),
+    }
+  }
+
+  private snapshot() {
+    return {
+      knowledgeBases: new Map(
+        [...this.knowledgeBases].map(([id, row]) => [id, this.copy(row)])
+      ),
+      targetConfigs: new Map(
+        [...this.targetConfigs].map(([id, row]) => [id, this.copy(row)])
+      ),
+      bindings: new Map(
+        [...this.bindings].map(([id, row]) => [id, this.copy(row)])
+      ),
+      servers: new Map(
+        [...this.servers].map(([id, row]) => [id, this.copy(row)])
+      ),
+    }
+  }
+
+  private restore(snapshot: ReturnType<MemoryStore['snapshot']>): void {
+    this.knowledgeBases.clear()
+    snapshot.knowledgeBases.forEach((row, id) => {
+      this.knowledgeBases.set(id, row)
+    })
+    this.targetConfigs.clear()
+    snapshot.targetConfigs.forEach((row, id) => {
+      this.targetConfigs.set(id, row)
+    })
+    this.bindings.clear()
+    snapshot.bindings.forEach((row, id) => {
+      this.bindings.set(id, row)
+    })
+    this.servers.clear()
+    snapshot.servers.forEach((row, id) => {
+      this.servers.set(id, row)
+    })
+  }
+
+  async findKnowledgeBaseById(id: string) {
+    const row = this.knowledgeBases.get(id)
+    return row ? this.copy(row) : null
+  }
+
+  async findKnowledgeBasesByName(name: string) {
+    return [...this.knowledgeBases.values()]
+      .filter((row) => row.name === name)
+      .map((row) => this.copy(row))
+  }
+
+  async findChatbotById(id: string) {
+    const row = this.chatbots.get(id)
+    return row ? this.copy(row) : null
+  }
+
+  async findServersByName(name: string) {
+    const rows =
+      name === this.sourceServer.name
+        ? [this.sourceServer]
+        : [...this.servers.values()].filter((row) => row.name === name)
+    return rows.map((row) => this.copy(row))
+  }
+
+  async findConfigById(id: string) {
+    const row = this.sourceConfigs.get(id) ?? this.targetConfigs.get(id)
+    return row ? this.copy(row) : null
+  }
+
+  async findConfigsByServerId(mcpServerId: string) {
+    return [...this.targetConfigs.values()]
+      .filter((row) => row.mcpServerId === mcpServerId)
+      .map((row) => this.copy(row))
+  }
+
+  async findBindingsByChatbotId(chatbotId: string) {
+    return [...this.bindings.values()]
+      .filter((row) => row.chatbotId === chatbotId)
+      .map((row) => this.copy(row))
+  }
+
+  async createKnowledgeBase(data: ActivationKnowledgeBaseCreate) {
+    this.writes += 1
+    const row = {
+      ...data,
+      deletedAt: null,
+      updatedAt: this.nextDate(),
+    }
+    this.knowledgeBases.set(row.id, row)
+    return this.copy(row)
+  }
+
+  async createServer(data: ActivationServerCreate) {
+    this.writes += 1
+    const row = {
+      id: this.nextId(),
+      ...data,
+      description: data.description,
+      updatedAt: this.nextDate(),
+    }
+    this.servers.set(row.id, row)
+    return this.copy(row)
+  }
+
+  async createBinding(data: ActivationBindingCreate) {
+    this.writes += 1
+    const row = {
+      id: this.nextId(),
+      ...data,
+      updatedAt: this.nextDate(),
+    }
+    this.bindings.set(row.id, row)
+    return this.copy(row)
+  }
+
+  async createConfig(data: ActivationConfigCreate) {
+    this.writes += 1
+    const row = {
+      id: this.nextId(),
+      ...data,
+      updatedAt: this.nextDate(),
+    }
+    this.targetConfigs.set(row.id, row)
+    return this.copy(row)
+  }
+
+  async updateBinding(snapshot: ActivationBindingRecord, isEnabled: boolean) {
+    const current = this.bindings.get(snapshot.id)
+    if (
+      !current ||
+      current.updatedAt.getTime() !== snapshot.updatedAt.getTime()
+    ) {
+      throw new CohortActivationError('CONCURRENT_EDIT', 'binding changed')
+    }
+    const updated = {
+      ...current,
+      isEnabled,
+      updatedAt: this.nextDate(),
+    }
+    this.bindings.set(updated.id, updated)
+    this.writes += 1
+    return this.copy(updated)
+  }
+
+  async updateConfig(snapshot: ActivationConfigRecord, isEnabled: boolean) {
+    if (this.failTargetConfigUpdate) {
+      this.failTargetConfigUpdate = false
+      throw new CohortActivationError('CONCURRENT_EDIT', 'config changed')
+    }
+    if (this.sourceConfigs.has(snapshot.id)) {
+      this.legacyUpdates += 1
+      throw new CohortActivationError('LEGACY_MUTATION', 'legacy row update')
+    }
+    const current = this.targetConfigs.get(snapshot.id)
+    if (
+      !current ||
+      current.updatedAt.getTime() !== snapshot.updatedAt.getTime()
+    ) {
+      throw new CohortActivationError('CONCURRENT_EDIT', 'config changed')
+    }
+    const updated = {
+      ...current,
+      isEnabled,
+      updatedAt: this.nextDate(),
+    }
+    this.targetConfigs.set(updated.id, updated)
+    this.writes += 1
+    return this.copy(updated)
+  }
+
+  async transaction<T>(
+    callback: (store: ActivationTransactionStore) => Promise<T>
+  ): Promise<T> {
+    this.transactions += 1
+    const before = this.snapshot()
+    try {
+      return await callback(this)
+    } catch (error) {
+      this.restore(before)
+      throw error
+    }
+  }
+
+  targetServer(): ActivationServerRecord | null {
+    return (
+      [...this.servers.values()].find((server) => server.name === 'KB') ?? null
+    )
+  }
+
+  targetConfigForChatbot(chatbotId: string) {
+    return [...this.targetConfigs.values()].filter(
+      (config) => config.chatbotId === chatbotId
+    )
+  }
+
+  bindingForChatbot(chatbotId: string) {
+    return [...this.bindings.values()].find(
+      (binding) => binding.chatbotId === chatbotId
+    )
+  }
+}
+
+class MemoryReceiptStore {
+  value: ActivationReceiptPayload | null = null
+  writes = 0
+
+  async read() {
+    return this.value
+  }
+
+  async write(receipt: ActivationReceiptPayload) {
+    this.value = clone(receipt)
+    this.writes += 1
+  }
+}
+
+function options(receiptStore: MemoryReceiptStore) {
+  return { receiptStore, target: TARGET }
+}
+
+function chatbotIdForAlias(
+  manifest: FrozenCohortManifest,
+  alias: string
+): string {
+  const ids = manifest.corpora.flatMap((corpus) => corpus.chatbotIds).sort()
+  return ids[Number(alias.slice(-3)) - 1]!
+}
+
+describe('cohort activation operator', () => {
+  let manifest: FrozenCohortManifest
+  let store: MemoryStore
+  let receiptStore: MemoryReceiptStore
+
+  beforeEach(() => {
+    manifest = makeManifest()
+    store = new MemoryStore(manifest)
+    receiptStore = new MemoryReceiptStore()
+  })
+
+  it('validates the frozen counts and excludes reserved corpora', () => {
+    validateCohortManifest(manifest)
+    expect(manifest.corpora).toHaveLength(15)
+    expect(
+      new Set(manifest.corpora.flatMap((corpus) => corpus.chatbotIds))
+    ).toHaveLength(22)
+    expect(
+      new Set(manifest.corpora.flatMap((corpus) => corpus.courseIds))
+    ).toHaveLength(16)
+    expect(
+      manifest.corpora.flatMap((corpus) => corpus.configurations)
+    ).toHaveLength(48)
+    expect(manifest.corpora[12]!.chatbotIds).toHaveLength(2)
+    expect(manifest.corpora[12]!.courseIds).toHaveLength(2)
+
+    const excluded = clone(manifest)
+    excluded.corpora[0]!.tool = 'bf1_expert'
+    expect(() => validateCohortManifest(excluded)).toThrowError(
+      expect.objectContaining({ code: 'EXCLUDED_CORPUS' })
+    )
+  })
+
+  it('dry-runs without invoking writes or a transaction', async () => {
+    const result = await dryRunCohortActivation(store, manifest, TARGET)
+    expect(result.status).toBe('dry-run')
+    expect(result.writes).toEqual({
+      knowledgeBases: 15,
+      server: 1,
+      bindings: 22,
+      configurations: 48,
+    })
+    expect(store.writes).toBe(0)
+    expect(store.transactions).toBe(0)
+    expect(JSON.stringify(result)).not.toContain(SOURCE_CREDENTIAL)
+  })
+
+  it('prepares idempotently with disabled scoped target rows and an opaque credential copy', async () => {
+    const first = await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore)
+    )
+    expect(first.status).toBe('prepared')
+    expect(first.writes).toEqual({
+      knowledgeBases: 15,
+      server: 1,
+      bindings: 22,
+      configurations: 48,
+    })
+    const targetServer = store.targetServer()!
+    expect(targetServer.authSecret).toBe(SOURCE_CREDENTIAL)
+    expect(targetServer.authType).toBe('scope_token')
+    expect(targetServer.passChatbotId).toBe(false)
+    expect(targetServer.chatbotIdHeader).toBeNull()
+    expect(targetServer.parameters).toEqual({})
+    expect([...store.targetConfigs.values()]).toHaveLength(48)
+    expect(
+      [...store.targetConfigs.values()].every(
+        (config) =>
+          config.isEnabled === false &&
+          JSON.stringify(config.allowedTools) ===
+            JSON.stringify(['doc_query']) &&
+          JSON.stringify(config.parameters) ===
+            JSON.stringify({ required: true, toolAlias: 'doc_query' })
+      )
+    ).toBe(true)
+    const second = await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore)
+    )
+    expect(second.writes).toEqual({
+      knowledgeBases: 0,
+      server: 0,
+      bindings: 0,
+      configurations: 0,
+    })
+    expect(store.legacyUpdates).toBe(0)
+    expect(JSON.stringify(first.receipt)).not.toContain(SOURCE_CREDENTIAL)
+  })
+
+  it('refuses target drift instead of reconciling an existing reserved server', async () => {
+    await prepareCohortActivation(store, manifest, options(receiptStore))
+    const targetServer = store.targetServer()!
+    targetServer.authType = 'bearer'
+    const writesBefore = store.writes
+    await expect(
+      prepareCohortActivation(store, manifest, options(receiptStore))
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'TARGET_SERVER_MISMATCH' })
+    )
+    expect(store.writes).toBe(writesBefore)
+  })
+
+  it('switches one chatbot atomically, preserves legacy rows, and rolls back exactly', async () => {
+    await prepareCohortActivation(store, manifest, options(receiptStore))
+    const firstAlias = 'chatbot-001'
+    const secondAlias = 'chatbot-002'
+    const firstId = chatbotIdForAlias(manifest, firstAlias)
+    const secondId = chatbotIdForAlias(manifest, secondAlias)
+    const legacyBefore = [...store.sourceConfigs.values()].map((config) => ({
+      ...config,
+      updatedAt: new Date(config.updatedAt),
+    }))
+
+    const switched = await switchCohortChatbot(store, manifest, {
+      ...options(receiptStore),
+      chatbotAlias: firstAlias,
+    })
+    expect(switched.status).toBe('switched')
+    expect(store.bindingForChatbot(firstId)!.isEnabled).toBe(true)
+    expect(
+      store.targetConfigForChatbot(firstId).every((config) => config.isEnabled)
+    ).toBe(true)
+    expect(store.bindingForChatbot(secondId)!.isEnabled).toBe(false)
+
+    store.failTargetConfigUpdate = true
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore),
+        chatbotAlias: secondAlias,
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'CONCURRENT_EDIT' }))
+    expect(store.bindingForChatbot(secondId)!.isEnabled).toBe(false)
+    expect(receiptStore.value).toEqual(
+      expect.objectContaining({ state: 'switching' })
+    )
+
+    const afterFailedSwitch = await rollbackCohortChatbot(store, manifest, {
+      ...options(receiptStore),
+      chatbotAlias: secondAlias,
+    })
+    expect(afterFailedSwitch.status).toBe('switched')
+    expect(store.bindingForChatbot(firstId)!.isEnabled).toBe(true)
+    expect(store.bindingForChatbot(secondId)!.isEnabled).toBe(false)
+
+    const rolledBack = await rollbackCohortChatbot(store, manifest, {
+      ...options(receiptStore),
+      chatbotAlias: firstAlias,
+    })
+    expect(rolledBack.status).toBe('rolled_back')
+    expect(
+      [...store.bindings.values()].every((binding) => !binding.isEnabled)
+    ).toBe(true)
+    expect([...store.sourceConfigs.values()]).toEqual(legacyBefore)
+    expect(store.legacyUpdates).toBe(0)
+  })
+
+  it('refuses a mixed target group and keeps the durable receipt unchanged', async () => {
+    await prepareCohortActivation(store, manifest, options(receiptStore))
+    const firstId = chatbotIdForAlias(manifest, 'chatbot-001')
+    const config = store.targetConfigForChatbot(firstId)[0]!
+    config.isEnabled = true
+    const receiptBefore = clone(receiptStore.value)
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'SNAPSHOT_MISMATCH' })
+    )
+    expect(receiptStore.value).toEqual(receiptBefore)
+  })
+
+  it('refuses an untracked partial target inventory', async () => {
+    const targetServer = await store.createServer({
+      name: 'KB',
+      description: TARGET.description,
+      url: TARGET.url,
+      authType: 'scope_token',
+      authSecret: SOURCE_CREDENTIAL,
+      passChatbotId: false,
+      chatbotIdHeader: null,
+      parameters: {},
+      isActive: true,
+    })
+    const firstCorpus = manifest.corpora[0]!
+    await store.createConfig({
+      chatbotId: firstCorpus.chatbotIds[0]!,
+      mcpServerId: targetServer.id,
+      chatMode: 'tutor',
+      allowedTools: ['doc_query'],
+      priority: 0,
+      isEnabled: false,
+      parameters: { required: true, toolAlias: 'doc_query' },
+    })
+    await expect(
+      prepareCohortActivation(store, manifest, options(receiptStore))
+    ).rejects.toThrowError(expect.objectContaining({ code: 'MIXED_STATE' }))
+  })
+
+  it('readback is receipt-bound and rejects an in-flight state', async () => {
+    await prepareCohortActivation(store, manifest, options(receiptStore))
+    const result = await readbackCohortActivation(
+      store,
+      manifest,
+      options(receiptStore)
+    )
+    expect(result.status).toBe('readback')
+    expect(result.fingerprints.receipt).toBe(
+      fingerprintManifest(manifest) === result.fingerprints.manifest
+        ? receiptStore.value?.payloadDigest
+        : undefined
+    )
+  })
+
+  it('writes a private atomic receipt without credential or raw row identifiers', async () => {
+    await prepareCohortActivation(store, manifest, options(receiptStore))
+    const receipt = receiptStore.value!
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-'))
+    const path = join(directory, 'receipt.json')
+    const fileStore = createFileActivationReceiptStore(path)
+    await fileStore.write(receipt)
+    const contents = readFileSync(path, 'utf8')
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+    expect(contents).not.toContain(SOURCE_CREDENTIAL)
+    expect(contents).not.toContain(SOURCE_SERVER_ID)
+    expect(await fileStore.read()).toEqual(receipt)
+  })
+})

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, readFileSync, statSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -9,6 +16,7 @@ import {
   type ActivationConfigRecord,
   type ActivationKnowledgeBaseCreate,
   type ActivationReceiptPayload,
+  type ActivationReceiptStore,
   type ActivationServerCreate,
   type ActivationServerRecord,
   type ActivationStore,
@@ -113,7 +121,7 @@ function makeManifest(): FrozenCohortManifest {
         chatMode: 'tutor',
         configId: uuid(7103),
         serverId: SOURCE_SERVER_ID,
-        tool: 'vorkurs2_expert',
+        tool: 'df_cf2_expert',
       },
       {
         chatbotId: uuid(7002),
@@ -143,6 +151,10 @@ class MemoryStore implements ActivationStore {
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   }
   readonly chatbots = new Map<string, ChatbotRecord>()
+  readonly courses = new Map<
+    string,
+    { id: string; ownerId: string; updatedAt: Date }
+  >()
   readonly knowledgeBases = new Map<string, KnowledgeBaseRecord>()
   readonly sourceConfigs = new Map<string, ActivationConfigRecord>()
   readonly targetConfigs = new Map<string, ActivationConfigRecord>()
@@ -168,6 +180,15 @@ class MemoryStore implements ActivationStore {
         updatedAt: new Date('2026-01-01T00:00:00.000Z'),
       })
     }
+    for (const courseId of new Set(
+      manifest.corpora.flatMap((corpus) => corpus.courseIds)
+    )) {
+      this.courses.set(courseId, {
+        id: courseId,
+        ownerId: OWNER_ID,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    }
     for (const corpus of manifest.corpora) {
       for (const configuration of corpus.configurations) {
         this.sourceConfigs.set(configuration.configId, {
@@ -182,6 +203,19 @@ class MemoryStore implements ActivationStore {
           updatedAt: new Date('2026-01-01T00:00:00.000Z'),
         })
       }
+    }
+    for (const configuration of manifest.excluded) {
+      this.sourceConfigs.set(configuration.configId, {
+        id: configuration.configId,
+        chatbotId: configuration.chatbotId,
+        mcpServerId: configuration.serverId,
+        chatMode: configuration.chatMode,
+        allowedTools: [configuration.tool],
+        priority: 0,
+        isEnabled: true,
+        parameters: { required: true, toolAlias: 'doc_query' },
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
     }
   }
 
@@ -251,6 +285,11 @@ class MemoryStore implements ActivationStore {
 
   async findChatbotById(id: string) {
     const row = this.chatbots.get(id)
+    return row ? this.copy(row) : null
+  }
+
+  async findCourseById(id: string) {
+    const row = this.courses.get(id)
     return row ? this.copy(row) : null
   }
 
@@ -408,14 +447,59 @@ class MemoryReceiptStore {
     return this.value
   }
 
-  async write(receipt: ActivationReceiptPayload) {
+  async compareAndSwap(
+    expectedDigest: string | null,
+    receipt: ActivationReceiptPayload
+  ) {
+    if ((this.value?.payloadDigest ?? null) !== expectedDigest) {
+      throw new CohortActivationError('RECEIPT_CAS_FAILED', 'stale receipt')
+    }
     this.value = clone(receipt)
     this.writes += 1
   }
 }
 
-function options(receiptStore: MemoryReceiptStore) {
-  return { receiptStore, target: TARGET }
+class ConcurrentReceiptStore implements ActivationReceiptStore {
+  private readCount = 0
+  private releaseReads: (() => void) | undefined
+  private readonly readsReleased = new Promise<void>((resolve) => {
+    this.releaseReads = resolve
+  })
+
+  constructor(private readonly delegate: ActivationReceiptStore) {}
+
+  async read() {
+    const value = await this.delegate.read()
+    this.readCount += 1
+    if (this.readCount === 1) {
+      await this.readsReleased
+    } else if (this.readCount === 2) {
+      this.releaseReads?.()
+    }
+    return value
+  }
+
+  async compareAndSwap(
+    expectedDigest: string | null,
+    receipt: ActivationReceiptPayload
+  ) {
+    return this.delegate.compareAndSwap(expectedDigest, receipt)
+  }
+}
+
+function expectedFingerprint(value: FrozenCohortManifest): string {
+  return fingerprintManifest(value)
+}
+
+function options(
+  receiptStore: ActivationReceiptStore,
+  manifest: FrozenCohortManifest
+) {
+  return {
+    expectedManifestFingerprint: expectedFingerprint(manifest),
+    receiptStore,
+    target: TARGET,
+  }
 }
 
 function chatbotIdForAlias(
@@ -457,10 +541,137 @@ describe('cohort activation operator', () => {
     expect(() => validateCohortManifest(excluded)).toThrowError(
       expect.objectContaining({ code: 'EXCLUDED_CORPUS' })
     )
+
+    const wrongExclusionMultiset = clone(manifest)
+    wrongExclusionMultiset.excluded[3]!.tool = 'bf1_expert'
+    expect(() => validateCohortManifest(wrongExclusionMultiset)).toThrowError(
+      expect.objectContaining({ code: 'COHORT_COUNT_MISMATCH' })
+    )
+  })
+
+  it('requires the source contract and every frozen server id to agree', async () => {
+    const cases: Array<keyof ActivationServerRecord> = [
+      'authType',
+      'passChatbotId',
+      'chatbotIdHeader',
+      'isActive',
+      'authSecret',
+    ]
+    for (const field of cases) {
+      const candidate = new MemoryStore(manifest)
+      if (field === 'authType') candidate.sourceServer.authType = 'scope_token'
+      if (field === 'passChatbotId')
+        candidate.sourceServer.passChatbotId = false
+      if (field === 'chatbotIdHeader')
+        candidate.sourceServer.chatbotIdHeader = 'X-Chatbot'
+      if (field === 'isActive') candidate.sourceServer.isActive = false
+      if (field === 'authSecret') candidate.sourceServer.authSecret = ' '
+      await expect(
+        dryRunCohortActivation(
+          candidate,
+          manifest,
+          TARGET,
+          expectedFingerprint(manifest)
+        )
+      ).rejects.toThrowError(
+        expect.objectContaining({ code: 'SOURCE_SERVER_MISMATCH' })
+      )
+    }
+
+    const mismatchedManifest = clone(manifest)
+    for (const corpus of mismatchedManifest.corpora) {
+      for (const configuration of corpus.configurations) {
+        configuration.sourceServerId = uuid(9999)
+      }
+    }
+    for (const configuration of mismatchedManifest.excluded) {
+      configuration.serverId = uuid(9999)
+    }
+    await expect(
+      dryRunCohortActivation(
+        new MemoryStore(mismatchedManifest),
+        mismatchedManifest,
+        TARGET,
+        expectedFingerprint(mismatchedManifest)
+      )
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'SOURCE_SERVER_MISMATCH' })
+    )
+  })
+
+  it('requires every listed course and excluded source row to exist with its frozen shape', async () => {
+    store.courses.delete(manifest.corpora[0]!.courseIds[0]!)
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        TARGET,
+        expectedFingerprint(manifest)
+      )
+    ).rejects.toThrowError(expect.objectContaining({ code: 'COURSE_MISSING' }))
+
+    store = new MemoryStore(manifest)
+    store.courses.get(manifest.corpora[0]!.courseIds[0]!)!.ownerId = uuid(9900)
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        TARGET,
+        expectedFingerprint(manifest)
+      )
+    ).rejects.toThrowError(expect.objectContaining({ code: 'COURSE_DRIFT' }))
+
+    store = new MemoryStore(manifest)
+    const sharedCorpus = manifest.corpora[12]!
+    const firstChatbot = store.chatbots.get(sharedCorpus.chatbotIds[0]!)!
+    const secondChatbot = store.chatbots.get(sharedCorpus.chatbotIds[1]!)!
+    secondChatbot.courseId = firstChatbot.courseId
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        TARGET,
+        expectedFingerprint(manifest)
+      )
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'COURSE_REFERENCE_MISSING' })
+    )
+
+    store = new MemoryStore(manifest)
+    store.sourceConfigs.delete(manifest.excluded[0]!.configId)
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        TARGET,
+        expectedFingerprint(manifest)
+      )
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'EXCLUDED_CONFIG_DRIFT' })
+    )
+
+    store = new MemoryStore(manifest)
+    const excluded = store.sourceConfigs.get(manifest.excluded[0]!.configId)!
+    excluded.allowedTools = ['unexpected_tool']
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        TARGET,
+        expectedFingerprint(manifest)
+      )
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'EXCLUDED_CONFIG_DRIFT' })
+    )
   })
 
   it('dry-runs without invoking writes or a transaction', async () => {
-    const result = await dryRunCohortActivation(store, manifest, TARGET)
+    const result = await dryRunCohortActivation(
+      store,
+      manifest,
+      TARGET,
+      expectedFingerprint(manifest)
+    )
     expect(result.status).toBe('dry-run')
     expect(result.writes).toEqual({
       knowledgeBases: 15,
@@ -473,11 +684,26 @@ describe('cohort activation operator', () => {
     expect(JSON.stringify(result)).not.toContain(SOURCE_CREDENTIAL)
   })
 
+  it('requires the approved manifest fingerprint at every operation boundary', async () => {
+    await expect(
+      dryRunCohortActivation(store, manifest, TARGET, undefined as never)
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'MANIFEST_FINGERPRINT_REQUIRED' })
+    )
+    await expect(
+      prepareCohortActivation(store, manifest, {
+        receiptStore,
+        target: TARGET,
+        expectedManifestFingerprint: '0'.repeat(64),
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'MANIFEST_DRIFT' }))
+  })
+
   it('prepares idempotently with disabled scoped target rows and an opaque credential copy', async () => {
     const first = await prepareCohortActivation(
       store,
       manifest,
-      options(receiptStore)
+      options(receiptStore, manifest)
     )
     expect(first.status).toBe('prepared')
     expect(first.writes).toEqual({
@@ -506,7 +732,7 @@ describe('cohort activation operator', () => {
     const second = await prepareCohortActivation(
       store,
       manifest,
-      options(receiptStore)
+      options(receiptStore, manifest)
     )
     expect(second.writes).toEqual({
       knowledgeBases: 0,
@@ -519,12 +745,16 @@ describe('cohort activation operator', () => {
   })
 
   it('refuses target drift instead of reconciling an existing reserved server', async () => {
-    await prepareCohortActivation(store, manifest, options(receiptStore))
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
     const targetServer = store.targetServer()!
     targetServer.authType = 'bearer'
     const writesBefore = store.writes
     await expect(
-      prepareCohortActivation(store, manifest, options(receiptStore))
+      prepareCohortActivation(store, manifest, options(receiptStore, manifest))
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'TARGET_SERVER_MISMATCH' })
     )
@@ -532,7 +762,11 @@ describe('cohort activation operator', () => {
   })
 
   it('switches one chatbot atomically, preserves legacy rows, and rolls back exactly', async () => {
-    await prepareCohortActivation(store, manifest, options(receiptStore))
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
     const firstAlias = 'chatbot-001'
     const secondAlias = 'chatbot-002'
     const firstId = chatbotIdForAlias(manifest, firstAlias)
@@ -543,7 +777,7 @@ describe('cohort activation operator', () => {
     }))
 
     const switched = await switchCohortChatbot(store, manifest, {
-      ...options(receiptStore),
+      ...options(receiptStore, manifest),
       chatbotAlias: firstAlias,
     })
     expect(switched.status).toBe('switched')
@@ -556,7 +790,7 @@ describe('cohort activation operator', () => {
     store.failTargetConfigUpdate = true
     await expect(
       switchCohortChatbot(store, manifest, {
-        ...options(receiptStore),
+        ...options(receiptStore, manifest),
         chatbotAlias: secondAlias,
       })
     ).rejects.toThrowError(expect.objectContaining({ code: 'CONCURRENT_EDIT' }))
@@ -566,7 +800,7 @@ describe('cohort activation operator', () => {
     )
 
     const afterFailedSwitch = await rollbackCohortChatbot(store, manifest, {
-      ...options(receiptStore),
+      ...options(receiptStore, manifest),
       chatbotAlias: secondAlias,
     })
     expect(afterFailedSwitch.status).toBe('switched')
@@ -574,7 +808,7 @@ describe('cohort activation operator', () => {
     expect(store.bindingForChatbot(secondId)!.isEnabled).toBe(false)
 
     const rolledBack = await rollbackCohortChatbot(store, manifest, {
-      ...options(receiptStore),
+      ...options(receiptStore, manifest),
       chatbotAlias: firstAlias,
     })
     expect(rolledBack.status).toBe('rolled_back')
@@ -585,21 +819,111 @@ describe('cohort activation operator', () => {
     expect(store.legacyUpdates).toBe(0)
   })
 
+  it('validates switch and rollback dry-runs without writing state or receipts', async () => {
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
+    const writesBefore = store.writes
+    const transactionsBefore = store.transactions
+    const receiptsBefore = receiptStore.writes
+    const switchDryRun = await switchCohortChatbot(store, manifest, {
+      ...options(receiptStore, manifest),
+      chatbotAlias: 'chatbot-001',
+      dryRun: true,
+    })
+    expect(switchDryRun.status).toBe('dry-run')
+    expect(store.writes).toBe(writesBefore)
+    expect(store.transactions).toBe(transactionsBefore)
+    expect(receiptStore.writes).toBe(receiptsBefore)
+
+    await switchCohortChatbot(store, manifest, {
+      ...options(receiptStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    const switchedWrites = store.writes
+    const switchedTransactions = store.transactions
+    const switchedReceipts = receiptStore.writes
+    const rollbackDryRun = await rollbackCohortChatbot(store, manifest, {
+      ...options(receiptStore, manifest),
+      chatbotAlias: 'chatbot-001',
+      dryRun: true,
+    })
+    expect(rollbackDryRun.status).toBe('dry-run')
+    expect(store.writes).toBe(switchedWrites)
+    expect(store.transactions).toBe(switchedTransactions)
+    expect(receiptStore.writes).toBe(switchedReceipts)
+  })
+
   it('refuses a mixed target group and keeps the durable receipt unchanged', async () => {
-    await prepareCohortActivation(store, manifest, options(receiptStore))
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
     const firstId = chatbotIdForAlias(manifest, 'chatbot-001')
     const config = store.targetConfigForChatbot(firstId)[0]!
     config.isEnabled = true
     const receiptBefore = clone(receiptStore.value)
     await expect(
       switchCohortChatbot(store, manifest, {
-        ...options(receiptStore),
+        ...options(receiptStore, manifest),
         chatbotAlias: 'chatbot-001',
       })
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'SNAPSHOT_MISMATCH' })
     )
     expect(receiptStore.value).toEqual(receiptBefore)
+  })
+
+  it('refuses enabled alternative bindings during switch and rollback validation', async () => {
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
+    const chatbotId = chatbotIdForAlias(manifest, 'chatbot-001')
+    const switchAlternative = await store.createBinding({
+      kbId: uuid(8800),
+      chatbotId,
+      isEnabled: false,
+    })
+    store.bindings.get(switchAlternative.id)!.isEnabled = true
+    await expect(
+      switchCohortChatbot(store, manifest, {
+        ...options(receiptStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'ENABLED_KB_CONFLICT' })
+    )
+
+    const cleanStore = new MemoryStore(manifest)
+    const cleanReceipts = new MemoryReceiptStore()
+    await prepareCohortActivation(
+      cleanStore,
+      manifest,
+      options(cleanReceipts, manifest)
+    )
+    await switchCohortChatbot(cleanStore, manifest, {
+      ...options(cleanReceipts, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    const rollbackAlternative = await cleanStore.createBinding({
+      kbId: uuid(8801),
+      chatbotId: chatbotIdForAlias(manifest, 'chatbot-001'),
+      isEnabled: false,
+    })
+    cleanStore.bindings.get(rollbackAlternative.id)!.isEnabled = true
+    await expect(
+      rollbackCohortChatbot(cleanStore, manifest, {
+        ...options(cleanReceipts, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'ENABLED_KB_CONFLICT' })
+    )
   })
 
   it('refuses an untracked partial target inventory', async () => {
@@ -625,16 +949,20 @@ describe('cohort activation operator', () => {
       parameters: { required: true, toolAlias: 'doc_query' },
     })
     await expect(
-      prepareCohortActivation(store, manifest, options(receiptStore))
+      prepareCohortActivation(store, manifest, options(receiptStore, manifest))
     ).rejects.toThrowError(expect.objectContaining({ code: 'MIXED_STATE' }))
   })
 
   it('readback is receipt-bound and rejects an in-flight state', async () => {
-    await prepareCohortActivation(store, manifest, options(receiptStore))
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
     const result = await readbackCohortActivation(
       store,
       manifest,
-      options(receiptStore)
+      options(receiptStore, manifest)
     )
     expect(result.status).toBe('readback')
     expect(result.fingerprints.receipt).toBe(
@@ -645,16 +973,76 @@ describe('cohort activation operator', () => {
   })
 
   it('writes a private atomic receipt without credential or raw row identifiers', async () => {
-    await prepareCohortActivation(store, manifest, options(receiptStore))
-    const receipt = receiptStore.value!
     const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-'))
     const path = join(directory, 'receipt.json')
     const fileStore = createFileActivationReceiptStore(path)
-    await fileStore.write(receipt)
+    await prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    const receipt = await fileStore.read()
+    expect(receipt).not.toBeNull()
     const contents = readFileSync(path, 'utf8')
     expect(statSync(path).mode & 0o777).toBe(0o600)
     expect(contents).not.toContain(SOURCE_CREDENTIAL)
     expect(contents).not.toContain(SOURCE_SERVER_ID)
     expect(await fileStore.read()).toEqual(receipt)
+  })
+
+  it('does not let concurrent prepare calls overwrite receipt recovery evidence', async () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), 'cohort-activation-concurrent-')
+    )
+    const fileStore = createFileActivationReceiptStore(
+      join(directory, 'receipt.json')
+    )
+    const concurrentStore = new ConcurrentReceiptStore(fileStore)
+    const outcomes = await Promise.allSettled([
+      prepareCohortActivation(store, manifest, {
+        ...options(concurrentStore, manifest),
+      }),
+      prepareCohortActivation(store, manifest, {
+        ...options(concurrentStore, manifest),
+      }),
+    ])
+    expect(
+      outcomes.filter((outcome) => outcome.status === 'fulfilled')
+    ).toHaveLength(1)
+    expect(
+      outcomes.filter((outcome) => outcome.status === 'rejected')
+    ).toHaveLength(1)
+    expect(['RECEIPT_LOCKED', 'RECEIPT_CAS_FAILED']).toContain(
+      outcomes.find((outcome) => outcome.status === 'rejected')?.reason.code
+    )
+    expect((await fileStore.read())?.state).toBe('prepared')
+  })
+
+  it('serializes receipt updates, rejects stale digests, and refuses tampered shape', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-cas-'))
+    const path = join(directory, 'receipt.json')
+    const fileStore = createFileActivationReceiptStore(path)
+    await prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    const prepared = await fileStore.read()
+    expect(prepared).not.toBeNull()
+
+    mkdirSync(`${path}.lock`)
+    await expect(
+      fileStore.compareAndSwap(prepared!.payloadDigest, prepared!)
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_LOCKED' }))
+    rmdirSync(`${path}.lock`)
+    expect(await fileStore.read()).toEqual(prepared)
+
+    await expect(
+      fileStore.compareAndSwap('0'.repeat(64), prepared!)
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_CAS_FAILED' })
+    )
+    expect(await fileStore.read()).toEqual(prepared)
+
+    const tampered = JSON.parse(readFileSync(path, 'utf8')) as {
+      aliases: Record<string, unknown>
+    }
+    delete tampered.aliases.courses
+    writeFileSync(path, `${JSON.stringify(tampered)}\n`)
+    await expect(fileStore.read()).rejects.toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_INVALID' })
+    )
   })
 })

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -68,11 +68,25 @@ function canonicalReceipt(value: unknown): unknown {
   return value
 }
 
-function receiptDigest(receipt: ActivationReceiptPayload): string {
+function receiptDigest(receipt: Record<string, unknown>): string {
   const { payloadDigest: _payloadDigest, ...withoutDigest } = receipt
   return createHash('sha256')
     .update(JSON.stringify(canonicalReceipt(withoutDigest)))
     .digest('hex')
+}
+
+function legacyReceipt(
+  receipt: ActivationReceipt,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const { pendingRollbackOrigin: _origin, ...withoutOrigin } = clone(receipt)
+  const legacy = {
+    ...withoutOrigin,
+    receiptVersion: 1,
+    ...overrides,
+  }
+  legacy.payloadDigest = receiptDigest(legacy)
+  return legacy
 }
 
 function deadPid(): number {
@@ -1273,6 +1287,12 @@ describe('cohort activation operator', () => {
     expect(['RECEIPT_LOCKED', 'RECEIPT_CAS_FAILED']).toContain(
       outcomes.find((outcome) => outcome.status === 'rejected')?.reason.code
     )
+    expect(store.writes).toBe(15 + 1 + 22 + 48)
+    expect(store.transactions).toBe(1)
+    expect(store.knowledgeBases).toHaveLength(15)
+    expect(store.targetServer()).not.toBeNull()
+    expect(store.bindings).toHaveLength(22)
+    expect(store.targetConfigs).toHaveLength(48)
     expect((await fileStore.read())?.state).toBe('prepared')
   })
 
@@ -1307,7 +1327,9 @@ describe('cohort activation operator', () => {
     ).toHaveLength(1)
     expect(
       outcomes.find((outcome) => outcome.status === 'rejected')?.reason
-    ).toMatchObject({ code: 'RECEIPT_CAS_FAILED' })
+    ).toMatchObject({
+      code: expect.stringMatching(/RECEIPT_(CAS_FAILED|LOCKED)/),
+    })
     expect(receiptStore.value?.state).toBe('prepared')
   })
 
@@ -1316,11 +1338,15 @@ describe('cohort activation operator', () => {
     const path = join(directory, 'receipt.json')
     const fileStore = createFileActivationReceiptStore(path)
     await prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    await switchCohortChatbot(store, manifest, {
+      ...options(fileStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
     store.failTargetConfigUpdate = true
     await expect(
       switchCohortChatbot(store, manifest, {
         ...options(fileStore, manifest),
-        chatbotAlias: 'chatbot-001',
+        chatbotAlias: 'chatbot-002',
       })
     ).rejects.toThrowError(expect.objectContaining({ code: 'CONCURRENT_EDIT' }))
     expect((await fileStore.read())?.state).toBe('switching')
@@ -1328,21 +1354,135 @@ describe('cohort activation operator', () => {
     await expect(
       rollbackCohortChatbot(store, manifest, {
         ...options(fileStore, manifest),
-        chatbotAlias: 'chatbot-001',
+        chatbotAlias: 'chatbot-002',
       })
     ).rejects.toThrowError('synthetic transaction failure')
     expect(await fileStore.read()).toMatchObject({
       state: 'rolling_back',
-      switchedChatbotAliases: [],
-      pendingRollbackAliases: ['chatbot-001'],
+      switchedChatbotAliases: ['chatbot-001'],
+      pendingRollbackAliases: ['chatbot-002'],
       pendingRollbackOrigin: 'switching',
     })
+    await expect(
+      rollbackCohortChatbot(store, manifest, {
+        ...options(fileStore, manifest),
+        chatbotAlias: 'chatbot-002',
+      })
+    ).resolves.toMatchObject({
+      status: 'switched',
+      aliases: { switchedChatbotAliases: ['chatbot-001'] },
+    })
+    expect(
+      store.bindingForChatbot(chatbotIdForAlias(manifest, 'chatbot-001'))
+        ?.isEnabled
+    ).toBe(true)
+    expect(
+      store.bindingForChatbot(chatbotIdForAlias(manifest, 'chatbot-002'))
+        ?.isEnabled
+    ).toBe(false)
     await expect(
       rollbackCohortChatbot(store, manifest, {
         ...options(fileStore, manifest),
         chatbotAlias: 'chatbot-001',
       })
     ).resolves.toMatchObject({ status: 'rolled_back' })
+  })
+
+  it('normalizes legacy receipts and refuses ambiguous rollback origin', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-legacy-'))
+    const path = join(directory, 'receipt.json')
+    const fileStore = createFileActivationReceiptStore(path)
+    await prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    const prepared = (await fileStore.read()) as ActivationReceipt
+
+    const legacyPrepared = legacyReceipt(prepared)
+    writeFileSync(path, `${JSON.stringify(legacyPrepared)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'prepared',
+      pendingRollbackOrigin: null,
+    })
+    writeFileSync(
+      path,
+      `${JSON.stringify({ ...legacyPrepared, payloadDigest: '0'.repeat(64) })}\n`
+    )
+    await expect(fileStore.read()).rejects.toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_INVALID' })
+    )
+
+    const legacySwitching = legacyReceipt(prepared, {
+      state: 'switching',
+      pendingChatbotAlias: 'chatbot-001',
+    })
+    writeFileSync(path, `${JSON.stringify(legacySwitching)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'switching',
+      pendingRollbackOrigin: null,
+    })
+
+    writeFileSync(path, `${JSON.stringify(legacyPrepared)}\n`)
+    await switchCohortChatbot(store, manifest, {
+      ...options(fileStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    const switched = (await fileStore.read()) as ActivationReceipt
+    const legacySwitched = legacyReceipt(switched)
+    writeFileSync(path, `${JSON.stringify(legacySwitched)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'switched',
+      pendingRollbackOrigin: null,
+    })
+    await rollbackCohortChatbot(store, manifest, {
+      ...options(fileStore, manifest),
+      chatbotAlias: 'chatbot-001',
+    })
+    const rolledBack = (await fileStore.read()) as ActivationReceipt
+    const legacyRolledBack = legacyReceipt(rolledBack)
+    writeFileSync(path, `${JSON.stringify(legacyRolledBack)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'rolled_back',
+      pendingRollbackOrigin: null,
+    })
+
+    const legacySwitchedRollback = legacyReceipt(switched, {
+      state: 'rolling_back',
+      pendingChatbotAlias: null,
+      pendingRollbackAliases: ['chatbot-001'],
+      switchedChatbotAliases: ['chatbot-001'],
+    })
+    writeFileSync(path, `${JSON.stringify(legacySwitchedRollback)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'rolling_back',
+      pendingRollbackOrigin: 'switched',
+    })
+
+    const unambiguousRollback = legacyReceipt(rolledBack, {
+      state: 'rolling_back',
+      pendingChatbotAlias: null,
+      pendingRollbackAliases: ['chatbot-001'],
+      switchedChatbotAliases: [],
+    })
+    writeFileSync(path, `${JSON.stringify(unambiguousRollback)}\n`)
+    await expect(fileStore.read()).resolves.toMatchObject({
+      receiptVersion: 2,
+      state: 'rolling_back',
+      pendingRollbackOrigin: 'switching',
+    })
+
+    const ambiguousRollback = legacyReceipt(rolledBack, {
+      state: 'rolling_back',
+      pendingChatbotAlias: null,
+      pendingRollbackAliases: [],
+      switchedChatbotAliases: [],
+    })
+    writeFileSync(path, `${JSON.stringify(ambiguousRollback)}\n`)
+    await expect(fileStore.read()).rejects.toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_STATE' })
+    )
   })
 
   it('serializes receipt updates, rejects stale digests, and refuses tampered shape', async () => {

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -1,9 +1,7 @@
 import { createHash } from 'node:crypto'
 import {
-  mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -101,14 +99,14 @@ function deadPid(): number {
 }
 
 function writeLockOwner(lockPath: string, pid: number, host = hostname()) {
-  mkdirSync(lockPath)
   writeFileSync(
-    join(lockPath, 'owner.json'),
+    lockPath,
     `${JSON.stringify({
-      version: 1,
+      version: 2,
       pid,
       host,
       token: uuid(9990),
+      acquiredAt: new Date().toISOString(),
     })}\n`
   )
 }
@@ -670,6 +668,31 @@ describe('cohort activation operator', () => {
     expect(() => validateCohortManifest(wrongExclusionMultiset)).toThrowError(
       expect.objectContaining({ code: 'COHORT_COUNT_MISMATCH' })
     )
+  })
+
+  it('allows HTTPS or only the reviewed internal PRD target', async () => {
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        {
+          description: TARGET.description,
+          url: 'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker',
+        },
+        fingerprintManifest(manifest)
+      )
+    ).resolves.toMatchObject({ status: 'dry-run' })
+    await expect(
+      dryRunCohortActivation(
+        store,
+        manifest,
+        {
+          description: TARGET.description,
+          url: 'http://other.internal.invalid/mcp',
+        },
+        fingerprintManifest(manifest)
+      )
+    ).rejects.toThrowError(expect.objectContaining({ code: 'INVALID_TARGET' }))
   })
 
   it('requires the source contract and every frozen server id to agree', async () => {
@@ -1235,8 +1258,8 @@ describe('cohort activation operator', () => {
       ).rejects.toThrowError(
         expect.objectContaining({ code: 'RECEIPT_LOCKED' })
       )
-      expect(statSync(`${path}.lock`).isDirectory()).toBe(true)
-      rmSync(`${path}.lock`, { force: true, recursive: true })
+      expect(statSync(`${path}.lock`).isFile()).toBe(true)
+      rmSync(`${path}.lock`, { force: true })
     }
   })
 
@@ -1247,7 +1270,7 @@ describe('cohort activation operator', () => {
     const primary = new Error('synthetic operation failure')
     const failure = await fileStore
       .runExclusive(async () => {
-        rmSync(`${path}.lock`, { force: true, recursive: true })
+        rmSync(`${path}.lock`, { force: true })
         throw primary
       })
       .catch((error: unknown) => error)
@@ -1493,11 +1516,11 @@ describe('cohort activation operator', () => {
     const prepared = await fileStore.read()
     expect(prepared).not.toBeNull()
 
-    mkdirSync(`${path}.lock`)
+    writeFileSync(`${path}.lock`, '')
     await expect(
       fileStore.compareAndSwap(prepared!.payloadDigest, prepared!)
     ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_LOCKED' }))
-    rmdirSync(`${path}.lock`)
+    rmSync(`${path}.lock`)
     expect(await fileStore.read()).toEqual(prepared)
 
     await expect(

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -68,7 +68,7 @@ function canonicalReceipt(value: unknown): unknown {
   return value
 }
 
-function receiptDigest(receipt: ActivationReceipt): string {
+function receiptDigest(receipt: ActivationReceiptPayload): string {
   const { payloadDigest: _payloadDigest, ...withoutDigest } = receipt
   return createHash('sha256')
     .update(JSON.stringify(canonicalReceipt(withoutDigest)))
@@ -212,6 +212,7 @@ class MemoryStore implements ActivationStore {
   transactions = 0
   legacyUpdates = 0
   failTargetConfigUpdate = false
+  failNextTransaction = false
   private sequence = 20000
   private clock = 1
 
@@ -458,6 +459,10 @@ class MemoryStore implements ActivationStore {
     callback: (store: ActivationTransactionStore) => Promise<T>
   ): Promise<T> {
     this.transactions += 1
+    if (this.failNextTransaction) {
+      this.failNextTransaction = false
+      throw new Error('synthetic transaction failure')
+    }
     const before = this.snapshot()
     try {
       return await callback(this)
@@ -1271,6 +1276,41 @@ describe('cohort activation operator', () => {
     expect((await fileStore.read())?.state).toBe('prepared')
   })
 
+  it('rejects a stale prepare intent without overwriting the winner', async () => {
+    await prepareCohortActivation(
+      store,
+      manifest,
+      options(receiptStore, manifest)
+    )
+    const prepared = receiptStore.value!
+    const intentWithoutDigest = {
+      receiptVersion: prepared.receiptVersion,
+      manifestFingerprint: prepared.manifestFingerprint,
+      counts: prepared.counts,
+      aliases: prepared.aliases,
+      state: 'preparing' as const,
+    }
+    receiptStore.value = {
+      ...intentWithoutDigest,
+      payloadDigest: receiptDigest(intentWithoutDigest),
+    }
+
+    const outcomes = await Promise.allSettled([
+      prepareCohortActivation(store, manifest, options(receiptStore, manifest)),
+      prepareCohortActivation(store, manifest, options(receiptStore, manifest)),
+    ])
+    expect(
+      outcomes.filter((outcome) => outcome.status === 'fulfilled')
+    ).toHaveLength(1)
+    expect(
+      outcomes.filter((outcome) => outcome.status === 'rejected')
+    ).toHaveLength(1)
+    expect(
+      outcomes.find((outcome) => outcome.status === 'rejected')?.reason
+    ).toMatchObject({ code: 'RECEIPT_CAS_FAILED' })
+    expect(receiptStore.value?.state).toBe('prepared')
+  })
+
   it('leaves a durable in-flight receipt readable for rollback recovery', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-inflight-'))
     const path = join(directory, 'receipt.json')
@@ -1284,6 +1324,19 @@ describe('cohort activation operator', () => {
       })
     ).rejects.toThrowError(expect.objectContaining({ code: 'CONCURRENT_EDIT' }))
     expect((await fileStore.read())?.state).toBe('switching')
+    store.failNextTransaction = true
+    await expect(
+      rollbackCohortChatbot(store, manifest, {
+        ...options(fileStore, manifest),
+        chatbotAlias: 'chatbot-001',
+      })
+    ).rejects.toThrowError('synthetic transaction failure')
+    expect(await fileStore.read()).toMatchObject({
+      state: 'rolling_back',
+      switchedChatbotAliases: [],
+      pendingRollbackAliases: ['chatbot-001'],
+      pendingRollbackOrigin: 'switching',
+    })
     await expect(
       rollbackCohortChatbot(store, manifest, {
         ...options(fileStore, manifest),

--- a/packages/prisma-data/src/scripts/cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.test.ts
@@ -670,6 +670,22 @@ describe('cohort activation operator', () => {
     )
   })
 
+  it('uses stable UTF-16 ordering for mixed-case identity fingerprints', () => {
+    const mixedCase = clone(manifest)
+    mixedCase.corpora[0]!.kbId = 'BBBBBBBB-BBBB-4BBB-8BBB-BBBBBBBBBBBB'
+    mixedCase.corpora[1]!.kbId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    mixedCase.corpora[0]!.configurations[0]!.configId =
+      'CCCCCCCC-CCCC-4CCC-8CCC-CCCCCCCCCCCC'
+    mixedCase.corpora[0]!.configurations[1]!.configId =
+      'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    mixedCase.excluded[0]!.configId = 'DDDDDDDD-DDDD-4DDD-8DDD-DDDDDDDDDDDD'
+    mixedCase.excluded[1]!.configId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+    expect(fingerprintManifest(mixedCase)).toBe(
+      '4fc6fe7ae1f5ab0de21993d21d292e929fdc4c6ab0418ca99e004dd41ca86fa0'
+    )
+  })
+
   it('allows HTTPS or only the reviewed internal PRD target', async () => {
     await expect(
       dryRunCohortActivation(
@@ -1217,18 +1233,16 @@ describe('cohort activation operator', () => {
     expect(await fileStore.read()).toEqual(receipt)
   })
 
-  it('reclaims only a dead same-host lock owner for in-flight recovery', async () => {
+  it('refuses a dead same-host lock until explicit manual recovery', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'cohort-activation-stale-'))
     const path = join(directory, 'receipt.json')
     writeLockOwner(`${path}.lock`, deadPid())
     const fileStore = createFileActivationReceiptStore(path)
-    const result = await prepareCohortActivation(
-      store,
-      manifest,
-      options(fileStore, manifest)
-    )
-    expect(result.status).toBe('prepared')
-    expect(() => statSync(`${path}.lock`)).toThrow()
+    await expect(
+      prepareCohortActivation(store, manifest, options(fileStore, manifest))
+    ).rejects.toThrowError(expect.objectContaining({ code: 'RECEIPT_LOCKED' }))
+    expect(statSync(`${path}.lock`).isFile()).toBe(true)
+    expect(store.writes).toBe(0)
   })
 
   it('refuses live and unknown receipt lock owners without expiry', async () => {

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -9,7 +9,7 @@ export const TARGET_SERVER_NAME = 'KB' as const
 export const TARGET_AUTH_TYPE = 'scope_token' as const
 export const DOC_QUERY_TOOL = 'doc_query' as const
 export const SOURCE_CHATBOT_ID_HEADER = 'Chatbot-ID' as const
-export const ACTIVATION_RECEIPT_VERSION = 1 as const
+export const ACTIVATION_RECEIPT_VERSION = 2 as const
 
 export const EXPECTED_CORPORA = 15 as const
 export const EXPECTED_COURSES = 16 as const
@@ -304,6 +304,9 @@ export type ActivationReceiptIntent = {
 export type ActivationReceiptPayload =
   | ActivationReceipt
   | ActivationReceiptIntent
+
+const LEGACY_ACTIVATION_RECEIPT_VERSION = 1 as const
+const legacyReceiptDigests = new WeakMap<object, string>()
 
 export interface ActivationReceiptStore extends ActivationReceiptSession {
   runExclusive<T>(
@@ -961,9 +964,7 @@ export function createFileActivationReceiptStore(
   async function readCurrent(): Promise<ActivationReceiptPayload | null> {
     try {
       const contents = await readFile(absolutePath, 'utf8')
-      const payload = JSON.parse(contents) as ActivationReceiptPayload
-      assertPayloadDigest(payload)
-      return payload
+      return normalizePersistedReceipt(JSON.parse(contents))
     } catch (error) {
       if (errorCode(error) === 'ENOENT') {
         return null
@@ -1880,14 +1881,120 @@ function assertPayloadShape(
   }
 }
 
+function assertPersistedPayloadDigest(
+  value: Record<string, unknown>
+): asserts value is Record<string, unknown> & { payloadDigest: string } {
+  assertReceiptFingerprint(value.payloadDigest)
+  const { payloadDigest: _payloadDigest, ...withoutDigest } = value
+  if (fingerprint(withoutDigest) !== value.payloadDigest) {
+    fail('RECEIPT_INVALID', 'receipt digest does not match')
+  }
+}
+
+function legacyReceiptDigest(payload: ActivationReceiptPayload): string {
+  const { payloadDigest: _payloadDigest, ...withoutDigest } = payload
+  const { pendingRollbackOrigin: _origin, ...withoutOrigin } =
+    withoutDigest as ActivationReceipt
+  return fingerprint({
+    ...withoutOrigin,
+    receiptVersion: LEGACY_ACTIVATION_RECEIPT_VERSION,
+  })
+}
+
+function inferLegacyRollbackOrigin(
+  value: Record<string, unknown>
+): ActivationRollbackOrigin {
+  const switchedAliases = value.switchedChatbotAliases
+  const rollbackAliases = value.pendingRollbackAliases
+  if (
+    !Array.isArray(switchedAliases) ||
+    !Array.isArray(rollbackAliases) ||
+    rollbackAliases.length !== 1
+  ) {
+    fail('RECEIPT_STATE', 'legacy rollback origin is ambiguous')
+  }
+  const pendingAlias = rollbackAliases[0]
+  if (
+    typeof pendingAlias !== 'string' ||
+    !switchedAliases.every((alias) => typeof alias === 'string')
+  ) {
+    fail('RECEIPT_STATE', 'legacy rollback origin is ambiguous')
+  }
+  return switchedAliases.includes(pendingAlias) ? 'switched' : 'switching'
+}
+
+function normalizePersistedReceipt(value: unknown): ActivationReceiptPayload {
+  assertReceiptObject(value)
+  if (value.receiptVersion !== LEGACY_ACTIVATION_RECEIPT_VERSION) {
+    assertPayloadDigest(value)
+    return value
+  }
+
+  const legacyIsIntent = value.state === 'preparing'
+  assertReceiptKeys(
+    value,
+    legacyIsIntent
+      ? [
+          'receiptVersion',
+          'manifestFingerprint',
+          'counts',
+          'aliases',
+          'state',
+          'payloadDigest',
+        ]
+      : [
+          'receiptVersion',
+          'manifestFingerprint',
+          'counts',
+          'aliases',
+          'sourceServer',
+          'targetServer',
+          'corpora',
+          'courses',
+          'chatbots',
+          'legacyConfigurations',
+          'excludedConfigurations',
+          'bindings',
+          'configurations',
+          'switchedChatbotAliases',
+          'pendingChatbotAlias',
+          'pendingRollbackAliases',
+          'state',
+          'payloadDigest',
+        ]
+  )
+  assertPersistedPayloadDigest(value)
+  const normalized = legacyIsIntent
+    ? {
+        ...value,
+        receiptVersion: ACTIVATION_RECEIPT_VERSION,
+      }
+    : {
+        ...value,
+        receiptVersion: ACTIVATION_RECEIPT_VERSION,
+        pendingRollbackOrigin:
+          value.state === 'rolling_back'
+            ? inferLegacyRollbackOrigin(value)
+            : null,
+      }
+  assertPayloadShape(normalized)
+  legacyReceiptDigests.set(normalized, value.payloadDigest)
+  return normalized
+}
+
 function assertPayloadDigest(
   payload: unknown
 ): asserts payload is ActivationReceiptPayload {
   assertPayloadShape(payload)
   const { payloadDigest: _payloadDigest, ...withoutDigest } = payload
-  if (fingerprint(withoutDigest) !== payload.payloadDigest) {
-    fail('RECEIPT_INVALID', 'receipt digest does not match')
+  if (fingerprint(withoutDigest) === payload.payloadDigest) return
+  if (
+    legacyReceiptDigests.get(payload) === payload.payloadDigest &&
+    legacyReceiptDigest(payload) === payload.payloadDigest
+  ) {
+    return
   }
+  fail('RECEIPT_INVALID', 'receipt digest does not match')
 }
 
 function assertReceiptTransition(
@@ -1910,7 +2017,7 @@ function assertReceiptTransition(
   const allowed: Record<ActivationReceiptState, ActivationReceiptState[]> = {
     prepared: ['switching'],
     switching: ['switched', 'rolling_back'],
-    switched: ['rolling_back'],
+    switched: ['switching', 'rolling_back'],
     rolling_back: ['switched', 'rolled_back'],
     rolled_back: [],
   }
@@ -1930,8 +2037,10 @@ async function readReceipt(
 ): Promise<ActivationReceiptPayload | null> {
   if (!receiptStore) return null
   const payload = await receiptStore.read()
-  if (payload) assertPayloadDigest(payload)
-  return payload
+  if (!payload) return null
+  const normalized = normalizePersistedReceipt(payload)
+  assertPayloadDigest(normalized)
+  return normalized
 }
 
 function assertReceiptMatchesIndex(
@@ -3112,138 +3221,158 @@ export async function prepareCohortActivation(
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
 
-  const existing = await readReceipt(options.receiptStore)
-  let expectedReceiptDigest: string | null = null
-  if (existing) {
-    assertReceiptMatchesIndex(existing, index, manifestFingerprint)
-    if (isReceiptIntent(existing)) {
-      expectedReceiptDigest = existing.payloadDigest
-      const intentState = await inspectCohortState(store, index, options.target)
-      assertNoEnabledTargetRows(intentState)
-      assertNoUntrackedPartialTargetRows(intentState, index)
-    } else {
-      validateReceiptState(existing, ['prepared'])
-      const state = await inspectCohortState(store, index, options.target)
-      assertReceiptCurrent(state, index, existing)
-      requirePreparedRows(state, index)
-      return operationResult(
-        'prepared',
-        index,
-        manifestFingerprint,
-        zeroWrites(),
-        existing
-      )
-    }
-  } else {
-    const initialState = await inspectCohortState(store, index, options.target)
-    assertNoEnabledTargetRows(initialState)
-    assertNoUntrackedPartialTargetRows(initialState, index)
-    const intent = makeIntent(index, manifestFingerprint)
-    await options.receiptStore.compareAndSwap(null, intent)
-    expectedReceiptDigest = intent.payloadDigest
-  }
-
-  const writes = zeroWrites()
-  const receipt = await store.transaction(async (tx) => {
-    const state = await inspectCohortState(tx, index, options.target)
-    assertNoEnabledTargetRows(state)
-
-    for (const [alias, corpus] of index.corpusByAlias.entries()) {
-      if (state.corpora.has(alias)) continue
-      const collisions = await tx.findKnowledgeBasesByName(corpus.kbName)
-      if (collisions.length > 0) {
-        fail('KB_NAME_COLLISION', 'a knowledge base name is not deterministic')
-      }
-      const created = await tx.createKnowledgeBase({
-        id: corpus.kbId,
-        name: corpus.kbName,
-        description: corpus.description ?? null,
-        ownerId: corpus.ownerId,
-      })
-      assertKnowledgeBase(created, corpus)
-      state.corpora.set(alias, created)
-      writes.knowledgeBases += 1
-    }
-
-    if (!state.targetServer) {
-      const encryptedTransportCredential = state.sourceServer.authSecret
-      if (!encryptedTransportCredential) {
-        fail(
-          'SOURCE_CREDENTIAL_MISSING',
-          'the source transport credential is unavailable'
+  const receiptStore = options.receiptStore
+  const execute = async (
+    session: ActivationReceiptSession
+  ): Promise<ActivationResult> => {
+    const existing = await readReceipt(session)
+    let expectedReceiptDigest: string | null = null
+    if (existing) {
+      assertReceiptMatchesIndex(existing, index, manifestFingerprint)
+      if (isReceiptIntent(existing)) {
+        expectedReceiptDigest = existing.payloadDigest
+        const intentState = await inspectCohortState(
+          store,
+          index,
+          options.target
+        )
+        assertNoEnabledTargetRows(intentState)
+        assertNoUntrackedPartialTargetRows(intentState, index)
+      } else {
+        validateReceiptState(existing, ['prepared'])
+        const state = await inspectCohortState(store, index, options.target)
+        assertReceiptCurrent(state, index, existing)
+        requirePreparedRows(state, index)
+        return operationResult(
+          'prepared',
+          index,
+          manifestFingerprint,
+          zeroWrites(),
+          existing
         )
       }
-      const created = await tx.createServer({
-        name: TARGET_SERVER_NAME,
-        description: options.target.description,
-        url: options.target.url,
-        authType: TARGET_AUTH_TYPE,
-        authSecret: encryptedTransportCredential,
-        passChatbotId: false,
-        chatbotIdHeader: null,
-        parameters: {},
-        isActive: true,
-      })
-      assertTargetServer(created, state.sourceServer, options.target)
-      state.targetServer = created
-      writes.server += 1
+    } else {
+      const initialState = await inspectCohortState(
+        store,
+        index,
+        options.target
+      )
+      assertNoEnabledTargetRows(initialState)
+      assertNoUntrackedPartialTargetRows(initialState, index)
+      const intent = makeIntent(index, manifestFingerprint)
+      await session.compareAndSwap(null, intent)
+      expectedReceiptDigest = intent.payloadDigest
     }
 
-    for (const [chatbotAlias, chatbotId] of index.chatbotIdByAlias.entries()) {
-      const corpusAlias = corpusAliasFor(index, chatbotId)
-      const kb = state.corpora.get(corpusAlias)
-      if (!kb) fail('KB_MISSING', 'a deterministic knowledge base is missing')
-      const existingBinding = state.bindings.get(chatbotAlias)
-      if (existingBinding) {
-        assertBinding(existingBinding, kb.id, chatbotId)
-      } else {
-        const createdBinding = await tx.createBinding({
-          kbId: kb.id,
-          chatbotId,
-          isEnabled: false,
+    const writes = zeroWrites()
+    const receipt = await store.transaction(async (tx) => {
+      const state = await inspectCohortState(tx, index, options.target)
+      assertNoEnabledTargetRows(state)
+
+      for (const [alias, corpus] of index.corpusByAlias.entries()) {
+        if (state.corpora.has(alias)) continue
+        const collisions = await tx.findKnowledgeBasesByName(corpus.kbName)
+        if (collisions.length > 0) {
+          fail(
+            'KB_NAME_COLLISION',
+            'a knowledge base name is not deterministic'
+          )
+        }
+        const created = await tx.createKnowledgeBase({
+          id: corpus.kbId,
+          name: corpus.kbName,
+          description: corpus.description ?? null,
+          ownerId: corpus.ownerId,
         })
-        assertBinding(createdBinding, kb.id, chatbotId)
-        state.bindings.set(chatbotAlias, createdBinding)
-        writes.bindings += 1
+        assertKnowledgeBase(created, corpus)
+        state.corpora.set(alias, created)
+        writes.knowledgeBases += 1
       }
-    }
 
-    for (const [alias, configuration] of index.configByAlias.entries()) {
-      const existingConfig = state.configurations.get(alias)
-      if (existingConfig) {
+      if (!state.targetServer) {
+        const encryptedTransportCredential = state.sourceServer.authSecret
+        if (!encryptedTransportCredential) {
+          fail(
+            'SOURCE_CREDENTIAL_MISSING',
+            'the source transport credential is unavailable'
+          )
+        }
+        const created = await tx.createServer({
+          name: TARGET_SERVER_NAME,
+          description: options.target.description,
+          url: options.target.url,
+          authType: TARGET_AUTH_TYPE,
+          authSecret: encryptedTransportCredential,
+          passChatbotId: false,
+          chatbotIdHeader: null,
+          parameters: {},
+          isActive: true,
+        })
+        assertTargetServer(created, state.sourceServer, options.target)
+        state.targetServer = created
+        writes.server += 1
+      }
+
+      for (const [
+        chatbotAlias,
+        chatbotId,
+      ] of index.chatbotIdByAlias.entries()) {
+        const corpusAlias = corpusAliasFor(index, chatbotId)
+        const kb = state.corpora.get(corpusAlias)
+        if (!kb) fail('KB_MISSING', 'a deterministic knowledge base is missing')
+        const existingBinding = state.bindings.get(chatbotAlias)
+        if (existingBinding) {
+          assertBinding(existingBinding, kb.id, chatbotId)
+        } else {
+          const createdBinding = await tx.createBinding({
+            kbId: kb.id,
+            chatbotId,
+            isEnabled: false,
+          })
+          assertBinding(createdBinding, kb.id, chatbotId)
+          state.bindings.set(chatbotAlias, createdBinding)
+          writes.bindings += 1
+        }
+      }
+
+      for (const [alias, configuration] of index.configByAlias.entries()) {
+        const existingConfig = state.configurations.get(alias)
+        if (existingConfig) {
+          assertTargetConfiguration(
+            existingConfig,
+            configuration,
+            state.targetServer.id
+          )
+          continue
+        }
+        const createdConfig = await tx.createConfig(
+          targetConfigData(configuration, state.targetServer.id)
+        )
         assertTargetConfiguration(
-          existingConfig,
+          createdConfig,
           configuration,
           state.targetServer.id
         )
-        continue
+        state.configurations.set(alias, createdConfig)
+        writes.configurations += 1
       }
-      const createdConfig = await tx.createConfig(
-        targetConfigData(configuration, state.targetServer.id)
-      )
-      assertTargetConfiguration(
-        createdConfig,
-        configuration,
-        state.targetServer.id
-      )
-      state.configurations.set(alias, createdConfig)
-      writes.configurations += 1
-    }
 
-    requirePreparedRows(state, index)
-    return makeReceiptFromState(state, index, manifestFingerprint, {
-      state: 'prepared',
-      switchedChatbotAliases: [],
+      requirePreparedRows(state, index)
+      return makeReceiptFromState(state, index, manifestFingerprint, {
+        state: 'prepared',
+        switchedChatbotAliases: [],
+      })
     })
-  })
-  await options.receiptStore.compareAndSwap(expectedReceiptDigest, receipt)
-  return operationResult(
-    'prepared',
-    index,
-    manifestFingerprint,
-    writes,
-    receipt
-  )
+    await session.compareAndSwap(expectedReceiptDigest, receipt)
+    return operationResult(
+      'prepared',
+      index,
+      manifestFingerprint,
+      writes,
+      receipt
+    )
+  }
+  return receiptStore.runExclusive(execute)
 }
 
 async function prepareOrReadReceipt(

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -1,5 +1,13 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import {
+  link,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  unlink,
+} from 'node:fs/promises'
 import { hostname } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
@@ -37,6 +45,14 @@ const NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
 const MODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
 const FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/i
 const CONTROL_CHARACTER_PATTERN = /\p{Cc}/u
+const INTERNAL_PRD_TARGET_URL =
+  'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker'
+
+function compareUtf16Strings(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
 
 export type JsonValue =
   | null
@@ -449,11 +465,17 @@ function assertUrl(value: unknown): asserts value is string {
   } catch {
     fail('INVALID_TARGET', 'target URL is invalid')
   }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    fail('INVALID_TARGET', 'target URL must use HTTP or HTTPS')
-  }
   if (parsed.username || parsed.password) {
     fail('INVALID_TARGET', 'target URL must not contain credentials')
+  }
+  if (
+    parsed.protocol !== 'https:' &&
+    parsed.href !== new URL(INTERNAL_PRD_TARGET_URL).href
+  ) {
+    fail(
+      'INVALID_TARGET',
+      'target URL must use HTTPS or the reviewed internal PRD endpoint'
+    )
   }
 }
 
@@ -465,7 +487,7 @@ function canonicalize(value: unknown): unknown {
     return Object.fromEntries(
       Object.keys(record)
         .filter((key) => record[key] !== undefined)
-        .sort()
+        .sort(compareUtf16Strings)
         .map((key) => [key, canonicalize(record[key])])
     )
   }
@@ -505,8 +527,8 @@ function canonicalManifest(manifest: FrozenCohortManifest): unknown {
         targetCollection: corpus.targetCollection,
         tool: corpus.tool,
         alias: corpus.alias,
-        chatbotIds: [...corpus.chatbotIds].sort(),
-        courseIds: [...corpus.courseIds].sort(),
+        chatbotIds: [...corpus.chatbotIds].sort(compareUtf16Strings),
+        courseIds: [...corpus.courseIds].sort(compareUtf16Strings),
         configurations: [...corpus.configurations]
           .sort((left, right) => left.configId.localeCompare(right.configId))
           .map((configuration) => ({
@@ -774,8 +796,7 @@ export function parseFrozenActivationManifest(
   return { ...manifest, fingerprint: fingerprintManifest(manifest) }
 }
 
-const RECEIPT_LOCK_OWNER_FILE = 'owner.json'
-const RECEIPT_LOCK_OWNER_VERSION = 1 as const
+const RECEIPT_LOCK_OWNER_VERSION = 2 as const
 const RECEIPT_LOCK_OWNER_MAX_BYTES = 512
 
 type ReceiptLockOwner = {
@@ -783,6 +804,7 @@ type ReceiptLockOwner = {
   pid: number
   host: string
   token: string
+  acquiredAt: string
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -796,7 +818,7 @@ function errorCode(error: unknown): string | undefined {
 function lockError(): CohortActivationError {
   return new CohortActivationError(
     'RECEIPT_LOCKED',
-    'activation receipt is already being updated'
+    'activation receipt is already being updated; verify and remove a stale lock file manually before retrying'
   )
 }
 
@@ -812,7 +834,8 @@ function sameLockOwner(left: ReceiptLockOwner, right: ReceiptLockOwner) {
     left.version === right.version &&
     left.pid === right.pid &&
     left.host === right.host &&
-    left.token === right.token
+    left.token === right.token &&
+    left.acquiredAt === right.acquiredAt
   )
 }
 
@@ -820,16 +843,13 @@ async function readLockOwner(
   lockPath: string
 ): Promise<ReceiptLockOwner | null> {
   try {
-    const contents = await readFile(
-      join(lockPath, RECEIPT_LOCK_OWNER_FILE),
-      'utf8'
-    )
+    const contents = await readFile(lockPath, 'utf8')
     if (Buffer.byteLength(contents, 'utf8') > RECEIPT_LOCK_OWNER_MAX_BYTES) {
       return null
     }
     const parsed: unknown = JSON.parse(contents)
     if (!isPlainObject(parsed)) return null
-    assertReceiptKeys(parsed, ['version', 'pid', 'host', 'token'])
+    assertReceiptKeys(parsed, ['version', 'pid', 'host', 'token', 'acquiredAt'])
     if (
       parsed.version !== RECEIPT_LOCK_OWNER_VERSION ||
       typeof parsed.pid !== 'number' ||
@@ -841,7 +861,10 @@ async function readLockOwner(
       parsed.host.length > 255 ||
       CONTROL_CHARACTER_PATTERN.test(parsed.host) ||
       typeof parsed.token !== 'string' ||
-      !UUID_PATTERN.test(parsed.token)
+      !UUID_PATTERN.test(parsed.token) ||
+      typeof parsed.acquiredAt !== 'string' ||
+      parsed.acquiredAt.length > 32 ||
+      !Number.isFinite(Date.parse(parsed.acquiredAt))
     ) {
       return null
     }
@@ -850,14 +873,87 @@ async function readLockOwner(
       pid: parsed.pid,
       host: parsed.host,
       token: parsed.token,
+      acquiredAt: parsed.acquiredAt,
     }
   } catch {
     return null
   }
 }
 
-async function removeUnownedLock(lockPath: string): Promise<void> {
-  await rm(lockPath, { force: false, recursive: true })
+async function syncContainingDirectory(path: string): Promise<void> {
+  const directory = await open(dirname(path), 'r')
+  try {
+    await directory.sync()
+  } finally {
+    await directory.close()
+  }
+}
+
+async function syncContainingDirectoryAfterPublish(
+  path: string
+): Promise<void> {
+  try {
+    await syncContainingDirectory(path)
+  } catch {
+    throw new CohortActivationError(
+      'RECEIPT_WRITE_FAILED',
+      'receipt publication durability is unknown'
+    )
+  }
+}
+
+async function writeDurablePrivateFile(
+  path: string,
+  contents: string
+): Promise<void> {
+  const file = await open(path, 'wx', 0o600)
+  try {
+    await file.writeFile(contents, { encoding: 'utf8' })
+    await file.sync()
+  } finally {
+    await file.close()
+  }
+}
+
+async function removeLockFile(lockPath: string): Promise<void> {
+  await unlink(lockPath)
+  await syncContainingDirectory(lockPath)
+}
+
+async function tryCreateReceiptLock(
+  lockPath: string,
+  owner: ReceiptLockOwner
+): Promise<boolean> {
+  const contents = `${JSON.stringify(owner)}\n`
+  if (Buffer.byteLength(contents, 'utf8') > RECEIPT_LOCK_OWNER_MAX_BYTES) {
+    throw new CohortActivationError(
+      'RECEIPT_WRITE_FAILED',
+      'receipt lock owner is too large'
+    )
+  }
+  const temporaryPath = `${lockPath}.tmp-${process.pid}-${randomUUID()}`
+  let linked = false
+  try {
+    await writeDurablePrivateFile(temporaryPath, contents)
+    try {
+      await link(temporaryPath, lockPath)
+      linked = true
+    } catch (error) {
+      if (errorCode(error) === 'EEXIST') return false
+      throw error
+    }
+    await syncContainingDirectoryAfterPublish(lockPath)
+    return true
+  } catch (error) {
+    if (linked) await syncContainingDirectory(lockPath).catch(() => undefined)
+    if (error instanceof CohortActivationError) throw error
+    throw new CohortActivationError(
+      'RECEIPT_WRITE_FAILED',
+      'receipt lock owner is unavailable'
+    )
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
 }
 
 async function reclaimDeadLock(
@@ -875,82 +971,34 @@ async function reclaimDeadLock(
   const currentOwner = await readLockOwner(lockPath)
   if (!currentOwner || !sameLockOwner(currentOwner, owner)) throw lockError()
   try {
-    await removeUnownedLock(lockPath)
+    await removeLockFile(lockPath)
   } catch (error) {
     throw new AggregateError([lockError(), error], lockCleanupError().message)
   }
 }
 
 async function acquireReceiptLock(lockPath: string): Promise<ReceiptLockOwner> {
-  try {
-    await mkdir(lockPath, { mode: 0o700 })
-  } catch (error) {
-    if (errorCode(error) !== 'EEXIST') {
-      throw new CohortActivationError(
-        'RECEIPT_WRITE_FAILED',
-        'receipt lock is unavailable'
-      )
-    }
-    const owner = await readLockOwner(lockPath)
-    if (!owner) throw lockError()
-    let dead = false
-    if (owner.host === hostname()) {
-      try {
-        process.kill(owner.pid, 0)
-      } catch (probeError) {
-        dead = errorCode(probeError) === 'ESRCH'
-      }
-    }
-    if (!dead) throw lockError()
-    await reclaimDeadLock(lockPath, owner)
-    try {
-      await mkdir(lockPath, { mode: 0o700 })
-    } catch (reacquireError) {
-      if (errorCode(reacquireError) === 'EEXIST') throw lockError()
-      throw new CohortActivationError(
-        'RECEIPT_WRITE_FAILED',
-        'receipt lock is unavailable'
-      )
-    }
-  }
-
   const owner: ReceiptLockOwner = {
     version: RECEIPT_LOCK_OWNER_VERSION,
     pid: process.pid,
     host: hostname(),
     token: randomUUID(),
+    acquiredAt: new Date().toISOString(),
   }
-  const contents = `${JSON.stringify(owner)}\n`
-  try {
-    await writeFile(join(lockPath, RECEIPT_LOCK_OWNER_FILE), contents, {
-      encoding: 'utf8',
-      flag: 'wx',
-      mode: 0o600,
-    })
-    await chmod(join(lockPath, RECEIPT_LOCK_OWNER_FILE), 0o600)
-  } catch {
-    const primary = new CohortActivationError(
-      'RECEIPT_WRITE_FAILED',
-      'receipt lock owner is unavailable'
-    )
-    try {
-      await removeUnownedLock(lockPath)
-    } catch (cleanupError) {
-      throw new AggregateError([primary, cleanupError], primary.message)
+  if (!(await tryCreateReceiptLock(lockPath, owner))) {
+    const existingOwner = await readLockOwner(lockPath)
+    if (!existingOwner) throw lockError()
+    let dead = false
+    if (existingOwner.host === hostname()) {
+      try {
+        process.kill(existingOwner.pid, 0)
+      } catch (probeError) {
+        dead = errorCode(probeError) === 'ESRCH'
+      }
     }
-    throw primary
-  }
-  if (Buffer.byteLength(contents, 'utf8') > RECEIPT_LOCK_OWNER_MAX_BYTES) {
-    const primary = new CohortActivationError(
-      'RECEIPT_WRITE_FAILED',
-      'receipt lock owner is too large'
-    )
-    try {
-      await removeUnownedLock(lockPath)
-    } catch (cleanupError) {
-      throw new AggregateError([primary, cleanupError], primary.message)
-    }
-    throw primary
+    if (!dead) throw lockError()
+    await reclaimDeadLock(lockPath, existingOwner)
+    if (!(await tryCreateReceiptLock(lockPath, owner))) throw lockError()
   }
   return owner
 }
@@ -993,13 +1041,12 @@ export function createFileActivationReceiptStore(
     }
     if (current?.payloadDigest === receipt.payloadDigest) return
     try {
-      await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
-        encoding: 'utf8',
-        flag: 'wx',
-        mode: 0o600,
-      })
-      await chmod(temporaryPath, 0o600)
+      await writeDurablePrivateFile(
+        temporaryPath,
+        `${JSON.stringify(receipt, null, 2)}\n`
+      )
       await rename(temporaryPath, absolutePath)
+      await syncContainingDirectoryAfterPublish(absolutePath)
     } catch (error) {
       if (error instanceof CohortActivationError) throw error
       fail('RECEIPT_WRITE_FAILED', 'could not persist activation receipt')
@@ -1014,7 +1061,7 @@ export function createFileActivationReceiptStore(
       throw lockCleanupError()
     }
     try {
-      await removeUnownedLock(lockPath)
+      await removeLockFile(lockPath)
     } catch (error) {
       throw new AggregateError(
         [lockCleanupError(), error],
@@ -1366,14 +1413,16 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
 
   const courseIds = [
     ...new Set(sortedCorpora.flatMap((corpus) => corpus.courseIds)),
-  ].sort()
+  ].sort(compareUtf16Strings)
   courseIds.forEach((courseId, index) => {
     const alias = `course-${padAlias(index)}`
     courseAliasForId.set(courseId, alias)
     courseIdByAlias.set(alias, courseId)
   })
 
-  const chatbotIds = [...corpusAliasByChatbotId.keys()].sort()
+  const chatbotIds = [...corpusAliasByChatbotId.keys()].sort(
+    compareUtf16Strings
+  )
   const chatbotAliasForId = new Map<string, string>()
   const chatbotIdByAlias = new Map<string, string>()
   chatbotIds.forEach((chatbotId, index) => {
@@ -1410,7 +1459,7 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
   })
   const excludedChatbotAliasForId = new Map<string, string>()
   ;[...new Set(sortedExcluded.map((configuration) => configuration.chatbotId))]
-    .sort()
+    .sort(compareUtf16Strings)
     .forEach((chatbotId, index) => {
       excludedChatbotAliasForId.set(
         chatbotId,
@@ -1444,12 +1493,16 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
     aliases: {
       sourceServer: SOURCE_SERVER_NAME,
       targetServer: TARGET_SERVER_NAME,
-      corpora: [...corpusByAlias.keys()].sort(),
-      courses: [...courseIdByAlias.keys()].sort(),
-      chatbots: [...chatbotIdByAlias.keys()].sort(),
-      configurations: [...configByAlias.keys()].sort(),
-      bindings: [...bindingAliasByChatbotAlias.values()].sort(),
-      excludedConfigurations: [...excludedByAlias.keys()].sort(),
+      corpora: [...corpusByAlias.keys()].sort(compareUtf16Strings),
+      courses: [...courseIdByAlias.keys()].sort(compareUtf16Strings),
+      chatbots: [...chatbotIdByAlias.keys()].sort(compareUtf16Strings),
+      configurations: [...configByAlias.keys()].sort(compareUtf16Strings),
+      bindings: [...bindingAliasByChatbotAlias.values()].sort(
+        compareUtf16Strings
+      ),
+      excludedConfigurations: [...excludedByAlias.keys()].sort(
+        compareUtf16Strings
+      ),
     },
     counts: {
       corpora: EXPECTED_CORPORA,
@@ -1519,8 +1572,8 @@ function assertReceiptKeys(
   value: Record<string, unknown>,
   keys: readonly string[]
 ): void {
-  const actual = Object.keys(value).sort()
-  const expected = [...keys].sort()
+  const actual = Object.keys(value).sort(compareUtf16Strings)
+  const expected = [...keys].sort(compareUtf16Strings)
   if (canonicalJson(actual) !== canonicalJson(expected)) {
     receiptInvalid('receipt shape is invalid')
   }
@@ -1647,7 +1700,10 @@ function assertReceiptIdentitySnapshot(
       receiptInvalid('receipt snapshots are duplicated')
     seen.add(entry.alias)
   }
-  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+  if (
+    canonicalJson([...seen].sort(compareUtf16Strings)) !==
+    canonicalJson([...aliases].sort(compareUtf16Strings))
+  ) {
     receiptInvalid('receipt snapshot aliases are invalid')
   }
 }
@@ -1684,7 +1740,10 @@ function assertReceiptConfigSnapshots(
       receiptInvalid('receipt snapshots are duplicated')
     seen.add(entry.alias)
   }
-  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+  if (
+    canonicalJson([...seen].sort(compareUtf16Strings)) !==
+    canonicalJson([...aliases].sort(compareUtf16Strings))
+  ) {
     receiptInvalid('receipt snapshot aliases are invalid')
   }
 }
@@ -1725,7 +1784,10 @@ function assertReceiptBindingSnapshots(
       receiptInvalid('receipt snapshots are duplicated')
     seen.add(entry.alias)
   }
-  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+  if (
+    canonicalJson([...seen].sort(compareUtf16Strings)) !==
+    canonicalJson([...aliases].sort(compareUtf16Strings))
+  ) {
     receiptInvalid('receipt binding snapshot aliases are invalid')
   }
 }
@@ -3070,11 +3132,13 @@ function makeReceiptFromState(
     excludedConfigurations,
     bindings,
     configurations,
-    switchedChatbotAliases: [...new Set(input.switchedChatbotAliases)].sort(),
+    switchedChatbotAliases: [...new Set(input.switchedChatbotAliases)].sort(
+      compareUtf16Strings
+    ),
     pendingChatbotAlias: input.pendingChatbotAlias ?? null,
     pendingRollbackAliases: [
       ...new Set(input.pendingRollbackAliases ?? []),
-    ].sort(),
+    ].sort(compareUtf16Strings),
     pendingRollbackOrigin: input.pendingRollbackOrigin ?? null,
     state: input.state,
   })
@@ -3600,8 +3664,7 @@ export async function rollbackCohortChatbot(
       fail('RECEIPT_STATE', 'chatbot was not switched')
     }
     if (
-      (receipt.state === 'rolling_back' || receipt.state === 'switching') &&
-      receipt.state !== 'switching' &&
+      receipt.state === 'rolling_back' &&
       !receipt.pendingRollbackAliases.includes(options.chatbotAlias)
     ) {
       fail('RECEIPT_STATE', 'rollback intent does not name the chatbot')

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -1,0 +1,2383 @@
+import { createHash } from 'node:crypto'
+import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { PrismaClient } from '@klicker-uzh/prisma/client'
+
+export const SOURCE_SERVER_NAME = 'Klicker-compat' as const
+export const TARGET_SERVER_NAME = 'KB' as const
+export const TARGET_AUTH_TYPE = 'scope_token' as const
+export const DOC_QUERY_TOOL = 'doc_query' as const
+export const ACTIVATION_RECEIPT_VERSION = 1 as const
+
+export const EXPECTED_CORPORA = 15 as const
+export const EXPECTED_COURSES = 16 as const
+export const EXPECTED_CHATBOTS = 22 as const
+export const EXPECTED_CONFIGURATIONS = 48 as const
+export const EXPECTED_BINDINGS = EXPECTED_CHATBOTS
+export const EXPECTED_EXCLUDED_CONFIGURATIONS = 4 as const
+export const EXPECTED_EXCLUDED_CHATBOTS = 2 as const
+
+export const EXCLUDED_SOURCE_TOOLS = [
+  'bf1_expert',
+  'df_cf2_expert',
+  'vorkurs2_expert',
+] as const
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+const MODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+const CONTROL_CHARACTER_PATTERN = /\p{Cc}/u
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type FrozenConfiguration = {
+  allowedTools: string[]
+  chatbotId: string
+  chatMode: string
+  configId: string
+  parameters: JsonValue
+  priority: number
+  sourceServerId: string
+  alias?: string
+}
+
+export type FrozenCorpus = {
+  chatbotIds: string[]
+  configurations: FrozenConfiguration[]
+  courseIds: string[]
+  kbId: string
+  kbName: string
+  ownerId: string
+  sourceCollection: string
+  targetCollection: string
+  tool: string
+  description?: string | null
+  alias?: string
+}
+
+export type FrozenExcludedConfiguration = {
+  chatbotId: string
+  chatMode: string
+  configId: string
+  serverId: string
+  tool: string
+}
+
+export type FrozenCohortManifest = {
+  collection: string
+  corpora: FrozenCorpus[]
+  environment: string
+  excluded: FrozenExcludedConfiguration[]
+  singletonCanaryKbId: string
+  version: number
+  fingerprint?: string
+}
+
+export type ActivationTarget = {
+  description: string
+  url: string
+}
+
+export type KnowledgeBaseRecord = {
+  id: string
+  name: string
+  description: string | null
+  ownerId: string
+  deletedAt: Date | null
+  updatedAt: Date
+}
+
+export type ChatbotRecord = {
+  id: string
+  courseId: string
+  ownerId: string
+  updatedAt: Date
+}
+
+export type ActivationServerRecord = {
+  id: string
+  name: string
+  description: string | null
+  url: string
+  authType: string
+  authSecret: string | null
+  passChatbotId: boolean
+  chatbotIdHeader: string | null
+  parameters: JsonValue
+  isActive: boolean
+  updatedAt: Date
+}
+
+export type ActivationConfigRecord = {
+  id: string
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: JsonValue
+  priority: number
+  isEnabled: boolean
+  parameters: JsonValue
+  updatedAt: Date
+}
+
+export type ActivationBindingRecord = {
+  id: string
+  kbId: string
+  chatbotId: string
+  isEnabled: boolean
+  updatedAt: Date
+}
+
+export type ActivationServerCreate = {
+  name: string
+  description: string
+  url: string
+  authType: string
+  authSecret: string
+  passChatbotId: false
+  chatbotIdHeader: null
+  parameters: JsonValue
+  isActive: true
+}
+
+export type ActivationKnowledgeBaseCreate = {
+  id: string
+  name: string
+  description: string | null
+  ownerId: string
+}
+
+export type ActivationBindingCreate = {
+  kbId: string
+  chatbotId: string
+  isEnabled: false
+}
+
+export type ActivationConfigCreate = {
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: JsonValue
+  priority: number
+  isEnabled: false
+  parameters: JsonValue
+}
+
+export type ActivationTransactionStore = {
+  findKnowledgeBaseById(id: string): Promise<KnowledgeBaseRecord | null>
+  findKnowledgeBasesByName(name: string): Promise<KnowledgeBaseRecord[]>
+  findChatbotById(id: string): Promise<ChatbotRecord | null>
+  findServersByName(name: string): Promise<ActivationServerRecord[]>
+  findConfigById(id: string): Promise<ActivationConfigRecord | null>
+  findConfigsByServerId(mcpServerId: string): Promise<ActivationConfigRecord[]>
+  findBindingsByChatbotId(chatbotId: string): Promise<ActivationBindingRecord[]>
+  createKnowledgeBase(
+    data: ActivationKnowledgeBaseCreate
+  ): Promise<KnowledgeBaseRecord>
+  createServer(data: ActivationServerCreate): Promise<ActivationServerRecord>
+  createBinding(data: ActivationBindingCreate): Promise<ActivationBindingRecord>
+  createConfig(data: ActivationConfigCreate): Promise<ActivationConfigRecord>
+  updateBinding(
+    snapshot: ActivationBindingRecord,
+    isEnabled: boolean
+  ): Promise<ActivationBindingRecord>
+  updateConfig(
+    snapshot: ActivationConfigRecord,
+    isEnabled: boolean
+  ): Promise<ActivationConfigRecord>
+}
+
+export type ActivationStore = ActivationTransactionStore & {
+  transaction<T>(
+    callback: (store: ActivationTransactionStore) => Promise<T>
+  ): Promise<T>
+}
+
+export type ReceiptAliases = {
+  sourceServer: typeof SOURCE_SERVER_NAME
+  targetServer: typeof TARGET_SERVER_NAME
+  corpora: string[]
+  chatbots: string[]
+  configurations: string[]
+}
+
+export type ReceiptCounts = {
+  corpora: typeof EXPECTED_CORPORA
+  courses: typeof EXPECTED_COURSES
+  chatbots: typeof EXPECTED_CHATBOTS
+  configurations: typeof EXPECTED_CONFIGURATIONS
+  bindings: typeof EXPECTED_BINDINGS
+}
+
+type SafeServerSnapshot = {
+  alias: typeof SOURCE_SERVER_NAME | typeof TARGET_SERVER_NAME
+  fingerprint: string
+  hasTransportCredential: boolean
+  isActive: boolean
+  updatedAt: string
+}
+
+type SafeIdentitySnapshot = {
+  alias: string
+  fingerprint: string
+  updatedAt: string
+}
+
+type SafeConfigSnapshot = SafeIdentitySnapshot & {
+  chatbotAlias: string
+  chatMode: string
+  isEnabled: boolean
+}
+
+type SafeBindingSnapshot = SafeIdentitySnapshot & {
+  chatbotAlias: string
+  corpusAlias: string
+  isEnabled: boolean
+}
+
+export type ActivationReceiptState =
+  | 'prepared'
+  | 'switching'
+  | 'switched'
+  | 'rolling_back'
+  | 'rolled_back'
+
+export type ActivationReceipt = {
+  receiptVersion: typeof ACTIVATION_RECEIPT_VERSION
+  manifestFingerprint: string
+  counts: ReceiptCounts
+  aliases: ReceiptAliases
+  sourceServer: SafeServerSnapshot
+  targetServer: SafeServerSnapshot
+  corpora: SafeIdentitySnapshot[]
+  chatbots: SafeIdentitySnapshot[]
+  legacyConfigurations: SafeConfigSnapshot[]
+  bindings: SafeBindingSnapshot[]
+  configurations: SafeConfigSnapshot[]
+  switchedChatbotAliases: string[]
+  pendingChatbotAlias: string | null
+  pendingRollbackAliases: string[]
+  state: ActivationReceiptState
+  payloadDigest: string
+}
+
+export type ActivationReceiptIntent = {
+  receiptVersion: typeof ACTIVATION_RECEIPT_VERSION
+  manifestFingerprint: string
+  counts: ReceiptCounts
+  aliases: ReceiptAliases
+  state: 'preparing'
+  payloadDigest: string
+}
+
+export type ActivationReceiptPayload =
+  | ActivationReceipt
+  | ActivationReceiptIntent
+
+export interface ActivationReceiptStore {
+  read(): Promise<ActivationReceiptPayload | null>
+  write(receipt: ActivationReceiptPayload): Promise<void>
+}
+
+export type ActivationOptions = {
+  receiptStore?: ActivationReceiptStore
+  target: ActivationTarget
+  dryRun?: boolean
+}
+
+export type ActivationWrites = {
+  knowledgeBases: number
+  server: number
+  bindings: number
+  configurations: number
+}
+
+export type ActivationResult = {
+  status: 'dry-run' | 'prepared' | 'switched' | 'rolled_back' | 'readback'
+  manifestFingerprint: string
+  counts: ReceiptCounts
+  aliases: {
+    sourceServer: typeof SOURCE_SERVER_NAME
+    targetServer: typeof TARGET_SERVER_NAME
+    chatbotAliases: string[]
+    switchedChatbotAliases: string[]
+  }
+  fingerprints: {
+    manifest: string
+    receipt?: string
+  }
+  writes: ActivationWrites
+  legacyRowsPreserved: true
+  receipt?: ActivationReceipt
+}
+
+export class CohortActivationError extends Error {
+  readonly code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'CohortActivationError'
+    this.code = code
+  }
+}
+
+type ManifestIndex = {
+  corpusByAlias: Map<string, FrozenCorpus>
+  corpusAliasByChatbotId: Map<string, string>
+  chatbotAliasForId: Map<string, string>
+  chatbotIdByAlias: Map<string, string>
+  configByAlias: Map<string, FrozenConfiguration>
+  configsByChatbotAlias: Map<string, Array<[string, FrozenConfiguration]>>
+  bindingAliasByChatbotAlias: Map<string, string>
+  aliases: ReceiptAliases
+  counts: ReceiptCounts
+  sourceServerIds: Set<string>
+}
+
+type InspectedState = {
+  sourceServer: ActivationServerRecord
+  targetServer: ActivationServerRecord | null
+  corpora: Map<string, KnowledgeBaseRecord>
+  chatbots: Map<string, ChatbotRecord>
+  legacyConfigurations: Map<string, ActivationConfigRecord>
+  configurations: Map<string, ActivationConfigRecord | null>
+  bindings: Map<string, ActivationBindingRecord | null>
+  otherBindingsByChatbotAlias: Map<string, ActivationBindingRecord[]>
+}
+
+function fail(code: string, message: string): never {
+  throw new CohortActivationError(code, message)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function assertUuid(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !UUID_PATTERN.test(value)) {
+    fail('INVALID_MANIFEST', 'an identifier is invalid')
+  }
+}
+
+function assertName(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !NAME_PATTERN.test(value)) {
+    fail('INVALID_MANIFEST', 'a name is invalid')
+  }
+}
+
+function assertKnowledgeBaseName(value: unknown): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 255 ||
+    !value.trim() ||
+    CONTROL_CHARACTER_PATTERN.test(value)
+  ) {
+    fail('INVALID_MANIFEST', 'a knowledge base name is invalid')
+  }
+}
+
+function assertMode(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !MODE_PATTERN.test(value)) {
+    fail('INVALID_MANIFEST', 'a chat mode is invalid')
+  }
+}
+
+function assertNonEmpty(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !value.trim()) {
+    fail('INVALID_MANIFEST', 'a required value is blank')
+  }
+}
+
+function assertUrl(value: unknown): asserts value is string {
+  if (typeof value !== 'string') fail('INVALID_TARGET', 'target URL is invalid')
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    fail('INVALID_TARGET', 'target URL is invalid')
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    fail('INVALID_TARGET', 'target URL must use HTTP or HTTPS')
+  }
+  if (parsed.username || parsed.password) {
+    fail('INVALID_TARGET', 'target URL must not contain credentials')
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item))
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return Object.fromEntries(
+      Object.keys(record)
+        .filter((key) => record[key] !== undefined)
+        .sort()
+        .map((key) => [key, canonicalize(record[key])])
+    )
+  }
+  return value
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+function jsonEqual(left: JsonValue, right: JsonValue): boolean {
+  return canonicalJson(left) === canonicalJson(right)
+}
+
+function fingerprint(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex')
+}
+
+function padAlias(index: number): string {
+  return String(index + 1).padStart(3, '0')
+}
+
+function canonicalManifest(manifest: FrozenCohortManifest): unknown {
+  return {
+    version: manifest.version,
+    collection: manifest.collection,
+    environment: manifest.environment,
+    singletonCanaryKbId: manifest.singletonCanaryKbId,
+    corpora: [...manifest.corpora]
+      .sort((left, right) => left.kbId.localeCompare(right.kbId))
+      .map((corpus) => ({
+        kbId: corpus.kbId,
+        kbName: corpus.kbName,
+        ownerId: corpus.ownerId,
+        description: corpus.description ?? null,
+        sourceCollection: corpus.sourceCollection,
+        targetCollection: corpus.targetCollection,
+        tool: corpus.tool,
+        alias: corpus.alias,
+        chatbotIds: [...corpus.chatbotIds].sort(),
+        courseIds: [...corpus.courseIds].sort(),
+        configurations: [...corpus.configurations]
+          .sort((left, right) => left.configId.localeCompare(right.configId))
+          .map((configuration) => ({
+            ...configuration,
+            allowedTools: [...configuration.allowedTools],
+          })),
+      })),
+    excluded: [...manifest.excluded].sort((left, right) =>
+      left.configId.localeCompare(right.configId)
+    ),
+  }
+}
+
+export function fingerprintManifest(manifest: FrozenCohortManifest): string {
+  return fingerprint(canonicalManifest(manifest))
+}
+
+export function fingerprintManifestText(contents: string): string {
+  return createHash('sha256').update(contents).digest('hex')
+}
+
+function assertManifestShape(manifest: FrozenCohortManifest): void {
+  if (!isPlainObject(manifest)) fail('INVALID_MANIFEST', 'manifest is invalid')
+  if (manifest.version !== 1) {
+    fail('INVALID_MANIFEST', 'manifest version is unsupported')
+  }
+  assertNonEmpty(manifest.collection)
+  assertNonEmpty(manifest.environment)
+  assertUuid(manifest.singletonCanaryKbId)
+  if (!Array.isArray(manifest.corpora) || !Array.isArray(manifest.excluded)) {
+    fail('INVALID_MANIFEST', 'manifest collections are invalid')
+  }
+  if (manifest.corpora.length !== EXPECTED_CORPORA) {
+    fail('COHORT_COUNT_MISMATCH', 'corpus count is not approved')
+  }
+  if (manifest.excluded.length !== EXPECTED_EXCLUDED_CONFIGURATIONS) {
+    fail(
+      'COHORT_COUNT_MISMATCH',
+      'excluded configuration count is not approved'
+    )
+  }
+  if (
+    manifest.excluded.some((entry) => !isPlainObject(entry)) ||
+    manifest.corpora.some((entry) => !isPlainObject(entry))
+  ) {
+    fail('INVALID_MANIFEST', 'manifest entries are invalid')
+  }
+}
+
+export function validateCohortManifest(manifest: FrozenCohortManifest): void {
+  assertManifestShape(manifest)
+  const corpusIds = new Set<string>()
+  const chatbotIds = new Set<string>()
+  const courseIds = new Set<string>()
+  const configIds = new Set<string>()
+  const chatbotModes = new Set<string>()
+  const excludedIds = new Set<string>()
+  const excludedChatbotIds = new Set<string>()
+  const sourceServerIds = new Set<string>()
+
+  for (const corpus of manifest.corpora) {
+    assertUuid(corpus.kbId)
+    assertUuid(corpus.ownerId)
+    assertKnowledgeBaseName(corpus.kbName)
+    assertNonEmpty(corpus.sourceCollection)
+    assertNonEmpty(corpus.targetCollection)
+    assertName(corpus.tool)
+    if (EXCLUDED_SOURCE_TOOLS.includes(corpus.tool as never)) {
+      fail('EXCLUDED_CORPUS', 'an excluded corpus is present')
+    }
+    if (corpusIds.has(corpus.kbId)) {
+      fail('DUPLICATE_CORPUS', 'a corpus identifier is repeated')
+    }
+    corpusIds.add(corpus.kbId)
+    if (!Array.isArray(corpus.chatbotIds) || !Array.isArray(corpus.courseIds)) {
+      fail('INVALID_MANIFEST', 'corpus references are invalid')
+    }
+    if (corpus.chatbotIds.length === 0 || corpus.courseIds.length === 0) {
+      fail('INVALID_MANIFEST', 'a corpus has no owners')
+    }
+    const localChatbots = new Set<string>()
+    const localCourses = new Set<string>()
+    for (const chatbotId of corpus.chatbotIds) {
+      assertUuid(chatbotId)
+      if (localChatbots.has(chatbotId) || chatbotIds.has(chatbotId)) {
+        fail('DUPLICATE_CHATBOT', 'a chatbot is assigned more than once')
+      }
+      localChatbots.add(chatbotId)
+      chatbotIds.add(chatbotId)
+    }
+    for (const courseId of corpus.courseIds) {
+      assertUuid(courseId)
+      if (localCourses.has(courseId) || courseIds.has(courseId)) {
+        fail('DUPLICATE_COURSE', 'a course is assigned more than once')
+      }
+      localCourses.add(courseId)
+      courseIds.add(courseId)
+    }
+    if (!Array.isArray(corpus.configurations)) {
+      fail('INVALID_MANIFEST', 'corpus configurations are invalid')
+    }
+    const localConfigChatbots = new Set<string>()
+    for (const configuration of corpus.configurations) {
+      assertUuid(configuration.configId)
+      assertUuid(configuration.chatbotId)
+      assertUuid(configuration.sourceServerId)
+      assertMode(configuration.chatMode)
+      if (!localChatbots.has(configuration.chatbotId)) {
+        fail(
+          'CONFIG_CHATBOT_MISMATCH',
+          'a configuration references another corpus'
+        )
+      }
+      if (
+        !Array.isArray(configuration.allowedTools) ||
+        configuration.allowedTools.length !== 1 ||
+        configuration.allowedTools[0] !== corpus.tool
+      ) {
+        fail('SOURCE_CONFIG_MISMATCH', 'a source allowlist is not frozen')
+      }
+      if (
+        !Number.isInteger(configuration.priority) ||
+        configuration.priority < 0
+      ) {
+        fail('INVALID_MANIFEST', 'a configuration priority is invalid')
+      }
+      if (
+        !isPlainObject(configuration.parameters) ||
+        configuration.parameters.required !== true ||
+        configuration.parameters.toolAlias !== DOC_QUERY_TOOL
+      ) {
+        fail('SOURCE_CONFIG_MISMATCH', 'a source parameter shape is not frozen')
+      }
+      if (configIds.has(configuration.configId)) {
+        fail('DUPLICATE_CONFIG', 'a configuration identifier is repeated')
+      }
+      configIds.add(configuration.configId)
+      localConfigChatbots.add(configuration.chatbotId)
+      const modeKey = `${configuration.chatbotId}:${configuration.chatMode}`
+      if (chatbotModes.has(modeKey)) {
+        fail('DUPLICATE_CONFIG', 'a chatbot mode is repeated')
+      }
+      chatbotModes.add(modeKey)
+      sourceServerIds.add(configuration.sourceServerId)
+    }
+    for (const chatbotId of localChatbots) {
+      if (!localConfigChatbots.has(chatbotId)) {
+        fail('INVALID_MANIFEST', 'a chatbot has no frozen configuration')
+      }
+    }
+  }
+
+  if (
+    chatbotIds.size !== EXPECTED_CHATBOTS ||
+    courseIds.size !== EXPECTED_COURSES ||
+    configIds.size !== EXPECTED_CONFIGURATIONS
+  ) {
+    fail(
+      'COHORT_COUNT_MISMATCH',
+      'chatbot, course, or configuration count is not approved'
+    )
+  }
+  if (sourceServerIds.size === 0) {
+    fail('INVALID_MANIFEST', 'source server is missing')
+  }
+  for (const entry of manifest.excluded) {
+    assertUuid(entry.configId)
+    assertUuid(entry.chatbotId)
+    assertUuid(entry.serverId)
+    assertMode(entry.chatMode)
+    assertName(entry.tool)
+    if (!EXCLUDED_SOURCE_TOOLS.includes(entry.tool as never)) {
+      fail('EXCLUDED_CORPUS', 'an excluded entry is not in the exclusion set')
+    }
+    if (!sourceServerIds.has(entry.serverId)) {
+      fail(
+        'SOURCE_SERVER_MISMATCH',
+        'excluded configuration uses another server'
+      )
+    }
+    if (excludedIds.has(entry.configId) || configIds.has(entry.configId)) {
+      fail('DUPLICATE_CONFIG', 'an excluded configuration overlaps the cohort')
+    }
+    excludedIds.add(entry.configId)
+    excludedChatbotIds.add(entry.chatbotId)
+    if (chatbotIds.has(entry.chatbotId)) {
+      fail('EXCLUDED_CORPUS', 'an excluded chatbot is in the cohort')
+    }
+  }
+  if (excludedChatbotIds.size !== EXPECTED_EXCLUDED_CHATBOTS) {
+    fail('COHORT_COUNT_MISMATCH', 'excluded chatbot count is not approved')
+  }
+  if (
+    manifest.fingerprint &&
+    manifest.fingerprint !== fingerprintManifest(manifest)
+  ) {
+    fail('MANIFEST_DRIFT', 'manifest fingerprint does not match contents')
+  }
+}
+
+export function parseFrozenActivationManifest(
+  contents: string,
+  expectedFileFingerprint?: string
+): FrozenCohortManifest {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(contents)
+  } catch {
+    fail('INVALID_MANIFEST', 'manifest JSON is invalid')
+  }
+  if (!isPlainObject(parsed)) fail('INVALID_MANIFEST', 'manifest is invalid')
+  const fileFingerprint = fingerprintManifestText(contents)
+  if (expectedFileFingerprint && fileFingerprint !== expectedFileFingerprint) {
+    fail('MANIFEST_DRIFT', 'manifest file fingerprint does not match')
+  }
+  const manifest = parsed as unknown as FrozenCohortManifest
+  validateCohortManifest(manifest)
+  return { ...manifest, fingerprint: fingerprintManifest(manifest) }
+}
+
+export function createFileActivationReceiptStore(
+  receiptPath: string
+): ActivationReceiptStore {
+  const absolutePath = resolve(receiptPath)
+  return {
+    async read() {
+      try {
+        const contents = await readFile(absolutePath, 'utf8')
+        return JSON.parse(contents) as ActivationReceiptPayload
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          'code' in error &&
+          error.code === 'ENOENT'
+        ) {
+          return null
+        }
+        fail('RECEIPT_READ_FAILED', 'could not read activation receipt')
+      }
+    },
+    async write(receipt) {
+      await mkdir(dirname(absolutePath), { recursive: true })
+      const temporaryPath = `${absolutePath}.tmp-${process.pid}`
+      await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      })
+      await chmod(temporaryPath, 0o600)
+      await rename(temporaryPath, absolutePath)
+    },
+  }
+}
+
+type PrismaActivationClient = Pick<
+  PrismaClient,
+  'kB' | 'chatbot' | 'kBChatbot' | 'chatbotMCPServer' | 'chatbotMCPConfig'
+>
+
+function mapKnowledgeBase(record: {
+  id: string
+  name: string
+  description: string | null
+  ownerId: string
+  deletedAt: Date | null
+  updatedAt: Date
+}): KnowledgeBaseRecord {
+  return record
+}
+
+function mapChatbot(record: {
+  id: string
+  courseId: string
+  course: { ownerId: string }
+  updatedAt: Date
+}): ChatbotRecord {
+  return {
+    id: record.id,
+    courseId: record.courseId,
+    ownerId: record.course.ownerId,
+    updatedAt: record.updatedAt,
+  }
+}
+
+function mapServer(record: {
+  id: string
+  name: string
+  description: string | null
+  url: string
+  authType: string
+  authSecret: string | null
+  passChatbotId: boolean
+  chatbotIdHeader: string | null
+  parameters: unknown
+  isActive: boolean
+  updatedAt: Date
+}): ActivationServerRecord {
+  return { ...record, parameters: record.parameters as JsonValue }
+}
+
+function mapConfig(record: {
+  id: string
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: unknown
+  priority: number
+  isEnabled: boolean
+  parameters: unknown
+  updatedAt: Date
+}): ActivationConfigRecord {
+  return {
+    ...record,
+    allowedTools: record.allowedTools as JsonValue,
+    parameters: record.parameters as JsonValue,
+  }
+}
+
+function mapBinding(record: {
+  id: string
+  kbId: string
+  chatbotId: string
+  isEnabled: boolean
+  updatedAt: Date
+}): ActivationBindingRecord {
+  return record
+}
+
+function createPrismaActivationDelegate(
+  client: PrismaActivationClient
+): ActivationTransactionStore {
+  const serverSelect = {
+    id: true,
+    name: true,
+    description: true,
+    url: true,
+    authType: true,
+    authSecret: true,
+    passChatbotId: true,
+    chatbotIdHeader: true,
+    parameters: true,
+    isActive: true,
+    updatedAt: true,
+  } as const
+  const configSelect = {
+    id: true,
+    chatbotId: true,
+    mcpServerId: true,
+    chatMode: true,
+    allowedTools: true,
+    priority: true,
+    isEnabled: true,
+    parameters: true,
+    updatedAt: true,
+  } as const
+  const bindingSelect = {
+    id: true,
+    kbId: true,
+    chatbotId: true,
+    isEnabled: true,
+    updatedAt: true,
+  } as const
+  const kbSelect = {
+    id: true,
+    name: true,
+    description: true,
+    ownerId: true,
+    deletedAt: true,
+    updatedAt: true,
+  } as const
+
+  return {
+    async findKnowledgeBaseById(id) {
+      const record = await client.kB.findUnique({
+        where: { id },
+        select: kbSelect,
+      })
+      return record ? mapKnowledgeBase(record) : null
+    },
+    async findKnowledgeBasesByName(name) {
+      const records = await client.kB.findMany({
+        where: { name },
+        select: kbSelect,
+      })
+      return records.map(mapKnowledgeBase)
+    },
+    async findChatbotById(id) {
+      const record = await client.chatbot.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          courseId: true,
+          updatedAt: true,
+          course: { select: { ownerId: true } },
+        },
+      })
+      return record ? mapChatbot(record) : null
+    },
+    async findServersByName(name) {
+      const records = await client.chatbotMCPServer.findMany({
+        where: { name },
+        select: serverSelect,
+      })
+      return records.map(mapServer)
+    },
+    async findConfigById(id) {
+      const record = await client.chatbotMCPConfig.findUnique({
+        where: { id },
+        select: configSelect,
+      })
+      return record ? mapConfig(record) : null
+    },
+    async findConfigsByServerId(mcpServerId) {
+      const records = await client.chatbotMCPConfig.findMany({
+        where: { mcpServerId },
+        select: configSelect,
+      })
+      return records.map(mapConfig)
+    },
+    async findBindingsByChatbotId(chatbotId) {
+      const records = await client.kBChatbot.findMany({
+        where: { chatbotId },
+        select: bindingSelect,
+      })
+      return records.map(mapBinding)
+    },
+    async createKnowledgeBase(data) {
+      const record = await client.kB.create({
+        data,
+        select: kbSelect,
+      })
+      return mapKnowledgeBase(record)
+    },
+    async createServer(data) {
+      const record = await client.chatbotMCPServer.create({
+        data: data as never,
+        select: serverSelect,
+      })
+      return mapServer(record)
+    },
+    async createBinding(data) {
+      const record = await client.kBChatbot.create({
+        data,
+        select: bindingSelect,
+      })
+      return mapBinding(record)
+    },
+    async createConfig(data) {
+      const record = await client.chatbotMCPConfig.create({
+        data: data as never,
+        select: configSelect,
+      })
+      return mapConfig(record)
+    },
+    async updateBinding(snapshot, isEnabled) {
+      const result = await client.kBChatbot.updateMany({
+        where: { id: snapshot.id, updatedAt: snapshot.updatedAt },
+        data: { isEnabled },
+      })
+      if (result.count !== 1) {
+        fail('CONCURRENT_EDIT', 'knowledge base binding changed during switch')
+      }
+      const updated = await client.kBChatbot.findUnique({
+        where: { id: snapshot.id },
+        select: bindingSelect,
+      })
+      if (!updated)
+        fail('BINDING_MISSING', 'knowledge base binding disappeared')
+      return mapBinding(updated)
+    },
+    async updateConfig(snapshot, isEnabled) {
+      const result = await client.chatbotMCPConfig.updateMany({
+        where: { id: snapshot.id, updatedAt: snapshot.updatedAt },
+        data: { isEnabled },
+      })
+      if (result.count !== 1) {
+        fail('CONCURRENT_EDIT', 'target configuration changed during switch')
+      }
+      const updated = await client.chatbotMCPConfig.findUnique({
+        where: { id: snapshot.id },
+        select: configSelect,
+      })
+      if (!updated)
+        fail('TARGET_CONFIG_MISSING', 'target configuration disappeared')
+      return mapConfig(updated)
+    },
+  }
+}
+
+export function createPrismaActivationStore(
+  client: PrismaClient
+): ActivationStore {
+  return {
+    ...createPrismaActivationDelegate(client),
+    async transaction(callback) {
+      return client.$transaction(
+        async (tx) => callback(createPrismaActivationDelegate(tx)),
+        { isolationLevel: 'Serializable' }
+      )
+    },
+  }
+}
+
+function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
+  validateCohortManifest(manifest)
+  const sortedCorpora = [...manifest.corpora].sort((left, right) =>
+    left.kbId.localeCompare(right.kbId)
+  )
+  const corpusByAlias = new Map<string, FrozenCorpus>()
+  const corpusAliasByChatbotId = new Map<string, string>()
+  sortedCorpora.forEach((corpus, index) => {
+    const alias = `corpus-${padAlias(index)}`
+    corpusByAlias.set(alias, corpus)
+    for (const chatbotId of corpus.chatbotIds) {
+      if (corpusAliasByChatbotId.has(chatbotId)) {
+        fail('DUPLICATE_CHATBOT', 'a chatbot is assigned to multiple corpora')
+      }
+      corpusAliasByChatbotId.set(chatbotId, alias)
+    }
+  })
+
+  const chatbotIds = [...corpusAliasByChatbotId.keys()].sort()
+  const chatbotAliasForId = new Map<string, string>()
+  const chatbotIdByAlias = new Map<string, string>()
+  chatbotIds.forEach((chatbotId, index) => {
+    const alias = `chatbot-${padAlias(index)}`
+    chatbotAliasForId.set(chatbotId, alias)
+    chatbotIdByAlias.set(alias, chatbotId)
+  })
+
+  const sortedConfigurations = manifest.corpora
+    .flatMap((corpus) => corpus.configurations)
+    .sort((left, right) => left.configId.localeCompare(right.configId))
+  const configByAlias = new Map<string, FrozenConfiguration>()
+  const configsByChatbotAlias = new Map<
+    string,
+    Array<[string, FrozenConfiguration]>
+  >()
+  sortedConfigurations.forEach((configuration, index) => {
+    const alias = `config-${padAlias(index)}`
+    configByAlias.set(alias, configuration)
+    const chatbotAlias = chatbotAliasForId.get(configuration.chatbotId)
+    if (!chatbotAlias) fail('INVALID_MANIFEST', 'a chatbot alias is missing')
+    const list = configsByChatbotAlias.get(chatbotAlias) ?? []
+    list.push([alias, configuration])
+    configsByChatbotAlias.set(chatbotAlias, list)
+  })
+
+  const bindingAliasByChatbotAlias = new Map<string, string>()
+  for (const chatbotAlias of chatbotIdByAlias.keys()) {
+    const chatbotId = chatbotIdByAlias.get(chatbotAlias)!
+    const corpusAlias = corpusAliasByChatbotId.get(chatbotId)
+    if (!corpusAlias) fail('INVALID_MANIFEST', 'a corpus alias is missing')
+    bindingAliasByChatbotAlias.set(
+      chatbotAlias,
+      `binding-${corpusAlias}-${chatbotAlias}`
+    )
+  }
+
+  return {
+    corpusByAlias,
+    corpusAliasByChatbotId,
+    chatbotAliasForId,
+    chatbotIdByAlias,
+    configByAlias,
+    configsByChatbotAlias,
+    bindingAliasByChatbotAlias,
+    aliases: {
+      sourceServer: SOURCE_SERVER_NAME,
+      targetServer: TARGET_SERVER_NAME,
+      corpora: [...corpusByAlias.keys()].sort(),
+      chatbots: [...chatbotIdByAlias.keys()].sort(),
+      configurations: [...configByAlias.keys()].sort(),
+    },
+    counts: {
+      corpora: EXPECTED_CORPORA,
+      courses: EXPECTED_COURSES,
+      chatbots: EXPECTED_CHATBOTS,
+      configurations: EXPECTED_CONFIGURATIONS,
+      bindings: EXPECTED_BINDINGS,
+    },
+    sourceServerIds: new Set(
+      sortedConfigurations.map((configuration) => configuration.sourceServerId)
+    ),
+  }
+}
+
+function makeIntent(
+  index: ManifestIndex,
+  manifestFingerprint: string
+): ActivationReceiptIntent {
+  const withoutDigest = {
+    receiptVersion: ACTIVATION_RECEIPT_VERSION,
+    manifestFingerprint,
+    counts: index.counts,
+    aliases: index.aliases,
+    state: 'preparing' as const,
+  }
+  return {
+    ...withoutDigest,
+    payloadDigest: fingerprint(withoutDigest),
+  }
+}
+
+function makeReceipt(
+  input: Omit<ActivationReceipt, 'receiptVersion' | 'payloadDigest'>
+): ActivationReceipt {
+  const withoutDigest = {
+    receiptVersion: ACTIVATION_RECEIPT_VERSION,
+    ...input,
+  }
+  return {
+    ...withoutDigest,
+    payloadDigest: fingerprint(withoutDigest),
+  }
+}
+
+function assertPayloadDigest(payload: ActivationReceiptPayload): void {
+  if (payload.receiptVersion !== ACTIVATION_RECEIPT_VERSION) {
+    fail('RECEIPT_INVALID', 'receipt version is unsupported')
+  }
+  const { payloadDigest: _payloadDigest, ...withoutDigest } = payload
+  if (fingerprint(withoutDigest) !== payload.payloadDigest) {
+    fail('RECEIPT_INVALID', 'receipt digest does not match')
+  }
+}
+
+function isReceiptIntent(
+  payload: ActivationReceiptPayload
+): payload is ActivationReceiptIntent {
+  return payload.state === 'preparing'
+}
+
+async function readReceipt(
+  receiptStore: ActivationReceiptStore | undefined
+): Promise<ActivationReceiptPayload | null> {
+  if (!receiptStore) return null
+  const payload = await receiptStore.read()
+  if (payload) assertPayloadDigest(payload)
+  return payload
+}
+
+function assertReceiptMatchesIndex(
+  receipt: ActivationReceiptPayload,
+  index: ManifestIndex,
+  manifestFingerprint: string
+): void {
+  assertPayloadDigest(receipt)
+  if (receipt.manifestFingerprint !== manifestFingerprint) {
+    fail('RECEIPT_MISMATCH', 'receipt does not match the manifest')
+  }
+  if (canonicalJson(receipt.counts) !== canonicalJson(index.counts)) {
+    fail('RECEIPT_MISMATCH', 'receipt counts do not match the manifest')
+  }
+  if (canonicalJson(receipt.aliases) !== canonicalJson(index.aliases)) {
+    fail('RECEIPT_MISMATCH', 'receipt aliases do not match the manifest')
+  }
+}
+
+function serverFingerprint(server: ActivationServerRecord): string {
+  return fingerprint({
+    id: server.id,
+    name: server.name,
+    description: server.description,
+    url: server.url,
+    authType: server.authType,
+    authSecret: server.authSecret,
+    passChatbotId: server.passChatbotId,
+    chatbotIdHeader: server.chatbotIdHeader,
+    parameters: server.parameters,
+    isActive: server.isActive,
+    updatedAt: server.updatedAt,
+  })
+}
+
+function knowledgeBaseFingerprint(kb: KnowledgeBaseRecord): string {
+  return fingerprint(kb)
+}
+
+function chatbotFingerprint(chatbot: ChatbotRecord): string {
+  return fingerprint(chatbot)
+}
+
+function configFingerprint(config: ActivationConfigRecord): string {
+  return fingerprint(config)
+}
+
+function bindingFingerprint(binding: ActivationBindingRecord): string {
+  return fingerprint(binding)
+}
+
+function safeServerSnapshot(
+  server: ActivationServerRecord,
+  alias: typeof SOURCE_SERVER_NAME | typeof TARGET_SERVER_NAME
+): SafeServerSnapshot {
+  return {
+    alias,
+    fingerprint: serverFingerprint(server),
+    hasTransportCredential: server.authSecret !== null,
+    isActive: server.isActive,
+    updatedAt: server.updatedAt.toISOString(),
+  }
+}
+
+function safeIdentitySnapshot(
+  alias: string,
+  record: { updatedAt: Date },
+  recordFingerprint: string
+): SafeIdentitySnapshot {
+  return {
+    alias,
+    fingerprint: recordFingerprint,
+    updatedAt: record.updatedAt.toISOString(),
+  }
+}
+
+function safeConfigSnapshot(
+  alias: string,
+  chatbotAlias: string,
+  config: ActivationConfigRecord
+): SafeConfigSnapshot {
+  return {
+    ...safeIdentitySnapshot(alias, config, configFingerprint(config)),
+    chatbotAlias,
+    chatMode: config.chatMode,
+    isEnabled: config.isEnabled,
+  }
+}
+
+function safeBindingSnapshot(
+  alias: string,
+  chatbotAlias: string,
+  corpusAlias: string,
+  binding: ActivationBindingRecord
+): SafeBindingSnapshot {
+  return {
+    ...safeIdentitySnapshot(alias, binding, bindingFingerprint(binding)),
+    chatbotAlias,
+    corpusAlias,
+    isEnabled: binding.isEnabled,
+  }
+}
+
+function targetConfigData(
+  configuration: FrozenConfiguration,
+  targetServerId: string
+): ActivationConfigCreate {
+  return {
+    chatbotId: configuration.chatbotId,
+    mcpServerId: targetServerId,
+    chatMode: configuration.chatMode,
+    allowedTools: [DOC_QUERY_TOOL],
+    priority: configuration.priority,
+    isEnabled: false,
+    parameters: { required: true, toolAlias: DOC_QUERY_TOOL },
+  }
+}
+
+function chatbotAliasFor(index: ManifestIndex, chatbotId: string): string {
+  const alias = index.chatbotAliasForId.get(chatbotId)
+  if (!alias) fail('INVALID_MANIFEST', 'a chatbot alias is missing')
+  return alias
+}
+
+function resolveChatbotAlias(index: ManifestIndex, alias: string): string {
+  const chatbotId = index.chatbotIdByAlias.get(alias)
+  if (!chatbotId)
+    fail('UNKNOWN_CHATBOT', 'chatbot alias is not in the manifest')
+  return chatbotId
+}
+
+function corpusAliasFor(index: ManifestIndex, chatbotId: string): string {
+  const corpusAlias = index.corpusAliasByChatbotId.get(chatbotId)
+  if (!corpusAlias) fail('INVALID_MANIFEST', 'a corpus alias is missing')
+  return corpusAlias
+}
+
+function configsForChatbot(
+  index: ManifestIndex,
+  chatbotAlias: string
+): Array<[string, FrozenConfiguration]> {
+  const configurations = index.configsByChatbotAlias.get(chatbotAlias)
+  if (!configurations || configurations.length === 0) {
+    fail('INVALID_MANIFEST', 'chatbot has no mode configurations')
+  }
+  return configurations
+}
+
+function targetConfigKey(chatbotId: string, chatMode: string): string {
+  return `${chatbotId}:${chatMode}`
+}
+
+function assertSourceServer(
+  server: ActivationServerRecord | null
+): asserts server is ActivationServerRecord {
+  if (!server || server.name !== SOURCE_SERVER_NAME) {
+    fail('SOURCE_SERVER_MISSING', 'the unique source server is missing')
+  }
+  if (!server.isActive || !server.authSecret?.trim()) {
+    fail(
+      'SOURCE_CREDENTIAL_MISSING',
+      'the source transport credential is unavailable'
+    )
+  }
+}
+
+function assertTargetServer(
+  server: ActivationServerRecord | null,
+  source: ActivationServerRecord,
+  target: ActivationTarget
+): asserts server is ActivationServerRecord {
+  if (!server || server.name !== TARGET_SERVER_NAME) {
+    fail('TARGET_SERVER_MISSING', 'the reserved target server is missing')
+  }
+  if (
+    server.description !== target.description ||
+    server.url !== target.url ||
+    server.authType !== TARGET_AUTH_TYPE ||
+    server.authSecret !== source.authSecret ||
+    server.passChatbotId !== false ||
+    server.chatbotIdHeader !== null ||
+    !jsonEqual(server.parameters, {}) ||
+    server.isActive !== true
+  ) {
+    fail(
+      'TARGET_SERVER_MISMATCH',
+      'the reserved target server contract drifted'
+    )
+  }
+}
+
+function assertKnowledgeBase(
+  kb: KnowledgeBaseRecord | null,
+  corpus: FrozenCorpus
+): asserts kb is KnowledgeBaseRecord {
+  if (
+    !kb ||
+    kb.id !== corpus.kbId ||
+    kb.name !== corpus.kbName ||
+    kb.ownerId !== corpus.ownerId ||
+    kb.description !== (corpus.description ?? null) ||
+    kb.deletedAt !== null
+  ) {
+    fail('KB_DRIFT', 'a deterministic knowledge base row drifted')
+  }
+}
+
+function assertChatbot(
+  chatbot: ChatbotRecord | null,
+  corpus: FrozenCorpus
+): asserts chatbot is ChatbotRecord {
+  if (!chatbot) fail('CHATBOT_MISSING', 'a manifest chatbot is missing')
+  if (
+    !corpus.chatbotIds.includes(chatbot.id) ||
+    !corpus.courseIds.includes(chatbot.courseId) ||
+    chatbot.ownerId !== corpus.ownerId
+  ) {
+    fail('CHATBOT_DRIFT', 'a chatbot owner or course drifted')
+  }
+}
+
+function assertSourceConfiguration(
+  config: ActivationConfigRecord | null,
+  configuration: FrozenConfiguration
+): asserts config is ActivationConfigRecord {
+  if (
+    !config ||
+    config.id !== configuration.configId ||
+    config.chatbotId !== configuration.chatbotId ||
+    config.mcpServerId !== configuration.sourceServerId ||
+    config.chatMode !== configuration.chatMode ||
+    !jsonEqual(config.allowedTools, configuration.allowedTools) ||
+    config.priority !== configuration.priority ||
+    !jsonEqual(config.parameters, configuration.parameters)
+  ) {
+    fail('SOURCE_CONFIG_DRIFT', 'a legacy configuration drifted')
+  }
+}
+
+function assertTargetConfiguration(
+  config: ActivationConfigRecord | null,
+  configuration: FrozenConfiguration,
+  targetServerId: string
+): asserts config is ActivationConfigRecord {
+  if (
+    !config ||
+    config.chatbotId !== configuration.chatbotId ||
+    config.mcpServerId !== targetServerId ||
+    config.chatMode !== configuration.chatMode ||
+    !jsonEqual(config.allowedTools, [DOC_QUERY_TOOL]) ||
+    config.priority !== configuration.priority ||
+    !jsonEqual(config.parameters, {
+      required: true,
+      toolAlias: DOC_QUERY_TOOL,
+    })
+  ) {
+    fail('TARGET_CONFIG_DRIFT', 'a target configuration drifted')
+  }
+}
+
+function assertBinding(
+  binding: ActivationBindingRecord | null,
+  kbId: string,
+  chatbotId: string
+): asserts binding is ActivationBindingRecord {
+  if (!binding || binding.kbId !== kbId || binding.chatbotId !== chatbotId) {
+    fail('BINDING_DRIFT', 'a knowledge base binding drifted')
+  }
+}
+
+async function findTargetServer(
+  store: ActivationTransactionStore
+): Promise<ActivationServerRecord | null> {
+  const servers = await store.findServersByName(TARGET_SERVER_NAME)
+  if (servers.length > 1) {
+    fail('TARGET_SERVER_DRIFT', 'target server ownership is not unique')
+  }
+  return servers[0] ?? null
+}
+
+async function inspectCohortState(
+  store: ActivationTransactionStore,
+  index: ManifestIndex,
+  target: ActivationTarget
+): Promise<InspectedState> {
+  const sourceServers = await store.findServersByName(SOURCE_SERVER_NAME)
+  if (sourceServers.length !== 1) {
+    fail('SOURCE_SERVER_MISSING', 'server ownership is not unique')
+  }
+  const sourceServer = sourceServers[0]!
+  assertSourceServer(sourceServer)
+
+  const corpora = new Map<string, KnowledgeBaseRecord>()
+  for (const [alias, corpus] of index.corpusByAlias.entries()) {
+    const kb = await store.findKnowledgeBaseById(corpus.kbId)
+    if (kb) {
+      assertKnowledgeBase(kb, corpus)
+      const sameName = await store.findKnowledgeBasesByName(corpus.kbName)
+      if (sameName.some((candidate) => candidate.id !== corpus.kbId)) {
+        fail('KB_NAME_COLLISION', 'a knowledge base name is not deterministic')
+      }
+      corpora.set(alias, kb)
+    } else {
+      const sameName = await store.findKnowledgeBasesByName(corpus.kbName)
+      if (sameName.length > 0) {
+        fail('KB_NAME_COLLISION', 'a knowledge base name is not deterministic')
+      }
+    }
+  }
+
+  const chatbots = new Map<string, ChatbotRecord>()
+  for (const [
+    chatbotId,
+    corpusAlias,
+  ] of index.corpusAliasByChatbotId.entries()) {
+    const corpus = index.corpusByAlias.get(corpusAlias)
+    if (!corpus) fail('INVALID_MANIFEST', 'a corpus alias is missing')
+    const chatbot = await store.findChatbotById(chatbotId)
+    assertChatbot(chatbot, corpus)
+    chatbots.set(chatbotAliasFor(index, chatbotId), chatbot)
+  }
+
+  const legacyConfigurations = new Map<string, ActivationConfigRecord>()
+  for (const [alias, configuration] of index.configByAlias.entries()) {
+    const config = await store.findConfigById(configuration.configId)
+    assertSourceConfiguration(config, configuration)
+    legacyConfigurations.set(alias, config)
+  }
+
+  const targetServer = await findTargetServer(store)
+  if (targetServer) assertTargetServer(targetServer, sourceServer, target)
+
+  const configurations = new Map<string, ActivationConfigRecord | null>()
+  for (const alias of index.configByAlias.keys()) {
+    configurations.set(alias, null)
+  }
+  if (targetServer) {
+    const expectedByKey = new Map<string, string>()
+    for (const [alias, configuration] of index.configByAlias.entries()) {
+      expectedByKey.set(
+        targetConfigKey(configuration.chatbotId, configuration.chatMode),
+        alias
+      )
+    }
+    const targetConfigurations = await store.findConfigsByServerId(
+      targetServer.id
+    )
+    for (const config of targetConfigurations) {
+      const alias = expectedByKey.get(
+        targetConfigKey(config.chatbotId, config.chatMode)
+      )
+      if (!alias || configurations.get(alias) !== null) {
+        fail(
+          'TARGET_CONFIG_DRIFT',
+          'the target server has an unexpected configuration'
+        )
+      }
+      const expected = index.configByAlias.get(alias)
+      if (!expected) fail('INVALID_MANIFEST', 'target configuration is missing')
+      assertTargetConfiguration(config, expected, targetServer.id)
+      configurations.set(alias, config)
+    }
+  }
+
+  const bindings = new Map<string, ActivationBindingRecord | null>()
+  const otherBindingsByChatbotAlias = new Map<
+    string,
+    ActivationBindingRecord[]
+  >()
+  for (const [
+    chatbotId,
+    corpusAlias,
+  ] of index.corpusAliasByChatbotId.entries()) {
+    const chatbotAlias = chatbotAliasFor(index, chatbotId)
+    const allBindings = await store.findBindingsByChatbotId(chatbotId)
+    const kb = corpora.get(corpusAlias)
+    const targetBindings = kb
+      ? allBindings.filter(
+          (binding) => binding.kbId === kb.id && binding.chatbotId === chatbotId
+        )
+      : []
+    if (targetBindings.length > 1) {
+      fail('BINDING_DRIFT', 'a target binding is duplicated')
+    }
+    const targetBinding = targetBindings[0] ?? null
+    if (targetBinding) assertBinding(targetBinding, kb!.id, chatbotId)
+    bindings.set(chatbotAlias, targetBinding)
+    otherBindingsByChatbotAlias.set(
+      chatbotAlias,
+      allBindings.filter((binding) => binding !== targetBinding)
+    )
+  }
+
+  return {
+    sourceServer,
+    targetServer,
+    corpora,
+    chatbots,
+    legacyConfigurations,
+    configurations,
+    bindings,
+    otherBindingsByChatbotAlias,
+  }
+}
+
+function assertNoEnabledTargetRows(state: InspectedState): void {
+  for (const binding of state.bindings.values()) {
+    if (binding?.isEnabled) {
+      fail('MIXED_STATE', 'a target binding is already enabled')
+    }
+  }
+  for (const config of state.configurations.values()) {
+    if (config?.isEnabled) {
+      fail('MIXED_STATE', 'a target configuration is already enabled')
+    }
+  }
+}
+
+function assertNoEnabledOtherBinding(state: InspectedState): void {
+  for (const bindings of state.otherBindingsByChatbotAlias.values()) {
+    if (bindings.some((binding) => binding.isEnabled)) {
+      fail(
+        'ENABLED_KB_CONFLICT',
+        'another knowledge base is already enabled for the chatbot'
+      )
+    }
+  }
+}
+
+type GroupState = 'missing' | 'prepared' | 'switched' | 'mixed'
+
+function groupAliases(index: ManifestIndex, chatbotAlias: string): string[] {
+  return configsForChatbot(index, chatbotAlias).map(([alias]) => alias)
+}
+
+function groupState(
+  state: InspectedState,
+  index: ManifestIndex,
+  chatbotAlias: string
+): GroupState {
+  const binding = state.bindings.get(chatbotAlias)
+  const configurations = groupAliases(index, chatbotAlias).map((alias) =>
+    state.configurations.get(alias)
+  )
+  if (!binding || configurations.some((configuration) => !configuration)) {
+    return 'missing'
+  }
+  const enabled = [
+    binding.isEnabled,
+    ...configurations.map((configuration) => configuration!.isEnabled),
+  ]
+  if (enabled.every((value) => value === false)) return 'prepared'
+  if (enabled.every((value) => value === true)) return 'switched'
+  return 'mixed'
+}
+
+function assertTargetGroupsCoherent(
+  state: InspectedState,
+  index: ManifestIndex
+): void {
+  for (const chatbotAlias of index.aliases.chatbots) {
+    const status = groupState(state, index, chatbotAlias)
+    if (status === 'missing' || status === 'mixed') {
+      fail('MIXED_STATE', 'a target chatbot group is incomplete or mixed')
+    }
+  }
+}
+
+function requirePreparedRows(
+  state: InspectedState,
+  index: ManifestIndex
+): void {
+  if (!state.targetServer) {
+    fail('PREPARE_INCOMPLETE', 'the target server is missing')
+  }
+  if (
+    [...state.corpora.values()].length !== EXPECTED_CORPORA ||
+    [...state.configurations.values()].some((config) => !config) ||
+    [...state.bindings.values()].some((binding) => !binding)
+  ) {
+    fail('PREPARE_INCOMPLETE', 'target rows are incomplete')
+  }
+  assertNoEnabledTargetRows(state)
+  for (const chatbotAlias of index.aliases.chatbots) {
+    if (groupState(state, index, chatbotAlias) !== 'prepared') {
+      fail('PREPARE_INCOMPLETE', 'a target chatbot group is not prepared')
+    }
+  }
+}
+
+function assertSafeIdentity(
+  expected: SafeIdentitySnapshot,
+  alias: string,
+  record: { updatedAt: Date },
+  recordFingerprint: string
+): void {
+  if (
+    expected.alias !== alias ||
+    expected.fingerprint !== recordFingerprint ||
+    expected.updatedAt !== record.updatedAt.toISOString()
+  ) {
+    fail('SNAPSHOT_MISMATCH', 'a receipt snapshot no longer matches')
+  }
+}
+
+function findReceiptSnapshot<T extends { alias: string }>(
+  entries: T[],
+  alias: string
+): T {
+  const entry = entries.find((candidate) => candidate.alias === alias)
+  if (!entry) fail('RECEIPT_INVALID', 'a receipt snapshot is missing')
+  return entry
+}
+
+function assertReceiptCurrent(
+  state: InspectedState,
+  index: ManifestIndex,
+  receipt: ActivationReceipt,
+  options: { pendingChatbotAlias?: string } = {}
+): void {
+  if (!state.targetServer) {
+    fail('SNAPSHOT_MISMATCH', 'the target server is missing')
+  }
+  if (
+    receipt.sourceServer.fingerprint !==
+      serverFingerprint(state.sourceServer) ||
+    receipt.sourceServer.updatedAt !==
+      state.sourceServer.updatedAt.toISOString() ||
+    receipt.sourceServer.isActive !== state.sourceServer.isActive ||
+    receipt.sourceServer.hasTransportCredential !==
+      Boolean(state.sourceServer.authSecret)
+  ) {
+    fail('SNAPSHOT_MISMATCH', 'the source server snapshot no longer matches')
+  }
+  if (
+    receipt.targetServer.fingerprint !==
+      serverFingerprint(state.targetServer) ||
+    receipt.targetServer.updatedAt !==
+      state.targetServer.updatedAt.toISOString() ||
+    receipt.targetServer.isActive !== state.targetServer.isActive
+  ) {
+    fail('SNAPSHOT_MISMATCH', 'the target server snapshot no longer matches')
+  }
+
+  for (const alias of index.corpusByAlias.keys()) {
+    const current = state.corpora.get(alias)
+    if (!current) fail('SNAPSHOT_MISMATCH', 'a knowledge base is missing')
+    assertSafeIdentity(
+      findReceiptSnapshot(receipt.corpora, alias),
+      alias,
+      current,
+      knowledgeBaseFingerprint(current)
+    )
+  }
+  for (const [alias, expectedChatbotId] of index.chatbotIdByAlias.entries()) {
+    const current = state.chatbots.get(alias)
+    if (!current || current.id !== expectedChatbotId) {
+      fail('SNAPSHOT_MISMATCH', 'a chatbot snapshot no longer matches')
+    }
+    assertSafeIdentity(
+      findReceiptSnapshot(receipt.chatbots, alias),
+      alias,
+      current,
+      chatbotFingerprint(current)
+    )
+  }
+  for (const [alias, config] of state.legacyConfigurations.entries()) {
+    const expected = findReceiptSnapshot(receipt.legacyConfigurations, alias)
+    const chatbotAlias = chatbotAliasFor(index, config.chatbotId)
+    assertSafeIdentity(expected, alias, config, configFingerprint(config))
+    if (
+      expected.chatbotAlias !== chatbotAlias ||
+      expected.chatMode !== config.chatMode ||
+      expected.isEnabled !== config.isEnabled
+    ) {
+      fail(
+        'SNAPSHOT_MISMATCH',
+        'a legacy configuration snapshot no longer matches'
+      )
+    }
+  }
+  for (const [alias, expectedConfiguration] of index.configByAlias.entries()) {
+    const current = state.configurations.get(alias)
+    if (!current) fail('SNAPSHOT_MISMATCH', 'a target configuration is missing')
+    const chatbotAlias = chatbotAliasFor(index, expectedConfiguration.chatbotId)
+    const expected = findReceiptSnapshot(receipt.configurations, alias)
+    if (options.pendingChatbotAlias === chatbotAlias) {
+      assertTargetConfiguration(
+        current,
+        expectedConfiguration,
+        state.targetServer.id
+      )
+      if (
+        expected.chatbotAlias !== chatbotAlias ||
+        expected.chatMode !== current.chatMode
+      ) {
+        fail('SNAPSHOT_MISMATCH', 'a target configuration identity changed')
+      }
+      continue
+    }
+    assertSafeIdentity(expected, alias, current, configFingerprint(current))
+    if (
+      expected.chatbotAlias !== chatbotAlias ||
+      expected.chatMode !== current.chatMode ||
+      expected.isEnabled !== current.isEnabled
+    ) {
+      fail(
+        'SNAPSHOT_MISMATCH',
+        'a target configuration snapshot no longer matches'
+      )
+    }
+  }
+  for (const chatbotAlias of index.aliases.chatbots) {
+    const binding = state.bindings.get(chatbotAlias)
+    if (!binding) fail('SNAPSHOT_MISMATCH', 'a target binding is missing')
+    const chatbotId = resolveChatbotAlias(index, chatbotAlias)
+    const corpusAlias = corpusAliasFor(index, chatbotId)
+    const kb = state.corpora.get(corpusAlias)
+    if (!kb) fail('SNAPSHOT_MISMATCH', 'a target knowledge base is missing')
+    const expected = findReceiptSnapshot(
+      receipt.bindings,
+      index.bindingAliasByChatbotAlias.get(chatbotAlias)!
+    )
+    if (options.pendingChatbotAlias === chatbotAlias) {
+      assertBinding(binding, kb.id, chatbotId)
+      if (
+        expected.chatbotAlias !== chatbotAlias ||
+        expected.corpusAlias !== corpusAlias
+      ) {
+        fail('SNAPSHOT_MISMATCH', 'a target binding identity changed')
+      }
+      continue
+    }
+    assertSafeIdentity(
+      expected,
+      expected.alias,
+      binding,
+      bindingFingerprint(binding)
+    )
+    if (
+      expected.chatbotAlias !== chatbotAlias ||
+      expected.corpusAlias !== corpusAlias ||
+      expected.isEnabled !== binding.isEnabled
+    ) {
+      fail('SNAPSHOT_MISMATCH', 'a target binding snapshot no longer matches')
+    }
+  }
+}
+
+function makeReceiptFromState(
+  state: InspectedState,
+  index: ManifestIndex,
+  manifestFingerprint: string,
+  input: {
+    state: ActivationReceiptState
+    switchedChatbotAliases: string[]
+    pendingChatbotAlias?: string | null
+    pendingRollbackAliases?: string[]
+  }
+): ActivationReceipt {
+  if (!state.targetServer) {
+    fail('TARGET_SERVER_MISSING', 'the target server is missing')
+  }
+  const corpora = [...index.corpusByAlias.entries()]
+    .map(([alias]) => {
+      const kb = state.corpora.get(alias)
+      if (!kb) fail('KB_MISSING', 'a deterministic knowledge base is missing')
+      return safeIdentitySnapshot(alias, kb, knowledgeBaseFingerprint(kb))
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+  const chatbots = [...index.chatbotIdByAlias.entries()]
+    .map(([alias]) => {
+      const chatbot = state.chatbots.get(alias)
+      if (!chatbot) fail('CHATBOT_MISSING', 'a manifest chatbot is missing')
+      return safeIdentitySnapshot(alias, chatbot, chatbotFingerprint(chatbot))
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+  const legacyConfigurations = [...index.configByAlias.entries()]
+    .map(([alias, configuration]) => {
+      const config = state.legacyConfigurations.get(alias)
+      if (!config)
+        fail('SOURCE_CONFIG_MISSING', 'a legacy configuration is missing')
+      return safeConfigSnapshot(
+        alias,
+        chatbotAliasFor(index, configuration.chatbotId),
+        config
+      )
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+  const configurations = [...index.configByAlias.entries()]
+    .map(([alias, configuration]) => {
+      const config = state.configurations.get(alias)
+      if (!config)
+        fail('TARGET_CONFIG_MISSING', 'a target configuration is missing')
+      return safeConfigSnapshot(
+        alias,
+        chatbotAliasFor(index, configuration.chatbotId),
+        config
+      )
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+  const bindings = [...index.chatbotIdByAlias.entries()]
+    .map(([chatbotAlias, chatbotId]) => {
+      const binding = state.bindings.get(chatbotAlias)
+      if (!binding) fail('BINDING_MISSING', 'a target binding is missing')
+      return safeBindingSnapshot(
+        index.bindingAliasByChatbotAlias.get(chatbotAlias)!,
+        chatbotAlias,
+        corpusAliasFor(index, chatbotId),
+        binding
+      )
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+
+  return makeReceipt({
+    manifestFingerprint,
+    counts: index.counts,
+    aliases: index.aliases,
+    sourceServer: safeServerSnapshot(state.sourceServer, SOURCE_SERVER_NAME),
+    targetServer: safeServerSnapshot(state.targetServer, TARGET_SERVER_NAME),
+    corpora,
+    chatbots,
+    legacyConfigurations,
+    bindings,
+    configurations,
+    switchedChatbotAliases: [...new Set(input.switchedChatbotAliases)].sort(),
+    pendingChatbotAlias: input.pendingChatbotAlias ?? null,
+    pendingRollbackAliases: [
+      ...new Set(input.pendingRollbackAliases ?? []),
+    ].sort(),
+    state: input.state,
+  })
+}
+
+function zeroWrites(): ActivationWrites {
+  return {
+    knowledgeBases: 0,
+    server: 0,
+    bindings: 0,
+    configurations: 0,
+  }
+}
+
+function operationResult(
+  status: ActivationResult['status'],
+  index: ManifestIndex,
+  manifestFingerprint: string,
+  writes: ActivationWrites,
+  receipt?: ActivationReceipt
+): ActivationResult {
+  return {
+    status,
+    manifestFingerprint,
+    counts: index.counts,
+    aliases: {
+      sourceServer: SOURCE_SERVER_NAME,
+      targetServer: TARGET_SERVER_NAME,
+      chatbotAliases: [...index.aliases.chatbots],
+      switchedChatbotAliases: receipt
+        ? [...receipt.switchedChatbotAliases]
+        : [],
+    },
+    fingerprints: {
+      manifest: manifestFingerprint,
+      ...(receipt ? { receipt: receipt.payloadDigest } : {}),
+    },
+    writes,
+    legacyRowsPreserved: true,
+    ...(receipt ? { receipt } : {}),
+  }
+}
+
+function validateTarget(target: ActivationTarget): void {
+  assertNonEmpty(target.description)
+  assertUrl(target.url)
+}
+
+function validateReceiptState(
+  receipt: ActivationReceipt,
+  allowed: ActivationReceiptState[]
+): void {
+  if (!allowed.includes(receipt.state)) {
+    fail('RECEIPT_STATE', 'receipt state is not valid for this operation')
+  }
+}
+
+function requireReceipt(
+  payload: ActivationReceiptPayload | null,
+  index: ManifestIndex,
+  manifestFingerprint: string
+): ActivationReceipt {
+  if (!payload || isReceiptIntent(payload)) {
+    fail('RECEIPT_MISSING', 'a complete activation receipt is required')
+  }
+  assertReceiptMatchesIndex(payload, index, manifestFingerprint)
+  return payload
+}
+
+function hasTargetRows(state: InspectedState): boolean {
+  return (
+    [...state.bindings.values()].some((binding) => Boolean(binding)) ||
+    [...state.configurations.values()].some((config) => Boolean(config))
+  )
+}
+
+function assertNoUntrackedPartialTargetRows(
+  state: InspectedState,
+  index: ManifestIndex
+): void {
+  if (!hasTargetRows(state)) return
+  if (!state.targetServer) {
+    fail('MIXED_STATE', 'target rows exist without the reserved target server')
+  }
+  assertTargetGroupsCoherent(state, index)
+}
+
+function targetWriteCounts(state: InspectedState): ActivationWrites {
+  return {
+    knowledgeBases: EXPECTED_CORPORA - state.corpora.size,
+    server: state.targetServer ? 0 : 1,
+    bindings: [...state.bindings.values()].filter((binding) => !binding).length,
+    configurations: [...state.configurations.values()].filter(
+      (configuration) => !configuration
+    ).length,
+  }
+}
+
+export async function dryRunCohortActivation(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  target: ActivationTarget
+): Promise<ActivationResult> {
+  validateTarget(target)
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = fingerprintManifest(manifest)
+  const state = await inspectCohortState(store, index, target)
+  if (state.targetServer) {
+    assertTargetGroupsCoherent(state, index)
+  }
+  assertNoEnabledTargetRows(state)
+  return operationResult(
+    'dry-run',
+    index,
+    manifestFingerprint,
+    targetWriteCounts(state)
+  )
+}
+
+export async function prepareCohortActivation(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  options: ActivationOptions
+): Promise<ActivationResult> {
+  validateTarget(options.target)
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = fingerprintManifest(manifest)
+  if (options.dryRun) {
+    return dryRunCohortActivation(store, manifest, options.target)
+  }
+  if (!options.receiptStore) {
+    fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
+  }
+
+  const existing = await readReceipt(options.receiptStore)
+  if (existing) {
+    assertReceiptMatchesIndex(existing, index, manifestFingerprint)
+    if (isReceiptIntent(existing)) {
+      const intentState = await inspectCohortState(store, index, options.target)
+      assertNoEnabledTargetRows(intentState)
+      assertNoUntrackedPartialTargetRows(intentState, index)
+    } else {
+      validateReceiptState(existing, ['prepared'])
+      const state = await inspectCohortState(store, index, options.target)
+      assertReceiptCurrent(state, index, existing)
+      requirePreparedRows(state, index)
+      return operationResult(
+        'prepared',
+        index,
+        manifestFingerprint,
+        zeroWrites(),
+        existing
+      )
+    }
+  } else {
+    const initialState = await inspectCohortState(store, index, options.target)
+    assertNoEnabledTargetRows(initialState)
+    assertNoUntrackedPartialTargetRows(initialState, index)
+    await options.receiptStore.write(makeIntent(index, manifestFingerprint))
+  }
+
+  const writes = zeroWrites()
+  const receipt = await store.transaction(async (tx) => {
+    const state = await inspectCohortState(tx, index, options.target)
+    assertNoEnabledTargetRows(state)
+
+    for (const [alias, corpus] of index.corpusByAlias.entries()) {
+      if (state.corpora.has(alias)) continue
+      const collisions = await tx.findKnowledgeBasesByName(corpus.kbName)
+      if (collisions.length > 0) {
+        fail('KB_NAME_COLLISION', 'a knowledge base name is not deterministic')
+      }
+      const created = await tx.createKnowledgeBase({
+        id: corpus.kbId,
+        name: corpus.kbName,
+        description: corpus.description ?? null,
+        ownerId: corpus.ownerId,
+      })
+      assertKnowledgeBase(created, corpus)
+      state.corpora.set(alias, created)
+      writes.knowledgeBases += 1
+    }
+
+    if (!state.targetServer) {
+      const encryptedTransportCredential = state.sourceServer.authSecret
+      if (!encryptedTransportCredential) {
+        fail(
+          'SOURCE_CREDENTIAL_MISSING',
+          'the source transport credential is unavailable'
+        )
+      }
+      const created = await tx.createServer({
+        name: TARGET_SERVER_NAME,
+        description: options.target.description,
+        url: options.target.url,
+        authType: TARGET_AUTH_TYPE,
+        authSecret: encryptedTransportCredential,
+        passChatbotId: false,
+        chatbotIdHeader: null,
+        parameters: {},
+        isActive: true,
+      })
+      assertTargetServer(created, state.sourceServer, options.target)
+      state.targetServer = created
+      writes.server += 1
+    }
+
+    for (const [chatbotAlias, chatbotId] of index.chatbotIdByAlias.entries()) {
+      const corpusAlias = corpusAliasFor(index, chatbotId)
+      const kb = state.corpora.get(corpusAlias)
+      if (!kb) fail('KB_MISSING', 'a deterministic knowledge base is missing')
+      const existingBinding = state.bindings.get(chatbotAlias)
+      if (existingBinding) {
+        assertBinding(existingBinding, kb.id, chatbotId)
+      } else {
+        const createdBinding = await tx.createBinding({
+          kbId: kb.id,
+          chatbotId,
+          isEnabled: false,
+        })
+        assertBinding(createdBinding, kb.id, chatbotId)
+        state.bindings.set(chatbotAlias, createdBinding)
+        writes.bindings += 1
+      }
+    }
+
+    for (const [alias, configuration] of index.configByAlias.entries()) {
+      const existingConfig = state.configurations.get(alias)
+      if (existingConfig) {
+        assertTargetConfiguration(
+          existingConfig,
+          configuration,
+          state.targetServer.id
+        )
+        continue
+      }
+      const createdConfig = await tx.createConfig(
+        targetConfigData(configuration, state.targetServer.id)
+      )
+      assertTargetConfiguration(
+        createdConfig,
+        configuration,
+        state.targetServer.id
+      )
+      state.configurations.set(alias, createdConfig)
+      writes.configurations += 1
+    }
+
+    requirePreparedRows(state, index)
+    return makeReceiptFromState(state, index, manifestFingerprint, {
+      state: 'prepared',
+      switchedChatbotAliases: [],
+    })
+  })
+  await options.receiptStore.write(receipt)
+  return operationResult(
+    'prepared',
+    index,
+    manifestFingerprint,
+    writes,
+    receipt
+  )
+}
+
+async function prepareOrReadReceipt(
+  manifest: FrozenCohortManifest,
+  receiptStore: ActivationReceiptStore
+): Promise<{
+  index: ManifestIndex
+  manifestFingerprint: string
+  receipt: ActivationReceipt
+}> {
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = fingerprintManifest(manifest)
+  const payload = await readReceipt(receiptStore)
+  const receipt = requireReceipt(payload, index, manifestFingerprint)
+  return {
+    index,
+    manifestFingerprint,
+    receipt,
+  }
+}
+
+async function applyChatbotSwitch(
+  tx: ActivationTransactionStore,
+  state: InspectedState,
+  index: ManifestIndex,
+  chatbotAlias: string,
+  enabled: boolean
+): Promise<void> {
+  const chatbotId = resolveChatbotAlias(index, chatbotAlias)
+  const corpusAlias = corpusAliasFor(index, chatbotId)
+  const kb = state.corpora.get(corpusAlias)
+  if (!kb) fail('KB_MISSING', 'a deterministic knowledge base is missing')
+
+  const binding = state.bindings.get(chatbotAlias)
+  if (!binding) fail('BINDING_MISSING', 'the chatbot binding is missing')
+  assertBinding(binding, kb.id, chatbotId)
+  if (binding.isEnabled !== enabled) {
+    await tx.updateBinding(binding, enabled)
+  }
+
+  for (const [alias, configuration] of configsForChatbot(index, chatbotAlias)) {
+    const config = state.configurations.get(alias)
+    if (!config)
+      fail('TARGET_CONFIG_MISSING', 'a chatbot configuration is missing')
+    if (!state.targetServer) {
+      fail('TARGET_SERVER_MISSING', 'the target server is missing')
+    }
+    assertTargetConfiguration(config, configuration, state.targetServer.id)
+    if (config.isEnabled !== enabled) {
+      await tx.updateConfig(config, enabled)
+    }
+  }
+}
+
+function assertCandidateGroup(
+  state: InspectedState,
+  index: ManifestIndex,
+  chatbotAlias: string,
+  desired: 'prepared' | 'switched'
+): void {
+  const current = groupState(state, index, chatbotAlias)
+  if (current !== desired) {
+    fail(
+      'MIXED_STATE',
+      'the selected chatbot group is not in the expected state'
+    )
+  }
+}
+
+export async function switchCohortChatbot(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  options: ActivationOptions & { chatbotAlias: string }
+): Promise<ActivationResult> {
+  validateTarget(options.target)
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = fingerprintManifest(manifest)
+  const chatbotId = resolveChatbotAlias(index, options.chatbotAlias)
+  void chatbotId
+  if (options.dryRun) {
+    return operationResult('dry-run', index, manifestFingerprint, zeroWrites())
+  }
+  if (!options.receiptStore) {
+    fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
+  }
+  const { receipt } = await prepareOrReadReceipt(manifest, options.receiptStore)
+  validateReceiptState(receipt, ['prepared', 'switched'])
+
+  const currentState = await inspectCohortState(store, index, options.target)
+  assertReceiptCurrent(currentState, index, receipt)
+  assertTargetGroupsCoherent(currentState, index)
+  if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
+    assertCandidateGroup(currentState, index, options.chatbotAlias, 'switched')
+    return operationResult(
+      'switched',
+      index,
+      manifestFingerprint,
+      zeroWrites(),
+      receipt
+    )
+  }
+  assertCandidateGroup(currentState, index, options.chatbotAlias, 'prepared')
+  assertNoEnabledOtherBinding(currentState)
+
+  const switchingReceipt = makeReceiptFromState(
+    currentState,
+    index,
+    manifestFingerprint,
+    {
+      state: 'switching',
+      switchedChatbotAliases: receipt.switchedChatbotAliases,
+      pendingChatbotAlias: options.chatbotAlias,
+    }
+  )
+  await options.receiptStore.write(switchingReceipt)
+
+  const switchedReceipt = await store.transaction(async (tx) => {
+    const state = await inspectCohortState(tx, index, options.target)
+    assertReceiptCurrent(state, index, receipt)
+    assertTargetGroupsCoherent(state, index)
+    assertCandidateGroup(state, index, options.chatbotAlias, 'prepared')
+    assertNoEnabledOtherBinding(state)
+    await applyChatbotSwitch(tx, state, index, options.chatbotAlias, true)
+    const after = await inspectCohortState(tx, index, options.target)
+    return makeReceiptFromState(after, index, manifestFingerprint, {
+      state: 'switched',
+      switchedChatbotAliases: [
+        ...receipt.switchedChatbotAliases,
+        options.chatbotAlias,
+      ],
+    })
+  })
+  await options.receiptStore.write(switchedReceipt)
+  return operationResult(
+    'switched',
+    index,
+    manifestFingerprint,
+    zeroWrites(),
+    switchedReceipt
+  )
+}
+
+export async function rollbackCohortChatbot(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  options: ActivationOptions & { chatbotAlias: string }
+): Promise<ActivationResult> {
+  validateTarget(options.target)
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = fingerprintManifest(manifest)
+  resolveChatbotAlias(index, options.chatbotAlias)
+  if (options.dryRun) {
+    return operationResult('dry-run', index, manifestFingerprint, zeroWrites())
+  }
+  if (!options.receiptStore) {
+    fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
+  }
+  const { receipt } = await prepareOrReadReceipt(manifest, options.receiptStore)
+  validateReceiptState(receipt, ['switched', 'switching', 'rolling_back'])
+  if (
+    !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
+    !(
+      receipt.state === 'switching' &&
+      receipt.pendingChatbotAlias === options.chatbotAlias
+    )
+  ) {
+    fail('RECEIPT_STATE', 'chatbot was not switched')
+  }
+  if (
+    (receipt.state === 'rolling_back' || receipt.state === 'switching') &&
+    receipt.state !== 'switching' &&
+    !receipt.pendingRollbackAliases.includes(options.chatbotAlias)
+  ) {
+    fail('RECEIPT_STATE', 'rollback intent does not name the chatbot')
+  }
+
+  const stateBefore = await inspectCohortState(store, index, options.target)
+  const pending =
+    receipt.state === 'rolling_back' || receipt.state === 'switching'
+  assertReceiptCurrent(
+    stateBefore,
+    index,
+    receipt,
+    pending ? { pendingChatbotAlias: options.chatbotAlias } : {}
+  )
+  assertTargetGroupsCoherent(stateBefore, index)
+  if (!pending) {
+    assertCandidateGroup(stateBefore, index, options.chatbotAlias, 'switched')
+  } else {
+    const current = groupState(stateBefore, index, options.chatbotAlias)
+    if (current !== 'switched' && current !== 'prepared') {
+      fail('MIXED_STATE', 'the selected chatbot group is mixed')
+    }
+  }
+
+  let rollbackReceipt = receipt
+  if (!pending) {
+    rollbackReceipt = makeReceiptFromState(
+      stateBefore,
+      index,
+      manifestFingerprint,
+      {
+        state: 'rolling_back',
+        switchedChatbotAliases: receipt.switchedChatbotAliases,
+        pendingRollbackAliases: [options.chatbotAlias],
+      }
+    )
+    await options.receiptStore.write(rollbackReceipt)
+  } else if (receipt.state === 'switching') {
+    rollbackReceipt = makeReceiptFromState(
+      stateBefore,
+      index,
+      manifestFingerprint,
+      {
+        state: 'rolling_back',
+        switchedChatbotAliases: receipt.switchedChatbotAliases.includes(
+          options.chatbotAlias
+        )
+          ? receipt.switchedChatbotAliases
+          : [...receipt.switchedChatbotAliases, options.chatbotAlias],
+        pendingRollbackAliases: [options.chatbotAlias],
+      }
+    )
+    await options.receiptStore.write(rollbackReceipt)
+  }
+
+  const finalReceipt = await store.transaction(async (tx) => {
+    const state = await inspectCohortState(tx, index, options.target)
+    assertReceiptCurrent(state, index, rollbackReceipt, {
+      pendingChatbotAlias: options.chatbotAlias,
+    })
+    assertTargetGroupsCoherent(state, index)
+    const current = groupState(state, index, options.chatbotAlias)
+    if (current !== 'switched' && current !== 'prepared') {
+      fail('MIXED_STATE', 'the selected chatbot group is mixed')
+    }
+    if (current === 'switched') {
+      await applyChatbotSwitch(tx, state, index, options.chatbotAlias, false)
+    }
+    const remaining = rollbackReceipt.switchedChatbotAliases.filter(
+      (alias) => alias !== options.chatbotAlias
+    )
+    const after = await inspectCohortState(tx, index, options.target)
+    return makeReceiptFromState(after, index, manifestFingerprint, {
+      state: remaining.length === 0 ? 'rolled_back' : 'switched',
+      switchedChatbotAliases: remaining,
+    })
+  })
+  await options.receiptStore.write(finalReceipt)
+  return operationResult(
+    finalReceipt.state === 'rolled_back' ? 'rolled_back' : 'switched',
+    index,
+    manifestFingerprint,
+    zeroWrites(),
+    finalReceipt
+  )
+}
+
+export async function readbackCohortActivation(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  options: ActivationOptions
+): Promise<ActivationResult> {
+  validateTarget(options.target)
+  if (!options.receiptStore) {
+    fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
+  }
+  const { index, manifestFingerprint, receipt } = await prepareOrReadReceipt(
+    manifest,
+    options.receiptStore
+  )
+  validateReceiptState(receipt, ['prepared', 'switched', 'rolled_back'])
+  const state = await inspectCohortState(store, index, options.target)
+  if (receipt.state === 'prepared' || receipt.state === 'rolled_back') {
+    requirePreparedRows(state, index)
+    assertReceiptCurrent(state, index, receipt)
+  } else {
+    assertReceiptCurrent(state, index, receipt)
+    assertTargetGroupsCoherent(state, index)
+  }
+  return operationResult(
+    'readback',
+    index,
+    manifestFingerprint,
+    zeroWrites(),
+    receipt
+  )
+}

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -3477,11 +3477,14 @@ function assertCandidateGroup(
   }
 }
 
-export async function switchCohortChatbot(
-  store: ActivationStore,
+function openCohortChatbotOperation(
   manifest: FrozenCohortManifest,
   options: ActivationOptions & { chatbotAlias: string }
-): Promise<ActivationResult> {
+): {
+  index: ReturnType<typeof buildManifestIndex>
+  manifestFingerprint: string
+  receiptStore: ActivationReceiptStore
+} {
   validateTarget(options.target)
   const index = buildManifestIndex(manifest)
   const manifestFingerprint = requireManifestFingerprint(
@@ -3493,15 +3496,40 @@ export async function switchCohortChatbot(
   if (!receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
+  return { index, manifestFingerprint, receiptStore }
+}
+
+async function requireSessionReceipt(
+  session: ActivationReceiptSession,
+  index: ReturnType<typeof buildManifestIndex>,
+  manifestFingerprint: string,
+  allowedStates: readonly string[]
+) {
+  const receipt = requireReceipt(
+    await readReceipt(session),
+    index,
+    manifestFingerprint
+  )
+  validateReceiptState(receipt, allowedStates)
+  return receipt
+}
+
+export async function switchCohortChatbot(
+  store: ActivationStore,
+  manifest: FrozenCohortManifest,
+  options: ActivationOptions & { chatbotAlias: string }
+): Promise<ActivationResult> {
+  const { index, manifestFingerprint, receiptStore } =
+    openCohortChatbotOperation(manifest, options)
   const execute = async (
     session: ActivationReceiptSession
   ): Promise<ActivationResult> => {
-    const receipt = requireReceipt(
-      await readReceipt(session),
+    const receipt = await requireSessionReceipt(
+      session,
       index,
-      manifestFingerprint
+      manifestFingerprint,
+      ['prepared', 'switched']
     )
-    validateReceiptState(receipt, ['prepared', 'switched'])
 
     const currentState = await inspectCohortState(store, index, options.target)
     assertReceiptCurrent(currentState, index, receipt)
@@ -3598,26 +3626,17 @@ export async function rollbackCohortChatbot(
   manifest: FrozenCohortManifest,
   options: ActivationOptions & { chatbotAlias: string }
 ): Promise<ActivationResult> {
-  validateTarget(options.target)
-  const index = buildManifestIndex(manifest)
-  const manifestFingerprint = requireManifestFingerprint(
-    manifest,
-    options.expectedManifestFingerprint
-  )
-  resolveChatbotAlias(index, options.chatbotAlias)
-  const receiptStore = options.receiptStore
-  if (!receiptStore) {
-    fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
-  }
+  const { index, manifestFingerprint, receiptStore } =
+    openCohortChatbotOperation(manifest, options)
   const execute = async (
     session: ActivationReceiptSession
   ): Promise<ActivationResult> => {
-    const receipt = requireReceipt(
-      await readReceipt(session),
+    const receipt = await requireSessionReceipt(
+      session,
       index,
-      manifestFingerprint
+      manifestFingerprint,
+      ['switched', 'switching', 'rolling_back']
     )
-    validateReceiptState(receipt, ['switched', 'switching', 'rolling_back'])
     if (
       !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
       !(

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -517,7 +517,7 @@ function canonicalManifest(manifest: FrozenCohortManifest): unknown {
     environment: manifest.environment,
     singletonCanaryKbId: manifest.singletonCanaryKbId,
     corpora: [...manifest.corpora]
-      .sort((left, right) => left.kbId.localeCompare(right.kbId))
+      .sort((left, right) => compareUtf16Strings(left.kbId, right.kbId))
       .map((corpus) => ({
         kbId: corpus.kbId,
         kbName: corpus.kbName,
@@ -530,14 +530,16 @@ function canonicalManifest(manifest: FrozenCohortManifest): unknown {
         chatbotIds: [...corpus.chatbotIds].sort(compareUtf16Strings),
         courseIds: [...corpus.courseIds].sort(compareUtf16Strings),
         configurations: [...corpus.configurations]
-          .sort((left, right) => left.configId.localeCompare(right.configId))
+          .sort((left, right) =>
+            compareUtf16Strings(left.configId, right.configId)
+          )
           .map((configuration) => ({
             ...configuration,
             allowedTools: [...configuration.allowedTools],
           })),
       })),
     excluded: [...manifest.excluded].sort((left, right) =>
-      left.configId.localeCompare(right.configId)
+      compareUtf16Strings(left.configId, right.configId)
     ),
   }
 }
@@ -956,27 +958,6 @@ async function tryCreateReceiptLock(
   }
 }
 
-async function reclaimDeadLock(
-  lockPath: string,
-  owner: ReceiptLockOwner
-): Promise<void> {
-  if (owner.host !== hostname()) throw lockError()
-  let dead = false
-  try {
-    process.kill(owner.pid, 0)
-  } catch (error) {
-    dead = errorCode(error) === 'ESRCH'
-  }
-  if (!dead) throw lockError()
-  const currentOwner = await readLockOwner(lockPath)
-  if (!currentOwner || !sameLockOwner(currentOwner, owner)) throw lockError()
-  try {
-    await removeLockFile(lockPath)
-  } catch (error) {
-    throw new AggregateError([lockError(), error], lockCleanupError().message)
-  }
-}
-
 async function acquireReceiptLock(lockPath: string): Promise<ReceiptLockOwner> {
   const owner: ReceiptLockOwner = {
     version: RECEIPT_LOCK_OWNER_VERSION,
@@ -985,12 +966,7 @@ async function acquireReceiptLock(lockPath: string): Promise<ReceiptLockOwner> {
     token: randomUUID(),
     acquiredAt: new Date().toISOString(),
   }
-  if (!(await tryCreateReceiptLock(lockPath, owner))) {
-    const existingOwner = await readLockOwner(lockPath)
-    if (!existingOwner) throw lockError()
-    await reclaimDeadLock(lockPath, existingOwner)
-    if (!(await tryCreateReceiptLock(lockPath, owner))) throw lockError()
-  }
+  if (!(await tryCreateReceiptLock(lockPath, owner))) throw lockError()
   return owner
 }
 
@@ -1385,7 +1361,7 @@ export function createPrismaActivationStore(
 function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
   validateCohortManifest(manifest)
   const sortedCorpora = [...manifest.corpora].sort((left, right) =>
-    left.kbId.localeCompare(right.kbId)
+    compareUtf16Strings(left.kbId, right.kbId)
   )
   const corpusByAlias = new Map<string, FrozenCorpus>()
   const corpusAliasByChatbotId = new Map<string, string>()
@@ -1424,7 +1400,7 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
 
   const sortedConfigurations = manifest.corpora
     .flatMap((corpus) => corpus.configurations)
-    .sort((left, right) => left.configId.localeCompare(right.configId))
+    .sort((left, right) => compareUtf16Strings(left.configId, right.configId))
   const configByAlias = new Map<string, FrozenConfiguration>()
   const configsByChatbotAlias = new Map<
     string,
@@ -1441,7 +1417,7 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
   })
 
   const sortedExcluded = [...manifest.excluded].sort((left, right) =>
-    left.configId.localeCompare(right.configId)
+    compareUtf16Strings(left.configId, right.configId)
   )
   const excludedByAlias = new Map<string, FrozenExcludedConfiguration>()
   sortedExcluded.forEach((configuration, index) => {

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -1,14 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
-import {
-  chmod,
-  mkdir,
-  readFile,
-  rename,
-  rm,
-  rmdir,
-  writeFile,
-} from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { hostname } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 
 export const SOURCE_SERVER_NAME = 'Klicker-compat' as const
@@ -230,6 +223,7 @@ export type ReceiptAliases = {
   courses: string[]
   chatbots: string[]
   configurations: string[]
+  bindings: string[]
   excludedConfigurations: string[]
 }
 
@@ -308,7 +302,13 @@ export type ActivationReceiptPayload =
   | ActivationReceipt
   | ActivationReceiptIntent
 
-export interface ActivationReceiptStore {
+export interface ActivationReceiptStore extends ActivationReceiptSession {
+  runExclusive<T>(
+    callback: (store: ActivationReceiptSession) => Promise<T>
+  ): Promise<T>
+}
+
+export interface ActivationReceiptSession {
   read(): Promise<ActivationReceiptPayload | null>
   compareAndSwap(
     expectedDigest: string | null,
@@ -371,7 +371,6 @@ type ManifestIndex = {
   configByAlias: Map<string, FrozenConfiguration>
   configsByChatbotAlias: Map<string, Array<[string, FrozenConfiguration]>>
   excludedByAlias: Map<string, FrozenExcludedConfiguration>
-  excludedConfigAliasById: Map<string, string>
   excludedChatbotAliasForId: Map<string, string>
   bindingAliasByChatbotAlias: Map<string, string>
   aliases: ReceiptAliases
@@ -769,6 +768,187 @@ export function parseFrozenActivationManifest(
   return { ...manifest, fingerprint: fingerprintManifest(manifest) }
 }
 
+const RECEIPT_LOCK_OWNER_FILE = 'owner.json'
+const RECEIPT_LOCK_OWNER_VERSION = 1 as const
+const RECEIPT_LOCK_OWNER_MAX_BYTES = 512
+
+type ReceiptLockOwner = {
+  version: typeof RECEIPT_LOCK_OWNER_VERSION
+  pid: number
+  host: string
+  token: string
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as Error & { code?: unknown }).code
+    return typeof code === 'string' ? code : undefined
+  }
+  return undefined
+}
+
+function lockError(): CohortActivationError {
+  return new CohortActivationError(
+    'RECEIPT_LOCKED',
+    'activation receipt is already being updated'
+  )
+}
+
+function lockCleanupError(): CohortActivationError {
+  return new CohortActivationError(
+    'RECEIPT_LOCK_CLEANUP_FAILED',
+    'activation receipt lock cleanup failed'
+  )
+}
+
+function sameLockOwner(left: ReceiptLockOwner, right: ReceiptLockOwner) {
+  return (
+    left.version === right.version &&
+    left.pid === right.pid &&
+    left.host === right.host &&
+    left.token === right.token
+  )
+}
+
+async function readLockOwner(
+  lockPath: string
+): Promise<ReceiptLockOwner | null> {
+  try {
+    const contents = await readFile(
+      join(lockPath, RECEIPT_LOCK_OWNER_FILE),
+      'utf8'
+    )
+    if (Buffer.byteLength(contents, 'utf8') > RECEIPT_LOCK_OWNER_MAX_BYTES) {
+      return null
+    }
+    const parsed: unknown = JSON.parse(contents)
+    if (!isPlainObject(parsed)) return null
+    assertReceiptKeys(parsed, ['version', 'pid', 'host', 'token'])
+    if (
+      parsed.version !== RECEIPT_LOCK_OWNER_VERSION ||
+      typeof parsed.pid !== 'number' ||
+      !Number.isSafeInteger(parsed.pid) ||
+      parsed.pid <= 0 ||
+      parsed.pid > 2_147_483_647 ||
+      typeof parsed.host !== 'string' ||
+      parsed.host.length === 0 ||
+      parsed.host.length > 255 ||
+      CONTROL_CHARACTER_PATTERN.test(parsed.host) ||
+      typeof parsed.token !== 'string' ||
+      !UUID_PATTERN.test(parsed.token)
+    ) {
+      return null
+    }
+    return {
+      version: RECEIPT_LOCK_OWNER_VERSION,
+      pid: parsed.pid,
+      host: parsed.host,
+      token: parsed.token,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function removeUnownedLock(lockPath: string): Promise<void> {
+  await rm(lockPath, { force: false, recursive: true })
+}
+
+async function reclaimDeadLock(
+  lockPath: string,
+  owner: ReceiptLockOwner
+): Promise<void> {
+  if (owner.host !== hostname()) throw lockError()
+  let dead = false
+  try {
+    process.kill(owner.pid, 0)
+  } catch (error) {
+    dead = errorCode(error) === 'ESRCH'
+  }
+  if (!dead) throw lockError()
+  const currentOwner = await readLockOwner(lockPath)
+  if (!currentOwner || !sameLockOwner(currentOwner, owner)) throw lockError()
+  try {
+    await removeUnownedLock(lockPath)
+  } catch (error) {
+    throw new AggregateError([lockError(), error], lockCleanupError().message)
+  }
+}
+
+async function acquireReceiptLock(lockPath: string): Promise<ReceiptLockOwner> {
+  try {
+    await mkdir(lockPath, { mode: 0o700 })
+  } catch (error) {
+    if (errorCode(error) !== 'EEXIST') {
+      throw new CohortActivationError(
+        'RECEIPT_WRITE_FAILED',
+        'receipt lock is unavailable'
+      )
+    }
+    const owner = await readLockOwner(lockPath)
+    if (!owner) throw lockError()
+    let dead = false
+    if (owner.host === hostname()) {
+      try {
+        process.kill(owner.pid, 0)
+      } catch (probeError) {
+        dead = errorCode(probeError) === 'ESRCH'
+      }
+    }
+    if (!dead) throw lockError()
+    await reclaimDeadLock(lockPath, owner)
+    try {
+      await mkdir(lockPath, { mode: 0o700 })
+    } catch (reacquireError) {
+      if (errorCode(reacquireError) === 'EEXIST') throw lockError()
+      throw new CohortActivationError(
+        'RECEIPT_WRITE_FAILED',
+        'receipt lock is unavailable'
+      )
+    }
+  }
+
+  const owner: ReceiptLockOwner = {
+    version: RECEIPT_LOCK_OWNER_VERSION,
+    pid: process.pid,
+    host: hostname(),
+    token: randomUUID(),
+  }
+  const contents = `${JSON.stringify(owner)}\n`
+  try {
+    await writeFile(join(lockPath, RECEIPT_LOCK_OWNER_FILE), contents, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    })
+    await chmod(join(lockPath, RECEIPT_LOCK_OWNER_FILE), 0o600)
+  } catch {
+    const primary = new CohortActivationError(
+      'RECEIPT_WRITE_FAILED',
+      'receipt lock owner is unavailable'
+    )
+    try {
+      await removeUnownedLock(lockPath)
+    } catch (cleanupError) {
+      throw new AggregateError([primary, cleanupError], primary.message)
+    }
+    throw primary
+  }
+  if (Buffer.byteLength(contents, 'utf8') > RECEIPT_LOCK_OWNER_MAX_BYTES) {
+    const primary = new CohortActivationError(
+      'RECEIPT_WRITE_FAILED',
+      'receipt lock owner is too large'
+    )
+    try {
+      await removeUnownedLock(lockPath)
+    } catch (cleanupError) {
+      throw new AggregateError([primary, cleanupError], primary.message)
+    }
+    throw primary
+  }
+  return owner
+}
+
 export function createFileActivationReceiptStore(
   receiptPath: string
 ): ActivationReceiptStore {
@@ -782,11 +962,7 @@ export function createFileActivationReceiptStore(
       assertPayloadDigest(payload)
       return payload
     } catch (error) {
-      if (
-        error instanceof Error &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
+      if (errorCode(error) === 'ENOENT') {
         return null
       }
       if (error instanceof CohortActivationError) throw error
@@ -794,62 +970,104 @@ export function createFileActivationReceiptStore(
     }
   }
 
-  return {
-    async read() {
-      return readCurrent()
-    },
-    async compareAndSwap(expectedDigest, receipt) {
-      if (
-        expectedDigest !== null &&
-        !FINGERPRINT_PATTERN.test(expectedDigest)
-      ) {
-        fail('RECEIPT_CAS_FAILED', 'receipt expected digest is invalid')
-      }
-      assertPayloadDigest(receipt)
-      try {
-        await mkdir(dirname(absolutePath), { recursive: true })
-      } catch {
-        fail('RECEIPT_WRITE_FAILED', 'receipt directory is unavailable')
-      }
-      try {
-        await mkdir(lockPath)
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          'code' in error &&
-          error.code === 'EEXIST'
-        ) {
-          fail('RECEIPT_LOCKED', 'receipt is already being updated')
-        }
-        fail('RECEIPT_WRITE_FAILED', 'receipt lock is unavailable')
-      }
-      const temporaryPath = `${absolutePath}.tmp-${process.pid}-${randomUUID()}`
-      try {
-        const current = await readCurrent()
-        if ((current?.payloadDigest ?? null) !== expectedDigest) {
-          fail('RECEIPT_CAS_FAILED', 'receipt changed concurrently')
-        }
-        if (current) assertReceiptTransition(current, receipt)
-        else if (!isReceiptIntent(receipt)) {
-          fail('RECEIPT_STATE', 'a new receipt must start with intent')
-        }
-        if (current?.payloadDigest === receipt.payloadDigest) return
-        await writeFile(
-          temporaryPath,
-          `${JSON.stringify(receipt, null, 2)}\n`,
-          {
-            encoding: 'utf8',
-            flag: 'wx',
-            mode: 0o600,
-          }
+  async function compareAndSwapLocked(
+    expectedDigest: string | null,
+    receipt: ActivationReceiptPayload
+  ): Promise<void> {
+    if (expectedDigest !== null && !FINGERPRINT_PATTERN.test(expectedDigest)) {
+      fail('RECEIPT_CAS_FAILED', 'receipt expected digest is invalid')
+    }
+    assertPayloadDigest(receipt)
+    const temporaryPath = `${absolutePath}.tmp-${process.pid}-${randomUUID()}`
+    const current = await readCurrent()
+    if ((current?.payloadDigest ?? null) !== expectedDigest) {
+      fail('RECEIPT_CAS_FAILED', 'receipt changed concurrently')
+    }
+    if (current) assertReceiptTransition(current, receipt)
+    else if (!isReceiptIntent(receipt)) {
+      fail('RECEIPT_STATE', 'a new receipt must start with intent')
+    }
+    if (current?.payloadDigest === receipt.payloadDigest) return
+    try {
+      await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      })
+      await chmod(temporaryPath, 0o600)
+      await rename(temporaryPath, absolutePath)
+    } catch (error) {
+      if (error instanceof CohortActivationError) throw error
+      fail('RECEIPT_WRITE_FAILED', 'could not persist activation receipt')
+    } finally {
+      await rm(temporaryPath, { force: true }).catch(() => undefined)
+    }
+  }
+
+  async function releaseReceiptLock(owner: ReceiptLockOwner): Promise<void> {
+    const currentOwner = await readLockOwner(lockPath)
+    if (!currentOwner || !sameLockOwner(currentOwner, owner)) {
+      throw lockCleanupError()
+    }
+    try {
+      await removeUnownedLock(lockPath)
+    } catch (error) {
+      throw new AggregateError(
+        [lockCleanupError(), error],
+        lockCleanupError().message
+      )
+    }
+  }
+
+  async function runExclusive<T>(
+    callback: (store: ActivationReceiptSession) => Promise<T>
+  ): Promise<T> {
+    try {
+      await mkdir(dirname(absolutePath), { recursive: true })
+    } catch {
+      fail('RECEIPT_WRITE_FAILED', 'receipt directory is unavailable')
+    }
+    const owner = await acquireReceiptLock(lockPath)
+    const session: ActivationReceiptSession = {
+      read: readCurrent,
+      compareAndSwap: compareAndSwapLocked,
+    }
+    let result: T | undefined
+    let completed = false
+    let primaryError: unknown
+    try {
+      result = await callback(session)
+      completed = true
+    } catch (error) {
+      primaryError = error
+    }
+    let cleanupError: unknown
+    try {
+      await releaseReceiptLock(owner)
+    } catch (error) {
+      cleanupError = error
+    }
+    if (cleanupError) {
+      if (!completed) {
+        throw new AggregateError(
+          [primaryError, cleanupError],
+          'activation receipt operation and lock cleanup failed'
         )
-        await chmod(temporaryPath, 0o600)
-        await rename(temporaryPath, absolutePath)
-      } finally {
-        await rm(temporaryPath, { force: true }).catch(() => undefined)
-        await rmdir(lockPath).catch(() => undefined)
       }
+      throw cleanupError
+    }
+    if (!completed) throw primaryError
+    return result as T
+  }
+
+  return {
+    read: readCurrent,
+    async compareAndSwap(expectedDigest, receipt) {
+      return runExclusive((session) =>
+        session.compareAndSwap(expectedDigest, receipt)
+      )
     },
+    runExclusive,
   }
 }
 
@@ -1182,11 +1400,9 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
     left.configId.localeCompare(right.configId)
   )
   const excludedByAlias = new Map<string, FrozenExcludedConfiguration>()
-  const excludedConfigAliasById = new Map<string, string>()
   sortedExcluded.forEach((configuration, index) => {
     const alias = `excluded-config-${padAlias(index)}`
     excludedByAlias.set(alias, configuration)
-    excludedConfigAliasById.set(configuration.configId, alias)
   })
   const excludedChatbotAliasForId = new Map<string, string>()
   ;[...new Set(sortedExcluded.map((configuration) => configuration.chatbotId))]
@@ -1219,7 +1435,6 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
     configByAlias,
     configsByChatbotAlias,
     excludedByAlias,
-    excludedConfigAliasById,
     excludedChatbotAliasForId,
     bindingAliasByChatbotAlias,
     aliases: {
@@ -1229,6 +1444,7 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
       courses: [...courseIdByAlias.keys()].sort(),
       chatbots: [...chatbotIdByAlias.keys()].sort(),
       configurations: [...configByAlias.keys()].sort(),
+      bindings: [...bindingAliasByChatbotAlias.values()].sort(),
       excludedConfigurations: [...excludedByAlias.keys()].sort(),
     },
     counts: {
@@ -1375,6 +1591,7 @@ function assertReceiptAliases(value: unknown): asserts value is ReceiptAliases {
     'courses',
     'chatbots',
     'configurations',
+    'bindings',
     'excludedConfigurations',
   ])
   if (
@@ -1394,6 +1611,11 @@ function assertReceiptAliases(value: unknown): asserts value is ReceiptAliases {
     value.configurations,
     CONFIGURATION_ALIAS_PATTERN,
     EXPECTED_CONFIGURATIONS
+  )
+  assertReceiptAliasArray(
+    value.bindings,
+    BINDING_ALIAS_PATTERN,
+    EXPECTED_BINDINGS
   )
   assertReceiptAliasArray(
     value.excludedConfigurations,
@@ -1471,9 +1693,9 @@ function assertModeForReceipt(value: unknown): asserts value is string {
 
 function assertReceiptBindingSnapshots(
   value: unknown,
-  expectedLength: number
+  aliases: string[]
 ): void {
-  if (!Array.isArray(value) || value.length !== expectedLength) {
+  if (!Array.isArray(value) || value.length !== aliases.length) {
     receiptInvalid('receipt binding snapshots are invalid')
   }
   const seen = new Set<string>()
@@ -1498,6 +1720,9 @@ function assertReceiptBindingSnapshots(
     if (seen.has(entry.alias))
       receiptInvalid('receipt snapshots are duplicated')
     seen.add(entry.alias)
+  }
+  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+    receiptInvalid('receipt binding snapshot aliases are invalid')
   }
 }
 
@@ -1524,7 +1749,9 @@ function assertReceiptServerSnapshot(
   }
 }
 
-function assertReceiptCommonFields(value: Record<string, unknown>): void {
+function assertReceiptCommonFields(
+  value: Record<string, unknown>
+): asserts value is Record<string, unknown> & { aliases: ReceiptAliases } {
   if (value.receiptVersion !== ACTIVATION_RECEIPT_VERSION) {
     receiptInvalid('receipt version is unsupported')
   }
@@ -1580,7 +1807,6 @@ function assertPayloadShape(
   ) {
     receiptInvalid('receipt state is invalid')
   }
-  assertReceiptAliases(value.aliases)
   const aliases = value.aliases
   assertReceiptServerSnapshot(value.sourceServer, SOURCE_SERVER_NAME)
   assertReceiptServerSnapshot(value.targetServer, TARGET_SERVER_NAME)
@@ -1610,7 +1836,7 @@ function assertPayloadShape(
     EXCLUDED_CONFIGURATION_ALIAS_PATTERN,
     EXCLUDED_CHATBOT_ALIAS_PATTERN
   )
-  assertReceiptBindingSnapshots(value.bindings, EXPECTED_BINDINGS)
+  assertReceiptBindingSnapshots(value.bindings, aliases.bindings)
   assertReceiptConfigSnapshots(
     value.configurations,
     aliases.configurations,
@@ -1689,7 +1915,7 @@ function isReceiptIntent(
 }
 
 async function readReceipt(
-  receiptStore: ActivationReceiptStore | undefined
+  receiptStore: ActivationReceiptSession | undefined
 ): Promise<ActivationReceiptPayload | null> {
   if (!receiptStore) return null
   const payload = await receiptStore.read()
@@ -1711,6 +1937,164 @@ function assertReceiptMatchesIndex(
   }
   if (canonicalJson(receipt.aliases) !== canonicalJson(index.aliases)) {
     fail('RECEIPT_MISMATCH', 'receipt aliases do not match the manifest')
+  }
+  if (!isReceiptIntent(receipt)) {
+    assertReceiptSemantics(receipt, index)
+  }
+}
+
+function assertReceiptSemantics(
+  receipt: ActivationReceipt,
+  index: ManifestIndex
+): void {
+  const expectedBindingAliases = new Set(index.aliases.bindings)
+  const actualBindingAliases = new Set(
+    receipt.bindings.map((binding) => binding.alias)
+  )
+  if (
+    actualBindingAliases.size !== expectedBindingAliases.size ||
+    [...expectedBindingAliases].some(
+      (alias) => !actualBindingAliases.has(alias)
+    )
+  ) {
+    fail(
+      'RECEIPT_MISMATCH',
+      'receipt binding aliases do not match the manifest'
+    )
+  }
+
+  const chatbotAliases = new Set(index.aliases.chatbots)
+  const switchedAliases = new Set(receipt.switchedChatbotAliases)
+  const rollbackAliases = new Set(receipt.pendingRollbackAliases)
+  if (
+    [...switchedAliases].some((alias) => !chatbotAliases.has(alias)) ||
+    [...rollbackAliases].some((alias) => !chatbotAliases.has(alias)) ||
+    (receipt.pendingChatbotAlias !== null &&
+      !chatbotAliases.has(receipt.pendingChatbotAlias))
+  ) {
+    fail(
+      'RECEIPT_MISMATCH',
+      'receipt chatbot aliases do not match the manifest'
+    )
+  }
+  if (
+    receipt.pendingChatbotAlias !== null &&
+    switchedAliases.has(receipt.pendingChatbotAlias)
+  ) {
+    fail('RECEIPT_STATE', 'receipt switch intent overlaps switched aliases')
+  }
+  if (rollbackAliases.size > 1) {
+    fail('RECEIPT_STATE', 'receipt rollback intent names multiple chatbots')
+  }
+  if ([...rollbackAliases].some((alias) => !switchedAliases.has(alias))) {
+    fail('RECEIPT_STATE', 'receipt rollback intent names an unswitched chatbot')
+  }
+
+  const bindingByAlias = new Map(
+    receipt.bindings.map((binding) => [binding.alias, binding])
+  )
+  const configurationByAlias = new Map(
+    receipt.configurations.map((configuration) => [
+      configuration.alias,
+      configuration,
+    ])
+  )
+  const enabledAliases = new Set<string>()
+  for (const chatbotAlias of index.aliases.chatbots) {
+    const bindingAlias = index.bindingAliasByChatbotAlias.get(chatbotAlias)
+    const binding = bindingAlias ? bindingByAlias.get(bindingAlias) : undefined
+    const chatbotId = index.chatbotIdByAlias.get(chatbotAlias)
+    if (!chatbotId) {
+      fail(
+        'RECEIPT_MISMATCH',
+        'receipt chatbot mapping does not match the manifest'
+      )
+    }
+    if (
+      !binding ||
+      binding.alias !== bindingAlias ||
+      binding.chatbotAlias !== chatbotAlias ||
+      binding.corpusAlias !== corpusAliasFor(index, chatbotId)
+    ) {
+      fail(
+        'RECEIPT_MISMATCH',
+        'receipt binding mapping does not match the manifest'
+      )
+    }
+    const expectedConfigurations = [...index.configByAlias.entries()].filter(
+      ([, configuration]) =>
+        chatbotAliasFor(index, configuration.chatbotId) === chatbotAlias
+    )
+    const configurations = expectedConfigurations.map(([alias]) =>
+      configurationByAlias.get(alias)
+    )
+    if (
+      configurations.length === 0 ||
+      configurations.some((configuration) => !configuration) ||
+      expectedConfigurations.some(([alias, expected], index) => {
+        const configuration = configurations[index]
+        return (
+          !configuration ||
+          configuration.alias !== alias ||
+          configuration.chatbotAlias !== chatbotAlias ||
+          configuration.chatMode !== expected.chatMode
+        )
+      })
+    ) {
+      fail(
+        'RECEIPT_MISMATCH',
+        'receipt configuration mapping does not match the manifest'
+      )
+    }
+    const enabled = [
+      binding.isEnabled,
+      ...configurations.map((configuration) => configuration!.isEnabled),
+    ]
+    if (!enabled.every((value) => value === enabled[0])) {
+      fail('RECEIPT_STATE', 'receipt chatbot snapshots are mixed')
+    }
+    if (enabled[0]) enabledAliases.add(chatbotAlias)
+  }
+  if (
+    enabledAliases.size !== switchedAliases.size ||
+    [...enabledAliases].some((alias) => !switchedAliases.has(alias))
+  ) {
+    fail(
+      'RECEIPT_STATE',
+      'receipt enabled snapshots do not match switched aliases'
+    )
+  }
+
+  if (receipt.state === 'prepared') {
+    if (
+      switchedAliases.size !== 0 ||
+      receipt.pendingChatbotAlias !== null ||
+      rollbackAliases.size !== 0
+    ) {
+      fail('RECEIPT_STATE', 'prepared receipt intent fields are invalid')
+    }
+  } else if (receipt.state === 'switching') {
+    if (receipt.pendingChatbotAlias === null || rollbackAliases.size !== 0) {
+      fail('RECEIPT_STATE', 'switching receipt intent fields are invalid')
+    }
+  } else if (receipt.state === 'switched') {
+    if (
+      switchedAliases.size === 0 ||
+      receipt.pendingChatbotAlias !== null ||
+      rollbackAliases.size !== 0
+    ) {
+      fail('RECEIPT_STATE', 'switched receipt intent fields are invalid')
+    }
+  } else if (receipt.state === 'rolling_back') {
+    if (receipt.pendingChatbotAlias !== null || rollbackAliases.size !== 1) {
+      fail('RECEIPT_STATE', 'rollback receipt intent fields are invalid')
+    }
+  } else if (
+    switchedAliases.size !== 0 ||
+    receipt.pendingChatbotAlias !== null ||
+    rollbackAliases.size !== 0
+  ) {
+    fail('RECEIPT_STATE', 'rolled-back receipt intent fields are invalid')
   }
 }
 
@@ -2667,9 +3051,7 @@ export async function dryRunCohortActivation(
     expectedManifestFingerprint
   )
   const state = await inspectCohortState(store, index, target)
-  if (state.targetServer) {
-    assertTargetGroupsCoherent(state, index)
-  }
+  assertNoUntrackedPartialTargetRows(state, index)
   assertNoEnabledTargetRows(state)
   return operationResult(
     'dry-run',
@@ -2685,11 +3067,6 @@ export async function prepareCohortActivation(
   options: ActivationOptions
 ): Promise<ActivationResult> {
   validateTarget(options.target)
-  const index = buildManifestIndex(manifest)
-  const manifestFingerprint = requireManifestFingerprint(
-    manifest,
-    options.expectedManifestFingerprint
-  )
   if (options.dryRun) {
     return dryRunCohortActivation(
       store,
@@ -2698,6 +3075,11 @@ export async function prepareCohortActivation(
       options.expectedManifestFingerprint
     )
   }
+  const index = buildManifestIndex(manifest)
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    options.expectedManifestFingerprint
+  )
   if (!options.receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
@@ -2838,7 +3220,7 @@ export async function prepareCohortActivation(
 
 async function prepareOrReadReceipt(
   manifest: FrozenCohortManifest,
-  receiptStore: ActivationReceiptStore,
+  receiptStore: ActivationReceiptSession,
   expectedManifestFingerprint: string
 ): Promise<{
   index: ManifestIndex
@@ -2919,21 +3301,48 @@ export async function switchCohortChatbot(
     options.expectedManifestFingerprint
   )
   resolveChatbotAlias(index, options.chatbotAlias)
-  if (!options.receiptStore) {
+  const receiptStore = options.receiptStore
+  if (!receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
-  const { receipt } = await prepareOrReadReceipt(
-    manifest,
-    options.receiptStore,
-    options.expectedManifestFingerprint
-  )
-  validateReceiptState(receipt, ['prepared', 'switched'])
+  const execute = async (
+    session: ActivationReceiptSession
+  ): Promise<ActivationResult> => {
+    const receipt = requireReceipt(
+      await readReceipt(session),
+      index,
+      manifestFingerprint
+    )
+    validateReceiptState(receipt, ['prepared', 'switched'])
 
-  const currentState = await inspectCohortState(store, index, options.target)
-  assertReceiptCurrent(currentState, index, receipt)
-  assertTargetGroupsCoherent(currentState, index)
-  assertNoEnabledOtherBinding(currentState, options.chatbotAlias)
-  if (options.dryRun) {
+    const currentState = await inspectCohortState(store, index, options.target)
+    assertReceiptCurrent(currentState, index, receipt)
+    assertTargetGroupsCoherent(currentState, index)
+    assertNoEnabledOtherBinding(currentState, options.chatbotAlias)
+    if (options.dryRun) {
+      if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
+        assertCandidateGroup(
+          currentState,
+          index,
+          options.chatbotAlias,
+          'switched'
+        )
+      } else {
+        assertCandidateGroup(
+          currentState,
+          index,
+          options.chatbotAlias,
+          'prepared'
+        )
+      }
+      return operationResult(
+        'dry-run',
+        index,
+        manifestFingerprint,
+        zeroWrites(),
+        receipt
+      )
+    }
     if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
       assertCandidateGroup(
         currentState,
@@ -2941,76 +3350,59 @@ export async function switchCohortChatbot(
         options.chatbotAlias,
         'switched'
       )
-    } else {
-      assertCandidateGroup(
-        currentState,
+      return operationResult(
+        'switched',
         index,
-        options.chatbotAlias,
-        'prepared'
+        manifestFingerprint,
+        zeroWrites(),
+        receipt
       )
     }
-    return operationResult(
-      'dry-run',
+    assertCandidateGroup(currentState, index, options.chatbotAlias, 'prepared')
+
+    const switchingReceipt = makeReceiptFromState(
+      currentState,
       index,
       manifestFingerprint,
-      zeroWrites(),
-      receipt
+      {
+        state: 'switching',
+        switchedChatbotAliases: receipt.switchedChatbotAliases,
+        pendingChatbotAlias: options.chatbotAlias,
+      }
     )
-  }
-  if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
-    assertCandidateGroup(currentState, index, options.chatbotAlias, 'switched')
+    await session.compareAndSwap(receipt.payloadDigest, switchingReceipt)
+
+    const switchedReceipt = await store.transaction(async (tx) => {
+      const state = await inspectCohortState(tx, index, options.target)
+      assertReceiptCurrent(state, index, receipt)
+      assertTargetGroupsCoherent(state, index)
+      assertCandidateGroup(state, index, options.chatbotAlias, 'prepared')
+      assertNoEnabledOtherBinding(state, options.chatbotAlias)
+      await applyChatbotSwitch(tx, state, index, options.chatbotAlias, true)
+      const after = await inspectCohortState(tx, index, options.target)
+      return makeReceiptFromState(after, index, manifestFingerprint, {
+        state: 'switched',
+        switchedChatbotAliases: [
+          ...receipt.switchedChatbotAliases,
+          options.chatbotAlias,
+        ],
+      })
+    })
+    await session.compareAndSwap(
+      switchingReceipt.payloadDigest,
+      switchedReceipt
+    )
     return operationResult(
       'switched',
       index,
       manifestFingerprint,
       zeroWrites(),
-      receipt
+      switchedReceipt
     )
   }
-  assertCandidateGroup(currentState, index, options.chatbotAlias, 'prepared')
 
-  const switchingReceipt = makeReceiptFromState(
-    currentState,
-    index,
-    manifestFingerprint,
-    {
-      state: 'switching',
-      switchedChatbotAliases: receipt.switchedChatbotAliases,
-      pendingChatbotAlias: options.chatbotAlias,
-    }
-  )
-  await options.receiptStore.compareAndSwap(
-    receipt.payloadDigest,
-    switchingReceipt
-  )
-
-  const switchedReceipt = await store.transaction(async (tx) => {
-    const state = await inspectCohortState(tx, index, options.target)
-    assertReceiptCurrent(state, index, receipt)
-    assertTargetGroupsCoherent(state, index)
-    assertCandidateGroup(state, index, options.chatbotAlias, 'prepared')
-    assertNoEnabledOtherBinding(state, options.chatbotAlias)
-    await applyChatbotSwitch(tx, state, index, options.chatbotAlias, true)
-    const after = await inspectCohortState(tx, index, options.target)
-    return makeReceiptFromState(after, index, manifestFingerprint, {
-      state: 'switched',
-      switchedChatbotAliases: [
-        ...receipt.switchedChatbotAliases,
-        options.chatbotAlias,
-      ],
-    })
-  })
-  await options.receiptStore.compareAndSwap(
-    switchingReceipt.payloadDigest,
-    switchedReceipt
-  )
-  return operationResult(
-    'switched',
-    index,
-    manifestFingerprint,
-    zeroWrites(),
-    switchedReceipt
-  )
+  if (options.dryRun) return execute(receiptStore)
+  return receiptStore.runExclusive(execute)
 }
 
 export async function rollbackCohortChatbot(
@@ -3025,132 +3417,131 @@ export async function rollbackCohortChatbot(
     options.expectedManifestFingerprint
   )
   resolveChatbotAlias(index, options.chatbotAlias)
-  if (!options.receiptStore) {
+  const receiptStore = options.receiptStore
+  if (!receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
-  const { receipt } = await prepareOrReadReceipt(
-    manifest,
-    options.receiptStore,
-    options.expectedManifestFingerprint
-  )
-  validateReceiptState(receipt, ['switched', 'switching', 'rolling_back'])
-  if (
-    !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
-    !(
-      receipt.state === 'switching' &&
-      receipt.pendingChatbotAlias === options.chatbotAlias
+  const execute = async (
+    session: ActivationReceiptSession
+  ): Promise<ActivationResult> => {
+    const receipt = requireReceipt(
+      await readReceipt(session),
+      index,
+      manifestFingerprint
     )
-  ) {
-    fail('RECEIPT_STATE', 'chatbot was not switched')
-  }
-  if (
-    (receipt.state === 'rolling_back' || receipt.state === 'switching') &&
-    receipt.state !== 'switching' &&
-    !receipt.pendingRollbackAliases.includes(options.chatbotAlias)
-  ) {
-    fail('RECEIPT_STATE', 'rollback intent does not name the chatbot')
-  }
-
-  const stateBefore = await inspectCohortState(store, index, options.target)
-  const pending =
-    receipt.state === 'rolling_back' || receipt.state === 'switching'
-  assertReceiptCurrent(
-    stateBefore,
-    index,
-    receipt,
-    pending ? { pendingChatbotAlias: options.chatbotAlias } : {}
-  )
-  assertTargetGroupsCoherent(stateBefore, index)
-  assertNoEnabledOtherBinding(stateBefore, options.chatbotAlias)
-  if (!pending) {
-    assertCandidateGroup(stateBefore, index, options.chatbotAlias, 'switched')
-  } else {
-    const current = groupState(stateBefore, index, options.chatbotAlias)
-    if (current !== 'switched' && current !== 'prepared') {
-      fail('MIXED_STATE', 'the selected chatbot group is mixed')
+    validateReceiptState(receipt, ['switched', 'switching', 'rolling_back'])
+    if (
+      !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
+      !(
+        receipt.state === 'switching' &&
+        receipt.pendingChatbotAlias === options.chatbotAlias
+      )
+    ) {
+      fail('RECEIPT_STATE', 'chatbot was not switched')
     }
-  }
-  if (options.dryRun) {
+    if (
+      (receipt.state === 'rolling_back' || receipt.state === 'switching') &&
+      receipt.state !== 'switching' &&
+      !receipt.pendingRollbackAliases.includes(options.chatbotAlias)
+    ) {
+      fail('RECEIPT_STATE', 'rollback intent does not name the chatbot')
+    }
+
+    const stateBefore = await inspectCohortState(store, index, options.target)
+    const pending =
+      receipt.state === 'rolling_back' || receipt.state === 'switching'
+    assertReceiptCurrent(
+      stateBefore,
+      index,
+      receipt,
+      pending ? { pendingChatbotAlias: options.chatbotAlias } : {}
+    )
+    assertTargetGroupsCoherent(stateBefore, index)
+    assertNoEnabledOtherBinding(stateBefore, options.chatbotAlias)
+    if (!pending) {
+      assertCandidateGroup(stateBefore, index, options.chatbotAlias, 'switched')
+    } else {
+      const current = groupState(stateBefore, index, options.chatbotAlias)
+      if (current !== 'switched' && current !== 'prepared') {
+        fail('MIXED_STATE', 'the selected chatbot group is mixed')
+      }
+    }
+    if (options.dryRun) {
+      return operationResult(
+        'dry-run',
+        index,
+        manifestFingerprint,
+        zeroWrites(),
+        receipt
+      )
+    }
+
+    let rollbackReceipt = receipt
+    if (!pending) {
+      rollbackReceipt = makeReceiptFromState(
+        stateBefore,
+        index,
+        manifestFingerprint,
+        {
+          state: 'rolling_back',
+          switchedChatbotAliases: receipt.switchedChatbotAliases,
+          pendingRollbackAliases: [options.chatbotAlias],
+        }
+      )
+      await session.compareAndSwap(receipt.payloadDigest, rollbackReceipt)
+    } else if (receipt.state === 'switching') {
+      const current = groupState(stateBefore, index, options.chatbotAlias)
+      rollbackReceipt = makeReceiptFromState(
+        stateBefore,
+        index,
+        manifestFingerprint,
+        {
+          state: 'rolling_back',
+          switchedChatbotAliases:
+            current === 'switched'
+              ? [...receipt.switchedChatbotAliases, options.chatbotAlias]
+              : receipt.switchedChatbotAliases,
+          pendingRollbackAliases: [options.chatbotAlias],
+        }
+      )
+      await session.compareAndSwap(receipt.payloadDigest, rollbackReceipt)
+    }
+
+    const finalReceipt = await store.transaction(async (tx) => {
+      const state = await inspectCohortState(tx, index, options.target)
+      assertReceiptCurrent(state, index, rollbackReceipt, {
+        pendingChatbotAlias: options.chatbotAlias,
+      })
+      assertTargetGroupsCoherent(state, index)
+      assertNoEnabledOtherBinding(state, options.chatbotAlias)
+      const current = groupState(state, index, options.chatbotAlias)
+      if (current !== 'switched' && current !== 'prepared') {
+        fail('MIXED_STATE', 'the selected chatbot group is mixed')
+      }
+      if (current === 'switched') {
+        await applyChatbotSwitch(tx, state, index, options.chatbotAlias, false)
+      }
+      const remaining = rollbackReceipt.switchedChatbotAliases.filter(
+        (alias) => alias !== options.chatbotAlias
+      )
+      const after = await inspectCohortState(tx, index, options.target)
+      return makeReceiptFromState(after, index, manifestFingerprint, {
+        state: remaining.length === 0 ? 'rolled_back' : 'switched',
+        switchedChatbotAliases: remaining,
+      })
+    })
+    await session.compareAndSwap(rollbackReceipt.payloadDigest, finalReceipt)
     return operationResult(
-      'dry-run',
+      finalReceipt.state === 'rolled_back' ? 'rolled_back' : 'switched',
       index,
       manifestFingerprint,
       zeroWrites(),
-      receipt
+      finalReceipt
     )
   }
 
-  let rollbackReceipt = receipt
-  if (!pending) {
-    rollbackReceipt = makeReceiptFromState(
-      stateBefore,
-      index,
-      manifestFingerprint,
-      {
-        state: 'rolling_back',
-        switchedChatbotAliases: receipt.switchedChatbotAliases,
-        pendingRollbackAliases: [options.chatbotAlias],
-      }
-    )
-    await options.receiptStore.compareAndSwap(
-      receipt.payloadDigest,
-      rollbackReceipt
-    )
-  } else if (receipt.state === 'switching') {
-    rollbackReceipt = makeReceiptFromState(
-      stateBefore,
-      index,
-      manifestFingerprint,
-      {
-        state: 'rolling_back',
-        switchedChatbotAliases: receipt.switchedChatbotAliases.includes(
-          options.chatbotAlias
-        )
-          ? receipt.switchedChatbotAliases
-          : [...receipt.switchedChatbotAliases, options.chatbotAlias],
-        pendingRollbackAliases: [options.chatbotAlias],
-      }
-    )
-    await options.receiptStore.compareAndSwap(
-      receipt.payloadDigest,
-      rollbackReceipt
-    )
-  }
-
-  const finalReceipt = await store.transaction(async (tx) => {
-    const state = await inspectCohortState(tx, index, options.target)
-    assertReceiptCurrent(state, index, rollbackReceipt, {
-      pendingChatbotAlias: options.chatbotAlias,
-    })
-    assertTargetGroupsCoherent(state, index)
-    assertNoEnabledOtherBinding(state, options.chatbotAlias)
-    const current = groupState(state, index, options.chatbotAlias)
-    if (current !== 'switched' && current !== 'prepared') {
-      fail('MIXED_STATE', 'the selected chatbot group is mixed')
-    }
-    if (current === 'switched') {
-      await applyChatbotSwitch(tx, state, index, options.chatbotAlias, false)
-    }
-    const remaining = rollbackReceipt.switchedChatbotAliases.filter(
-      (alias) => alias !== options.chatbotAlias
-    )
-    const after = await inspectCohortState(tx, index, options.target)
-    return makeReceiptFromState(after, index, manifestFingerprint, {
-      state: remaining.length === 0 ? 'rolled_back' : 'switched',
-      switchedChatbotAliases: remaining,
-    })
-  })
-  await options.receiptStore.compareAndSwap(
-    rollbackReceipt.payloadDigest,
-    finalReceipt
-  )
-  return operationResult(
-    finalReceipt.state === 'rolled_back' ? 'rolled_back' : 'switched',
-    index,
-    manifestFingerprint,
-    zeroWrites(),
-    finalReceipt
-  )
+  if (options.dryRun) return execute(receiptStore)
+  return receiptStore.runExclusive(execute)
 }
 
 export async function readbackCohortActivation(

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -268,6 +268,8 @@ export type ActivationReceiptState =
   | 'rolling_back'
   | 'rolled_back'
 
+type ActivationRollbackOrigin = 'switched' | 'switching'
+
 export type ActivationReceipt = {
   receiptVersion: typeof ACTIVATION_RECEIPT_VERSION
   manifestFingerprint: string
@@ -285,6 +287,7 @@ export type ActivationReceipt = {
   switchedChatbotAliases: string[]
   pendingChatbotAlias: string | null
   pendingRollbackAliases: string[]
+  pendingRollbackOrigin: ActivationRollbackOrigin | null
   state: ActivationReceiptState
   payloadDigest: string
 }
@@ -1794,6 +1797,7 @@ function assertPayloadShape(
     'switchedChatbotAliases',
     'pendingChatbotAlias',
     'pendingRollbackAliases',
+    'pendingRollbackOrigin',
     'state',
     'payloadDigest',
   ])
@@ -1867,6 +1871,13 @@ function assertPayloadShape(
     CHATBOT_ALIAS_PATTERN,
     pendingRollbackAliases.length
   )
+  if (
+    value.pendingRollbackOrigin !== null &&
+    value.pendingRollbackOrigin !== 'switched' &&
+    value.pendingRollbackOrigin !== 'switching'
+  ) {
+    receiptInvalid('receipt rollback origin is invalid')
+  }
 }
 
 function assertPayloadDigest(
@@ -1966,6 +1977,7 @@ function assertReceiptSemantics(
   const chatbotAliases = new Set(index.aliases.chatbots)
   const switchedAliases = new Set(receipt.switchedChatbotAliases)
   const rollbackAliases = new Set(receipt.pendingRollbackAliases)
+  const rollbackOrigin = receipt.pendingRollbackOrigin
   if (
     [...switchedAliases].some((alias) => !chatbotAliases.has(alias)) ||
     [...rollbackAliases].some((alias) => !chatbotAliases.has(alias)) ||
@@ -1986,7 +1998,10 @@ function assertReceiptSemantics(
   if (rollbackAliases.size > 1) {
     fail('RECEIPT_STATE', 'receipt rollback intent names multiple chatbots')
   }
-  if ([...rollbackAliases].some((alias) => !switchedAliases.has(alias))) {
+  if (
+    rollbackOrigin !== 'switching' &&
+    [...rollbackAliases].some((alias) => !switchedAliases.has(alias))
+  ) {
     fail('RECEIPT_STATE', 'receipt rollback intent names an unswitched chatbot')
   }
 
@@ -2069,30 +2084,41 @@ function assertReceiptSemantics(
     if (
       switchedAliases.size !== 0 ||
       receipt.pendingChatbotAlias !== null ||
-      rollbackAliases.size !== 0
+      rollbackAliases.size !== 0 ||
+      rollbackOrigin !== null
     ) {
       fail('RECEIPT_STATE', 'prepared receipt intent fields are invalid')
     }
   } else if (receipt.state === 'switching') {
-    if (receipt.pendingChatbotAlias === null || rollbackAliases.size !== 0) {
+    if (
+      receipt.pendingChatbotAlias === null ||
+      rollbackAliases.size !== 0 ||
+      rollbackOrigin !== null
+    ) {
       fail('RECEIPT_STATE', 'switching receipt intent fields are invalid')
     }
   } else if (receipt.state === 'switched') {
     if (
       switchedAliases.size === 0 ||
       receipt.pendingChatbotAlias !== null ||
-      rollbackAliases.size !== 0
+      rollbackAliases.size !== 0 ||
+      rollbackOrigin !== null
     ) {
       fail('RECEIPT_STATE', 'switched receipt intent fields are invalid')
     }
   } else if (receipt.state === 'rolling_back') {
-    if (receipt.pendingChatbotAlias !== null || rollbackAliases.size !== 1) {
+    if (
+      receipt.pendingChatbotAlias !== null ||
+      rollbackAliases.size !== 1 ||
+      (rollbackOrigin !== 'switched' && rollbackOrigin !== 'switching')
+    ) {
       fail('RECEIPT_STATE', 'rollback receipt intent fields are invalid')
     }
   } else if (
     switchedAliases.size !== 0 ||
     receipt.pendingChatbotAlias !== null ||
-    rollbackAliases.size !== 0
+    rollbackAliases.size !== 0 ||
+    rollbackOrigin !== null
   ) {
     fail('RECEIPT_STATE', 'rolled-back receipt intent fields are invalid')
   }
@@ -2844,6 +2870,7 @@ function makeReceiptFromState(
     switchedChatbotAliases: string[]
     pendingChatbotAlias?: string | null
     pendingRollbackAliases?: string[]
+    pendingRollbackOrigin?: ActivationRollbackOrigin | null
   }
 ): ActivationReceipt {
   if (!state.targetServer) {
@@ -2939,6 +2966,7 @@ function makeReceiptFromState(
     pendingRollbackAliases: [
       ...new Set(input.pendingRollbackAliases ?? []),
     ].sort(),
+    pendingRollbackOrigin: input.pendingRollbackOrigin ?? null,
     state: input.state,
   })
 }
@@ -3433,8 +3461,11 @@ export async function rollbackCohortChatbot(
     if (
       !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
       !(
-        receipt.state === 'switching' &&
-        receipt.pendingChatbotAlias === options.chatbotAlias
+        (receipt.state === 'switching' &&
+          receipt.pendingChatbotAlias === options.chatbotAlias) ||
+        (receipt.state === 'rolling_back' &&
+          receipt.pendingRollbackOrigin === 'switching' &&
+          receipt.pendingRollbackAliases.includes(options.chatbotAlias))
       )
     ) {
       fail('RECEIPT_STATE', 'chatbot was not switched')
@@ -3486,8 +3517,10 @@ export async function rollbackCohortChatbot(
           state: 'rolling_back',
           switchedChatbotAliases: receipt.switchedChatbotAliases,
           pendingRollbackAliases: [options.chatbotAlias],
+          pendingRollbackOrigin: 'switched',
         }
       )
+      assertReceiptMatchesIndex(rollbackReceipt, index, manifestFingerprint)
       await session.compareAndSwap(receipt.payloadDigest, rollbackReceipt)
     } else if (receipt.state === 'switching') {
       const current = groupState(stateBefore, index, options.chatbotAlias)
@@ -3502,8 +3535,10 @@ export async function rollbackCohortChatbot(
               ? [...receipt.switchedChatbotAliases, options.chatbotAlias]
               : receipt.switchedChatbotAliases,
           pendingRollbackAliases: [options.chatbotAlias],
+          pendingRollbackOrigin: 'switching',
         }
       )
+      assertReceiptMatchesIndex(rollbackReceipt, index, manifestFingerprint)
       await session.compareAndSwap(receipt.payloadDigest, rollbackReceipt)
     }
 

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -9,7 +9,7 @@ import {
   unlink,
 } from 'node:fs/promises'
 import { hostname } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 
 export const SOURCE_SERVER_NAME = 'Klicker-compat' as const
@@ -988,15 +988,6 @@ async function acquireReceiptLock(lockPath: string): Promise<ReceiptLockOwner> {
   if (!(await tryCreateReceiptLock(lockPath, owner))) {
     const existingOwner = await readLockOwner(lockPath)
     if (!existingOwner) throw lockError()
-    let dead = false
-    if (existingOwner.host === hostname()) {
-      try {
-        process.kill(existingOwner.pid, 0)
-      } catch (probeError) {
-        dead = errorCode(probeError) === 'ESRCH'
-      }
-    }
-    if (!dead) throw lockError()
     await reclaimDeadLock(lockPath, existingOwner)
     if (!(await tryCreateReceiptLock(lockPath, owner))) throw lockError()
   }

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -3158,7 +3158,7 @@ function validateTarget(target: ActivationTarget): void {
 
 function validateReceiptState(
   receipt: ActivationReceipt,
-  allowed: ActivationReceiptState[]
+  allowed: readonly ActivationReceiptState[]
 ): void {
   if (!allowed.includes(receipt.state)) {
     fail('RECEIPT_STATE', 'receipt state is not valid for this operation')
@@ -3503,7 +3503,7 @@ async function requireSessionReceipt(
   session: ActivationReceiptSession,
   index: ReturnType<typeof buildManifestIndex>,
   manifestFingerprint: string,
-  allowedStates: readonly string[]
+  allowedStates: readonly ActivationReceiptState[]
 ) {
   const receipt = requireReceipt(
     await readReceipt(session),

--- a/packages/prisma-data/src/scripts/cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/cohort-activation.ts
@@ -1,5 +1,13 @@
-import { createHash } from 'node:crypto'
-import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  rmdir,
+  writeFile,
+} from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 
@@ -7,6 +15,7 @@ export const SOURCE_SERVER_NAME = 'Klicker-compat' as const
 export const TARGET_SERVER_NAME = 'KB' as const
 export const TARGET_AUTH_TYPE = 'scope_token' as const
 export const DOC_QUERY_TOOL = 'doc_query' as const
+export const SOURCE_CHATBOT_ID_HEADER = 'Chatbot-ID' as const
 export const ACTIVATION_RECEIPT_VERSION = 1 as const
 
 export const EXPECTED_CORPORA = 15 as const
@@ -23,10 +32,17 @@ export const EXCLUDED_SOURCE_TOOLS = [
   'vorkurs2_expert',
 ] as const
 
+export const EXPECTED_EXCLUDED_TOOL_COUNTS = {
+  bf1_expert: 2,
+  df_cf2_expert: 1,
+  vorkurs2_expert: 1,
+} as const
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
 const MODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+const FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/i
 const CONTROL_CHARACTER_PATTERN = /\p{Cc}/u
 
 export type JsonValue =
@@ -97,6 +113,12 @@ export type KnowledgeBaseRecord = {
 export type ChatbotRecord = {
   id: string
   courseId: string
+  ownerId: string
+  updatedAt: Date
+}
+
+export type CourseRecord = {
+  id: string
   ownerId: string
   updatedAt: Date
 }
@@ -173,6 +195,7 @@ export type ActivationConfigCreate = {
 export type ActivationTransactionStore = {
   findKnowledgeBaseById(id: string): Promise<KnowledgeBaseRecord | null>
   findKnowledgeBasesByName(name: string): Promise<KnowledgeBaseRecord[]>
+  findCourseById(id: string): Promise<CourseRecord | null>
   findChatbotById(id: string): Promise<ChatbotRecord | null>
   findServersByName(name: string): Promise<ActivationServerRecord[]>
   findConfigById(id: string): Promise<ActivationConfigRecord | null>
@@ -204,8 +227,10 @@ export type ReceiptAliases = {
   sourceServer: typeof SOURCE_SERVER_NAME
   targetServer: typeof TARGET_SERVER_NAME
   corpora: string[]
+  courses: string[]
   chatbots: string[]
   configurations: string[]
+  excludedConfigurations: string[]
 }
 
 export type ReceiptCounts = {
@@ -257,8 +282,10 @@ export type ActivationReceipt = {
   sourceServer: SafeServerSnapshot
   targetServer: SafeServerSnapshot
   corpora: SafeIdentitySnapshot[]
+  courses: SafeIdentitySnapshot[]
   chatbots: SafeIdentitySnapshot[]
   legacyConfigurations: SafeConfigSnapshot[]
+  excludedConfigurations: SafeConfigSnapshot[]
   bindings: SafeBindingSnapshot[]
   configurations: SafeConfigSnapshot[]
   switchedChatbotAliases: string[]
@@ -283,10 +310,14 @@ export type ActivationReceiptPayload =
 
 export interface ActivationReceiptStore {
   read(): Promise<ActivationReceiptPayload | null>
-  write(receipt: ActivationReceiptPayload): Promise<void>
+  compareAndSwap(
+    expectedDigest: string | null,
+    receipt: ActivationReceiptPayload
+  ): Promise<void>
 }
 
 export type ActivationOptions = {
+  expectedManifestFingerprint: string
   receiptStore?: ActivationReceiptStore
   target: ActivationTarget
   dryRun?: boolean
@@ -306,7 +337,9 @@ export type ActivationResult = {
   aliases: {
     sourceServer: typeof SOURCE_SERVER_NAME
     targetServer: typeof TARGET_SERVER_NAME
+    courseAliases: string[]
     chatbotAliases: string[]
+    excludedConfigurationAliases: string[]
     switchedChatbotAliases: string[]
   }
   fingerprints: {
@@ -331,10 +364,15 @@ export class CohortActivationError extends Error {
 type ManifestIndex = {
   corpusByAlias: Map<string, FrozenCorpus>
   corpusAliasByChatbotId: Map<string, string>
+  courseAliasForId: Map<string, string>
+  courseIdByAlias: Map<string, string>
   chatbotAliasForId: Map<string, string>
   chatbotIdByAlias: Map<string, string>
   configByAlias: Map<string, FrozenConfiguration>
   configsByChatbotAlias: Map<string, Array<[string, FrozenConfiguration]>>
+  excludedByAlias: Map<string, FrozenExcludedConfiguration>
+  excludedConfigAliasById: Map<string, string>
+  excludedChatbotAliasForId: Map<string, string>
   bindingAliasByChatbotAlias: Map<string, string>
   aliases: ReceiptAliases
   counts: ReceiptCounts
@@ -345,8 +383,10 @@ type InspectedState = {
   sourceServer: ActivationServerRecord
   targetServer: ActivationServerRecord | null
   corpora: Map<string, KnowledgeBaseRecord>
+  courses: Map<string, CourseRecord>
   chatbots: Map<string, ChatbotRecord>
   legacyConfigurations: Map<string, ActivationConfigRecord>
+  excludedConfigurations: Map<string, ActivationConfigRecord>
   configurations: Map<string, ActivationConfigRecord | null>
   bindings: Map<string, ActivationBindingRecord | null>
   otherBindingsByChatbotAlias: Map<string, ActivationBindingRecord[]>
@@ -483,6 +523,26 @@ export function fingerprintManifestText(contents: string): string {
   return createHash('sha256').update(contents).digest('hex')
 }
 
+function requireManifestFingerprint(
+  manifest: FrozenCohortManifest,
+  expectedManifestFingerprint: string | undefined
+): string {
+  if (
+    typeof expectedManifestFingerprint !== 'string' ||
+    !FINGERPRINT_PATTERN.test(expectedManifestFingerprint)
+  ) {
+    fail(
+      'MANIFEST_FINGERPRINT_REQUIRED',
+      'an approved manifest fingerprint is required'
+    )
+  }
+  const actualFingerprint = fingerprintManifest(manifest)
+  if (actualFingerprint !== expectedManifestFingerprint) {
+    fail('MANIFEST_DRIFT', 'manifest fingerprint does not match contents')
+  }
+  return actualFingerprint
+}
+
 function assertManifestShape(manifest: FrozenCohortManifest): void {
   if (!isPlainObject(manifest)) fail('INVALID_MANIFEST', 'manifest is invalid')
   if (manifest.version !== 1) {
@@ -521,6 +581,7 @@ export function validateCohortManifest(manifest: FrozenCohortManifest): void {
   const excludedIds = new Set<string>()
   const excludedChatbotIds = new Set<string>()
   const sourceServerIds = new Set<string>()
+  const excludedToolCounts = new Map<string, number>()
 
   for (const corpus of manifest.corpora) {
     assertUuid(corpus.kbId)
@@ -627,6 +688,17 @@ export function validateCohortManifest(manifest: FrozenCohortManifest): void {
   if (sourceServerIds.size === 0) {
     fail('INVALID_MANIFEST', 'source server is missing')
   }
+  const [cohortSourceServerId] = sourceServerIds
+  for (const configuration of manifest.corpora.flatMap(
+    (corpus) => corpus.configurations
+  )) {
+    if (configuration.sourceServerId !== cohortSourceServerId) {
+      fail(
+        'SOURCE_SERVER_MISMATCH',
+        'cohort configurations use multiple servers'
+      )
+    }
+  }
   for (const entry of manifest.excluded) {
     assertUuid(entry.configId)
     assertUuid(entry.chatbotId)
@@ -647,12 +719,27 @@ export function validateCohortManifest(manifest: FrozenCohortManifest): void {
     }
     excludedIds.add(entry.configId)
     excludedChatbotIds.add(entry.chatbotId)
+    excludedToolCounts.set(
+      entry.tool,
+      (excludedToolCounts.get(entry.tool) ?? 0) + 1
+    )
     if (chatbotIds.has(entry.chatbotId)) {
       fail('EXCLUDED_CORPUS', 'an excluded chatbot is in the cohort')
     }
   }
   if (excludedChatbotIds.size !== EXPECTED_EXCLUDED_CHATBOTS) {
     fail('COHORT_COUNT_MISMATCH', 'excluded chatbot count is not approved')
+  }
+  for (const tool of EXCLUDED_SOURCE_TOOLS) {
+    if (excludedToolCounts.get(tool) !== EXPECTED_EXCLUDED_TOOL_COUNTS[tool]) {
+      fail(
+        'COHORT_COUNT_MISMATCH',
+        'the excluded tool multiset is not approved'
+      )
+    }
+  }
+  if (excludedToolCounts.size !== EXCLUDED_SOURCE_TOOLS.length) {
+    fail('COHORT_COUNT_MISMATCH', 'the excluded tool multiset is not approved')
   }
   if (
     manifest.fingerprint &&
@@ -686,39 +773,94 @@ export function createFileActivationReceiptStore(
   receiptPath: string
 ): ActivationReceiptStore {
   const absolutePath = resolve(receiptPath)
+  const lockPath = `${absolutePath}.lock`
+
+  async function readCurrent(): Promise<ActivationReceiptPayload | null> {
+    try {
+      const contents = await readFile(absolutePath, 'utf8')
+      const payload = JSON.parse(contents) as ActivationReceiptPayload
+      assertPayloadDigest(payload)
+      return payload
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return null
+      }
+      if (error instanceof CohortActivationError) throw error
+      fail('RECEIPT_READ_FAILED', 'could not read activation receipt')
+    }
+  }
+
   return {
     async read() {
+      return readCurrent()
+    },
+    async compareAndSwap(expectedDigest, receipt) {
+      if (
+        expectedDigest !== null &&
+        !FINGERPRINT_PATTERN.test(expectedDigest)
+      ) {
+        fail('RECEIPT_CAS_FAILED', 'receipt expected digest is invalid')
+      }
+      assertPayloadDigest(receipt)
       try {
-        const contents = await readFile(absolutePath, 'utf8')
-        return JSON.parse(contents) as ActivationReceiptPayload
+        await mkdir(dirname(absolutePath), { recursive: true })
+      } catch {
+        fail('RECEIPT_WRITE_FAILED', 'receipt directory is unavailable')
+      }
+      try {
+        await mkdir(lockPath)
       } catch (error) {
         if (
           error instanceof Error &&
           'code' in error &&
-          error.code === 'ENOENT'
+          error.code === 'EEXIST'
         ) {
-          return null
+          fail('RECEIPT_LOCKED', 'receipt is already being updated')
         }
-        fail('RECEIPT_READ_FAILED', 'could not read activation receipt')
+        fail('RECEIPT_WRITE_FAILED', 'receipt lock is unavailable')
       }
-    },
-    async write(receipt) {
-      await mkdir(dirname(absolutePath), { recursive: true })
-      const temporaryPath = `${absolutePath}.tmp-${process.pid}`
-      await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
-        encoding: 'utf8',
-        flag: 'wx',
-        mode: 0o600,
-      })
-      await chmod(temporaryPath, 0o600)
-      await rename(temporaryPath, absolutePath)
+      const temporaryPath = `${absolutePath}.tmp-${process.pid}-${randomUUID()}`
+      try {
+        const current = await readCurrent()
+        if ((current?.payloadDigest ?? null) !== expectedDigest) {
+          fail('RECEIPT_CAS_FAILED', 'receipt changed concurrently')
+        }
+        if (current) assertReceiptTransition(current, receipt)
+        else if (!isReceiptIntent(receipt)) {
+          fail('RECEIPT_STATE', 'a new receipt must start with intent')
+        }
+        if (current?.payloadDigest === receipt.payloadDigest) return
+        await writeFile(
+          temporaryPath,
+          `${JSON.stringify(receipt, null, 2)}\n`,
+          {
+            encoding: 'utf8',
+            flag: 'wx',
+            mode: 0o600,
+          }
+        )
+        await chmod(temporaryPath, 0o600)
+        await rename(temporaryPath, absolutePath)
+      } finally {
+        await rm(temporaryPath, { force: true }).catch(() => undefined)
+        await rmdir(lockPath).catch(() => undefined)
+      }
     },
   }
 }
 
 type PrismaActivationClient = Pick<
   PrismaClient,
-  'kB' | 'chatbot' | 'kBChatbot' | 'chatbotMCPServer' | 'chatbotMCPConfig'
+  | 'kB'
+  | 'course'
+  | 'chatbot'
+  | 'kBChatbot'
+  | 'chatbotMCPServer'
+  | 'chatbotMCPConfig'
 >
 
 function mapKnowledgeBase(record: {
@@ -744,6 +886,14 @@ function mapChatbot(record: {
     ownerId: record.course.ownerId,
     updatedAt: record.updatedAt,
   }
+}
+
+function mapCourse(record: {
+  id: string
+  ownerId: string
+  updatedAt: Date
+}): CourseRecord {
+  return record
 }
 
 function mapServer(record: {
@@ -847,6 +997,13 @@ function createPrismaActivationDelegate(
         select: kbSelect,
       })
       return records.map(mapKnowledgeBase)
+    },
+    async findCourseById(id) {
+      const record = await client.course.findUnique({
+        where: { id },
+        select: { id: true, ownerId: true, updatedAt: true },
+      })
+      return record ? mapCourse(record) : null
     },
     async findChatbotById(id) {
       const record = await client.chatbot.findUnique({
@@ -972,6 +1129,8 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
   )
   const corpusByAlias = new Map<string, FrozenCorpus>()
   const corpusAliasByChatbotId = new Map<string, string>()
+  const courseAliasForId = new Map<string, string>()
+  const courseIdByAlias = new Map<string, string>()
   sortedCorpora.forEach((corpus, index) => {
     const alias = `corpus-${padAlias(index)}`
     corpusByAlias.set(alias, corpus)
@@ -981,6 +1140,15 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
       }
       corpusAliasByChatbotId.set(chatbotId, alias)
     }
+  })
+
+  const courseIds = [
+    ...new Set(sortedCorpora.flatMap((corpus) => corpus.courseIds)),
+  ].sort()
+  courseIds.forEach((courseId, index) => {
+    const alias = `course-${padAlias(index)}`
+    courseAliasForId.set(courseId, alias)
+    courseIdByAlias.set(alias, courseId)
   })
 
   const chatbotIds = [...corpusAliasByChatbotId.keys()].sort()
@@ -1010,6 +1178,26 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
     configsByChatbotAlias.set(chatbotAlias, list)
   })
 
+  const sortedExcluded = [...manifest.excluded].sort((left, right) =>
+    left.configId.localeCompare(right.configId)
+  )
+  const excludedByAlias = new Map<string, FrozenExcludedConfiguration>()
+  const excludedConfigAliasById = new Map<string, string>()
+  sortedExcluded.forEach((configuration, index) => {
+    const alias = `excluded-config-${padAlias(index)}`
+    excludedByAlias.set(alias, configuration)
+    excludedConfigAliasById.set(configuration.configId, alias)
+  })
+  const excludedChatbotAliasForId = new Map<string, string>()
+  ;[...new Set(sortedExcluded.map((configuration) => configuration.chatbotId))]
+    .sort()
+    .forEach((chatbotId, index) => {
+      excludedChatbotAliasForId.set(
+        chatbotId,
+        `excluded-chatbot-${padAlias(index)}`
+      )
+    })
+
   const bindingAliasByChatbotAlias = new Map<string, string>()
   for (const chatbotAlias of chatbotIdByAlias.keys()) {
     const chatbotId = chatbotIdByAlias.get(chatbotAlias)!
@@ -1024,17 +1212,24 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
   return {
     corpusByAlias,
     corpusAliasByChatbotId,
+    courseAliasForId,
+    courseIdByAlias,
     chatbotAliasForId,
     chatbotIdByAlias,
     configByAlias,
     configsByChatbotAlias,
+    excludedByAlias,
+    excludedConfigAliasById,
+    excludedChatbotAliasForId,
     bindingAliasByChatbotAlias,
     aliases: {
       sourceServer: SOURCE_SERVER_NAME,
       targetServer: TARGET_SERVER_NAME,
       corpora: [...corpusByAlias.keys()].sort(),
+      courses: [...courseIdByAlias.keys()].sort(),
       chatbots: [...chatbotIdByAlias.keys()].sort(),
       configurations: [...configByAlias.keys()].sort(),
+      excludedConfigurations: [...excludedByAlias.keys()].sort(),
     },
     counts: {
       corpora: EXPECTED_CORPORA,
@@ -1043,9 +1238,12 @@ function buildManifestIndex(manifest: FrozenCohortManifest): ManifestIndex {
       configurations: EXPECTED_CONFIGURATIONS,
       bindings: EXPECTED_BINDINGS,
     },
-    sourceServerIds: new Set(
-      sortedConfigurations.map((configuration) => configuration.sourceServerId)
-    ),
+    sourceServerIds: new Set([
+      ...sortedConfigurations.map(
+        (configuration) => configuration.sourceServerId
+      ),
+      ...sortedExcluded.map((configuration) => configuration.serverId),
+    ]),
   }
 }
 
@@ -1079,13 +1277,408 @@ function makeReceipt(
   }
 }
 
-function assertPayloadDigest(payload: ActivationReceiptPayload): void {
-  if (payload.receiptVersion !== ACTIVATION_RECEIPT_VERSION) {
-    fail('RECEIPT_INVALID', 'receipt version is unsupported')
+const CORPUS_ALIAS_PATTERN = /^corpus-\d{3}$/
+const COURSE_ALIAS_PATTERN = /^course-\d{3}$/
+const CHATBOT_ALIAS_PATTERN = /^chatbot-\d{3}$/
+const EXCLUDED_CONFIGURATION_ALIAS_PATTERN = /^excluded-config-\d{3}$/
+const CONFIGURATION_ALIAS_PATTERN = /^config-\d{3}$/
+const BINDING_ALIAS_PATTERN = /^binding-corpus-\d{3}-chatbot-\d{3}$/
+const EXCLUDED_CHATBOT_ALIAS_PATTERN = /^excluded-chatbot-\d{3}$/
+
+function receiptInvalid(message: string): never {
+  fail('RECEIPT_INVALID', message)
+}
+
+function assertReceiptObject(
+  value: unknown
+): asserts value is Record<string, unknown> {
+  if (!isPlainObject(value)) receiptInvalid('receipt shape is invalid')
+}
+
+function assertReceiptKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[]
+): void {
+  const actual = Object.keys(value).sort()
+  const expected = [...keys].sort()
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    receiptInvalid('receipt shape is invalid')
   }
+}
+
+function assertReceiptFingerprint(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !FINGERPRINT_PATTERN.test(value)) {
+    receiptInvalid('receipt fingerprint is invalid')
+  }
+}
+
+function assertReceiptTimestamp(value: unknown): asserts value is string {
+  if (typeof value !== 'string') receiptInvalid('receipt timestamp is invalid')
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+    receiptInvalid('receipt timestamp is invalid')
+  }
+}
+
+function assertReceiptAlias(
+  value: unknown,
+  pattern: RegExp
+): asserts value is string {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    receiptInvalid('receipt alias is invalid')
+  }
+}
+
+function assertReceiptAliasArray(
+  value: unknown,
+  pattern: RegExp,
+  expectedLength: number
+): asserts value is string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length !== expectedLength ||
+    value.some((alias) => typeof alias !== 'string' || !pattern.test(alias))
+  ) {
+    receiptInvalid('receipt aliases are invalid')
+  }
+  if (new Set(value).size !== value.length) {
+    receiptInvalid('receipt aliases are duplicated')
+  }
+}
+
+function assertReceiptCounts(value: unknown): asserts value is ReceiptCounts {
+  assertReceiptObject(value)
+  assertReceiptKeys(value, [
+    'corpora',
+    'courses',
+    'chatbots',
+    'configurations',
+    'bindings',
+  ])
+  if (
+    value.corpora !== EXPECTED_CORPORA ||
+    value.courses !== EXPECTED_COURSES ||
+    value.chatbots !== EXPECTED_CHATBOTS ||
+    value.configurations !== EXPECTED_CONFIGURATIONS ||
+    value.bindings !== EXPECTED_BINDINGS
+  ) {
+    receiptInvalid('receipt counts are invalid')
+  }
+}
+
+function assertReceiptAliases(value: unknown): asserts value is ReceiptAliases {
+  assertReceiptObject(value)
+  assertReceiptKeys(value, [
+    'sourceServer',
+    'targetServer',
+    'corpora',
+    'courses',
+    'chatbots',
+    'configurations',
+    'excludedConfigurations',
+  ])
+  if (
+    value.sourceServer !== SOURCE_SERVER_NAME ||
+    value.targetServer !== TARGET_SERVER_NAME
+  ) {
+    receiptInvalid('receipt server aliases are invalid')
+  }
+  assertReceiptAliasArray(value.corpora, CORPUS_ALIAS_PATTERN, EXPECTED_CORPORA)
+  assertReceiptAliasArray(value.courses, COURSE_ALIAS_PATTERN, EXPECTED_COURSES)
+  assertReceiptAliasArray(
+    value.chatbots,
+    CHATBOT_ALIAS_PATTERN,
+    EXPECTED_CHATBOTS
+  )
+  assertReceiptAliasArray(
+    value.configurations,
+    CONFIGURATION_ALIAS_PATTERN,
+    EXPECTED_CONFIGURATIONS
+  )
+  assertReceiptAliasArray(
+    value.excludedConfigurations,
+    EXCLUDED_CONFIGURATION_ALIAS_PATTERN,
+    EXPECTED_EXCLUDED_CONFIGURATIONS
+  )
+}
+
+function assertReceiptIdentitySnapshot(
+  value: unknown,
+  aliases: string[],
+  pattern: RegExp
+): void {
+  if (!Array.isArray(value) || value.length !== aliases.length) {
+    receiptInvalid('receipt snapshots are invalid')
+  }
+  const seen = new Set<string>()
+  for (const entry of value) {
+    assertReceiptObject(entry)
+    assertReceiptKeys(entry, ['alias', 'fingerprint', 'updatedAt'])
+    assertReceiptAlias(entry.alias, pattern)
+    assertReceiptFingerprint(entry.fingerprint)
+    assertReceiptTimestamp(entry.updatedAt)
+    if (seen.has(entry.alias))
+      receiptInvalid('receipt snapshots are duplicated')
+    seen.add(entry.alias)
+  }
+  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+    receiptInvalid('receipt snapshot aliases are invalid')
+  }
+}
+
+function assertReceiptConfigSnapshots(
+  value: unknown,
+  aliases: string[],
+  expectedAliasPattern: RegExp,
+  chatbotAliasPattern = CHATBOT_ALIAS_PATTERN
+): void {
+  if (!Array.isArray(value) || value.length !== aliases.length) {
+    receiptInvalid('receipt configuration snapshots are invalid')
+  }
+  const seen = new Set<string>()
+  for (const entry of value) {
+    assertReceiptObject(entry)
+    assertReceiptKeys(entry, [
+      'alias',
+      'fingerprint',
+      'updatedAt',
+      'chatbotAlias',
+      'chatMode',
+      'isEnabled',
+    ])
+    assertReceiptAlias(entry.alias, expectedAliasPattern)
+    assertReceiptFingerprint(entry.fingerprint)
+    assertReceiptTimestamp(entry.updatedAt)
+    assertReceiptAlias(entry.chatbotAlias, chatbotAliasPattern)
+    assertModeForReceipt(entry.chatMode)
+    if (typeof entry.isEnabled !== 'boolean') {
+      receiptInvalid('receipt configuration state is invalid')
+    }
+    if (seen.has(entry.alias))
+      receiptInvalid('receipt snapshots are duplicated')
+    seen.add(entry.alias)
+  }
+  if (canonicalJson([...seen].sort()) !== canonicalJson([...aliases].sort())) {
+    receiptInvalid('receipt snapshot aliases are invalid')
+  }
+}
+
+function assertModeForReceipt(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !MODE_PATTERN.test(value)) {
+    receiptInvalid('receipt chat mode is invalid')
+  }
+}
+
+function assertReceiptBindingSnapshots(
+  value: unknown,
+  expectedLength: number
+): void {
+  if (!Array.isArray(value) || value.length !== expectedLength) {
+    receiptInvalid('receipt binding snapshots are invalid')
+  }
+  const seen = new Set<string>()
+  for (const entry of value) {
+    assertReceiptObject(entry)
+    assertReceiptKeys(entry, [
+      'alias',
+      'fingerprint',
+      'updatedAt',
+      'chatbotAlias',
+      'corpusAlias',
+      'isEnabled',
+    ])
+    assertReceiptAlias(entry.alias, BINDING_ALIAS_PATTERN)
+    assertReceiptFingerprint(entry.fingerprint)
+    assertReceiptTimestamp(entry.updatedAt)
+    assertReceiptAlias(entry.chatbotAlias, CHATBOT_ALIAS_PATTERN)
+    assertReceiptAlias(entry.corpusAlias, CORPUS_ALIAS_PATTERN)
+    if (typeof entry.isEnabled !== 'boolean') {
+      receiptInvalid('receipt binding state is invalid')
+    }
+    if (seen.has(entry.alias))
+      receiptInvalid('receipt snapshots are duplicated')
+    seen.add(entry.alias)
+  }
+}
+
+function assertReceiptServerSnapshot(
+  value: unknown,
+  alias: typeof SOURCE_SERVER_NAME | typeof TARGET_SERVER_NAME
+): void {
+  assertReceiptObject(value)
+  assertReceiptKeys(value, [
+    'alias',
+    'fingerprint',
+    'hasTransportCredential',
+    'isActive',
+    'updatedAt',
+  ])
+  if (value.alias !== alias) receiptInvalid('receipt server alias is invalid')
+  assertReceiptFingerprint(value.fingerprint)
+  assertReceiptTimestamp(value.updatedAt)
+  if (
+    typeof value.hasTransportCredential !== 'boolean' ||
+    typeof value.isActive !== 'boolean'
+  ) {
+    receiptInvalid('receipt server state is invalid')
+  }
+}
+
+function assertReceiptCommonFields(value: Record<string, unknown>): void {
+  if (value.receiptVersion !== ACTIVATION_RECEIPT_VERSION) {
+    receiptInvalid('receipt version is unsupported')
+  }
+  assertReceiptFingerprint(value.manifestFingerprint)
+  assertReceiptCounts(value.counts)
+  assertReceiptAliases(value.aliases)
+  assertReceiptFingerprint(value.payloadDigest)
+}
+
+function assertPayloadShape(
+  value: unknown
+): asserts value is ActivationReceiptPayload {
+  assertReceiptObject(value)
+  if (value.state === 'preparing') {
+    assertReceiptKeys(value, [
+      'receiptVersion',
+      'manifestFingerprint',
+      'counts',
+      'aliases',
+      'state',
+      'payloadDigest',
+    ])
+    assertReceiptCommonFields(value)
+    return
+  }
+  assertReceiptKeys(value, [
+    'receiptVersion',
+    'manifestFingerprint',
+    'counts',
+    'aliases',
+    'sourceServer',
+    'targetServer',
+    'corpora',
+    'courses',
+    'chatbots',
+    'legacyConfigurations',
+    'excludedConfigurations',
+    'bindings',
+    'configurations',
+    'switchedChatbotAliases',
+    'pendingChatbotAlias',
+    'pendingRollbackAliases',
+    'state',
+    'payloadDigest',
+  ])
+  assertReceiptCommonFields(value)
+  if (
+    value.state !== 'prepared' &&
+    value.state !== 'switching' &&
+    value.state !== 'switched' &&
+    value.state !== 'rolling_back' &&
+    value.state !== 'rolled_back'
+  ) {
+    receiptInvalid('receipt state is invalid')
+  }
+  assertReceiptAliases(value.aliases)
+  const aliases = value.aliases
+  assertReceiptServerSnapshot(value.sourceServer, SOURCE_SERVER_NAME)
+  assertReceiptServerSnapshot(value.targetServer, TARGET_SERVER_NAME)
+  assertReceiptIdentitySnapshot(
+    value.corpora,
+    aliases.corpora,
+    CORPUS_ALIAS_PATTERN
+  )
+  assertReceiptIdentitySnapshot(
+    value.courses,
+    aliases.courses,
+    COURSE_ALIAS_PATTERN
+  )
+  assertReceiptIdentitySnapshot(
+    value.chatbots,
+    aliases.chatbots,
+    CHATBOT_ALIAS_PATTERN
+  )
+  assertReceiptConfigSnapshots(
+    value.legacyConfigurations,
+    aliases.configurations,
+    CONFIGURATION_ALIAS_PATTERN
+  )
+  assertReceiptConfigSnapshots(
+    value.excludedConfigurations,
+    aliases.excludedConfigurations,
+    EXCLUDED_CONFIGURATION_ALIAS_PATTERN,
+    EXCLUDED_CHATBOT_ALIAS_PATTERN
+  )
+  assertReceiptBindingSnapshots(value.bindings, EXPECTED_BINDINGS)
+  assertReceiptConfigSnapshots(
+    value.configurations,
+    aliases.configurations,
+    CONFIGURATION_ALIAS_PATTERN
+  )
+  const switchedChatbotAliases = value.switchedChatbotAliases
+  if (!Array.isArray(switchedChatbotAliases)) {
+    receiptInvalid('receipt switched aliases are invalid')
+  }
+  assertReceiptAliasArray(
+    switchedChatbotAliases,
+    CHATBOT_ALIAS_PATTERN,
+    switchedChatbotAliases.length
+  )
+  if (
+    value.pendingChatbotAlias !== null &&
+    (typeof value.pendingChatbotAlias !== 'string' ||
+      !CHATBOT_ALIAS_PATTERN.test(value.pendingChatbotAlias))
+  ) {
+    receiptInvalid('receipt pending alias is invalid')
+  }
+  const pendingRollbackAliases = value.pendingRollbackAliases
+  if (!Array.isArray(pendingRollbackAliases)) {
+    receiptInvalid('receipt rollback aliases are invalid')
+  }
+  assertReceiptAliasArray(
+    pendingRollbackAliases,
+    CHATBOT_ALIAS_PATTERN,
+    pendingRollbackAliases.length
+  )
+}
+
+function assertPayloadDigest(
+  payload: unknown
+): asserts payload is ActivationReceiptPayload {
+  assertPayloadShape(payload)
   const { payloadDigest: _payloadDigest, ...withoutDigest } = payload
   if (fingerprint(withoutDigest) !== payload.payloadDigest) {
     fail('RECEIPT_INVALID', 'receipt digest does not match')
+  }
+}
+
+function assertReceiptTransition(
+  current: ActivationReceiptPayload,
+  next: ActivationReceiptPayload
+): void {
+  assertPayloadShape(current)
+  assertPayloadShape(next)
+  if (current.manifestFingerprint !== next.manifestFingerprint) {
+    fail('RECEIPT_MISMATCH', 'receipt manifest identity changed')
+  }
+  if (current.payloadDigest === next.payloadDigest) return
+  if (isReceiptIntent(current)) {
+    if (!isReceiptIntent(next) && next.state === 'prepared') return
+    fail('RECEIPT_STATE', 'receipt intent has an invalid transition')
+  }
+  if (isReceiptIntent(next)) {
+    fail('RECEIPT_STATE', 'a complete receipt cannot return to intent')
+  }
+  const allowed: Record<ActivationReceiptState, ActivationReceiptState[]> = {
+    prepared: ['switching'],
+    switching: ['switched', 'rolling_back'],
+    switched: ['rolling_back'],
+    rolling_back: ['switched', 'rolled_back'],
+    rolled_back: [],
+  }
+  if (!allowed[current.state].includes(next.state)) {
+    fail('RECEIPT_STATE', 'receipt state transition is invalid')
   }
 }
 
@@ -1260,10 +1853,16 @@ function assertSourceServer(
   if (!server || server.name !== SOURCE_SERVER_NAME) {
     fail('SOURCE_SERVER_MISSING', 'the unique source server is missing')
   }
-  if (!server.isActive || !server.authSecret?.trim()) {
+  if (
+    server.authType !== 'bearer' ||
+    !server.isActive ||
+    server.passChatbotId !== true ||
+    server.chatbotIdHeader !== SOURCE_CHATBOT_ID_HEADER ||
+    !server.authSecret?.trim()
+  ) {
     fail(
-      'SOURCE_CREDENTIAL_MISSING',
-      'the source transport credential is unavailable'
+      'SOURCE_SERVER_MISMATCH',
+      'the source server contract is not the approved legacy contract'
     )
   }
 }
@@ -1323,6 +1922,17 @@ function assertChatbot(
   }
 }
 
+function assertCourse(
+  course: CourseRecord | null,
+  courseId: string,
+  ownerId: string
+): asserts course is CourseRecord {
+  if (!course) fail('COURSE_MISSING', 'a manifest course is missing')
+  if (course.id !== courseId || course.ownerId !== ownerId) {
+    fail('COURSE_DRIFT', 'a course owner or identifier drifted')
+  }
+}
+
 function assertSourceConfiguration(
   config: ActivationConfigRecord | null,
   configuration: FrozenConfiguration
@@ -1338,6 +1948,29 @@ function assertSourceConfiguration(
     !jsonEqual(config.parameters, configuration.parameters)
   ) {
     fail('SOURCE_CONFIG_DRIFT', 'a legacy configuration drifted')
+  }
+}
+
+function assertExcludedConfiguration(
+  config: ActivationConfigRecord | null,
+  configuration: FrozenExcludedConfiguration,
+  sourceServerId: string
+): asserts config is ActivationConfigRecord {
+  if (
+    !config ||
+    config.id !== configuration.configId ||
+    config.chatbotId !== configuration.chatbotId ||
+    config.mcpServerId !== sourceServerId ||
+    config.chatMode !== configuration.chatMode ||
+    !jsonEqual(config.allowedTools, [configuration.tool]) ||
+    config.priority !== 0 ||
+    !jsonEqual(config.parameters, {
+      required: true,
+      toolAlias: DOC_QUERY_TOOL,
+    }) ||
+    typeof config.isEnabled !== 'boolean'
+  ) {
+    fail('EXCLUDED_CONFIG_DRIFT', 'an excluded configuration drifted')
   }
 }
 
@@ -1393,6 +2026,15 @@ async function inspectCohortState(
   }
   const sourceServer = sourceServers[0]!
   assertSourceServer(sourceServer)
+  if (
+    index.sourceServerIds.size !== 1 ||
+    !index.sourceServerIds.has(sourceServer.id)
+  ) {
+    fail(
+      'SOURCE_SERVER_MISMATCH',
+      'a frozen server identifier does not match the source server'
+    )
+  }
 
   const corpora = new Map<string, KnowledgeBaseRecord>()
   for (const [alias, corpus] of index.corpusByAlias.entries()) {
@@ -1412,6 +2054,17 @@ async function inspectCohortState(
     }
   }
 
+  const courses = new Map<string, CourseRecord>()
+  for (const [courseId, courseAlias] of index.courseAliasForId.entries()) {
+    const corpus = [...index.corpusByAlias.values()].find((candidate) =>
+      candidate.courseIds.includes(courseId)
+    )
+    if (!corpus) fail('INVALID_MANIFEST', 'a course corpus is missing')
+    const course = await store.findCourseById(courseId)
+    assertCourse(course, courseId, corpus.ownerId)
+    courses.set(courseAlias, course)
+  }
+
   const chatbots = new Map<string, ChatbotRecord>()
   for (const [
     chatbotId,
@@ -1423,12 +2076,27 @@ async function inspectCohortState(
     assertChatbot(chatbot, corpus)
     chatbots.set(chatbotAliasFor(index, chatbotId), chatbot)
   }
+  const referencedCourseIds = new Set(
+    [...chatbots.values()].map((chatbot) => chatbot.courseId)
+  )
+  for (const courseId of index.courseIdByAlias.values()) {
+    if (!referencedCourseIds.has(courseId)) {
+      fail('COURSE_REFERENCE_MISSING', 'a listed course is not referenced')
+    }
+  }
 
   const legacyConfigurations = new Map<string, ActivationConfigRecord>()
   for (const [alias, configuration] of index.configByAlias.entries()) {
     const config = await store.findConfigById(configuration.configId)
     assertSourceConfiguration(config, configuration)
     legacyConfigurations.set(alias, config)
+  }
+
+  const excludedConfigurations = new Map<string, ActivationConfigRecord>()
+  for (const [alias, configuration] of index.excludedByAlias.entries()) {
+    const config = await store.findConfigById(configuration.configId)
+    assertExcludedConfiguration(config, configuration, sourceServer.id)
+    excludedConfigurations.set(alias, config)
   }
 
   const targetServer = await findTargetServer(store)
@@ -1499,8 +2167,10 @@ async function inspectCohortState(
     sourceServer,
     targetServer,
     corpora,
+    courses,
     chatbots,
     legacyConfigurations,
+    excludedConfigurations,
     configurations,
     bindings,
     otherBindingsByChatbotAlias,
@@ -1520,14 +2190,16 @@ function assertNoEnabledTargetRows(state: InspectedState): void {
   }
 }
 
-function assertNoEnabledOtherBinding(state: InspectedState): void {
-  for (const bindings of state.otherBindingsByChatbotAlias.values()) {
-    if (bindings.some((binding) => binding.isEnabled)) {
-      fail(
-        'ENABLED_KB_CONFLICT',
-        'another knowledge base is already enabled for the chatbot'
-      )
-    }
+function assertNoEnabledOtherBinding(
+  state: InspectedState,
+  chatbotAlias: string
+): void {
+  const bindings = state.otherBindingsByChatbotAlias.get(chatbotAlias)
+  if (bindings?.some((binding) => binding.isEnabled)) {
+    fail(
+      'ENABLED_KB_CONFLICT',
+      'another knowledge base is already enabled for the chatbot'
+    )
   }
 }
 
@@ -1656,6 +2328,16 @@ function assertReceiptCurrent(
       knowledgeBaseFingerprint(current)
     )
   }
+  for (const alias of index.courseIdByAlias.keys()) {
+    const current = state.courses.get(alias)
+    if (!current) fail('SNAPSHOT_MISMATCH', 'a course is missing')
+    assertSafeIdentity(
+      findReceiptSnapshot(receipt.courses, alias),
+      alias,
+      current,
+      fingerprint(current)
+    )
+  }
   for (const [alias, expectedChatbotId] of index.chatbotIdByAlias.entries()) {
     const current = state.chatbots.get(alias)
     if (!current || current.id !== expectedChatbotId) {
@@ -1680,6 +2362,24 @@ function assertReceiptCurrent(
       fail(
         'SNAPSHOT_MISMATCH',
         'a legacy configuration snapshot no longer matches'
+      )
+    }
+  }
+  for (const [alias, config] of state.excludedConfigurations.entries()) {
+    const expected = findReceiptSnapshot(receipt.excludedConfigurations, alias)
+    const chatbotAlias = index.excludedChatbotAliasForId.get(config.chatbotId)
+    if (!chatbotAlias) {
+      fail('SNAPSHOT_MISMATCH', 'an excluded chatbot alias is missing')
+    }
+    assertSafeIdentity(expected, alias, config, configFingerprint(config))
+    if (
+      expected.chatbotAlias !== chatbotAlias ||
+      expected.chatMode !== config.chatMode ||
+      expected.isEnabled !== config.isEnabled
+    ) {
+      fail(
+        'SNAPSHOT_MISMATCH',
+        'an excluded configuration snapshot no longer matches'
       )
     }
   }
@@ -1772,11 +2472,32 @@ function makeReceiptFromState(
       return safeIdentitySnapshot(alias, kb, knowledgeBaseFingerprint(kb))
     })
     .sort((left, right) => left.alias.localeCompare(right.alias))
+  const courses = [...index.courseIdByAlias.entries()]
+    .map(([alias]) => {
+      const course = state.courses.get(alias)
+      if (!course) fail('COURSE_MISSING', 'a manifest course is missing')
+      return safeIdentitySnapshot(alias, course, fingerprint(course))
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
   const chatbots = [...index.chatbotIdByAlias.entries()]
     .map(([alias]) => {
       const chatbot = state.chatbots.get(alias)
       if (!chatbot) fail('CHATBOT_MISSING', 'a manifest chatbot is missing')
       return safeIdentitySnapshot(alias, chatbot, chatbotFingerprint(chatbot))
+    })
+    .sort((left, right) => left.alias.localeCompare(right.alias))
+  const excludedConfigurations = [...index.excludedByAlias.entries()]
+    .map(([alias, configuration]) => {
+      const config = state.excludedConfigurations.get(alias)
+      if (!config)
+        fail('EXCLUDED_CONFIG_MISSING', 'an excluded configuration is missing')
+      const chatbotAlias = index.excludedChatbotAliasForId.get(
+        configuration.chatbotId
+      )
+      if (!chatbotAlias) {
+        fail('INVALID_MANIFEST', 'an excluded chatbot alias is missing')
+      }
+      return safeConfigSnapshot(alias, chatbotAlias, config)
     })
     .sort((left, right) => left.alias.localeCompare(right.alias))
   const legacyConfigurations = [...index.configByAlias.entries()]
@@ -1823,8 +2544,10 @@ function makeReceiptFromState(
     sourceServer: safeServerSnapshot(state.sourceServer, SOURCE_SERVER_NAME),
     targetServer: safeServerSnapshot(state.targetServer, TARGET_SERVER_NAME),
     corpora,
+    courses,
     chatbots,
     legacyConfigurations,
+    excludedConfigurations,
     bindings,
     configurations,
     switchedChatbotAliases: [...new Set(input.switchedChatbotAliases)].sort(),
@@ -1859,7 +2582,9 @@ function operationResult(
     aliases: {
       sourceServer: SOURCE_SERVER_NAME,
       targetServer: TARGET_SERVER_NAME,
+      courseAliases: [...index.aliases.courses],
       chatbotAliases: [...index.aliases.chatbots],
+      excludedConfigurationAliases: [...index.aliases.excludedConfigurations],
       switchedChatbotAliases: receipt
         ? [...receipt.switchedChatbotAliases]
         : [],
@@ -1932,11 +2657,15 @@ function targetWriteCounts(state: InspectedState): ActivationWrites {
 export async function dryRunCohortActivation(
   store: ActivationStore,
   manifest: FrozenCohortManifest,
-  target: ActivationTarget
+  target: ActivationTarget,
+  expectedManifestFingerprint: string
 ): Promise<ActivationResult> {
   validateTarget(target)
   const index = buildManifestIndex(manifest)
-  const manifestFingerprint = fingerprintManifest(manifest)
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    expectedManifestFingerprint
+  )
   const state = await inspectCohortState(store, index, target)
   if (state.targetServer) {
     assertTargetGroupsCoherent(state, index)
@@ -1957,18 +2686,28 @@ export async function prepareCohortActivation(
 ): Promise<ActivationResult> {
   validateTarget(options.target)
   const index = buildManifestIndex(manifest)
-  const manifestFingerprint = fingerprintManifest(manifest)
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    options.expectedManifestFingerprint
+  )
   if (options.dryRun) {
-    return dryRunCohortActivation(store, manifest, options.target)
+    return dryRunCohortActivation(
+      store,
+      manifest,
+      options.target,
+      options.expectedManifestFingerprint
+    )
   }
   if (!options.receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
 
   const existing = await readReceipt(options.receiptStore)
+  let expectedReceiptDigest: string | null = null
   if (existing) {
     assertReceiptMatchesIndex(existing, index, manifestFingerprint)
     if (isReceiptIntent(existing)) {
+      expectedReceiptDigest = existing.payloadDigest
       const intentState = await inspectCohortState(store, index, options.target)
       assertNoEnabledTargetRows(intentState)
       assertNoUntrackedPartialTargetRows(intentState, index)
@@ -1989,7 +2728,9 @@ export async function prepareCohortActivation(
     const initialState = await inspectCohortState(store, index, options.target)
     assertNoEnabledTargetRows(initialState)
     assertNoUntrackedPartialTargetRows(initialState, index)
-    await options.receiptStore.write(makeIntent(index, manifestFingerprint))
+    const intent = makeIntent(index, manifestFingerprint)
+    await options.receiptStore.compareAndSwap(null, intent)
+    expectedReceiptDigest = intent.payloadDigest
   }
 
   const writes = zeroWrites()
@@ -2085,7 +2826,7 @@ export async function prepareCohortActivation(
       switchedChatbotAliases: [],
     })
   })
-  await options.receiptStore.write(receipt)
+  await options.receiptStore.compareAndSwap(expectedReceiptDigest, receipt)
   return operationResult(
     'prepared',
     index,
@@ -2097,14 +2838,18 @@ export async function prepareCohortActivation(
 
 async function prepareOrReadReceipt(
   manifest: FrozenCohortManifest,
-  receiptStore: ActivationReceiptStore
+  receiptStore: ActivationReceiptStore,
+  expectedManifestFingerprint: string
 ): Promise<{
   index: ManifestIndex
   manifestFingerprint: string
   receipt: ActivationReceipt
 }> {
   const index = buildManifestIndex(manifest)
-  const manifestFingerprint = fingerprintManifest(manifest)
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    expectedManifestFingerprint
+  )
   const payload = await readReceipt(receiptStore)
   const receipt = requireReceipt(payload, index, manifestFingerprint)
   return {
@@ -2169,21 +2914,49 @@ export async function switchCohortChatbot(
 ): Promise<ActivationResult> {
   validateTarget(options.target)
   const index = buildManifestIndex(manifest)
-  const manifestFingerprint = fingerprintManifest(manifest)
-  const chatbotId = resolveChatbotAlias(index, options.chatbotAlias)
-  void chatbotId
-  if (options.dryRun) {
-    return operationResult('dry-run', index, manifestFingerprint, zeroWrites())
-  }
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    options.expectedManifestFingerprint
+  )
+  resolveChatbotAlias(index, options.chatbotAlias)
   if (!options.receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
-  const { receipt } = await prepareOrReadReceipt(manifest, options.receiptStore)
+  const { receipt } = await prepareOrReadReceipt(
+    manifest,
+    options.receiptStore,
+    options.expectedManifestFingerprint
+  )
   validateReceiptState(receipt, ['prepared', 'switched'])
 
   const currentState = await inspectCohortState(store, index, options.target)
   assertReceiptCurrent(currentState, index, receipt)
   assertTargetGroupsCoherent(currentState, index)
+  assertNoEnabledOtherBinding(currentState, options.chatbotAlias)
+  if (options.dryRun) {
+    if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
+      assertCandidateGroup(
+        currentState,
+        index,
+        options.chatbotAlias,
+        'switched'
+      )
+    } else {
+      assertCandidateGroup(
+        currentState,
+        index,
+        options.chatbotAlias,
+        'prepared'
+      )
+    }
+    return operationResult(
+      'dry-run',
+      index,
+      manifestFingerprint,
+      zeroWrites(),
+      receipt
+    )
+  }
   if (receipt.switchedChatbotAliases.includes(options.chatbotAlias)) {
     assertCandidateGroup(currentState, index, options.chatbotAlias, 'switched')
     return operationResult(
@@ -2195,7 +2968,6 @@ export async function switchCohortChatbot(
     )
   }
   assertCandidateGroup(currentState, index, options.chatbotAlias, 'prepared')
-  assertNoEnabledOtherBinding(currentState)
 
   const switchingReceipt = makeReceiptFromState(
     currentState,
@@ -2207,14 +2979,17 @@ export async function switchCohortChatbot(
       pendingChatbotAlias: options.chatbotAlias,
     }
   )
-  await options.receiptStore.write(switchingReceipt)
+  await options.receiptStore.compareAndSwap(
+    receipt.payloadDigest,
+    switchingReceipt
+  )
 
   const switchedReceipt = await store.transaction(async (tx) => {
     const state = await inspectCohortState(tx, index, options.target)
     assertReceiptCurrent(state, index, receipt)
     assertTargetGroupsCoherent(state, index)
     assertCandidateGroup(state, index, options.chatbotAlias, 'prepared')
-    assertNoEnabledOtherBinding(state)
+    assertNoEnabledOtherBinding(state, options.chatbotAlias)
     await applyChatbotSwitch(tx, state, index, options.chatbotAlias, true)
     const after = await inspectCohortState(tx, index, options.target)
     return makeReceiptFromState(after, index, manifestFingerprint, {
@@ -2225,7 +3000,10 @@ export async function switchCohortChatbot(
       ],
     })
   })
-  await options.receiptStore.write(switchedReceipt)
+  await options.receiptStore.compareAndSwap(
+    switchingReceipt.payloadDigest,
+    switchedReceipt
+  )
   return operationResult(
     'switched',
     index,
@@ -2242,15 +3020,19 @@ export async function rollbackCohortChatbot(
 ): Promise<ActivationResult> {
   validateTarget(options.target)
   const index = buildManifestIndex(manifest)
-  const manifestFingerprint = fingerprintManifest(manifest)
+  const manifestFingerprint = requireManifestFingerprint(
+    manifest,
+    options.expectedManifestFingerprint
+  )
   resolveChatbotAlias(index, options.chatbotAlias)
-  if (options.dryRun) {
-    return operationResult('dry-run', index, manifestFingerprint, zeroWrites())
-  }
   if (!options.receiptStore) {
     fail('RECEIPT_REQUIRED', 'a durable receipt store is required')
   }
-  const { receipt } = await prepareOrReadReceipt(manifest, options.receiptStore)
+  const { receipt } = await prepareOrReadReceipt(
+    manifest,
+    options.receiptStore,
+    options.expectedManifestFingerprint
+  )
   validateReceiptState(receipt, ['switched', 'switching', 'rolling_back'])
   if (
     !receipt.switchedChatbotAliases.includes(options.chatbotAlias) &&
@@ -2279,6 +3061,7 @@ export async function rollbackCohortChatbot(
     pending ? { pendingChatbotAlias: options.chatbotAlias } : {}
   )
   assertTargetGroupsCoherent(stateBefore, index)
+  assertNoEnabledOtherBinding(stateBefore, options.chatbotAlias)
   if (!pending) {
     assertCandidateGroup(stateBefore, index, options.chatbotAlias, 'switched')
   } else {
@@ -2286,6 +3069,15 @@ export async function rollbackCohortChatbot(
     if (current !== 'switched' && current !== 'prepared') {
       fail('MIXED_STATE', 'the selected chatbot group is mixed')
     }
+  }
+  if (options.dryRun) {
+    return operationResult(
+      'dry-run',
+      index,
+      manifestFingerprint,
+      zeroWrites(),
+      receipt
+    )
   }
 
   let rollbackReceipt = receipt
@@ -2300,7 +3092,10 @@ export async function rollbackCohortChatbot(
         pendingRollbackAliases: [options.chatbotAlias],
       }
     )
-    await options.receiptStore.write(rollbackReceipt)
+    await options.receiptStore.compareAndSwap(
+      receipt.payloadDigest,
+      rollbackReceipt
+    )
   } else if (receipt.state === 'switching') {
     rollbackReceipt = makeReceiptFromState(
       stateBefore,
@@ -2316,7 +3111,10 @@ export async function rollbackCohortChatbot(
         pendingRollbackAliases: [options.chatbotAlias],
       }
     )
-    await options.receiptStore.write(rollbackReceipt)
+    await options.receiptStore.compareAndSwap(
+      receipt.payloadDigest,
+      rollbackReceipt
+    )
   }
 
   const finalReceipt = await store.transaction(async (tx) => {
@@ -2325,6 +3123,7 @@ export async function rollbackCohortChatbot(
       pendingChatbotAlias: options.chatbotAlias,
     })
     assertTargetGroupsCoherent(state, index)
+    assertNoEnabledOtherBinding(state, options.chatbotAlias)
     const current = groupState(state, index, options.chatbotAlias)
     if (current !== 'switched' && current !== 'prepared') {
       fail('MIXED_STATE', 'the selected chatbot group is mixed')
@@ -2341,7 +3140,10 @@ export async function rollbackCohortChatbot(
       switchedChatbotAliases: remaining,
     })
   })
-  await options.receiptStore.write(finalReceipt)
+  await options.receiptStore.compareAndSwap(
+    rollbackReceipt.payloadDigest,
+    finalReceipt
+  )
   return operationResult(
     finalReceipt.state === 'rolled_back' ? 'rolled_back' : 'switched',
     index,
@@ -2362,7 +3164,8 @@ export async function readbackCohortActivation(
   }
   const { index, manifestFingerprint, receipt } = await prepareOrReadReceipt(
     manifest,
-    options.receiptStore
+    options.receiptStore,
+    options.expectedManifestFingerprint
   )
   validateReceiptState(receipt, ['prepared', 'switched', 'rolled_back'])
   const state = await inspectCohortState(store, index, options.target)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,10 @@ sonar.exclusions=apps/frontend-pwa/android/**,apps/frontend-pwa/ios/**,
 # copy-paste detection reads that as duplication by construction, and any
 # string-heavy PR then fails the new-code duplication gate. Duplication
 # analysis only; the files stay in scope for all other rules.
-sonar.cpd.exclusions=apps/docs/static/office-addin/content.html,packages/i18n/messages/**
+# The PRD proof is intentionally environment-sealed from the established STG
+# operator so their endpoints, credentials, limits, and receipts remain
+# independently reviewable. It remains in scope for every non-CPD rule.
+sonar.cpd.exclusions=apps/docs/static/office-addin/content.html,packages/i18n/messages/**,apps/chat/scripts/prd-doc-query-proof.mjs
 
 # S3776 is reported on the function declaration line, and Biome always moves a
 # trailing NOSONAR comment off that line onto its own, so an inline suppression


### PR DESCRIPTION
## What This Adds

This PR adds the fail-closed local tooling for the approved 15-corpus Klicker production Doc Query activation. It does not change a chatbot binding, deploy an application, contact Doc Query, or read a credential by itself.

1. Adds a production-sealed direct Doc Query proof runner with bounded calls and values-free receipts.
2. Adds a guarded Prisma Data cohort operator with dry-run, prepare, per-chatbot compare-and-swap switching, rollback, and exact postcondition checks.
3. Freezes the approved corpus, course, chatbot, compatibility-server, and exclusion contracts into every activation receipt.
4. Preserves legacy receipt compatibility while failing closed on ambiguous recovery or concurrent lifecycle execution.

## How It Works

- The proof runner accepts only the sealed production contract, suppresses sensitive output, caps the complete matrix at 37 direct MCP calls, and records ordinary identifiers and result categories only.
- The cohort operator validates the frozen manifest and database state before any write, serializes receipt transitions, switches one chatbot transactionally, and restores the exact pre-switch binding on failure.
- Recovery accepts the reviewed version-1 receipt shape only after normalizing and revalidating its protected origin, manifest, course, and exclusion evidence.
- BF1, DF CF2, and Vorkurs2 remain explicitly excluded from the 15-corpus activation cohort.

## Branch Coverage

- Base: `v3-ai` at `e9e8f2952aec96bc7e5e80e2ce7a8cc82493ebd1`
- Head: `12380f204c497def13dd0da7f844342665737309`
- Reviewed source range: 19 commits; 6 files; test duplication extracted into one shared support module
- Substantive changes: production proof runner and tests, cohort activation operator and tests, recovery compatibility, switching rollback intent, receipt serialization, frozen-contract binding, proof-call cap, and shared proof-test support
- Excluded permanently: BF1, DF CF2, and Vorkurs2
- Generated artifacts, lockfiles, production payloads, and project artifacts are not included

## Review Focus

- Confirm every write is preceded by the frozen-state and exclusion checks and uses per-chatbot compare-and-swap semantics.
- Confirm concurrent prepare, switch, rollback, and recovery cannot lose or overwrite terminal evidence.
- Confirm recovery preserves exact pre-switch state and rejects ambiguous, foreign, incomplete, or incompatible receipts.
- Confirm the proof runner cannot exceed the bounded call matrix or expose bearer, secret, production content, or raw model output.
- Confirm the tooling remains inert until an operator supplies the separately controlled production inputs.

## Verification

Exact head `12380f204c497def13dd0da7f844342665737309`:

- Focused PRD/STG proof suites -> 51 tests passed
- Biome checks on the script, shared support module, and both environment suites -> passed
- `apps/chat` TypeScript check -> 0 errors
- Commit hooks and pre-push production build -> passed
- `git diff --check` -> passed
- SonarCloud exact-head workflow run `33366272780` -> passed
- SonarCloud public metrics endpoint currently returns no measure rows for pull request 5682; the exact-head SonarCloud workflow remains passing
- Hosted Playwright workflow run `33366273038` -> passed; shards 1-8 and aggregate `test-playwright-status` passed
- Final-review workflow run `33376491309` (attempt 2) -> terminal success; the review validated exact head `12380f204c497def13dd0da7f844342665737309` and reported no actionable findings
- OCR review and Claude checks -> intentionally skipped by the v3-ai workflow filters
- The PR check list still displays stale SonarCloud failure records from superseded analyses; current exact-head Sonar, Playwright, CodeQL, unit, build, and gitleaks workflows are passing.

Not run:

- No production database, Doc Query request, chatbot binding, deployment, migration, or cluster action was run from this branch.

Prior review dispositions retained:

- The persistent marker and sidecar SQLite exclusive proof-lock guard are covered by focused concurrency and replacement tests; cleanup never unlinks the marker or guard paths.
- The proof runner uses the fixed call cap, minimal child environment, null output, and values-free receipts.
- The cohort operator preserves legacy digest compatibility and fails closed on foreign digests, mismatched ownership, and ambiguous recovery.
- The shared support module removes test duplication without changing either environment's matrix or rejection semantics.
- UUID normalization now uses the default `toLowerCase()` contract.

## Security / Privacy

- The operator keeps the transport bearer opaque and the proof runner emits values-free result categories only.
- Receipts contain ordinary identifiers and protected digests, never secret values or production content.
- The branch contains no secret values, personal data, database exports, or production payloads.

## Blocking Before Merge

- [ ] Exact-head GitHub CI and repository review settled without an in-scope blocker.
- [ ] Repository-required final AI review passes for this ready PR.
- [ ] The production release custodian confirms this tooling is included in the immutable signer-capable release tree.

## Follow-Up After Merge

- Qualify the immutable Klicker release against the production migration baseline and deploy it dark.
- Add the reviewed PRD v3 Doc Query reader through GitOps.
- Run the separately controlled canary and serial 15-corpus activation proof.

## Local Session Artifacts

Machine-local pointers for resuming this package; they are not review evidence.

- Machine: `Rolands-Mac-Studio`
- Worktree: `trees/klicker-prd-doc-query-activation` in repository `klicker-uzh`
- Plan/progress: `~/Git/ai/deployment/trees/klicker-prd-doc-query-activation/project/2026-08-30-klicker-prd-doc-query-activation-plan.md`

