### PR TITLE
chore(deploy): pin chat to v3.4.0-alpha.73.1 disclaimer hotfix

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -360,7 +360,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.73
+    tag: v3.4.0-alpha.73.1
 
   ingress:
     annotations:


### PR DESCRIPTION
Pins the production chat deployment to the maintenance image `v3.4.0-alpha.73.1`.

## What this is

Production runs `v3.4.0-alpha.73`, in which the chatbot disclaimer's accept button renders with no visible background (the design-system `primary` prop resolves to an undefined Chat colour), so students cannot see the action they need to click. The fix already landed on `v3` and `v3-ai` (#5596), but `v3` carries many other changes that are not production ready, so it cannot be released as a whole.

Tag `v3.4.0-alpha.73.1` is a maintenance release built from branch `maintenance/v3.4.0-alpha.73`, which is the exact production commit `bad33cae` plus a cherry-pick of the single-file disclaimer fix (`c672bde9a`, +3 / −1). Nothing else differs from what production runs today.

## Verification

`apps/chat/src/components/disclaimer-modal.tsx` at `v3.4.0-alpha.73` is byte-identical to the file the fix was reviewed against in #5596, `apps/chat/src/app/globals.css` is unchanged, and `@uzh-bf/design-system` is the same version, so the contrast measured there (10.89:1, foreground `oklch(0.985 0 0)` on `--color-uzh-blue`) applies to this build unchanged.

## Rollback

Restore `chat.image.tag` to `v3.4.0-alpha.73` and re-sync the Argo application. No other application is affected: only the `chat` image pin changes.

## After merge

Argo autosync is disabled for this application, so the rollout needs a manual sync.