### PR TITLE
fix(ci): widen individual final-review headroom for oversized groups

### DIFF
--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -69,10 +69,11 @@ test('bounds individual and stack review retries, tokens, and runtime', () => {
     'utf8'
   )
 
-  assert.equal(source.match(/--timeout 30/g)?.length, 2)
+  assert.equal(source.match(/--timeout 45/g)?.length, 1)
+  assert.equal(source.match(/--timeout 30/g)?.length, 1)
   assert.equal(source.match(/plan-ocr-resume/g)?.length, 2)
   assert.equal(source.match(/merge-ocr-resume/g)?.length, 2)
-  assert.match(source, /run_ocr_attempt "\$\{RESULT_PATH\}" 750000/)
+  assert.match(source, /run_ocr_attempt "\$\{RESULT_PATH\}" 1000000/)
   assert.match(source, /"\$\{REVIEW_FROM\}" "\$\{HEAD_SHA\}" 2000000/)
   assert.match(source, /resume_partial_result[\s\S]*750000 "\$\{RANGE_PATH\}"/)
   assert.equal(
@@ -85,10 +86,9 @@ test('bounds individual and stack review retries, tokens, and runtime', () => {
     )?.length,
     2
   )
-  assert.match(source, /now \+ 1860 > REVIEW_JOB_STARTED_AT \+ 3900/)
+  assert.match(source, /now \+ 2760 > REVIEW_JOB_STARTED_AT \+ 4800/)
   assert.match(source, /now \+ 1860 > REVIEW_JOB_STARTED_AT \+ 4200/)
-  assert.match(source, /timeout-minutes: 75/)
-  assert.match(source, /timeout-minutes: 90/)
+  assert.equal(source.match(/timeout-minutes: 90/g)?.length, 2)
   assert.equal(source.match(/RESUME_USED=true/g)?.length, 1)
   assert.match(
     source,

--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -301,7 +301,7 @@ jobs:
       needs.authorize.outputs.authorized == 'true' &&
       needs.start.outputs.run_review == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 90
     concurrency:
       group: final-ai-review-${{ needs.authorize.outputs.pr_number }}
       cancel-in-progress: true
@@ -409,7 +409,7 @@ jobs:
             local now
             [[ "${REVIEW_JOB_STARTED_AT}" =~ ^[1-9][0-9]*$ ]]
             now="$(date +%s)"
-            if (( now + 1860 > REVIEW_JOB_STARTED_AT + 3900 )); then
+            if (( now + 2760 > REVIEW_JOB_STARTED_AT + 4800 )); then
               echo 'Refusing to start OCR without the reserved cleanup window' >&2
               return 1
             fi
@@ -421,7 +421,7 @@ jobs:
               --to "${HEAD_SHA}" \
               --audience agent \
               --effort low \
-              --timeout 30 \
+              --timeout 45 \
               --max-tokens-budget "${token_budget}" \
               --format json \
               --background "${BACKGROUND}" \
@@ -431,10 +431,10 @@ jobs:
           }
 
           : >"${STDERR_PATH}"
-          run_ocr_attempt "${RESULT_PATH}" 750000
+          run_ocr_attempt "${RESULT_PATH}" 1000000
           RESUME_PLAN_PATH="${RESULT_PATH}.resume-plan"
           node .github/scripts/final-ai-review.js plan-ocr-resume \
-            "${RESULT_PATH}" 750000 >"${RESUME_PLAN_PATH}"
+            "${RESULT_PATH}" 1000000 >"${RESUME_PLAN_PATH}"
           mapfile -t RESUME_PLAN <"${RESUME_PLAN_PATH}"
           if (( ${#RESUME_PLAN[@]} > 0 )); then
             (( ${#RESUME_PLAN[@]} == 2 ))
@@ -447,7 +447,7 @@ jobs:
             run_ocr_attempt \
               "${RESUMED_PATH}" "${REMAINING_TOKENS}" "${SESSION_ID}"
             node .github/scripts/final-ai-review.js merge-ocr-resume \
-              "${RESULT_PATH}" "${RESUMED_PATH}" 750000 >"${MERGED_PATH}"
+              "${RESULT_PATH}" "${RESUMED_PATH}" 1000000 >"${MERGED_PATH}"
             mv "${MERGED_PATH}" "${RESULT_PATH}"
           fi
 


### PR DESCRIPTION
## Summary

- The exact-head final AI review of large PR #5676 deterministically fails fail-closed: one 5-file group (the PR's core chat-history files) hits the individual lane's per-group `--timeout 30` wall, the entire 750000-token range budget is consumed, and the bounded-resume planner correctly refuses a zero-budget retry (`Partial OCR result has no token budget left to resume`, run `33334279642`). Earlier exact-head runs `33329853042`, `33318153424`, and `33315970932` failed the same way on budget exhaustion.
- This gives the individual review lane the same envelope the stack lane already has: review job `timeout-minutes` 75 -> 90, OCR window constant 3900 -> 4800 (the 600 s cleanup/publication reserve is preserved), resume-start reserve 1860 -> 2760 (so a worst-case 45-minute attempt plus a 60 s buffer always fits before the window), per-group `--timeout` 30 -> 45, and range token budget 750000 -> 1000000 across `run_ocr_attempt`, `plan-ocr-resume`, and `merge-ocr-resume`.
- The stack lane is intentionally untouched (30-minute group cap, 750000/2000000 budgets, 4200 s window, 1860 s guard). Fail-closed behavior is unchanged: a partial or budget-exhausted result still never publishes as clean, and the resume planner still allows at most one validated resume.
- Policy assertions in `final-ai-review.test.js` now pin the new values, including exactly one `--timeout 45` (individual) and one `--timeout 30` (stack) and two `timeout-minutes: 90` jobs.

## Verification

On exact head `ebff82745` (local, worktree `trees/rs-final-review-individual-headroom`):

- `node --test .github/scripts/final-ai-review.test.js`: 50/50 pass.
- Full script test directory (`node --test .github/scripts/*.test.js`): 102 pass, 0 fail.
`check-ocr-final-review.yml` parses; job timeouts resolve to `review` 90, `review_stack` 90, `finalize` 10, `finalize_stack` 10.
- `git diff origin/v3..HEAD` confirmed individual-lane-only scope: 2 files, 11 insertions, 11 deletions, no other hunks.

## Review gates

- Independent Gemini 3.7 Flash (high) slice review of the committed range: `DONE_NO_FINDINGS` (verified the coupled reserve arithmetic, budget consistency, scope discipline, and assertion fidelity).
- Integrated final review disclosure: the configured Sol final-reviewer route failed terminally three consecutive times before any work (`adapter_eof` transport disconnects: two native attempts, then one generic-continuity child on `gpt-5.6-sol` at `xhigh`). Per the model-routing continuity ladder the gate is recorded as blocked rather than substituted; this PR is published on the light-path gate (main-session diff inspection plus the focused checks above) with this disclosure. A Sol pass can be run before merge if desired.

No merge, deployment, or activation is part of this package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased OCR review timeouts and token budgets to support larger or more complex reviews.
  * Extended the overall review job duration and reserved cleanup window.
  * Updated workflow validation to reflect the revised timing and resource limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->