### PR TITLE
chore(deploy): pin chat to v3.4.0-alpha.73.2 disclaimer dark-scheme fix

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -360,7 +360,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.73.1
+    tag: v3.4.0-alpha.73.2
 
   ingress:
     annotations:


### PR DESCRIPTION
Pins production chat to `v3.4.0-alpha.73.2`, which makes the disclaimer accept button visible for students whose browser prefers a dark colour scheme.

## Why a second hotfix

`v3.4.0-alpha.73.1` (#5689) fixed the button only in light mode. Verified against the deployed stylesheets:

| Colour scheme | Button background on alpha.73.1 |
| --- | --- |
| light | `rgb(0, 40, 165)` — correct |
| dark | `oklab(0.92 … / 0.3)` — near-white behind near-white text |

Cause: `apps/chat` never defines `--color-primary-100`, which every other app does (`apps/frontend-manage/src/globals.css:83`). That is why the design-system `primary` prop rendered the button invisible in the first place. Dropping the prop falls the button back to the `outline` variant, and that variant's `dark:bg-input/30` survives tailwind-merge — a different modifier is a different class group — so it overrides `bg-primary` under `prefers-color-scheme: dark`.

`v3.4.0-alpha.73.2` restores the `primary` prop while keeping the explicit colour classes. The `default` variant carries no `dark:` background overrides, so `bg-primary` wins in both schemes. Measured with the production CSS in an emulated dark scheme: `rgb(0, 40, 165)` on `lab(98.26 0 0)`.

## Follow-up

The component fix needs to reach `v3` and `v3-ai` separately, and the underlying gap — Chat's missing `primary-100` token scale — should be closed so the design-system `primary` prop works without per-call-site overrides.

## Rollback

Restore `chat.image.tag` to `v3.4.0-alpha.73.1` (light-mode fix only) or `v3.4.0-alpha.73` (original state) and re-sync. Argo autosync is disabled, so a manual sync is required either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment to use the latest chat application release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->