### PR TITLE
chore(deploy): promote 5b5c448cc1ac to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -41,7 +41,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+        rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -66,7 +66,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+        rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -88,7 +88,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+        rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -122,7 +122,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -177,7 +177,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -360,7 +360,7 @@ chat:
 mcpStudent:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -437,7 +437,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -490,7 +490,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -544,7 +544,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -598,7 +598,7 @@ backendGraphql:
   betaSavedGroupId: grp_2CeKcuxYw3c567fSV7CPPQ
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -698,7 +698,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -751,7 +751,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
   replicaCount: 1
 
   affinity:
@@ -800,7 +800,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+    rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
 
   replicaCount: 1
 
@@ -854,7 +854,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+      rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -918,7 +918,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+      rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -996,7 +996,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: 'd32bff8b1987'
+      rollout.klicker.uzh.ch/release: '5b5c448cc1ac'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `5b5c448cc1ac129497e70dfb3f61f19f603d875a`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging deployment release marker across application services.
  * No user-facing functionality or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->