### PR TITLE
fix(deploy): allow FernUni Moodle quiz embedding

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -391,7 +391,7 @@ chat:
       memory: 1Gi
 
 frontendPWA:
-  allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://ius.zone https://*.df-app.ch'
+  allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://ius.zone https://*.df-app.ch https://moodle.fernuni.ch https://*.localhost'
   priorityClassName: production-workload
 
   replicaCount: 4

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -343,7 +343,7 @@ chat:
       memory: 768Mi
 
 frontendPWA:
-  allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
+  allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch https://moodle.fernuni.ch https://*.localhost'
   priorityClassName: staging-workload
   podAnnotations:
     rollout.klicker.uzh.ch/release: '66b27d0d521e'

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -2,7 +2,7 @@
 type: Frontend Conventions
 title: Frontend Conventions
 description: Shared conventions for manage, pwa, control, and auth — design system, Apollo with generated ops, i18n, Formik, data-cy, and CSP rules.
-timestamp: '2026-08-29'
+timestamp: '2026-08-31'
 tags:
   - frontend
 ---
@@ -110,9 +110,9 @@ Namespaces are per-app plus `shared` (`shared`, `auth`, `pwa`, `manage`, `contro
     - `privatePreview` (User-profile level): Gates advanced beta features such as element/activity sharing, microlearning, and administrator panels. Managed via the admin page (`apps/frontend-manage/src/pages/admin.tsx`).
     - `publicPreview` (User-profile level): Retained in Prisma and the public GraphQL schema, but no longer selected by Manage's user-profile query or used for learning analytics.
   - `@klicker-uzh/feature-flags` is the shared GrowthBook integration. Manage's `learning-analytics` flag defaults to false and leaves analytics controls visible but disabled. Use stable internal actor IDs for targeting, and never treat a flag as authorization. See [Feature Flags](./feature-flags.md) and [ADR 0008](./adr/0008-use-growthbook-for-feature-flags.md).
-- **CSP `frame-ancestors` is set at the proxy, never in Next.js middleware.** Middleware CSP breaks `_next/data` routes in production builds (known Next.js bug). Production: HAProxy ingress annotations (`haproxy.org/response-set-header` in `deploy/charts/klicker-uzh-v3/templates/ingress-*.yaml`); local: Traefik `customResponseHeaders` (`util/traefik/rules_docker.yaml`).
+- **CSP `frame-ancestors` is set at the proxy, never in Next.js middleware.** Middleware CSP breaks `_next/data` routes in production builds (known Next.js bug). Production: HAProxy ingress annotations (`haproxy.org/response-set-header` in `deploy/charts/klicker-uzh-v3/templates/ingress-*.yaml`) with environment-specific parent origins in `deploy/env-uzh-{stg,prd}/values.yaml`; local: Traefik `customResponseHeaders` (`util/traefik/rules_{docker,wsl}.yaml`). Use exact HTTPS origins for external LMS instances and reserve the PWA-only `*.localhost` wildcard for local development parents.
 - **Embedded PWA messaging**: use a parent-initiated `postMessage` handshake to capture `event.origin`; no `'*'` target origins and no second per-platform allowlist in page code — embedding permission is enforced by ingress `frame-ancestors`.
-- **Local embed testing**: `util/embed-harness/` must target the branch-local PWA (`http://127.0.0.1:3101/...`), not the production PWA — production CSP blocks localhost embedding.
+- **Local embed testing**: deployed PWA CSP allows HTTPS parents under `*.localhost`; the `util/embed-harness/` origin is plain HTTP on `127.0.0.1`, so it must still target the branch-local PWA (`http://127.0.0.1:3101/...`) rather than production.
 
 ## Verification
 

--- a/util/traefik/rules_docker.yaml
+++ b/util/traefik/rules_docker.yaml
@@ -21,7 +21,7 @@ http:
         - 'websecure'
       service: 'pwa'
       middlewares:
-        - 'csp-frame-ancestors'
+        - 'csp-frame-ancestors-pwa'
 
     assessment:
       rule: 'Host(`assessment.klicker.com`)'
@@ -30,7 +30,7 @@ http:
         - 'websecure'
       service: 'pwa'
       middlewares:
-        - 'csp-frame-ancestors'
+        - 'csp-frame-ancestors-pwa'
 
     manage:
       rule: 'Host(`manage.klicker.com`)'
@@ -83,6 +83,10 @@ http:
       headers:
         customResponseHeaders:
           Content-Security-Policy: "frame-ancestors 'self' *.uzh.ch"
+    csp-frame-ancestors-pwa:
+      headers:
+        customResponseHeaders:
+          Content-Security-Policy: "frame-ancestors 'self' *.uzh.ch *.localhost"
 
   services:
     api:

--- a/util/traefik/rules_wsl.yaml
+++ b/util/traefik/rules_wsl.yaml
@@ -21,7 +21,7 @@ http:
         - 'websecure'
       service: 'pwa'
       middlewares:
-        - 'csp-frame-ancestors'
+        - 'csp-frame-ancestors-pwa'
 
     assessment:
       rule: 'Host(`assessment.klicker.com`)'
@@ -30,7 +30,7 @@ http:
         - 'websecure'
       service: 'pwa'
       middlewares:
-        - 'csp-frame-ancestors'
+        - 'csp-frame-ancestors-pwa'
 
     manage:
       rule: 'Host(`manage.klicker.com`)'
@@ -83,6 +83,10 @@ http:
       headers:
         customResponseHeaders:
           Content-Security-Policy: "frame-ancestors 'self' *.uzh.ch"
+    csp-frame-ancestors-pwa:
+      headers:
+        customResponseHeaders:
+          Content-Security-Policy: "frame-ancestors 'self' *.uzh.ch *.localhost"
 
   services:
     api:


### PR DESCRIPTION
## What This Fixes

Allows KlickerUZH quiz pages to be embedded by the FernUni Moodle instance and HTTPS development origins under `*.localhost`.

- Adds `https://moodle.fernuni.ch` and `https://*.localhost` to the staging and production PWA `frame-ancestors` allowlists.
- Gives legacy local PWA and assessment routes a scoped Traefik middleware for `*.localhost`; Chat and Control keep their existing policy.
- Updates the engineering guidance for deployed and local PWA embedding.

## Branch Coverage

- Base: `v3`
- Head: `3b27b9223`
- Reviewed: 1 commit, 26 substantive changed lines across 5 files.
- Packaging: complete, isolated allowlist package under the approximately 50-line packaging floor.

## Review Focus

- Confirm the external LMS entry remains an exact HTTPS origin.
- Confirm the localhost wildcard is limited to PWA/assessment routes in local Traefik configuration.

## Verification

Current head:

- `helm lint deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-prd/values.yaml` -> 1 chart linted, 0 failed.
- `helm lint deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-stg/values.yaml` -> 1 chart linted, 0 failed.
- Focused Helm renders -> both PWA ingress headers contain the exact Moodle and HTTPS localhost sources.
- Ruby YAML assertions -> both Traefik files parse and only PWA/assessment routes receive the localhost-capable middleware.
- `gitleaks git --log-opts='origin/v3..HEAD'` -> 1 commit scanned, no leaks found.

Failed/Warning:

- The repository-wide OKF validator reports 25 pre-existing core conformance errors; none reference the changed page.

Not run:

- No deployment or live browser verification. This PR proves the desired headers render from source; deployed response headers and Moodle embedding remain post-rollout checks.
- Full application build; the change is limited to YAML and Markdown, and exact-head CI remains required.

## Security / Privacy

- The LMS parent is restricted to the exact HTTPS origin `https://moodle.fernuni.ch`.
- Deployed localhost embedding is restricted to HTTPS subdomains under `.localhost`.
- No secrets, personal data, dependencies, application data flows, or authentication behavior changed.

## Blocking Before Merge

- [ ] Exact-head required CI passes.
- [ ] Human review confirms the CSP allowlist scope.

## Follow-Up After Merge

- [ ] After rollout, verify the deployed PWA `Content-Security-Policy` response header and an actual FernUni Moodle quiz embed.

## Local Session Artifacts

- Machine: `MacBook-Pro`
- Worktree: `trees/allow-fernuni-quiz-embedding` in repository `klicker-uzh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the PWA and assessment interfaces to be embedded from Moodle, local development environments, and approved university domains.
  * Added support for local HTTPS and HTTP embed-harness scenarios.

* **Documentation**
  * Updated embedding and Content Security Policy guidance with environment-specific configuration details and local development instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->