### PR TITLE
enhance(manage): improve question library scanning

### DIFF
--- a/apps/frontend-manage/src/components/common/Pagination.tsx
+++ b/apps/frontend-manage/src/components/common/Pagination.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from 'next-intl'
 import { Dispatch, SetStateAction } from 'react'
 import { twMerge } from 'tailwind-merge'
 import usePaginationPageNumbers from '../../lib/hooks/usePaginationPageNumbers'
+import { computeResultRange } from '../../lib/resultRange'
 
 export type PaginationPageSize = 10 | 20 | 50 | 'all'
 
@@ -42,6 +43,11 @@ function Pagination({
 }) {
   const t = useTranslations()
   const pageNumbers = usePaginationPageNumbers({ currentPage, totalPages })
+  const { start, end, total } = computeResultRange({
+    currentPage,
+    pageSize,
+    numOfElements: numOfObjects,
+  })
 
   return (
     <div
@@ -51,14 +57,14 @@ function Pagination({
       )}
     >
       {/* Left zone: result range summary */}
-      <div className="text-muted-foreground text-center text-xs lg:col-start-1 lg:justify-self-start lg:text-left">
+      <div
+        data-cy="result-range-summary"
+        className="text-muted-foreground text-center text-xs lg:col-start-1 lg:justify-self-start lg:text-left"
+      >
         {t('manage.general.showingResults', {
-          start: pageSize === 'all' ? 1 : (currentPage - 1) * pageSize + 1,
-          end:
-            pageSize === 'all'
-              ? numOfObjects
-              : Math.min(currentPage * pageSize, numOfObjects),
-          total: numOfObjects,
+          start,
+          end,
+          total,
         })}
       </div>
 

--- a/apps/frontend-manage/src/components/elements/Element.tsx
+++ b/apps/frontend-manage/src/components/elements/Element.tsx
@@ -13,7 +13,7 @@ import {
   type Tag,
   UserProfileDocument,
 } from '@klicker-uzh/graphql/dist/ops'
-import { Ellipsis } from '@klicker-uzh/markdown'
+import { Ellipsis, markdownToPlainText } from '@klicker-uzh/markdown'
 import { Badge, Button, Checkbox, Dropdown } from '@uzh-bf/design-system'
 import dayjs from 'dayjs'
 import { useTranslations } from 'next-intl'
@@ -211,6 +211,7 @@ function Element({
                 <Ellipsis
                   maxLines={2}
                   withMarkdown={false}
+                  previewContent={markdownToPlainText(element.content)}
                   className={{ root: 'text-left' }}
                 >
                   {element.content}

--- a/apps/frontend-manage/src/components/elements/manipulation/ElementBatchOperationsModal.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementBatchOperationsModal.tsx
@@ -293,7 +293,10 @@ function ElementBatchOperationsModal({
           ) : (
             <div className="flex h-auto min-h-0 flex-col gap-6 md:flex-row md:gap-6 lg:h-full lg:max-h-full">
               <div className="flex h-max max-h-full min-h-0 w-full flex-col gap-4 overflow-auto md:w-1/2 lg:max-h-[calc(100vh-6rem)] lg:w-2/5">
-                <div className="text-sm">
+                <div
+                  className="text-sm"
+                  data-cy="batch-selected-elements-description"
+                >
                   {t('manage.questionPool.selectedElementsDescription')}
                 </div>
                 <div className="min-h-0 flex-1 overflow-auto">

--- a/apps/frontend-manage/src/components/elements/manipulation/batchOperations/ElementInstanceUpdatesCard.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/batchOperations/ElementInstanceUpdatesCard.tsx
@@ -44,10 +44,8 @@ function ElementInstanceUpdatesCard({
       <CardContent className="px-0">
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-600">
-              {t('manage.questionPool.draftScheduledActivities')}
-            </span>
             <Switch
+              id="batch-update-instances"
               checked={selectedActions.updateInstances ?? false}
               onCheckedChange={(checked) => {
                 setSelectedActions((prev) => ({
@@ -60,12 +58,16 @@ function ElementInstanceUpdatesCard({
               }}
               data={{ cy: 'instance-updates-switch' }}
             />
+            <label
+              htmlFor="batch-update-instances"
+              className="text-sm text-gray-600"
+            >
+              {t('manage.questionPool.batchUpdateInstancesConsequence')}
+            </label>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-600">
-              {t('manage.questionPool.templateUpdates')}
-            </span>
             <Switch
+              id="batch-update-template-instances"
               disabled={!selectedActions.updateInstances}
               checked={selectedActions.updateTemplateInstances ?? false}
               onCheckedChange={(checked) => {
@@ -76,6 +78,15 @@ function ElementInstanceUpdatesCard({
               }}
               data={{ cy: 'template-updates-switch' }}
             />
+            <label
+              htmlFor="batch-update-template-instances"
+              className={twMerge(
+                'text-sm text-gray-600',
+                !selectedActions.updateInstances && 'text-gray-400'
+              )}
+            >
+              {t('manage.questionPool.batchUpdateTemplateInstancesConsequence')}
+            </label>
           </div>
         </div>
       </CardContent>

--- a/apps/frontend-manage/src/components/elements/manipulation/batchOperations/SelectedElementsList.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/batchOperations/SelectedElementsList.tsx
@@ -34,40 +34,32 @@ function SelectedElementsList({
       <ShadcnTable className="mt-2">
         <ShadcnTableHeader>
           <ShadcnTableRow>
-            <ShadcnTableHead>
-              <span className="sr-only">
-                {t('manage.questionPool.batchElementName')}
-              </span>
+            <ShadcnTableHead
+              className="px-2 text-left"
+              data-cy="batch-element-name-heading"
+            >
+              {t('manage.questionPool.batchElementName')}
             </ShadcnTableHead>
             {!allAdminPermissions ? (
-              <ShadcnTableHead className="w-5.5 px-0">
-                <span className="sr-only">
-                  {t('manage.questionPool.batchElementPermission')}
-                </span>
+              <ShadcnTableHead
+                className="w-28 px-2 text-left"
+                data-cy="batch-element-permission-heading"
+              >
+                {t('manage.questionPool.batchElementPermission')}
               </ShadcnTableHead>
             ) : null}
             <ShadcnTableHead
-              className="w-5.5 px-0 text-center"
-              aria-disabled={!updatesConfigured}
+              className="w-28 px-2 text-center"
+              data-cy="batch-element-update-heading"
             >
-              <span className="sr-only">
-                {updatesConfigured
-                  ? t('manage.questionPool.batchUpdateStatus')
-                  : t('manage.questionPool.batchUpdateStatusInactive')}
-              </span>
-              {!updatesConfigured ? (
-                <FontAwesomeIcon
-                  aria-hidden
-                  icon={faMinus}
-                  className="text-gray-400"
-                />
-              ) : null}
+              {t('manage.questionPool.batchUpdateStatus')}
             </ShadcnTableHead>
             {sharingEnabled ? (
-              <ShadcnTableHead className="w-5.5 px-0 text-center">
-                <span className="sr-only">
-                  {t('manage.questionPool.batchSharingStatus')}
-                </span>
+              <ShadcnTableHead
+                className="w-28 px-2 text-center"
+                data-cy="batch-element-sharing-heading"
+              >
+                {t('manage.questionPool.batchSharingStatus')}
               </ShadcnTableHead>
             ) : null}
           </ShadcnTableRow>
@@ -90,7 +82,7 @@ function SelectedElementsList({
               </ShadcnTableCell>
               {!allAdminPermissions ? (
                 !element.isOwner ? (
-                  <ShadcnTableCell className="w-5.5 px-0 text-center">
+                  <ShadcnTableCell className="w-28 px-2 text-center">
                     <ObjectPermissionLevel
                       iconOnly
                       objectName={element.name}
@@ -98,10 +90,10 @@ function SelectedElementsList({
                     />
                   </ShadcnTableCell>
                 ) : (
-                  <ShadcnTableCell className="w-5.5" />
+                  <ShadcnTableCell className="w-28 px-2" />
                 )
               ) : null}
-              <ShadcnTableCell className="w-5.5 px-0 text-center">
+              <ShadcnTableCell className="w-28 px-2 text-center">
                 {!updatesConfigured ? (
                   <span
                     role="img"
@@ -163,7 +155,7 @@ function SelectedElementsList({
                 )}
               </ShadcnTableCell>
               {sharingEnabled ? (
-                <ShadcnTableCell className="w-5.5 px-0 text-center">
+                <ShadcnTableCell className="w-28 px-2 text-center">
                   {element.sharingApplied ? (
                     <span
                       role="img"

--- a/apps/frontend-manage/src/components/elements/manipulation/types.ts
+++ b/apps/frontend-manage/src/components/elements/manipulation/types.ts
@@ -148,7 +148,7 @@ export const INITIAL_ELEMENT_BATCH_OPERATIONS: ElementBatchOperationActions = {
   status: undefined,
   multiplier: undefined,
   basePoints: undefined,
-  updateInstances: true,
+  updateInstances: false,
   updateTemplateInstances: false,
 }
 

--- a/apps/frontend-manage/src/components/elements/tags/FilterList.tsx
+++ b/apps/frontend-manage/src/components/elements/tags/FilterList.tsx
@@ -130,11 +130,16 @@ function FilterList({
 
   return (
     <div className="flex h-max max-h-full flex-1 flex-col overflow-y-auto rounded-md border border-solid p-2 text-sm md:w-56">
-      <Accordion type="single" defaultValue={defaultValue} className="w-full">
+      <Accordion
+        type="multiple"
+        defaultValue={[defaultValue]}
+        className="w-full"
+      >
         <FilterListEntry
           trigger={t('manage.questionPool.elementStatus')}
           value="element-status"
           active={!!filters.status}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: 'collapse-tag-header-status' }}
         >
           {Object.entries(ELEMENT_STATUS_FILTERS).map(([status, icons]) => (
@@ -160,6 +165,7 @@ function FilterList({
           trigger={t('manage.questionPool.elementTypes')}
           value="element-types"
           active={!!filters.type}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: 'collapse-tag-header-types' }}
         >
           {Object.entries(ELEMENT_TYPE_FILTERS).map(([type, icons]) => {
@@ -210,6 +216,7 @@ function FilterList({
             trigger={t('shared.generic.sharing')}
             value="sharing-types"
             active={filters.sharingType?.length !== 3}
+            appliedLabel={t('manage.questionPool.filterApplied')}
             data={{ cy: `collapse-tag-header-sharing` }}
           >
             {Object.entries(SHARING_TYPE_FILTERS).map(([type, icons]) => {
@@ -249,6 +256,7 @@ function FilterList({
           trigger={t('manage.questionPool.tags')}
           value="user-tags"
           active={filters.tags.length > 0 || filters.untagged}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: `collapse-tag-header-user-tags` }}
         >
           <Suspense fallback={<Loader />}>
@@ -265,6 +273,7 @@ function FilterList({
           trigger={t('manage.questionPool.activityUsage')}
           value="used-in-activity"
           active={typeof filters.activityId !== 'undefined'}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: `collapse-tag-header-used-in-activity` }}
         >
           <Suspense fallback={<Loader />}>
@@ -281,6 +290,7 @@ function FilterList({
           trigger={t('shared.generic.multiplier')}
           value="multiplier-filters"
           active={filters.multiplier !== undefined}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: `collapse-tag-header-multiplier` }}
         >
           {['1', '2', '3', '4'].map((multiplier) => (
@@ -303,6 +313,7 @@ function FilterList({
           trigger={t('shared.generic.gamification')}
           value="gamification-tags"
           active={filters.sampleSolution || filters.answerFeedbacks}
+          appliedLabel={t('manage.questionPool.filterApplied')}
           data={{ cy: `collapse-tag-header-gamification` }}
         >
           <FilterItem

--- a/apps/frontend-manage/src/components/elements/tags/FilterListEntry.tsx
+++ b/apps/frontend-manage/src/components/elements/tags/FilterListEntry.tsx
@@ -9,12 +9,14 @@ function FilterListEntry({
   trigger,
   value,
   active = false,
+  appliedLabel,
   data,
   children,
 }: {
   trigger: string
   value: string
   active?: boolean
+  appliedLabel?: string
   data?: { cy?: string; test?: string }
   children: React.ReactNode
 }) {
@@ -27,7 +29,19 @@ function FilterListEntry({
         )}
         data-cy={data?.cy}
       >
-        {trigger}
+        {active && appliedLabel ? (
+          <span className="flex w-full flex-row items-center justify-between gap-2">
+            <span>{trigger}</span>
+            <span
+              data-cy={data?.cy ? `${data.cy}-applied` : undefined}
+              className="rounded-full bg-primary-100 px-2 py-0.5 text-xs font-bold text-white"
+            >
+              {appliedLabel}
+            </span>
+          </span>
+        ) : (
+          trigger
+        )}
       </AccordionTrigger>
       <AccordionContent className="pb-2">
         <ul className="list-none">{children}</ul>

--- a/apps/frontend-manage/src/lib/resultRange.ts
+++ b/apps/frontend-manage/src/lib/resultRange.ts
@@ -1,0 +1,23 @@
+import type { PaginationPageSize } from '@components/common/Pagination'
+
+export function computeResultRange({
+  currentPage,
+  pageSize,
+  numOfElements,
+}: {
+  currentPage: number
+  pageSize: PaginationPageSize
+  numOfElements: number
+}): { start: number; end: number; total: number } {
+  if (numOfElements === 0) {
+    return { start: 0, end: 0, total: 0 }
+  }
+
+  const start = pageSize === 'all' ? 1 : (currentPage - 1) * pageSize + 1
+  const end =
+    pageSize === 'all'
+      ? numOfElements
+      : Math.min(currentPage * pageSize, numOfElements)
+
+  return { start, end, total: numOfElements }
+}

--- a/apps/frontend-manage/src/pages/index.tsx
+++ b/apps/frontend-manage/src/pages/index.tsx
@@ -18,6 +18,7 @@ import Pagination, {
   isPaginationPageSize,
   type PaginationPageSize,
 } from '@components/common/Pagination'
+import { computeResultRange } from '@lib/resultRange'
 import ElementList from '../components/elements/ElementList'
 import ElementListSearch from '../components/elements/ElementListSearch'
 import ElementListSelectAllCheckbox from '../components/elements/ElementListSelectAllCheckbox'
@@ -180,6 +181,11 @@ function Index() {
   // compute the number of total pagination pages
   const totalPages =
     pageSize === 'all' ? 1 : Math.max(1, Math.ceil(numOfElements / pageSize))
+  const resultRange = computeResultRange({
+    currentPage,
+    pageSize,
+    numOfElements,
+  })
 
   // if the filters or sorting state changes, save it to local storage
   useEffect(() => {
@@ -403,6 +409,16 @@ function Index() {
               </div>
             ) : (
               <div className="flex min-h-0 flex-1 flex-col">
+                <div
+                  data-cy="result-range-summary-top"
+                  className="text-muted-foreground flex-none pb-2 text-xs"
+                >
+                  {t('manage.general.showingResults', {
+                    start: resultRange.start,
+                    end: resultRange.end,
+                    total: resultRange.total,
+                  })}
+                </div>
                 <div className="min-h-0 flex-1 overflow-y-auto">
                   <ElementList
                     filtersActive={filtersActiveExceptCourse}

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -24,6 +24,7 @@ The valid repository pattern for an icon-only action is one non-interactive rela
 3. The tooltip is a sibling `span` with `role="tooltip"`, `pointer-events-none`, and no `tabIndex`; it is revealed by the CSS classes `group-hover` and `group-focus-within` only.
 
 The element card uses this pattern for every visible icon action and for the overflow trigger, whose Dropdown trigger contains the ellipsis plus a localized `sr-only` label (`apps/frontend-manage/src/components/elements/IconActionTooltip.tsx:IconActionTooltip`, `apps/frontend-manage/src/components/elements/Element.tsx:Element`). The sort-order toggle applies the same wrapper with the label of the _next_ action, so an ascending list discloses "Sort descending" and flips on activation (`apps/frontend-manage/src/components/elements/ElementListSorting.tsx:ElementListSorting`).
+The element-card preview is the only place that projects Markdown to plain text: the visible two-line preview must go through `markdownToPlainText` and into `Ellipsis.previewContent` so it shows readable text without raw formatting controls, while the hover/focus tooltip must keep rendering the original stored Markdown via the `Markdown` component (`apps/frontend-manage/src/components/elements/Element.tsx:Element`, `packages/markdown/src/plainText.ts:markdownToPlainText`).
 
 Assessment participant administration follows that rule: managers reach the dedicated invitation page from the course overflow menu (`CourseOverviewHeader.tsx:courseActionMenuItems`). The page parses CSV files with a small dependency-free browser parser only after file selection, then sends typed rows through generated GraphQL operations (`apps/frontend-manage/src/components/courses/participantInvitations/ParticipantInvitationCsvUpload.tsx:handleFileSelection`). The canonical browser-generated template contains only `email,matriculationNumber`; uploaded files may use comma or semicolon delimiters and supported matriculation-header aliases, but required semantic headers must be unique and every non-empty record must match the header width. Reject malformed quoting locally while preserving server-side per-row email errors and partial success. The affiliation notice is advisory: only a verified Swiss Edu-ID affiliation can establish the identity match, so do not infer or enforce affiliation from a domain suffix. Keep per-row import failures visible, show `PENDING` and `ACCEPTED` as distinct table states, and expose deletion only on pending rows (`ParticipantInvitationsTable.tsx:ParticipantInvitationsTable`).
 
@@ -73,7 +74,7 @@ contract is unchanged.
 - Function components with hooks only; PascalCase files; app-local components under `src/components/` with relative imports.
 - Clickable rows must ignore events from marked interactive subtrees so opening a dropdown or modal cannot also trigger the row navigation.
 - Async Formik submit handlers must return or await their mutation promise so `isSubmitting` remains active and users cannot navigate away before the save completes.
-- **Pinned list controls**: pagination / entries-per-page controls must never scroll away with their list. On a page, make the container `flex flex-col`, give the scrolling list its own `min-h-0 flex-1 overflow-y-auto` child, and keep the pager a `flex-none` sibling below it (`pages/index.tsx`, `pages/activities.tsx`). Inside the design-system `Modal` — whose content is itself `overflow-y-auto` — neutralize that with `className.content: 'overflow-visible'` and cap the list with `max-h-[...] overflow-y-auto` so it is the single scroll boundary (`ExistingElementSelectionModal.tsx`, `courses/CourseVerifiableCredentialsModal.tsx`).
+- **Pinned list controls**: pagination / entries-per-page controls must never scroll away with their list. On a page, make the container `flex flex-col`, give the scrolling list its own `min-h-0 flex-1 overflow-y-auto` child, and keep the pager a `flex-none` sibling below it (`pages/index.tsx`, `pages/activities.tsx`). When the list itself scrolls, the same result-range summary the pager shows must also render above the scroll boundary, derived from the same calculation and values (`pages/index.tsx`, `apps/frontend-manage/src/lib/resultRange.ts:computeResultRange`). Inside the design-system `Modal` — whose content is itself `overflow-y-auto` — neutralize that with `className.content: 'overflow-visible'` and cap the list with `max-h-[...] overflow-y-auto` so it is the single scroll boundary (`ExistingElementSelectionModal.tsx`, `courses/CourseVerifiableCredentialsModal.tsx`).
 
 ### Domain-specific creation actions
 
@@ -86,6 +87,7 @@ contract is unchanged.
 
 - Element type choices must be explained before selection: render every option as the existing type label plus a concise authoring description derived from `apps/docs/docs/tutorials/supported_element_types.mdx`, keep the type label as the select's `shortLabel` so the selected trigger stays compact, and preserve the existing values, ordering, and `select-question-type-*` `data-cy` hooks. Normal library creation additionally shows one paired-language notice that the type cannot be changed after creation; edit, duplicate, and template creation keep their existing semantics (`apps/frontend-manage/src/components/elements/manipulation/useElementTypeOptions.ts:useElementTypeOptions`, `apps/frontend-manage/src/components/elements/manipulation/ElementInformationFields.tsx:ElementInformationFields`).
 - A Boolean that must be decided explicitly stays unset (`boolean | undefined`) until the user chooses: render it as a design-system `RadioGroup` with stable Yes and No `data-cy` hooks, convert the radio string to a real boolean at the UI boundary, and never let `undefined` reach the mutation — no `?? false` fallback, Save disabled while unset, and keyboard/form submission blocked independently (`apps/frontend-manage/src/components/user/SuspendedFirstLoginModal.tsx:SuspendedFirstLoginModal`).
+- Batch operations that propagate element changes into activities default to off. Keep selected-element column headings visible, put each propagation consequence beside and programmatically associate it with its switch, and keep template propagation disabled until the lecturer explicitly enables activity-instance propagation (`apps/frontend-manage/src/components/elements/manipulation/batchOperations/SelectedElementsList.tsx:SelectedElementsList`, `apps/frontend-manage/src/components/elements/manipulation/batchOperations/ElementInstanceUpdatesCard.tsx:ElementInstanceUpdatesCard`).
 
 ## Markdown and Video Embeds
 
@@ -119,7 +121,12 @@ keeps the active filters and sort, resets to page 1, omits `numEntries` and
 `offset`, and hides page navigation. It loads the current filtered result and
 does not select records; the existing list checkbox remains the explicit
 select-all action. Page-size preferences accept only those four values when
-read from local storage. The verification-record modal keeps the shared
+read from local storage. The Elements page renders the same start/end/total
+summary above its scrolling list and in the pager, both fed by the shared
+range calculation. The question library filter sidebar lets several groups
+remain open at once, marks each group whose values are applied with a localized label, and
+keeps Status open by default (or Used in activity when a course/activity
+filter selects it). The verification-record modal keeps the shared
 control's default opt-out because its backend fetch remains capped at 100
 records (`apps/frontend-manage/src/components/common/Pagination.tsx:Pagination`,
 `apps/frontend-manage/src/pages/index.tsx:Index`,

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2047,6 +2047,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       moreActions: 'Weitere Aktionen für {name}',
       elementTypes: 'Elementtypen',
       elementStatus: 'Status',
+      filterApplied: 'Filter aktiv',
       tags: 'Tags',
       selectOrType: 'Auswählen oder Eingeben...',
       untagged: 'Ohne Tags',
@@ -2112,12 +2113,12 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       batchOperationsElements: 'Elemente - Batch-Operationen',
       batchOperationsApplying: 'Batch-Operationen werden angewendet…',
       selectedElementsDescription:
-        'Sie haben die folgenden Elemente ausgewählt. Alle Elemente, welche von den gewählten Aktionen betroffen sind, sind markiert. Fokussieren Sie das Symbol für nicht betroffene Elemente mit der Tastatur oder Maus, um weitere Informationen zu erhalten. Bitte beachten Sie: Einige Aktionen können nur einzeln durchgeführt werden oder erfordern bestimmte Zugriffsrechte (siehe Tooltip). Überprüfen Sie die ausgewählten Aktionen sorgfältig, bevor Sie diese anwenden.',
+        'Prüfen Sie die ausgewählten Elemente unten. Wählen Sie anschliessend die anzuwendenden Aktionen.',
       batchElementName: 'Element',
-      batchElementPermission: 'Ihre Berechtigung',
-      batchUpdateStatus: 'Eignung für Elementänderungen',
+      batchElementPermission: 'Berechtigung',
+      batchUpdateStatus: 'Änderungen',
       batchUpdateStatusInactive: 'Keine Elementänderung konfiguriert',
-      batchSharingStatus: 'Eignung für Elementfreigaben',
+      batchSharingStatus: 'Freigabe',
       actionApplies: 'Aktion wird angewendet',
       batchSharingApplies: 'Freigabe wird angewendet',
       modifyStatus: 'Status ändern',
@@ -2179,8 +2180,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       updateActivitiesBatchInfo:
         'Wählen Sie hier, ob die Änderungen, die an den ausgewählten Elementen vorgenommen werden, auch auf alle Aktivitäten im Entwurf- und Planungsstatus angewendet werden sollen. Optional können Sie auch Aktivitätsvorlagen mit diesem Element in das Update einbeziehen.',
       activityUpdates: 'Aktivitäts-Updates',
-      draftScheduledActivities: 'Entwurfs- und geplante Aktivitäten',
-      templateUpdates: 'Aktivitätsvorlagen-Updates',
+      batchUpdateInstancesConsequence:
+        'Änderungen auch auf entworfene und geplante Aktivitäten anwenden',
+      batchUpdateTemplateInstancesConsequence:
+        'Aktivitätsvorlagen ebenfalls aktualisieren',
       batchOperationSuccess:
         'Ihre Batch-Operation wurde erfolgreich durchgeführt.',
       batchOperationPartialSuccess:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2034,6 +2034,7 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       moreActions: 'More actions for {name}',
       elementTypes: 'Element Types',
       elementStatus: 'Status',
+      filterApplied: 'Filter applied',
       tags: 'Tags',
       selectOrType: 'Select or Type...',
       untagged: 'Untagged',
@@ -2098,12 +2099,12 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       batchOperationsElements: 'Elements - Batch Operations',
       batchOperationsApplying: 'Applying batch operations…',
       selectedElementsDescription:
-        'You have selected the following elements. All elements, which are affected by the selected actions, are marked. Focus or hover over the icon for unaffected elements for more information. Please note: Some actions can only be performed separately or require specific permissions (see tooltip). Carefully review the selected actions and affected elements before applying them.',
+        'Review the selected elements below. Then choose the actions to apply.',
       batchElementName: 'Element',
-      batchElementPermission: 'Your permission',
-      batchUpdateStatus: 'Element update eligibility',
+      batchElementPermission: 'Permission',
+      batchUpdateStatus: 'Changes',
       batchUpdateStatusInactive: 'No element update configured',
-      batchSharingStatus: 'Element sharing eligibility',
+      batchSharingStatus: 'Sharing',
       actionApplies: 'Action applies',
       batchSharingApplies: 'Sharing applies',
       modifyStatus: 'Modify status',
@@ -2164,8 +2165,9 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       updateActivitiesBatchInfo:
         'Choose here if the modifications made to the selected elements should also be applied to all activities in draft and scheduled state. Optionally, you can also include activity templates with this element in the update.',
       activityUpdates: 'Activity updates',
-      draftScheduledActivities: 'Draft and scheduled activities',
-      templateUpdates: 'Activity template updates',
+      batchUpdateInstancesConsequence:
+        'Also apply these changes to draft and scheduled activities',
+      batchUpdateTemplateInstancesConsequence: 'Also update activity templates',
       batchOperationSuccess: 'Your batch operation was successfully applied.',
       batchOperationPartialSuccess:
         'Only a part of your batch operation could be applied successfully. Please check the affected elements and your permissions.',

--- a/packages/markdown/src/Ellipsis.tsx
+++ b/packages/markdown/src/Ellipsis.tsx
@@ -28,10 +28,12 @@ export interface EllipsisBaseProps {
 export interface EllipsisPropsMaxLength extends EllipsisBaseProps {
   maxLength: number
   maxLines?: never
+  previewContent?: never
 }
 export interface EllipsisPropsMaxLines extends EllipsisBaseProps {
   maxLength?: never
   maxLines: 1 | 2 | 3
+  previewContent?: string
 }
 
 export type EllipsisProps = EllipsisPropsMaxLength | EllipsisPropsMaxLines
@@ -43,9 +45,12 @@ function Ellipsis({
   withoutPopup = false,
   withMarkdown = true,
   withMarkdownTooltip = true,
+  previewContent,
   className,
 }: EllipsisProps): React.ReactElement {
   if (maxLines) {
+    const visibleContent = previewContent ?? children
+
     return (
       <Tooltip
         delay={1000}
@@ -103,8 +108,11 @@ function Ellipsis({
               className?.content
             )}
           >
-            {typeof children === 'string'
-              ? decodeHtmlEntities(children)
+            {typeof visibleContent === 'string'
+              ? (previewContent === undefined
+                  ? decodeHtmlEntities(visibleContent)
+                  : visibleContent
+                )
                   .split('\n')
                   .filter((line) => line.trim() !== '')
                   .slice(0, maxLines) // only include the first maxLines lines
@@ -114,7 +122,7 @@ function Ellipsis({
                       {i < arr.length - 1 && <br />}
                     </React.Fragment>
                   ))
-              : children}
+              : visibleContent}
           </div>
         )}
       </Tooltip>

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Ellipsis } from './Ellipsis.js'
 export { default as ImgWithModal } from './ImgWithModal.js'
 export { default as Markdown } from './Markdown.js'
+export { markdownToPlainText } from './plainText.js'
 export { getVideoEmbedSrc, parseVideoEmbedUrl } from './VideoEmbedUrl.js'

--- a/packages/markdown/src/plainText.ts
+++ b/packages/markdown/src/plainText.ts
@@ -1,0 +1,73 @@
+import remarkMath from 'remark-math'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+// Project a Markdown string to a single line of readable plain text.
+//
+// This is a synchronous projector with no additional dependencies, used for the visible
+// element-card preview in the question library. It keeps human-readable
+// text (headings, emphasis, links, images, code, math), decodes character
+// references through parsing, and collapses block/line whitespace into a
+// single space. URL destinations, media sources, raw HTML, and formatting
+// controls are omitted.
+//
+// This projector deliberately uses structural node types instead of the
+// mdast typings, which are not a direct dependency of this package. The
+// remark-parse AST is a plain tree of { type, value?, alt?, children? }.
+
+interface MarkdownNode {
+  type: string
+  value?: string
+  alt?: string
+  children?: MarkdownNode[]
+}
+
+const BLOCK_CONTAINERS = new Set(['root', 'blockquote', 'list', 'listItem'])
+
+function projectNode(node: MarkdownNode): string {
+  switch (node.type) {
+    case 'text':
+    case 'inlineCode':
+    case 'inlineMath':
+    case 'code':
+    case 'math':
+      return node.value ?? ''
+    case 'image':
+    case 'imageReference':
+      return node.alt ?? ''
+    case 'break':
+    case 'thematicBreak':
+      return ' '
+    case 'html':
+    case 'definition':
+    case 'footnoteReference':
+    case 'yaml':
+    case 'toml':
+      return ''
+    default:
+      return (node.children ?? [])
+        .map(projectNode)
+        .filter(Boolean)
+        .join(BLOCK_CONTAINERS.has(node.type) ? ' ' : '')
+  }
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Project Markdown to a single line of readable plain text.
+ *
+ * This is a synchronous projector over the unified/remark-parse AST. It is
+ * used only for the two-line element-card preview in the Manage question
+ * library; the original Markdown is never modified and all other rendering
+ * paths keep their current behavior.
+ */
+export function markdownToPlainText(markdown: string): string {
+  const tree = unified()
+    .use(remarkParse)
+    .use(remarkMath)
+    .parse(markdown) as MarkdownNode
+  return collapseWhitespace(projectNode(tree))
+}

--- a/packages/markdown/test/plainText.test.ts
+++ b/packages/markdown/test/plainText.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { markdownToPlainText } from '../src/plainText.js'
+
+describe('markdownToPlainText', () => {
+  it('projects headings and emphasis while keeping inline adjacency', () => {
+    expect(
+      markdownToPlainText(
+        '# Heading\n\nSome **bold** and word**part**end text.'
+      )
+    ).toBe('Heading Some bold and wordpartend text.')
+  })
+
+  it('keeps link labels but omits destinations', () => {
+    expect(
+      markdownToPlainText('[KlickerUZH](https://klicker.uzh.ch) is a tool.')
+    ).toBe('KlickerUZH is a tool.')
+  })
+
+  it('keeps image alt text but omits sources', () => {
+    expect(markdownToPlainText('![Diagram](https://example.com/a.png)')).toBe(
+      'Diagram'
+    )
+  })
+
+  it('projects video and embed links as their visible labels', () => {
+    expect(
+      markdownToPlainText(
+        '[video](https://www.youtube.com/watch?v=dQw4w9WgXcQ) and [embed](https://uzh.mediaspace.cast.switch.ch/media/x/0_abc123/123)'
+      )
+    ).toBe('video and embed')
+  })
+
+  it('decodes named and numeric character references', () => {
+    expect(
+      markdownToPlainText('A &amp; B &lt;tag&gt; &#39;quote&#39; &quot;x&quot;')
+    ).toBe('A & B <tag> \'quote\' "x"')
+  })
+
+  it('keeps inline and fenced code values', () => {
+    expect(
+      markdownToPlainText('Use `const x = 1` now.\n\n```ts\nconst y = 2\n```')
+    ).toBe('Use const x = 1 now. const y = 2')
+  })
+
+  it('keeps inline and display math values', () => {
+    expect(
+      markdownToPlainText('Inline $E(R_i)$ and display $$E(R_i) = R_f$$ math.')
+    ).toBe('Inline E(R_i) and display E(R_i) = R_f math.')
+  })
+
+  it('omits raw HTML controls while retaining readable inline text', () => {
+    expect(
+      markdownToPlainText('Before <span class="x">inside</span> after.')
+    ).toBe('Before inside after.')
+  })
+
+  it('omits raw active-content blocks', () => {
+    expect(
+      markdownToPlainText(
+        'Before\n\n<script>alert("not visible")</script>\n\nAfter'
+      )
+    ).toBe('Before After')
+  })
+
+  it('projects lists, line breaks, and collapses whitespace', () => {
+    expect(
+      markdownToPlainText(
+        '- one\n- two\n\n1. first\n2. second\n\nLine one  \nLine two'
+      )
+    ).toBe('one two first second Line one Line two')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(markdownToPlainText('')).toBe('')
+    expect(markdownToPlainText('   \n\n  ')).toBe('')
+  })
+})

--- a/playwright/profiles.json
+++ b/playwright/profiles.json
@@ -23,6 +23,8 @@
         "L-elements-case-study.spec.ts",
         "MB-instance-updates.spec.ts",
         "P-pagination-show-all.spec.ts",
+        "P-question-library-batch-operations.spec.ts",
+        "P-question-library-filters.spec.ts",
         "T-resources.spec.ts",
         "U-catalog.spec.ts",
         "W-activity-log.spec.ts",

--- a/playwright/tests/P-pagination-show-all.spec.ts
+++ b/playwright/tests/P-pagination-show-all.spec.ts
@@ -4,8 +4,17 @@ import { selectOption } from '../util/fixtures/activities.js'
 import { createQuestionSC } from '../util/fixtures/elements.js'
 import { createLiveQuiz, deleteLiveQuiz } from '../util/fixtures/manage.js'
 
+async function expectSummariesEqual(page: import('@playwright/test').Page) {
+  const top = page.getByTestId('result-range-summary-top')
+  const bottom = page.getByTestId('result-range-summary')
+  await expect(top).toBeVisible()
+  await expect(bottom).toBeVisible()
+  const bottomText = await bottom.innerText()
+  await expect(top).toHaveText(bottomText)
+}
+
 async function expectAllResultsLoaded(page: import('@playwright/test').Page) {
-  const summary = page.getByText(/Showing 1 to \d+ of \d+ results/)
+  const summary = page.getByTestId('result-range-summary')
   await expect(summary).toBeVisible()
 
   const summaryText = await summary.textContent()
@@ -48,13 +57,16 @@ test.describe('Show all pagination option', () => {
       await page.reload()
 
       await expect(page.getByTestId('pagination-page-size')).toBeVisible()
+      await expectSummariesEqual(page)
 
       await selectOption(page, '[data-cy="pagination-page-size"]', 'all')
       await expect(page.getByTestId('pagination-page-size')).toContainText(
         'All'
       )
+      await expectSummariesEqual(page)
       await expect(page.getByTestId('pagination-next')).toHaveCount(0)
       const totalElements = await expectAllResultsLoaded(page)
+      await expectSummariesEqual(page)
       await expect(page.locator('[data-cy^="element-item-"]')).toHaveCount(
         totalElements
       )
@@ -65,6 +77,7 @@ test.describe('Show all pagination option', () => {
 
       await selectOption(page, '[data-cy="pagination-page-size"]', '50')
       await expect(page.getByTestId('pagination-page-size')).toContainText('50')
+      await expectSummariesEqual(page)
 
       await page.getByTestId('activities').click()
       await expect(page).toHaveURL(/\/activities/)

--- a/playwright/tests/P-question-library-batch-operations.spec.ts
+++ b/playwright/tests/P-question-library-batch-operations.spec.ts
@@ -1,0 +1,115 @@
+import type { Page } from '@playwright/test'
+import { getPrisma } from '../global-setup.js'
+import { LECTURER_ID } from '../util/constants.js'
+import { expect, test } from '../util/fixtures.js'
+import { createQuestionSC } from '../util/fixtures/elements.js'
+
+async function openBatchOperations(page: Page, elementName: string) {
+  const search = page.getByTestId('elements-search-input')
+  await search.fill(elementName)
+  await search.press('Enter')
+
+  await expect(page.getByTestId(`element-item-${elementName}`)).toBeVisible()
+  await page.getByTestId(`element-checkbox-${elementName}`).check()
+  await page.getByTestId('element-batch-operations').click()
+  await expect(
+    page.getByTestId('batch-selected-elements-description')
+  ).toBeVisible()
+}
+
+test('requires explicit opt-in before propagating batch changes', async ({
+  page,
+  loginLecturer,
+}, testInfo) => {
+  const elementName = `W6 Batch Operations ${testInfo.workerIndex}-${testInfo.retry}`
+  await createQuestionSC({
+    name: elementName,
+    content: 'Synthetic batch operations test content.',
+    choices: [{ value: 'Correct' }, { value: 'Incorrect' }],
+    userId: LECTURER_ID,
+  })
+
+  try {
+    await loginLecturer()
+
+    const capturedVariables: Record<string, unknown>[] = []
+    await page.route('**/api/graphql', async (route) => {
+      const rawBody = route.request().postData()
+      const body = rawBody
+        ? (JSON.parse(rawBody) as {
+            operationName?: string
+            variables?: Record<string, unknown>
+          })
+        : undefined
+
+      if (body?.operationName !== 'ApplyElementBatchOperations') {
+        await route.continue()
+        return
+      }
+
+      capturedVariables.push(body.variables ?? {})
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { applyElementBatchOperations: 1 } }),
+      })
+    })
+
+    await openBatchOperations(page, elementName)
+
+    await expect(
+      page.getByTestId('batch-selected-elements-description')
+    ).toHaveText(
+      'Review the selected elements below. Then choose the actions to apply.'
+    )
+    await expect(page.getByTestId('batch-element-name-heading')).toBeVisible()
+    await expect(page.getByTestId('batch-element-update-heading')).toBeVisible()
+
+    const instanceUpdates = page.getByRole('switch', {
+      name: 'Also apply these changes to draft and scheduled activities',
+    })
+    const templateUpdates = page.getByRole('switch', {
+      name: 'Also update activity templates',
+    })
+    await expect(instanceUpdates).not.toBeChecked()
+    await expect(templateUpdates).not.toBeChecked()
+    await expect(templateUpdates).toBeDisabled()
+
+    await page.getByTestId('archive-button').click()
+    await page.getByTestId('apply-batch-operations').click()
+    await expect.poll(() => capturedVariables.length).toBe(1)
+    await expect(page.getByTestId('close-batch-operations-modal')).toHaveCount(
+      0
+    )
+    expect(capturedVariables[0]).toMatchObject({
+      archive: true,
+      unarchive: false,
+      updateInstances: false,
+      updateTemplateInstances: false,
+    })
+
+    await openBatchOperations(page, elementName)
+    await page.getByTestId('archive-button').click()
+
+    await instanceUpdates.click()
+    await expect(instanceUpdates).toBeChecked()
+    await expect(templateUpdates).toBeEnabled()
+    await templateUpdates.click()
+    await expect(templateUpdates).toBeChecked()
+
+    await page.getByTestId('apply-batch-operations').click()
+    await expect.poll(() => capturedVariables.length).toBe(2)
+    await expect(page.getByTestId('close-batch-operations-modal')).toHaveCount(
+      0
+    )
+    expect(capturedVariables[1]).toMatchObject({
+      archive: true,
+      unarchive: false,
+      updateInstances: true,
+      updateTemplateInstances: true,
+    })
+  } finally {
+    const prisma = await getPrisma()
+    await prisma.element.deleteMany({ where: { name: elementName } })
+  }
+})

--- a/playwright/tests/P-question-library-filters.spec.ts
+++ b/playwright/tests/P-question-library-filters.spec.ts
@@ -1,0 +1,115 @@
+import { getPrisma } from '../global-setup.js'
+import { LECTURER_ID } from '../util/constants.js'
+import { expect, test } from '../util/fixtures.js'
+import { createQuestionMC } from '../util/fixtures/elements.js'
+
+const STATUS_HEADER = 'collapse-tag-header-status'
+const TYPES_HEADER = 'collapse-tag-header-types'
+const MULTIPLIER_HEADER = 'collapse-tag-header-multiplier'
+const GAMIFICATION_HEADER = 'collapse-tag-header-gamification'
+const RESET_BUTTON = 'reset-question-pool-filters'
+test.describe('Question library filter groups', () => {
+  test.beforeEach(async ({ loginLecturer }) => {
+    await loginLecturer()
+  })
+
+  test('keeps several groups open, marks applied groups, and clears on reset', async ({
+    page,
+  }) => {
+    // Status opens by default, without a marker while nothing is applied.
+    // The advanced groups start collapsed.
+    await expect(page.getByTestId(STATUS_HEADER)).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+    await expect(page.getByTestId(`${STATUS_HEADER}-applied`)).toHaveCount(0)
+    await expect(page.getByTestId(MULTIPLIER_HEADER)).toHaveAttribute(
+      'data-state',
+      'closed'
+    )
+    await expect(page.getByTestId(GAMIFICATION_HEADER)).toHaveAttribute(
+      'data-state',
+      'closed'
+    )
+
+    // Apply one filter in the Types group and one in the Multiplier group,
+    // opening the second group without collapsing the first.
+    await page.getByTestId(TYPES_HEADER).click()
+    await page.getByTestId('element-type-filter-CONTENT').click()
+    await expect(page.getByTestId(`${TYPES_HEADER}-applied`)).toBeVisible()
+
+    await page.getByTestId(MULTIPLIER_HEADER).click()
+    await page.getByTestId('multiplier-filter-1').click()
+    await expect(page.getByTestId(`${MULTIPLIER_HEADER}-applied`)).toBeVisible()
+
+    // Both groups stay open while their applied markers remain visible.
+    await expect(page.getByTestId(TYPES_HEADER)).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+    await expect(page.getByTestId(MULTIPLIER_HEADER)).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+
+    // Reset clears every applied marker without changing group behavior.
+    await page.getByTestId(RESET_BUTTON).click()
+    await expect(page.getByTestId(`${TYPES_HEADER}-applied`)).toHaveCount(0)
+    await expect(page.getByTestId(`${MULTIPLIER_HEADER}-applied`)).toHaveCount(
+      0
+    )
+    await expect(page.getByTestId(STATUS_HEADER)).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+  })
+
+  test('projects the Markdown-rich card preview to plain text while the tooltip keeps the rendered Markdown', async ({
+    page,
+  }, testInfo) => {
+    const elementName = `W6 Markdown Preview ${testInfo.workerIndex}-${testInfo.retry}`
+    await createQuestionMC({
+      name: elementName,
+      content: `## Understanding Financial Goals and Conflicts
+
+The financial target triangle includes:
+* **Profitability**
+* Liquidity
+* Security`,
+      choices: [{ value: 'Correct' }, { value: 'Incorrect' }],
+      userId: LECTURER_ID,
+    })
+
+    try {
+      const search = page.getByTestId('elements-search-input')
+      await search.fill(elementName)
+      await search.press('Enter')
+
+      const card = page.getByTestId(`element-item-${elementName}`)
+      await expect(card).toBeVisible()
+
+      // The visible two-line preview must read as plain text: heading and list
+      // wording survive, but Markdown controls are gone.
+      await expect(card).toContainText(
+        'Understanding Financial Goals and Conflicts'
+      )
+      await expect(card).toContainText('Profitability')
+      await expect(card).not.toContainText('##')
+      await expect(card).not.toContainText('**')
+
+      // The hover/focus tooltip still renders the original stored Markdown: the
+      // first heading appears as a real heading element in the tooltip content.
+      await card
+        .getByText(/Understanding Financial Goals and Conflicts/)
+        .hover()
+      await expect(
+        page.locator('[role="tooltip"]').getByRole('heading', {
+          name: 'Understanding Financial Goals and Conflicts',
+        })
+      ).toBeVisible()
+    } finally {
+      const prisma = await getPrisma()
+      await prisma.element.deleteMany({ where: { name: elementName } })
+    }
+  })
+})


### PR DESCRIPTION
## What This Adds

This layer improves scanning, selection, filtering, and batch-operation feedback in the Manage question library.

1. Makes long question and content previews readable without changing stored element content.
2. Clarifies selection ranges, pagination, filters, and batch-operation summaries for mixed element types.
3. Adds focused batch-operation and filter coverage plus the shared markdown plain-text behavior needed for safe previews.

## How It Works

- The library derives bounded plain-text previews from markdown and keeps the full editor content unchanged.
- Selection and result-range helpers preserve the existing pagination and permission boundaries while making the active scope explicit.
- Batch instance propagation now requires explicit opt-in, so a selected element does not silently imply all of its instances.
- The layer remains Manage-only and introduces no GraphQL, database, or devrouter changes.

## Branch Coverage

- Base: `rs/question-library-onboarding` (PR #5717)
- Head: `7f25f706b7e5bd661c745254830eafea314a5e3a`
- Reviewed: 1 commit, substantive diff `+559/-66` across 21 files. No lockfiles, generated output, or project artifacts are in this branch diff.
- Covered: pagination and result ranges, markdown preview extraction, filter/selection feedback, batch-operation scope, bilingual copy, focused unit tests, and Playwright profile updates.

## Stack Relation

- Layer 5 of 7 in native stack `#5721`.
- Parent: PR #5717 (`rs/question-library-onboarding`).
- Next layer: PR #5719 (`rs/question-library-status-empty-state-clean`).

## Review Focus

- Confirm plain-text preview extraction remains safe for markdown edge cases and does not render raw HTML.
- Check that pagination, filtering, and batch selection retain their existing permission semantics.
- Review the explicit instance-propagation choice in the batch-operation UI.

## Screenshots

The current-top integrated browser captures are machine-local and show the shared Manage library shell. They are not isolated scanning or batch-operation screenshots; no image files were added to the branch.

- English loaded state: `/private/tmp/question-library-stack-loaded.png`
- English search/no-result state: `/private/tmp/question-library-stack-search.png`
- German loaded state: `/private/tmp/question-library-stack-german.png`
- German search/no-result state: `/private/tmp/question-library-stack-german-search.png`

## Verification

Current integrated top head (includes this branch):

- `devrouter exec <task-worktree> -- pnpm run check:all` -> 25 successful, 25 total.
- Fresh integrated final review of `origin/v3..75cfea445` -> zero blockers; one low-priority follow-up.

Not run:

- An isolated browser walkthrough of scanning and batch operations; the available browser captures are from the integrated top stack.

Failed/Warning:

- Devrouter's optional Manage course warm-up returned 404 for its synthetic warm-up course while the readiness contracts remained satisfied; this is runtime fixture noise, not a branch failure.

## Security / Privacy

- Preview processing stays client-side and does not add a data owner or external data flow.
- No authentication, secrets, schema, migration, or devrouter configuration changes; test content is synthetic.

## Blocking Before Merge

- [ ] Complete senior human review and required GitHub checks for this draft and the dependent stack.

## Follow-Up After Merge

The earlier slice review recorded a low-priority preview fallback/performance question; no correctness blocker was identified.

## Local Session Artifacts

- Machine: local macOS host
- Worktree: `trees/ux-review-question-library` in repository `klicker-uzh`
