### PR TITLE
fix(ci): remove invalid composite action timeout

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -163,7 +163,6 @@ runs:
         DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
 
     - name: Start services, wait for readiness, and run Playwright tests
-      timeout-minutes: 120
       shell: bash
       run: |
         set -euo pipefail

--- a/util/playwright-profile-runtime.test.mjs
+++ b/util/playwright-profile-runtime.test.mjs
@@ -240,7 +240,7 @@ test('workflow shard startup steps explicitly select Bash', () => {
   )
   assert.match(
     action,
-    /- name: Start services, wait for readiness, and run Playwright tests\n\s+timeout-minutes: 120\n\s+shell: bash\n\s+run: \|/
+    /- name: Start services, wait for readiness, and run Playwright tests\n\s+shell: bash\n\s+run: \|/
   )
 })
 


### PR DESCRIPTION
## Summary

- remove the unsupported step-level `timeout-minutes` field from the shared Playwright composite action
- preserve all four existing job-level 120-minute timeouts in the reusable workflow
- update the focused Bash-selection regression assertion so it no longer encodes the invalid composite-action field

## Why

PR #5709 exposed the shared defect: all eight Playwright shards failed during job setup, before checkout or test execution, with `Unexpected value 'timeout-minutes'` for `.github/actions/playwright-shard/action.yml`.

## Verification

- focused Playwright CI contract suite: 57/57 passed
- composite action YAML parsed and contains no step-level `timeout-minutes`
- reusable workflow still contains the four expected job-level 120-minute timeouts
- `git diff --check`

## Exact-head CI

- `check`, CodeQL, gitleaks, GitGuardian, GraphQL status, and OpenCodeReview passed at `4451ad8ee7e8bacd287579b9df5bcce7f8aab849`
- all eight Playwright shards fail before checkout because the reusable workflow deliberately downloads the trusted action from `v3@88cc043944ef90093c7c9785f7ac07b5dcfc4dab`, which still contains the field this PR removes
- the observed error remains `Unexpected value 'timeout-minutes'`; no candidate Playwright test executed

## Scope

This is an isolated shared-CI unblocker: one behavioral YAML deletion and its existing regression assertion. It does not change application behavior, deployment, data, or runtime configuration.

Merge is not part of this package. Rerunning PR #5709 and triggering its final review remain separate follow-up actions after this fix is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workflow validation to reflect the removal of a fixed 120-minute timeout from Playwright test startup.
* **Chores**
  * Playwright service startup now uses the workflow’s default step timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->