### PR TITLE
fix(deploy): correct assessment affinity values

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -806,19 +806,19 @@ assessment:
                   operator: In
                   values:
                     - reserved
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: frontend-pwa-assessment
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: frontend-pwa-assessment
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: frontend-pwa-assessment
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: frontend-pwa-assessment
     tolerations:
       - key: klickerasm
         operator: Equal
@@ -883,19 +883,19 @@ assessment:
                   operator: In
                   values:
                     - reserved
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: backend-assessment
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: backend-assessment
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: backend-assessment
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: backend-assessment
     tolerations:
       - key: klickerasm
         operator: Equal


### PR DESCRIPTION
## What This Fixes

This PR removes the two Kubernetes-invalid `topologySpreadConstraints` fields currently rendered inside assessment `affinity` in production.

- Moves the existing frontend and backend constraint lists to the assessment workload level in the production values file.
- Leaves replicas, images, resources, tolerations, selectors, and valid affinity rules unchanged.
- Keeps the recovery narrower than draft PR #5694, which separately adds chart support and activates topology spreading for five workloads.

The current chart does not render these top-level keys. The resulting assessment manifests therefore drop only the invalid nested fields that the Kubernetes API server already omits from live objects. No assessment pod rollout is expected from this fix.

## Branch Coverage

- Base: `v3`
- Head: `2776ae47d`
- Reviewed: 1 commit and 52 substantive changed lines in one production values file; all line changes are the two indentation corrections.
- Packaging: isolated production reconciliation needed to unblock the RadioSurfVet lecturer preflight.

## Review Focus

- Confirm both blocks are siblings of `affinity` and `tolerations`, not children of `affinity`.
- Confirm the rendered assessment diff removes only the two invalid nested fields.
- Confirm this incident fix does not activate the broader scheduling behavior from draft PR #5694.

## Verification

Current head:

- `helm lint deploy/charts/klicker-uzh-v3 --values deploy/env-uzh-prd/values.yaml` -> 1 chart linted, 0 failed.
- Focused assessment render comparison against `origin/v3` -> exactly two invalid `affinity.topologySpreadConstraints` lists removed; no other rendered field changed.
- Focused render count -> 0 `topologySpreadConstraints` fields after the change, 2 on the base.
- Prettier check for `deploy/env-uzh-prd/values.yaml` -> passed.
- `git diff --check` -> passed.
- Staged gitleaks scan -> no leaks found.

Not run:

- Cluster schema validation: the installed `kubectl` tried Azure authentication even with client dry-run, so that attempt is not counted as proof. Helm render and post-merge Argo readback are the acceptance seams.
- Live rollout proof: performed after merge through the approved GitOps path.

## Security / Privacy

- No secrets, personal data, permissions, authentication behavior, or external dependencies change.
- The diff contains only declarative production scheduling values already present on `v3`.

## Blocking Before Merge

- [ ] Required exact-head CI passes.
- [ ] Independent final review has no blocking source finding.

## Follow-Up After Merge

- [ ] Confirm `app-klicker` reconciles to `Synced` and remains `Healthy` with both assessment Deployments ready.
- [ ] Complete the values-free RadioSurfVet production preflight and bounded authenticated GET smoke before credential delivery.

## Local Session Artifacts

- Machine: local macOS host
- Worktree: `trees/fix-prd-assessment-affinity` in repository `klicker-uzh`
- Review report: `project/_local/reviews/2026-09-02-prd-assessment-affinity-combined-final.md`
