### PR TITLE
chore(prisma-data): add Doc Query activation operator

### DIFF
--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation-prisma.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation-prisma.ts
@@ -1,0 +1,253 @@
+import type { Prisma, PrismaClient } from '@klicker-uzh/prisma/client'
+import type {
+  CohortActivationConfigCreate,
+  CohortActivationConfigRecord,
+  CohortActivationConfigUpdate,
+  CohortActivationServerCreate,
+  CohortActivationServerRecord,
+  CohortActivationStore,
+  CohortActivationTransactionStore,
+  JsonValue,
+} from './doc-query-cohort-activation.js'
+
+type PrismaCohortActivationClient = Pick<
+  PrismaClient,
+  'chatbotMCPServer' | 'chatbotMCPConfig'
+>
+
+const serverSelect = {
+  id: true,
+  name: true,
+  description: true,
+  url: true,
+  authType: true,
+  passChatbotId: true,
+  chatbotIdHeader: true,
+  parameters: true,
+  isActive: true,
+  updatedAt: true,
+} as const
+
+const configSelect = {
+  id: true,
+  chatbotId: true,
+  mcpServerId: true,
+  chatMode: true,
+  allowedTools: true,
+  priority: true,
+  isEnabled: true,
+  parameters: true,
+  updatedAt: true,
+} as const
+
+const SERIALIZABLE_TRANSACTION_RETRY_LIMIT = 3
+
+function isSerializationConflict(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'P2034'
+  )
+}
+
+function mapServer(
+  record: {
+    id: string
+    name: string
+    description: string | null
+    url: string
+    authType: string
+    passChatbotId: boolean
+    chatbotIdHeader: string | null
+    parameters: unknown
+    isActive: boolean
+    updatedAt: Date
+  },
+  hasAuthSecret: boolean
+): CohortActivationServerRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    description: record.description,
+    url: record.url,
+    authType: record.authType,
+    passChatbotId: record.passChatbotId,
+    chatbotIdHeader: record.chatbotIdHeader,
+    hasAuthSecret,
+    parameters: record.parameters as JsonValue,
+    isActive: record.isActive,
+    updatedAt: record.updatedAt,
+  }
+}
+
+async function hasAuthSecret(
+  client: PrismaCohortActivationClient,
+  id: string
+): Promise<boolean> {
+  const count = await client.chatbotMCPServer.count({
+    where: { id, authSecret: { not: null } },
+  })
+  return count === 1
+}
+
+function mapConfig(record: {
+  id: string
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: unknown
+  priority: number
+  isEnabled: boolean
+  parameters: unknown
+  updatedAt: Date
+}): CohortActivationConfigRecord {
+  return {
+    ...record,
+    allowedTools: record.allowedTools as JsonValue,
+    parameters: record.parameters as JsonValue,
+  }
+}
+
+function createTransactionStore(
+  client: PrismaCohortActivationClient
+): CohortActivationTransactionStore {
+  return {
+    async findServerByName(name) {
+      const record = await client.chatbotMCPServer.findUnique({
+        where: { name },
+        select: serverSelect,
+      })
+      return record
+        ? mapServer(record, await hasAuthSecret(client, record.id))
+        : null
+    },
+    async findServerById(id) {
+      const record = await client.chatbotMCPServer.findUnique({
+        where: { id },
+        select: serverSelect,
+      })
+      return record
+        ? mapServer(record, await hasAuthSecret(client, record.id))
+        : null
+    },
+    async findConfigById(id) {
+      const record = await client.chatbotMCPConfig.findUnique({
+        where: { id },
+        select: configSelect,
+      })
+      return record ? mapConfig(record) : null
+    },
+    async findConfigByChatbotServer(chatbotId, mcpServerId, chatMode) {
+      const record = await client.chatbotMCPConfig.findUnique({
+        where: {
+          chatbotId_mcpServerId_chatMode: {
+            chatbotId,
+            mcpServerId,
+            chatMode,
+          },
+        },
+        select: configSelect,
+      })
+      return record ? mapConfig(record) : null
+    },
+    async findConfigsByServerId(mcpServerId) {
+      const records = await client.chatbotMCPConfig.findMany({
+        where: { mcpServerId },
+        select: configSelect,
+      })
+      return records.map(mapConfig)
+    },
+    async createServer(data: CohortActivationServerCreate) {
+      const record = await client.chatbotMCPServer.create({
+        data: {
+          ...(data.id ? { id: data.id } : {}),
+          name: data.name,
+          description: data.description,
+          url: data.url,
+          authType: data.authType,
+          authSecret: data.encryptedBearer,
+          passChatbotId: data.passChatbotId,
+          chatbotIdHeader: data.chatbotIdHeader,
+          parameters: data.parameters as Prisma.InputJsonValue,
+          isActive: data.isActive,
+        },
+        select: serverSelect,
+      })
+      return mapServer(record, await hasAuthSecret(client, record.id))
+    },
+    async createConfig(data: CohortActivationConfigCreate) {
+      const record = await client.chatbotMCPConfig.create({
+        data: {
+          ...(data.id ? { id: data.id } : {}),
+          chatbotId: data.chatbotId,
+          mcpServerId: data.mcpServerId,
+          chatMode: data.chatMode,
+          allowedTools: data.allowedTools as Prisma.InputJsonValue,
+          priority: data.priority,
+          isEnabled: data.isEnabled,
+          parameters: data.parameters as Prisma.InputJsonValue,
+        },
+        select: configSelect,
+      })
+      return mapConfig(record)
+    },
+    async updateConfig(
+      id,
+      expectedUpdatedAt,
+      data: CohortActivationConfigUpdate
+    ) {
+      const result = await client.chatbotMCPConfig.updateMany({
+        where: { id, updatedAt: expectedUpdatedAt },
+        data: {
+          chatbotId: data.chatbotId,
+          mcpServerId: data.mcpServerId,
+          chatMode: data.chatMode,
+          allowedTools: data.allowedTools as Prisma.InputJsonValue,
+          priority: data.priority,
+          isEnabled: data.isEnabled,
+          parameters: data.parameters as Prisma.InputJsonValue,
+        },
+      })
+      if (result.count !== 1) return null
+      const record = await client.chatbotMCPConfig.findUnique({
+        where: { id },
+        select: configSelect,
+      })
+      return record ? mapConfig(record) : null
+    },
+  }
+}
+
+export function createPrismaCohortActivationStore(
+  client: PrismaClient
+): CohortActivationStore {
+  return {
+    async transaction(callback) {
+      for (
+        let attempt = 0;
+        attempt < SERIALIZABLE_TRANSACTION_RETRY_LIMIT;
+        attempt += 1
+      ) {
+        try {
+          return await client.$transaction(
+            (tx) => callback(createTransactionStore(tx)),
+            {
+              isolationLevel: 'Serializable',
+              timeout: 120_000,
+            }
+          )
+        } catch (error) {
+          if (
+            !isSerializationConflict(error) ||
+            attempt === SERIALIZABLE_TRANSACTION_RETRY_LIMIT - 1
+          ) {
+            throw error
+          }
+        }
+      }
+
+      throw new Error('Serializable transaction retry limit exceeded')
+    },
+  }
+}

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
@@ -1,0 +1,548 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, open, readFile, rename, unlink } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { fileURLToPath } from 'node:url'
+import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { encrypt } from '@klicker-uzh/util'
+import { PrismaPg } from '@prisma/adapter-pg'
+import {
+  assertCohortActivationNotPrepared,
+  assertReceiptMatchesManifest,
+  assertReceiptTransition,
+  CohortActivationError,
+  type CohortActivationManifest,
+  type CohortActivationReceipt,
+  type CohortActivationReceiptExpectation,
+  type CohortActivationReceiptFile,
+  type CohortActivationReceiptIntent,
+  dryRunCohortActivation,
+  makeCohortActivationReceiptIntent,
+  prepareCohortActivation,
+  readCohortActivationState,
+  receiptExpectation,
+  recoverPreparedCohortActivation,
+  rollbackCohortActivation,
+  switchCohortActivation,
+  validateCohortActivationReceiptIntent,
+  validatePinnedManifest,
+  validateReceipt,
+} from './doc-query-cohort-activation.js'
+import { createPrismaCohortActivationStore } from './doc-query-cohort-activation-prisma.js'
+
+const TOKEN_ENV = 'DOC_QUERY_JWT_TOKEN_KLICKER'
+const DB_PORT_FORWARD_PORT = 7432
+
+type Command =
+  | 'dry-run'
+  | 'migrate'
+  | 'recover'
+  | 'clear'
+  | 'rollback'
+  | 'readback'
+type ReceiptFile = CohortActivationReceiptFile
+
+export type CohortActivationSessionLock = {
+  release: () => Promise<void>
+}
+
+function usage(): never {
+  throw new Error('usage')
+}
+
+function parseArgs(argv: string[]): {
+  command: Command
+  manifestPath: string
+  receiptPath: string
+} {
+  const command = argv[0]
+  if (
+    command !== 'dry-run' &&
+    command !== 'migrate' &&
+    command !== 'recover' &&
+    command !== 'clear' &&
+    command !== 'rollback' &&
+    command !== 'readback'
+  ) {
+    return usage()
+  }
+  const manifestIndex = argv.indexOf('--manifest')
+  const receiptIndex = argv.indexOf('--receipt')
+  const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined
+  const receiptPath = receiptIndex >= 0 ? argv[receiptIndex + 1] : undefined
+  if (!manifestPath || !receiptPath || argv.length !== 5) return usage()
+  return {
+    command,
+    manifestPath: resolve(manifestPath),
+    receiptPath: resolve(receiptPath),
+  }
+}
+
+async function readJsonFile<T>(path: string): Promise<T> {
+  const raw = await readFile(path, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+function isDatabaseLockError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    error.message.includes('database is locked')
+  )
+}
+
+/**
+ * Keep one process-wide lifecycle lock for a receipt path. SQLite releases
+ * the exclusive transaction when its owner exits, so crash recovery does not
+ * require unlinking a stale path that another contender may already own.
+ */
+export async function acquireCohortActivationSessionLock(
+  receiptPath: string
+): Promise<CohortActivationSessionLock> {
+  const lockPath = `${receiptPath}.lock.sqlite`
+  await mkdir(dirname(receiptPath), { recursive: true })
+  let database: DatabaseSync | undefined
+  try {
+    database = new DatabaseSync(lockPath, { timeout: 0 })
+    database.exec('BEGIN EXCLUSIVE')
+    return {
+      release: async () => {
+        try {
+          database?.exec('ROLLBACK')
+        } finally {
+          database?.close()
+        }
+      },
+    }
+  } catch (error) {
+    try {
+      database?.close()
+    } catch {
+      // The connection may not have opened.
+    }
+    if (isDatabaseLockError(error)) throw new Error('SESSION_LOCKED')
+    throw error
+  }
+}
+
+export async function writeReceipt(
+  path: string,
+  receipt: ReceiptFile,
+  expected: CohortActivationReceiptExpectation
+): Promise<void> {
+  if (receipt.state === 'preparing')
+    validateCohortActivationReceiptIntent(receipt)
+  else validateReceipt(receipt)
+  const current = await readReceipt(path)
+  assertReceiptTransition(expected, current, receipt)
+  if (current?.payloadDigest === receipt.payloadDigest) return
+  const temporary = `${path}.tmp-${process.pid}-${randomUUID()}`
+  await mkdir(dirname(path), { recursive: true })
+  let renamed = false
+  try {
+    const file = await open(temporary, 'wx', 0o600)
+    try {
+      await file.writeFile(`${JSON.stringify(receipt)}\n`, 'utf8')
+      await file.sync()
+    } finally {
+      await file.close()
+    }
+    const latest = await readReceipt(path)
+    assertReceiptTransition(expected, latest, receipt)
+    await rename(temporary, path)
+    renamed = true
+    const directory = await open(dirname(path), 'r')
+    try {
+      await directory.sync()
+    } finally {
+      await directory.close()
+    }
+  } finally {
+    if (!renamed) {
+      await unlink(temporary).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') throw error
+      })
+    }
+  }
+}
+
+export async function clearPreparingReceipt(
+  path: string,
+  expected: NonNullable<CohortActivationReceiptExpectation>
+): Promise<void> {
+  const current = await readReceipt(path)
+  if (
+    !current ||
+    current.state !== 'preparing' ||
+    current.manifestFingerprint !== expected.manifestFingerprint ||
+    current.payloadDigest !== expected.payloadDigest ||
+    current.state !== expected.state
+  ) {
+    throw new CohortActivationError(
+      'RECEIPT_CONCURRENT_WRITE',
+      'receipt changed before the preparing intent could be cleared'
+    )
+  }
+  await unlink(path)
+  const directory = await open(dirname(path), 'r')
+  try {
+    await directory.sync()
+  } finally {
+    await directory.close()
+  }
+}
+
+async function readReceipt(path: string): Promise<ReceiptFile | null> {
+  try {
+    const receipt = await readJsonFile<ReceiptFile>(path)
+    if (receipt.state === 'preparing')
+      validateCohortActivationReceiptIntent(receipt)
+    else validateReceipt(receipt)
+    return receipt
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return null
+    }
+    throw error
+  }
+}
+
+function printResult(result: Record<string, unknown>): void {
+  // Only fixed categories and ordinary counts/fingerprints are emitted.
+  console.log(JSON.stringify(result))
+}
+
+function isCohortActivationIntent(
+  receipt: ReceiptFile
+): receipt is CohortActivationReceiptIntent {
+  return receipt.state === 'preparing'
+}
+
+function classifyError(error: unknown): string {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    (/^[A-Z_]+$/.test(error.code) || /^P\d{4}$/.test(error.code))
+  ) {
+    return /^P\d{4}$/.test(error.code) ? `DB_${error.code}` : error.code
+  }
+  if (error instanceof Error) {
+    if (error.name === 'PrismaClientInitializationError')
+      return 'DB_INIT_FAILED'
+    if (error.name === 'PrismaClientKnownRequestError')
+      return 'DB_REQUEST_FAILED'
+    if (error.name === 'PrismaClientUnknownRequestError')
+      return 'DB_UNKNOWN_FAILED'
+    if (error.name === 'PrismaClientValidationError') return 'DB_INPUT_FAILED'
+  }
+  return 'FAILED'
+}
+
+function createPrismaClient(): PrismaClient {
+  const rawDatabaseUrl = process.env.DATABASE_URL
+  if (!rawDatabaseUrl) throw new Error('database_missing')
+  const databaseUrl = new URL(rawDatabaseUrl)
+  const sslmode = databaseUrl.searchParams.get('sslmode')
+  if (sslmode === 'disable') throw new Error('database_tls_disabled')
+  const certificateHostname = databaseUrl.hostname
+  databaseUrl.hostname = '127.0.0.1'
+  databaseUrl.port = String(DB_PORT_FORWARD_PORT)
+  // pg's connection-string parser can override an explicit TLS object when
+  // sslmode remains in the URL. Keep verification in the object instead.
+  databaseUrl.searchParams.delete('sslmode')
+  const adapter = new PrismaPg({
+    connectionString: databaseUrl.toString(),
+    ssl: { servername: certificateHostname, rejectUnauthorized: true },
+  })
+  return new PrismaClient({ adapter })
+}
+
+type ReceiptPersister = (receipt: ReceiptFile) => Promise<void>
+
+async function runDryRun(
+  store: ReturnType<typeof createPrismaCohortActivationStore>,
+  manifest: CohortActivationManifest
+): Promise<void> {
+  const result = await dryRunCohortActivation(store, manifest)
+  printResult({
+    status: result.status,
+    entryCount: result.entryCount,
+    heldCount: result.heldCount,
+    wouldCreateServer: result.wouldCreateServer,
+    wouldCreateConfigs: result.wouldCreateConfigs,
+    wouldSwitch: result.wouldSwitch,
+    wouldPreserveSourceRows: result.wouldPreserveSourceRows,
+  })
+}
+
+async function runMigrate(
+  store: ReturnType<typeof createPrismaCohortActivationStore>,
+  manifest: CohortActivationManifest,
+  existingReceipt: ReceiptFile | null,
+  persistReceipt: ReceiptPersister
+): Promise<void> {
+  if (existingReceipt) {
+    printResult({ status: 'refused', reason: 'receipt_exists' })
+    process.exitCode = 3
+    return
+  }
+  const existingTargetServerId = await store.transaction(async (tx) => {
+    const target = await tx.findServerByName(manifest.target.serverName)
+    return target?.id ?? null
+  })
+  const bearer = existingTargetServerId ? undefined : process.env[TOKEN_ENV]
+  if (
+    !existingTargetServerId &&
+    (!bearer || bearer.trim() === '' || /[\r\n]/.test(bearer))
+  ) {
+    printResult({ status: 'refused', reason: 'bearer_missing_or_invalid' })
+    process.exitCode = 3
+    return
+  }
+  const intent = makeCohortActivationReceiptIntent(
+    manifest,
+    existingTargetServerId
+  )
+  await persistReceipt(intent)
+  // The token is read only long enough to encrypt it. It is never written
+  // to a receipt, argument list, log, or child process.
+  const encryptedBearer = bearer ? encrypt(bearer) : undefined
+  if (bearer) delete process.env[TOKEN_ENV]
+  const prepared = await prepareCohortActivation(store, manifest, {
+    encryptedBearer,
+    intent,
+  })
+  await persistReceipt(prepared)
+  const switched = await switchCohortActivation(
+    store,
+    prepared,
+    (checkpoint: CohortActivationReceipt) => persistReceipt(checkpoint)
+  )
+  await persistReceipt(switched)
+  const state = await readCohortActivationState(store, switched)
+  printResult({
+    status: 'switched',
+    state: state.state,
+    entryCount: state.entryCount,
+    chatbotCount: state.chatbotCount,
+    sourceDisabled: state.sourceDisabled,
+    targetEnabled: state.targetEnabled,
+  })
+}
+
+async function runRecover(
+  store: ReturnType<typeof createPrismaCohortActivationStore>,
+  manifest: CohortActivationManifest,
+  existingReceipt: ReceiptFile | null,
+  persistReceipt: ReceiptPersister
+): Promise<void> {
+  if (!existingReceipt) {
+    printResult({ status: 'refused', reason: 'receipt_missing' })
+    process.exitCode = 3
+    return
+  }
+  if (!isCohortActivationIntent(existingReceipt)) {
+    printResult({ status: 'refused', reason: 'receipt_complete' })
+    process.exitCode = 3
+    return
+  }
+  if (existingReceipt.manifestFingerprint !== manifest.fingerprint) {
+    printResult({ status: 'refused', reason: 'receipt_manifest_mismatch' })
+    process.exitCode = 3
+    return
+  }
+  const recovered = await recoverPreparedCohortActivation(
+    store,
+    manifest,
+    existingReceipt
+  )
+  await persistReceipt(recovered)
+  printResult({
+    status: 'prepared_recovered',
+    state: recovered.state,
+    entryCount: recovered.entries.length,
+  })
+}
+
+async function runClear(
+  store: ReturnType<typeof createPrismaCohortActivationStore>,
+  manifest: CohortActivationManifest,
+  receiptPath: string,
+  existingReceipt: ReceiptFile | null
+): Promise<void> {
+  if (!existingReceipt) {
+    printResult({ status: 'refused', reason: 'receipt_missing' })
+    process.exitCode = 3
+    return
+  }
+  if (!isCohortActivationIntent(existingReceipt)) {
+    printResult({ status: 'refused', reason: 'receipt_complete' })
+    process.exitCode = 3
+    return
+  }
+  if (existingReceipt.manifestFingerprint !== manifest.fingerprint) {
+    printResult({ status: 'refused', reason: 'receipt_manifest_mismatch' })
+    process.exitCode = 3
+    return
+  }
+  await assertCohortActivationNotPrepared(store, manifest, existingReceipt)
+  const expected = receiptExpectation(existingReceipt)
+  if (!expected) {
+    throw new CohortActivationError(
+      'RECEIPT_CONCURRENT_WRITE',
+      'receipt disappeared before the preparing intent could be cleared'
+    )
+  }
+  await clearPreparingReceipt(receiptPath, expected)
+  printResult({ status: 'intent_cleared' })
+}
+
+async function runSettledCommand(
+  store: ReturnType<typeof createPrismaCohortActivationStore>,
+  command: Command,
+  manifest: CohortActivationManifest,
+  existingReceipt: ReceiptFile | null,
+  persistReceipt: ReceiptPersister
+): Promise<void> {
+  if (!existingReceipt) {
+    printResult({ status: 'refused', reason: 'receipt_missing' })
+    process.exitCode = 3
+    return
+  }
+  if (isCohortActivationIntent(existingReceipt)) {
+    printResult({ status: 'refused', reason: 'preparing_receipt' })
+    process.exitCode = 3
+    return
+  }
+  assertReceiptMatchesManifest(existingReceipt, manifest)
+  if (command === 'rollback') {
+    const rolledBack = await rollbackCohortActivation(
+      store,
+      existingReceipt,
+      (checkpoint: CohortActivationReceipt) => persistReceipt(checkpoint)
+    )
+    await persistReceipt(rolledBack)
+    const state = await readCohortActivationState(store, rolledBack)
+    printResult({
+      status: 'rolled_back',
+      state: state.state,
+      entryCount: state.entryCount,
+      chatbotCount: state.chatbotCount,
+      sourceEnabled: state.sourceEnabled,
+      targetDisabled: state.targetDisabled,
+    })
+    return
+  }
+
+  const state = await readCohortActivationState(store, existingReceipt)
+  printResult({
+    status: 'readback',
+    state: state.state,
+    entryCount: state.entryCount,
+    sourceEnabled: state.sourceEnabled,
+    sourceDisabled: state.sourceDisabled,
+    targetEnabled: state.targetEnabled,
+    targetDisabled: state.targetDisabled,
+  })
+}
+
+async function main(): Promise<void> {
+  let args: ReturnType<typeof parseArgs>
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch {
+    printResult({ status: 'usage_error' })
+    process.exitCode = 2
+    return
+  }
+
+  let sessionLock: CohortActivationSessionLock
+  try {
+    sessionLock = await acquireCohortActivationSessionLock(args.receiptPath)
+  } catch (error) {
+    if (error instanceof Error && error.message === 'SESSION_LOCKED') {
+      printResult({ status: 'refused', reason: 'session_locked' })
+      process.exitCode = 3
+      return
+    }
+    printResult({ status: 'failed', category: 'SESSION_LOCK_FAILED' })
+    process.exitCode = 1
+    return
+  }
+
+  let prisma: PrismaClient
+  try {
+    prisma = createPrismaClient()
+  } catch {
+    await sessionLock.release()
+    printResult({ status: 'failed', category: 'DB_CONFIG_FAILED' })
+    process.exitCode = 1
+    return
+  }
+  const store = createPrismaCohortActivationStore(prisma)
+
+  try {
+    const manifest = await readJsonFile<CohortActivationManifest>(
+      args.manifestPath
+    )
+    validatePinnedManifest(manifest)
+    if (args.command === 'dry-run') {
+      await runDryRun(store, manifest)
+      return
+    }
+
+    const existingReceipt = await readReceipt(args.receiptPath)
+    let expectedReceipt = receiptExpectation(existingReceipt)
+    const persistReceipt = async (receipt: ReceiptFile): Promise<void> => {
+      await writeReceipt(args.receiptPath, receipt, expectedReceipt)
+      expectedReceipt = receiptExpectation(receipt)
+    }
+    if (args.command === 'migrate') {
+      await runMigrate(store, manifest, existingReceipt, persistReceipt)
+      return
+    }
+
+    if (args.command === 'recover') {
+      await runRecover(store, manifest, existingReceipt, persistReceipt)
+      return
+    }
+
+    if (args.command === 'clear') {
+      await runClear(store, manifest, args.receiptPath, existingReceipt)
+      return
+    }
+
+    await runSettledCommand(
+      store,
+      args.command,
+      manifest,
+      existingReceipt,
+      persistReceipt
+    )
+  } catch (error) {
+    printResult({ status: 'failed', category: classifyError(error) })
+    process.exitCode = 1
+  } finally {
+    try {
+      await prisma.$disconnect()
+    } finally {
+      await sessionLock.release()
+    }
+  }
+}
+
+const entrypoint = process.argv[1]
+const isEntrypoint =
+  entrypoint !== undefined &&
+  resolve(entrypoint) === fileURLToPath(import.meta.url)
+
+if (isEntrypoint) await main()

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
@@ -850,6 +850,33 @@ describe('cohort activation contract', () => {
     ).rejects.toMatchObject({ code: 'MIXED_MODE_COVERAGE' })
   })
 
+  it('refuses mixed knowledge bases for one chatbot', async () => {
+    const manifest = makeManifest([sourceConfig, secondModeConfig])
+    const conflicted = {
+      ...manifest,
+      entries: [
+        manifest.entries[0]!,
+        {
+          ...manifest.entries[1]!,
+          kbId: '00000000-0000-4000-8000-000000000022',
+        },
+      ],
+    }
+    conflicted.fingerprint = fingerprintManifest({
+      target: conflicted.target,
+      entries: conflicted.entries,
+      heldConfigIds: conflicted.heldConfigIds,
+      excludedCorpora: conflicted.excludedCorpora,
+      excludedConfigIds: conflicted.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(
+        fakeStore([sourceConfig, secondModeConfig]).store,
+        conflicted
+      )
+    ).rejects.toMatchObject({ code: 'MIXED_KB_COVERAGE' })
+  })
+
   it('refuses repeated knowledge-base ids with conflicting corpus ownership', async () => {
     const manifest = makeManifest([sourceConfig, secondChatbotConfig])
     const conflicted = {

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
@@ -1,0 +1,1127 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { PrismaClient } from '@klicker-uzh/prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  assertCohortActivationNotPrepared,
+  assertReceiptMatchesManifest,
+  type CohortActivationConfigRecord,
+  type CohortActivationConfigUpdate,
+  type CohortActivationManifest,
+  type CohortActivationServerCreate,
+  type CohortActivationServerRecord,
+  type CohortActivationStore,
+  type CohortActivationTransactionStore,
+  DOC_QUERY_ROUTE_PATH,
+  DOC_QUERY_TARGET_DESCRIPTION,
+  DOC_QUERY_TARGET_SCOPE,
+  DOC_QUERY_TARGET_SERVER_NAME,
+  DOC_QUERY_TARGET_URL,
+  dryRunCohortActivation,
+  fingerprintManifest,
+  makeCohortActivationReceiptIntent,
+  prepareCohortActivation,
+  readCohortActivationState,
+  receiptExpectation,
+  recoverPreparedCohortActivation,
+  rollbackCohortActivation,
+  switchCohortActivation,
+  validatePinnedManifest,
+  validateReceipt,
+} from './doc-query-cohort-activation.js'
+import { createPrismaCohortActivationStore } from './doc-query-cohort-activation-prisma.js'
+import {
+  acquireCohortActivationSessionLock,
+  clearPreparingReceipt,
+  writeReceipt,
+} from './doc-query-cohort-activation-run.js'
+
+const sourceServer: CohortActivationServerRecord = {
+  id: '00000000-0000-4000-8000-000000000001',
+  name: 'Source course server',
+  description: 'Source course server for synthetic tests',
+  url: 'http://source.example.invalid/mcp',
+  authType: 'bearer',
+  passChatbotId: true,
+  chatbotIdHeader: 'Chatbot-ID',
+  parameters: {},
+  hasAuthSecret: true,
+  isActive: true,
+  updatedAt: new Date('2026-08-24T10:00:00.000Z'),
+}
+
+const sourceConfig: CohortActivationConfigRecord = {
+  id: '00000000-0000-4000-8000-000000000002',
+  chatbotId: '00000000-0000-4000-8000-000000000003',
+  mcpServerId: sourceServer.id,
+  chatMode: 'tutor',
+  allowedTools: ['doc_query'],
+  priority: 4,
+  isEnabled: true,
+  parameters: {},
+  updatedAt: new Date('2026-08-24T10:00:00.000Z'),
+}
+
+const secondModeConfig: CohortActivationConfigRecord = {
+  ...sourceConfig,
+  id: '00000000-0000-4000-8000-000000000004',
+  chatMode: 'review',
+}
+
+const secondChatbotConfig: CohortActivationConfigRecord = {
+  ...sourceConfig,
+  id: '00000000-0000-4000-8000-000000000005',
+  chatbotId: '00000000-0000-4000-8000-000000000006',
+}
+
+const targetServer: CohortActivationServerRecord = {
+  id: '00000000-0000-4000-8000-000000000010',
+  name: DOC_QUERY_TARGET_SERVER_NAME,
+  description: DOC_QUERY_TARGET_DESCRIPTION,
+  url: DOC_QUERY_TARGET_URL,
+  authType: 'bearer',
+  passChatbotId: true,
+  chatbotIdHeader: 'Chatbot-ID',
+  parameters: {},
+  hasAuthSecret: true,
+  isActive: true,
+  updatedAt: new Date('2026-08-24T10:00:00.001Z'),
+}
+
+function makeManifest(
+  configs: CohortActivationConfigRecord[] = [sourceConfig]
+): CohortActivationManifest {
+  const unsigned = {
+    target: {
+      serverName: DOC_QUERY_TARGET_SERVER_NAME,
+      routePath: DOC_QUERY_ROUTE_PATH,
+      scope: DOC_QUERY_TARGET_SCOPE,
+      url: DOC_QUERY_TARGET_URL,
+    },
+    entries: configs.map((config) => ({
+      configId: config.id,
+      chatbotId: config.chatbotId,
+      chatMode: config.chatMode,
+      sourceServerId: sourceServer.id,
+      targetTool: 'doc_query' as const,
+      kbId:
+        config.chatbotId === sourceConfig.chatbotId
+          ? '00000000-0000-4000-8000-000000000020'
+          : '00000000-0000-4000-8000-000000000021',
+      corpusIdentity:
+        config.chatbotId === sourceConfig.chatbotId
+          ? 'synthetic-corpus-a'
+          : 'synthetic-corpus-b',
+      corpusOwner: 'synthetic-owner',
+    })),
+    heldConfigIds: [],
+    excludedCorpora: ['BF1', 'DF CF2', 'Vorkurs2'],
+    excludedConfigIds: [],
+  }
+  return { ...unsigned, fingerprint: fingerprintManifest(unsigned) }
+}
+
+function cloneConfig(
+  config: CohortActivationConfigRecord
+): CohortActivationConfigRecord {
+  return {
+    ...config,
+    allowedTools: structuredClone(config.allowedTools),
+    parameters: structuredClone(config.parameters),
+    updatedAt: new Date(config.updatedAt),
+  }
+}
+
+function cloneServer(
+  server: CohortActivationServerRecord
+): CohortActivationServerRecord {
+  return {
+    ...server,
+    parameters: structuredClone(server.parameters),
+    updatedAt: new Date(server.updatedAt),
+  }
+}
+
+function fakeStore(
+  initialConfigs:
+    | CohortActivationConfigRecord[]
+    | CohortActivationConfigRecord = [sourceConfig],
+  initialTarget?: CohortActivationServerRecord
+): {
+  store: CohortActivationStore
+  currentConfig: (id: string) => CohortActivationConfigRecord | undefined
+  currentTarget: () => CohortActivationServerRecord | undefined
+  writes: () => number
+  transactions: () => number
+  targetConfigCount: () => number
+  replaceConfig: (config: CohortActivationConfigRecord) => void
+  replaceSourceServer: (server: CohortActivationServerRecord) => void
+  failNextTargetUpdate: () => void
+} {
+  let servers = new Map<string, CohortActivationServerRecord>([
+    [sourceServer.id, cloneServer(sourceServer)],
+  ])
+  if (initialTarget) servers.set(initialTarget.id, cloneServer(initialTarget))
+  const configsToSeed = Array.isArray(initialConfigs)
+    ? initialConfigs
+    : [initialConfigs]
+  let configs = new Map<string, CohortActivationConfigRecord>(
+    configsToSeed.map((config) => [config.id, cloneConfig(config)])
+  )
+  let writes = 0
+  let transactions = 0
+  let failTargetUpdate = false
+  const makeTransaction = (
+    workingServers: Map<string, CohortActivationServerRecord>,
+    workingConfigs: Map<string, CohortActivationConfigRecord>
+  ): CohortActivationTransactionStore => ({
+    async findServerByName(name) {
+      const found = [...workingServers.values()].find(
+        (server) => server.name === name
+      )
+      return found ? cloneServer(found) : null
+    },
+    async findServerById(id) {
+      const found = workingServers.get(id)
+      return found ? cloneServer(found) : null
+    },
+    async findConfigById(id) {
+      const found = workingConfigs.get(id)
+      return found ? cloneConfig(found) : null
+    },
+    async findConfigByChatbotServer(chatbotId, mcpServerId, chatMode) {
+      const found = [...workingConfigs.values()].find(
+        (config) =>
+          config.chatbotId === chatbotId &&
+          config.mcpServerId === mcpServerId &&
+          config.chatMode === chatMode
+      )
+      return found ? cloneConfig(found) : null
+    },
+    async findConfigsByServerId(mcpServerId) {
+      return [...workingConfigs.values()]
+        .filter((config) => config.mcpServerId === mcpServerId)
+        .map(cloneConfig)
+    },
+    async createServer(data: CohortActivationServerCreate) {
+      const id = data.id ?? '00000000-0000-4000-8000-000000000010'
+      const created: CohortActivationServerRecord = {
+        id,
+        name: data.name,
+        description: data.description,
+        url: data.url,
+        authType: data.authType,
+        passChatbotId: data.passChatbotId,
+        chatbotIdHeader: data.chatbotIdHeader,
+        parameters: structuredClone(data.parameters),
+        hasAuthSecret: true,
+        isActive: data.isActive,
+        updatedAt: new Date('2026-08-24T10:00:00.001Z'),
+      }
+      workingServers.set(id, created)
+      writes += 1
+      return cloneServer(created)
+    },
+    async createConfig(data) {
+      const id =
+        data.id ??
+        `00000000-0000-4000-8000-${String(workingConfigs.size + 10).padStart(12, '0')}`
+      const created: CohortActivationConfigRecord = {
+        id,
+        ...data,
+        allowedTools: structuredClone(data.allowedTools),
+        parameters: structuredClone(data.parameters),
+        updatedAt: new Date('2026-08-24T10:00:00.001Z'),
+      }
+      workingConfigs.set(id, created)
+      writes += 1
+      return cloneConfig(created)
+    },
+    async updateConfig(
+      id,
+      expectedUpdatedAt,
+      data: CohortActivationConfigUpdate
+    ) {
+      if (failTargetUpdate && data.mcpServerId !== sourceServer.id) {
+        failTargetUpdate = false
+        return null
+      }
+      const current = workingConfigs.get(id)
+      if (
+        !current ||
+        current.updatedAt.getTime() !== expectedUpdatedAt.getTime()
+      ) {
+        return null
+      }
+      const updated: CohortActivationConfigRecord = {
+        ...current,
+        ...data,
+        allowedTools: structuredClone(data.allowedTools),
+        parameters: structuredClone(data.parameters),
+        updatedAt: new Date(current.updatedAt.getTime() + 1),
+      }
+      workingConfigs.set(id, updated)
+      writes += 1
+      return cloneConfig(updated)
+    },
+  })
+
+  const store: CohortActivationStore = {
+    async transaction(callback) {
+      transactions += 1
+      const workingServers = new Map(
+        [...servers].map(([id, server]) => [id, cloneServer(server)])
+      )
+      const workingConfigs = new Map(
+        [...configs].map(([id, config]) => [id, cloneConfig(config)])
+      )
+      const result = await callback(
+        makeTransaction(workingServers, workingConfigs)
+      )
+      servers = workingServers
+      configs = workingConfigs
+      return result
+    },
+  }
+  return {
+    store,
+    currentConfig: (id) => {
+      const config = configs.get(id)
+      return config ? cloneConfig(config) : undefined
+    },
+    currentTarget: () => {
+      const target = [...servers.values()].find(
+        (server) => server.name === DOC_QUERY_TARGET_SERVER_NAME
+      )
+      return target ? cloneServer(target) : undefined
+    },
+    writes: () => writes,
+    transactions: () => transactions,
+    targetConfigCount: () => {
+      const targetId = [...servers.values()].find(
+        (server) => server.name === DOC_QUERY_TARGET_SERVER_NAME
+      )?.id
+      return targetId
+        ? [...configs.values()].filter(
+            (config) => config.mcpServerId === targetId
+          ).length
+        : 0
+    },
+    replaceConfig: (config) => configs.set(config.id, cloneConfig(config)),
+    replaceSourceServer: (server) =>
+      servers.set(server.id, cloneServer(server)),
+    failNextTargetUpdate: () => {
+      failTargetUpdate = true
+    },
+  }
+}
+
+describe('cohort activation contract', () => {
+  it('rejects a self-authenticated manifest that is not the reviewed PRD set', () => {
+    expect(() => validatePinnedManifest(makeManifest())).toThrow(
+      expect.objectContaining({ code: 'MANIFEST_NOT_PINNED' })
+    )
+  })
+
+  it('refuses a receipt bound to a different manifest', async () => {
+    const fake = fakeStore()
+    const manifest = makeManifest()
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    expect(() =>
+      assertReceiptMatchesManifest(
+        prepared,
+        makeManifest([sourceConfig, secondModeConfig])
+      )
+    ).toThrow(expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' }))
+  })
+
+  it('persists receipts from canonical exclusion aliases', async () => {
+    const base = makeManifest()
+    const unsigned = {
+      target: base.target,
+      entries: base.entries,
+      heldConfigIds: base.heldConfigIds,
+      excludedCorpora: [' bf1 ', 'DF_CF2', 'VORKURS2'],
+      excludedConfigIds: ['AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA'],
+    }
+    const manifest = {
+      ...unsigned,
+      fingerprint: fingerprintManifest(unsigned),
+    }
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    const prepared = await prepareCohortActivation(
+      fakeStore().store,
+      manifest,
+      { encryptedBearer: 'encrypted-synthetic-bearer', intent }
+    )
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-alias-receipt-')
+    )
+    const receiptPath = join(directory, 'receipt.json')
+
+    try {
+      await writeReceipt(receiptPath, intent, null)
+      await writeReceipt(receiptPath, prepared, receiptExpectation(intent))
+      const persisted = JSON.parse(await readFile(receiptPath, 'utf8'))
+      expect(() => validateReceipt(persisted)).not.toThrow()
+      expect(persisted.excludedCorpora).toEqual(['BF1', 'DF CF2', 'Vorkurs2'])
+      expect(persisted.excludedConfigIds).toEqual([
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      ])
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('reconstructs a prepared receipt after the intent survives a write failure', async () => {
+    const fake = fakeStore()
+    const manifest = makeManifest()
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+      intent,
+    })
+    const recovered = await recoverPreparedCohortActivation(
+      fake.store,
+      manifest,
+      intent
+    )
+    expect(recovered.state).toBe('prepared')
+    expect(recovered.entries).toHaveLength(1)
+    expect(recovered.targetServer.id).toBeDefined()
+    expect(recovered.entries[0]!.target.id).toBe(
+      intent.targetConfigIds[sourceConfig.id]
+    )
+  })
+
+  it('refuses recovery when prepare did not commit', async () => {
+    const fake = fakeStore()
+    const manifest = makeManifest()
+    await expect(
+      recoverPreparedCohortActivation(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest)
+      )
+    ).rejects.toMatchObject({ code: 'RECOVERY_NOT_PREPARED' })
+  })
+
+  it('refuses recovery when the target server UUID belongs to another intent', async () => {
+    const fake = fakeStore()
+    const manifest = makeManifest()
+    const preparedIntent = makeCohortActivationReceiptIntent(manifest)
+    await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+      intent: preparedIntent,
+    })
+    await expect(
+      recoverPreparedCohortActivation(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest)
+      )
+    ).rejects.toMatchObject({ code: 'RECOVERY_AMBIGUOUS' })
+  })
+
+  it('proves a preparing intent was not committed before clearing it', async () => {
+    const manifest = makeManifest()
+    const fake = fakeStore()
+    await expect(
+      assertCohortActivationNotPrepared(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest)
+      )
+    ).resolves.toBeUndefined()
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('accepts an unchanged pre-existing target with no prepared slots', async () => {
+    const manifest = makeManifest()
+    const fake = fakeStore([sourceConfig], targetServer)
+    await expect(
+      assertCohortActivationNotPrepared(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest, targetServer.id)
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('refuses to clear when a target server appeared after the intent', async () => {
+    const manifest = makeManifest()
+    const fake = fakeStore([sourceConfig], targetServer)
+    await expect(
+      assertCohortActivationNotPrepared(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest)
+      )
+    ).rejects.toMatchObject({ code: 'CLEAR_AMBIGUOUS' })
+  })
+
+  it('refuses to clear when any deterministic target config was prepared', async () => {
+    const manifest = makeManifest()
+    const intent = makeCohortActivationReceiptIntent(manifest, targetServer.id)
+    const fake = fakeStore([sourceConfig], targetServer)
+    await prepareCohortActivation(fake.store, manifest, { intent })
+    await expect(
+      assertCohortActivationNotPrepared(fake.store, manifest, intent)
+    ).rejects.toMatchObject({ code: 'CLEAR_AMBIGUOUS' })
+  })
+
+  it('refuses to clear when the frozen source state drifted', async () => {
+    const manifest = makeManifest()
+    const fake = fakeStore()
+    fake.replaceConfig({ ...sourceConfig, isEnabled: false })
+    await expect(
+      assertCohortActivationNotPrepared(
+        fake.store,
+        manifest,
+        makeCohortActivationReceiptIntent(manifest)
+      )
+    ).rejects.toMatchObject({ code: 'SOURCE_MISMATCH' })
+  })
+
+  it('refuses a concurrent session for the same receipt path', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-lock-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const first = await acquireCohortActivationSessionLock(receiptPath)
+    try {
+      await expect(
+        acquireCohortActivationSessionLock(receiptPath)
+      ).rejects.toMatchObject({ message: 'SESSION_LOCKED' })
+    } finally {
+      await first.release()
+      const second = await acquireCohortActivationSessionLock(receiptPath)
+      await second.release()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('allows at most one simultaneous session-lock contender', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-lock-'))
+    const receiptPath = join(directory, 'receipt.json')
+    try {
+      const contenders = await Promise.allSettled([
+        acquireCohortActivationSessionLock(receiptPath),
+        acquireCohortActivationSessionLock(receiptPath),
+      ])
+      const acquired = contenders.filter(
+        (
+          result
+        ): result is PromiseFulfilledResult<
+          Awaited<ReturnType<typeof acquireCohortActivationSessionLock>>
+        > => result.status === 'fulfilled'
+      )
+      const refused = contenders.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected'
+      )
+
+      expect(acquired).toHaveLength(1)
+      expect(refused).toHaveLength(1)
+      expect(refused[0]!.reason).toMatchObject({ message: 'SESSION_LOCKED' })
+      await acquired[0]!.value.release()
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses stale and out-of-order receipt replacement', async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-receipt-')
+    )
+    const receiptPath = join(directory, 'receipt.json')
+    const intent = makeCohortActivationReceiptIntent(makeManifest())
+    try {
+      await writeReceipt(receiptPath, intent, null)
+
+      const fake = fakeStore()
+      const prepared = await prepareCohortActivation(
+        fake.store,
+        makeManifest(),
+        { encryptedBearer: 'encrypted-synthetic-bearer' }
+      )
+      const switched = await switchCohortActivation(fake.store, prepared)
+
+      await expect(
+        writeReceipt(receiptPath, prepared, null)
+      ).rejects.toMatchObject({ code: 'RECEIPT_CONCURRENT_WRITE' })
+      await expect(
+        writeReceipt(receiptPath, switched, receiptExpectation(intent))
+      ).rejects.toMatchObject({ code: 'RECEIPT_STATE_TRANSITION' })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('clears only the exact preparing receipt expectation', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-clear-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const intent = makeCohortActivationReceiptIntent(makeManifest())
+    try {
+      await writeReceipt(receiptPath, intent, null)
+      await expect(
+        clearPreparingReceipt(receiptPath, {
+          ...receiptExpectation(intent)!,
+          payloadDigest: '0'.repeat(64),
+        })
+      ).rejects.toMatchObject({ code: 'RECEIPT_CONCURRENT_WRITE' })
+      await clearPreparingReceipt(receiptPath, receiptExpectation(intent)!)
+      await expect(readFile(receiptPath, 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('dry-runs without writes and reports target creation', async () => {
+    const fake = fakeStore()
+    const result = await dryRunCohortActivation(fake.store, makeManifest())
+    expect(result).toMatchObject({
+      status: 'dry-run',
+      entryCount: 1,
+      heldCount: 0,
+      wouldCreateServer: true,
+      wouldCreateConfigs: 1,
+      wouldSwitch: 1,
+      wouldPreserveSourceRows: true,
+    })
+    expect(fake.writes()).toBe(0)
+    expect(fake.currentTarget()).toBeUndefined()
+  })
+
+  it('creates target rows, switches by CAS, and restores exact source content', async () => {
+    const fake = fakeStore()
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    expect(prepared.state).toBe('prepared')
+    expect(fake.currentConfig(sourceConfig.id)).toMatchObject({
+      ...sourceConfig,
+      parameters: {},
+    })
+    expect(fake.targetConfigCount()).toBe(1)
+    expect(fake.currentConfig(prepared.entries[0]!.target.id)).toMatchObject({
+      allowedTools: ['doc_query'],
+      parameters: {
+        required: true,
+        toolAlias: 'doc_query',
+        kb_id: '00000000-0000-4000-8000-000000000020',
+      },
+    })
+
+    const switched = await switchCohortActivation(fake.store, prepared)
+    expect(fake.currentConfig(sourceConfig.id)?.isEnabled).toBe(false)
+    expect(await readCohortActivationState(fake.store, switched)).toMatchObject(
+      {
+        state: 'switched',
+        entryCount: 1,
+        sourceEnabled: 0,
+        sourceDisabled: 1,
+        targetEnabled: 1,
+        targetDisabled: 0,
+      }
+    )
+
+    const rolledBack = await rollbackCohortActivation(fake.store, switched)
+    expect(rolledBack.state).toBe('rolled_back')
+    expect(fake.currentConfig(sourceConfig.id)).toMatchObject({
+      id: sourceConfig.id,
+      chatbotId: sourceConfig.chatbotId,
+      mcpServerId: sourceConfig.mcpServerId,
+      chatMode: sourceConfig.chatMode,
+      allowedTools: sourceConfig.allowedTools,
+      priority: sourceConfig.priority,
+      isEnabled: true,
+      parameters: sourceConfig.parameters,
+    })
+    expect(
+      fake.currentConfig(sourceConfig.id)?.updatedAt.getTime()
+    ).toBeGreaterThan(sourceConfig.updatedAt.getTime())
+    expect(
+      await readCohortActivationState(fake.store, rolledBack)
+    ).toMatchObject({
+      sourceEnabled: 1,
+      sourceDisabled: 0,
+      targetEnabled: 0,
+      targetDisabled: 1,
+    })
+  })
+
+  it('switches every mode for one chatbot in one transaction', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    const prepared = await prepareCohortActivation(
+      fake.store,
+      makeManifest([sourceConfig, secondModeConfig]),
+      { encryptedBearer: 'encrypted-synthetic-bearer' }
+    )
+
+    const switched = await switchCohortActivation(fake.store, prepared)
+
+    expect(fake.transactions()).toBe(2)
+    expect(fake.targetConfigCount()).toBe(2)
+    expect(await readCohortActivationState(fake.store, switched)).toMatchObject(
+      {
+        state: 'switched',
+        chatbotCount: 1,
+        switchedChatbotCount: 1,
+        sourceDisabled: 2,
+        targetEnabled: 2,
+      }
+    )
+  })
+
+  it('refuses a mixed chatbot rollback before writing either mode', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    const prepared = await prepareCohortActivation(
+      fake.store,
+      makeManifest([sourceConfig, secondModeConfig]),
+      { encryptedBearer: 'encrypted-synthetic-bearer' }
+    )
+    const writesBeforeRollback = fake.writes()
+    const source = fake.currentConfig(sourceConfig.id)!
+    const target = fake.currentConfig(prepared.entries[0]!.target.id)!
+    fake.replaceConfig({ ...source, isEnabled: false })
+    fake.replaceConfig({ ...target, isEnabled: true })
+
+    await expect(
+      rollbackCohortActivation(fake.store, prepared)
+    ).rejects.toMatchObject({ code: 'READBACK_STATE_MISMATCH' })
+    expect(fake.writes()).toBe(writesBeforeRollback)
+    expect(fake.currentConfig(sourceConfig.id)?.isEnabled).toBe(false)
+    expect(fake.currentConfig(prepared.entries[0]!.target.id)?.isEnabled).toBe(
+      true
+    )
+  })
+
+  it('treats case-variant chatbot UUIDs as one readback group', async () => {
+    const chatbotId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const firstMode = {
+      ...sourceConfig,
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+      chatbotId,
+    }
+    const secondMode = {
+      ...secondModeConfig,
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2',
+      chatbotId: chatbotId.toUpperCase(),
+    }
+    const fake = fakeStore([firstMode, secondMode])
+    const prepared = await prepareCohortActivation(
+      fake.store,
+      makeManifest([firstMode, secondMode]),
+      { encryptedBearer: 'encrypted-synthetic-bearer' }
+    )
+    fake.replaceConfig({
+      ...fake.currentConfig(firstMode.id)!,
+      isEnabled: false,
+    })
+    fake.replaceConfig({
+      ...fake.currentConfig(prepared.entries[0]!.target.id)!,
+      isEnabled: true,
+    })
+
+    await expect(
+      readCohortActivationState(fake.store, prepared)
+    ).rejects.toMatchObject({ code: 'READBACK_STATE_MISMATCH' })
+  })
+
+  it('checkpoints chatbot groups and rolls back a stale partial receipt', async () => {
+    const fake = fakeStore([sourceConfig, secondChatbotConfig])
+    const prepared = await prepareCohortActivation(
+      fake.store,
+      makeManifest([sourceConfig, secondChatbotConfig]),
+      { encryptedBearer: 'encrypted-synthetic-bearer' }
+    )
+    const checkpoints = [] as Awaited<
+      ReturnType<typeof switchCohortActivation>
+    >[]
+
+    const switched = await switchCohortActivation(
+      fake.store,
+      prepared,
+      async (checkpoint) => {
+        checkpoints.push(checkpoint)
+      }
+    )
+    const partial = checkpoints.find(
+      (checkpoint) =>
+        checkpoint.state === 'switching' &&
+        checkpoint.switchedChatbotIds.length === 1
+    )
+    expect(partial).toBeDefined()
+    expect(switched.state).toBe('switched')
+    expect(fake.transactions()).toBe(3)
+
+    const rolledBack = await rollbackCohortActivation(fake.store, partial!)
+    expect(rolledBack.state).toBe('rolled_back')
+    expect(
+      await readCohortActivationState(fake.store, rolledBack)
+    ).toMatchObject({
+      state: 'rolled_back',
+      chatbotCount: 2,
+      switchedChatbotCount: 0,
+      sourceEnabled: 2,
+      targetDisabled: 2,
+    })
+  })
+
+  it('refuses source drift before any switch write', async () => {
+    const fake = fakeStore()
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    fake.replaceConfig({ ...sourceConfig, priority: 9 })
+    await expect(
+      switchCohortActivation(fake.store, prepared)
+    ).rejects.toMatchObject({
+      code: 'SOURCE_DRIFT',
+    })
+    expect(fake.currentConfig(sourceConfig.id)?.priority).toBe(9)
+  })
+
+  it('refuses inactive and test-route source rows', async () => {
+    const inactive = fakeStore()
+    inactive.replaceSourceServer({ ...sourceServer, isActive: false })
+    await expect(
+      dryRunCohortActivation(inactive.store, makeManifest())
+    ).rejects.toMatchObject({ code: 'SOURCE_SERVER_INACTIVE' })
+
+    const testRoute = fakeStore()
+    testRoute.replaceSourceServer({
+      ...sourceServer,
+      url: 'http://test.example.invalid/mcp/klicker',
+    })
+    await expect(
+      dryRunCohortActivation(testRoute.store, makeManifest())
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+  })
+
+  it('refuses source parameters that could leak into a receipt', async () => {
+    const fake = fakeStore()
+    const unsafe = { ...sourceConfig, parameters: { source: true } }
+    fake.replaceConfig(unsafe)
+    await expect(
+      prepareCohortActivation(fake.store, makeManifest(), {
+        encryptedBearer: 'encrypted-synthetic-bearer',
+      })
+    ).rejects.toMatchObject({ code: 'SOURCE_SHAPE_UNSUPPORTED' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('requires complete source mode coverage for each chatbot', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    await expect(
+      dryRunCohortActivation(fake.store, makeManifest([sourceConfig]))
+    ).rejects.toMatchObject({ code: 'PARTIAL_MODE_COVERAGE' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('refuses mixed source servers for one chatbot', async () => {
+    const manifest = makeManifest([sourceConfig, secondModeConfig])
+    const mixed = {
+      ...manifest,
+      entries: [
+        manifest.entries[0]!,
+        {
+          ...manifest.entries[1]!,
+          sourceServerId: '00000000-0000-4000-8000-000000000011',
+        },
+      ],
+    }
+    mixed.fingerprint = fingerprintManifest({
+      target: mixed.target,
+      entries: mixed.entries,
+      heldConfigIds: mixed.heldConfigIds,
+      excludedCorpora: mixed.excludedCorpora,
+      excludedConfigIds: mixed.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(
+        fakeStore([sourceConfig, secondModeConfig]).store,
+        mixed
+      )
+    ).rejects.toMatchObject({ code: 'MIXED_MODE_COVERAGE' })
+  })
+
+  it('refuses repeated knowledge-base ids with conflicting corpus ownership', async () => {
+    const manifest = makeManifest([sourceConfig, secondChatbotConfig])
+    const conflicted = {
+      ...manifest,
+      entries: [
+        manifest.entries[0]!,
+        { ...manifest.entries[1]!, kbId: manifest.entries[0]!.kbId },
+      ],
+    }
+    conflicted.fingerprint = fingerprintManifest({
+      target: conflicted.target,
+      entries: conflicted.entries,
+      heldConfigIds: conflicted.heldConfigIds,
+      excludedCorpora: conflicted.excludedCorpora,
+      excludedConfigIds: conflicted.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(
+        fakeStore([sourceConfig, secondChatbotConfig]).store,
+        conflicted
+      )
+    ).rejects.toMatchObject({ code: 'KB_ID_OWNERSHIP_CONFLICT' })
+  })
+
+  it('refuses an excluded corpus and malformed knowledge-base id', async () => {
+    const manifest = makeManifest()
+    const excluded = {
+      ...manifest,
+      entries: [{ ...manifest.entries[0]!, corpusIdentity: 'BF1' }],
+    }
+    excluded.fingerprint = fingerprintManifest({
+      target: excluded.target,
+      entries: excluded.entries,
+      heldConfigIds: excluded.heldConfigIds,
+      excludedCorpora: excluded.excludedCorpora,
+      excludedConfigIds: excluded.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fakeStore().store, excluded)
+    ).rejects.toMatchObject({ code: 'EXCLUDED_CORPUS_INCLUDED' })
+
+    const malformed = {
+      ...manifest,
+      entries: [{ ...manifest.entries[0]!, kbId: 'not-a-uuid' }],
+    }
+    malformed.fingerprint = fingerprintManifest({
+      target: malformed.target,
+      entries: malformed.entries,
+      heldConfigIds: malformed.heldConfigIds,
+      excludedCorpora: malformed.excludedCorpora,
+      excludedConfigIds: malformed.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fakeStore().store, malformed)
+    ).rejects.toMatchObject({ code: 'INVALID_ID' })
+  })
+
+  it('rolls back the synthetic transaction when a later target update fails', async () => {
+    const base = fakeStore()
+    const prepared = await prepareCohortActivation(base.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    base.failNextTargetUpdate()
+    await expect(
+      switchCohortActivation(base.store, prepared)
+    ).rejects.toMatchObject({
+      code: 'CONCURRENT_EDIT',
+    })
+    expect(base.currentConfig(sourceConfig.id)?.isEnabled).toBe(true)
+    expect(base.targetConfigCount()).toBe(1)
+    expect(
+      [...(base.currentConfig(sourceConfig.id)?.allowedTools as string[])].join(
+        ','
+      )
+    ).toBe('doc_query')
+  })
+
+  it('reuses an owned target server and preserves unrelated target configs', async () => {
+    const target: CohortActivationServerRecord = {
+      id: '00000000-0000-4000-8000-000000000010',
+      name: DOC_QUERY_TARGET_SERVER_NAME,
+      description: DOC_QUERY_TARGET_DESCRIPTION,
+      url: DOC_QUERY_TARGET_URL,
+      authType: 'bearer',
+      passChatbotId: true,
+      chatbotIdHeader: 'Chatbot-ID',
+      parameters: {},
+      hasAuthSecret: true,
+      isActive: true,
+      updatedAt: new Date('2026-08-24T10:00:00.000Z'),
+    }
+    const existingTargetConfig: CohortActivationConfigRecord = {
+      ...sourceConfig,
+      id: '00000000-0000-4000-8000-000000000007',
+      chatbotId: '00000000-0000-4000-8000-000000000008',
+      mcpServerId: target.id,
+      allowedTools: ['banking_expert'],
+      isEnabled: false,
+      parameters: { required: true, toolAlias: 'doc_query' },
+    }
+    const fake = fakeStore([sourceConfig, existingTargetConfig], target)
+    expect(fake.currentTarget()?.id).toBe(target.id)
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      intent: makeCohortActivationReceiptIntent(makeManifest()),
+    })
+    expect(prepared.targetServer.id).toBe(target.id)
+    expect(fake.targetConfigCount()).toBe(2)
+  })
+
+  it('refuses any pre-existing target server before ownership reuse', async () => {
+    const target: CohortActivationServerRecord = {
+      id: '00000000-0000-4000-8000-000000000010',
+      name: DOC_QUERY_TARGET_SERVER_NAME,
+      description: 'unmanaged compatibility route',
+      url: DOC_QUERY_TARGET_URL,
+      authType: 'bearer',
+      passChatbotId: true,
+      chatbotIdHeader: 'Chatbot-ID',
+      parameters: {},
+      hasAuthSecret: true,
+      isActive: true,
+      updatedAt: new Date('2026-08-24T10:00:00.000Z'),
+    }
+    const fake = fakeStore([sourceConfig], target)
+    await expect(
+      dryRunCohortActivation(fake.store, makeManifest())
+    ).rejects.toMatchObject({ code: 'TARGET_OWNERSHIP_UNKNOWN' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('refuses a target contract that points at the test route', async () => {
+    const fake = fakeStore()
+    const manifest = makeManifest()
+    const invalid = {
+      ...manifest,
+      target: { ...manifest.target, url: 'http://test/mcp/klicker' as const },
+    }
+    invalid.fingerprint = fingerprintManifest({
+      target: invalid.target,
+      entries: invalid.entries,
+      heldConfigIds: invalid.heldConfigIds,
+      excludedCorpora: invalid.excludedCorpora,
+      excludedConfigIds: invalid.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fake.store, invalid)
+    ).rejects.toMatchObject({
+      code: 'TARGET_CONTRACT_MISMATCH',
+    })
+  })
+
+  it('refuses malformed target tools and held-row overlap', async () => {
+    const fake = fakeStore()
+    const malformed = {
+      ...makeManifest(),
+      entries: [
+        { ...makeManifest().entries[0]!, targetTool: 'banking*' as never },
+      ],
+      heldConfigIds: [],
+    }
+    malformed.fingerprint = fingerprintManifest({
+      target: malformed.target,
+      entries: malformed.entries,
+      heldConfigIds: malformed.heldConfigIds,
+      excludedCorpora: malformed.excludedCorpora,
+      excludedConfigIds: malformed.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fake.store, malformed)
+    ).rejects.toMatchObject({
+      code: 'INVALID_TARGET_SHAPE',
+    })
+
+    const held = {
+      ...makeManifest(),
+      heldConfigIds: [sourceConfig.id],
+    }
+    held.fingerprint = fingerprintManifest({
+      target: held.target,
+      entries: held.entries,
+      heldConfigIds: held.heldConfigIds,
+      excludedCorpora: held.excludedCorpora,
+      excludedConfigIds: held.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fake.store, held)
+    ).rejects.toMatchObject({
+      code: 'HELD_CONFIG_INCLUDED',
+    })
+
+    const excluded = {
+      ...makeManifest(),
+      excludedConfigIds: [sourceConfig.id],
+    }
+    excluded.fingerprint = fingerprintManifest({
+      target: excluded.target,
+      entries: excluded.entries,
+      heldConfigIds: excluded.heldConfigIds,
+      excludedCorpora: excluded.excludedCorpora,
+      excludedConfigIds: excluded.excludedConfigIds,
+    })
+    await expect(
+      dryRunCohortActivation(fake.store, excluded)
+    ).rejects.toMatchObject({ code: 'EXCLUDED_CONFIG_INCLUDED' })
+  })
+
+  it('binds target contract state to the receipt digest', async () => {
+    const fake = fakeStore()
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    const changed = {
+      ...prepared,
+      targetServer: {
+        ...prepared.targetServer,
+        updatedAt: '2026-08-24T10:00:00.002Z',
+      },
+    }
+    expect(() => validateReceipt(changed)).toThrow(
+      expect.objectContaining({ code: 'RECEIPT_INVALID' })
+    )
+  })
+})
+
+describe('Prisma cohort activation transactions', () => {
+  it('retries a P2034 transaction until it succeeds', async () => {
+    const transaction = vi.fn()
+    let attempts = 0
+    transaction.mockImplementation(async (operation) => {
+      attempts += 1
+      const result = await operation({} as never)
+      if (attempts === 1) throw { code: 'P2034' }
+      return result
+    })
+    const store = createPrismaCohortActivationStore({
+      $transaction: transaction,
+    } as unknown as PrismaClient)
+    const callback = vi.fn(async () => 'committed')
+
+    await expect(store.transaction(callback)).resolves.toBe('committed')
+    expect(transaction).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds P2034 retries and rethrows the final conflict', async () => {
+    const transaction = vi.fn()
+    const conflict = { code: 'P2034' }
+    transaction.mockImplementation(async (operation) => {
+      await operation({} as never)
+      throw conflict
+    })
+    const store = createPrismaCohortActivationStore({
+      $transaction: transaction,
+    } as unknown as PrismaClient)
+
+    await expect(store.transaction(async () => 'unreachable')).rejects.toBe(
+      conflict
+    )
+    expect(transaction).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry non-P2034 transaction errors', async () => {
+    const transaction = vi.fn()
+    const error = new Error('transaction timeout')
+    transaction.mockRejectedValue(error)
+    const store = createPrismaCohortActivationStore({
+      $transaction: transaction,
+    } as unknown as PrismaClient)
+
+    await expect(store.transaction(async () => 'unreachable')).rejects.toBe(
+      error
+    )
+    expect(transaction).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
@@ -1,0 +1,2193 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+export const DOC_QUERY_TOOL_ALIAS = 'doc_query' as const
+export const DOC_QUERY_ROUTE_PATH = '/mcp/klicker' as const
+export const DOC_QUERY_TARGET_SERVER_NAME = 'KB' as const
+export const DOC_QUERY_TARGET_DESCRIPTION =
+  'managed-by:klicker-doc-query-cohort-activation;scope:prd-klicker' as const
+export const DOC_QUERY_TARGET_URL =
+  'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker' as const
+export const DOC_QUERY_TARGET_SCOPE = 'prd-klicker' as const
+export const COHORT_ACTIVATION_RECEIPT_VERSION = 1 as const
+/** Name of the explicit, values-free approval pin supplied to the runner. */
+export const COHORT_ACTIVATION_MANIFEST_FINGERPRINT_ENV =
+  'DOC_QUERY_COHORT_ACTIVATION_MANIFEST_FINGERPRINT' as const
+
+/** The named corpora are held out of this operator by contract. */
+export const COHORT_ACTIVATION_EXCLUDED_CORPORA = [
+  'BF1',
+  'DF CF2',
+  'Vorkurs2',
+] as const
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const TOOL_PATTERN = /^[A-Za-z0-9_-]+$/
+
+export const DOC_QUERY_TOOL_NAMES = [DOC_QUERY_TOOL_ALIAS] as const
+const SOURCE_DOC_QUERY_TOOL_NAMES = [
+  'banking_expert',
+  'bf1_expert',
+  'bio144_expert',
+  'cf1_expert',
+  'df_ap_expert',
+  'df_bf2_expert',
+  'df_cf2_expert',
+  'df_fineco_expert',
+  'df_qf_expert',
+  'fs26_intro_r_expert',
+  'informatik_und_wirtschaft_video_expert',
+  'mat141_expert',
+  'mat182_expert',
+  'mat183_expert',
+  'python_and_r_expert',
+  'radiosurfvet_expert',
+  'vorkurs_expert',
+] as const
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type CohortActivationConfigRecord = {
+  id: string
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: JsonValue
+  priority: number
+  isEnabled: boolean
+  parameters: JsonValue
+  updatedAt: Date
+}
+
+export type CohortActivationServerRecord = {
+  id: string
+  name: string
+  description: string | null
+  url: string
+  authType: string
+  passChatbotId: boolean
+  chatbotIdHeader: string | null
+  parameters: JsonValue
+  hasAuthSecret: boolean
+  isActive: boolean
+  updatedAt: Date
+}
+
+export type CohortActivationServerCreate = {
+  id?: string
+  name: string
+  description: string
+  url: string
+  authType: 'bearer'
+  /** Encrypted at rest; plaintext never enters this contract. */
+  encryptedBearer: string
+  passChatbotId: true
+  chatbotIdHeader: 'Chatbot-ID'
+  parameters: JsonValue
+  isActive: true
+}
+
+export type CohortActivationConfigCreate = {
+  id?: string
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: JsonValue
+  priority: number
+  isEnabled: false
+  parameters: JsonValue
+}
+
+export type CohortActivationConfigUpdate = {
+  chatbotId: string
+  mcpServerId: string
+  chatMode: string
+  allowedTools: JsonValue
+  priority: number
+  isEnabled: boolean
+  parameters: JsonValue
+}
+
+export type CohortActivationTransactionStore = {
+  findServerByName(name: string): Promise<CohortActivationServerRecord | null>
+  findServerById(id: string): Promise<CohortActivationServerRecord | null>
+  findConfigById(id: string): Promise<CohortActivationConfigRecord | null>
+  findConfigByChatbotServer(
+    chatbotId: string,
+    mcpServerId: string,
+    chatMode: string
+  ): Promise<CohortActivationConfigRecord | null>
+  findConfigsByServerId(
+    mcpServerId: string
+  ): Promise<CohortActivationConfigRecord[]>
+  createServer(
+    data: CohortActivationServerCreate
+  ): Promise<CohortActivationServerRecord>
+  createConfig(
+    data: CohortActivationConfigCreate
+  ): Promise<CohortActivationConfigRecord>
+  updateConfig(
+    id: string,
+    expectedUpdatedAt: Date,
+    data: CohortActivationConfigUpdate
+  ): Promise<CohortActivationConfigRecord | null>
+}
+
+export type CohortActivationStore = {
+  transaction<T>(
+    callback: (store: CohortActivationTransactionStore) => Promise<T>
+  ): Promise<T>
+}
+
+export type CohortActivationTargetContract = {
+  serverName: string
+  routePath: string
+  scope: string
+  url: string
+}
+
+export type CohortActivationManifestEntry = {
+  configId: string
+  chatbotId: string
+  chatMode: string
+  sourceServerId: string
+  /** The multi-tenant reader exposes one stable public tool. */
+  targetTool?: typeof DOC_QUERY_TOOL_ALIAS
+  /** External knowledge-base identifier used by the reader scope. */
+  kbId: string
+  /** Stable corpus identity; aliases are accepted when reading a handoff. */
+  corpusIdentity?: string
+  corpusId?: string
+  /** Stable corpus owner identity; aliases are accepted when reading a handoff. */
+  corpusOwner?: string
+  corpusOwnerId?: string
+}
+
+export type CohortActivationManifest = {
+  fingerprint: string
+  target: CohortActivationTargetContract
+  entries: CohortActivationManifestEntry[]
+  heldConfigIds: string[]
+  /** Canonical exclusion names are required; this alias eases handoff parsing. */
+  excludedCorpora?: string[]
+  exclusions?: string[]
+  /** Optional explicit row holds, kept separate from the named exclusions. */
+  excludedConfigIds?: string[]
+}
+
+type SafeConfigSnapshot = Omit<
+  CohortActivationConfigRecord,
+  'allowedTools' | 'parameters' | 'updatedAt'
+> & {
+  allowedTools: JsonValue
+  parameters: JsonValue
+  updatedAt: string
+}
+
+type SafeServerSnapshot = Omit<
+  CohortActivationServerRecord,
+  'parameters' | 'updatedAt'
+> & {
+  parameters: JsonValue
+  updatedAt: string
+}
+
+export type CohortActivationReceiptEntry = {
+  manifest: CohortActivationManifestEntry
+  prior: SafeConfigSnapshot
+  target: SafeConfigSnapshot
+}
+
+export type CohortActivationReceiptState =
+  | 'prepared'
+  | 'switching'
+  | 'switched'
+  | 'rolling_back'
+  | 'rolled_back'
+
+export type CohortActivationReceipt = {
+  receiptVersion: typeof COHORT_ACTIVATION_RECEIPT_VERSION
+  manifestFingerprint: string
+  target: CohortActivationTargetContract
+  targetServer: SafeServerSnapshot
+  heldConfigIds: string[]
+  excludedCorpora: string[]
+  excludedConfigIds: string[]
+  entries: CohortActivationReceiptEntry[]
+  switchedChatbotIds: string[]
+  state: CohortActivationReceiptState
+  payloadDigest: string
+}
+
+export type CohortActivationReceiptIntent = {
+  receiptVersion: typeof COHORT_ACTIVATION_RECEIPT_VERSION
+  manifestFingerprint: string
+  target: CohortActivationTargetContract
+  /** Null means the target server is resolved during the prepare transaction. */
+  targetServerId: string | null
+  targetConfigIds: Record<string, string>
+  heldConfigIds: string[]
+  excludedCorpora: string[]
+  excludedConfigIds: string[]
+  state: 'preparing'
+  payloadDigest: string
+}
+
+export type CohortActivationReceiptFile =
+  | CohortActivationReceipt
+  | CohortActivationReceiptIntent
+
+export type CohortActivationReceiptExpectation = {
+  manifestFingerprint: string
+  payloadDigest: string
+  state: CohortActivationReceiptFile['state']
+} | null
+
+export type CohortActivationPrepareOptions = {
+  encryptedBearer?: string
+  intent?: CohortActivationReceiptIntent
+}
+
+export type CohortActivationDryRunResult = {
+  status: 'dry-run'
+  manifestFingerprint: string
+  target: CohortActivationTargetContract
+  entryCount: number
+  heldCount: number
+  wouldCreateServer: boolean
+  wouldCreateConfigs: number
+  wouldSwitch: number
+  wouldPreserveSourceRows: true
+}
+
+export type CohortActivationReadback = {
+  state: CohortActivationReceiptState | 'partial'
+  entryCount: number
+  chatbotCount: number
+  switchedChatbotCount: number
+  sourceEnabled: number
+  sourceDisabled: number
+  targetEnabled: number
+  targetDisabled: number
+  targetServerActive: boolean
+}
+
+export class CohortActivationError extends Error {
+  readonly code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'CohortActivationError'
+    this.code = code
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new CohortActivationError(code, message)
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right)
+}
+
+function cloneJson(value: JsonValue): JsonValue {
+  if (value === null || typeof value !== 'object') return value
+  return structuredClone(value)
+}
+
+function jsonEqual(left: JsonValue, right: JsonValue): boolean {
+  if (left === right) return true
+  if (left === null || right === null) return false
+  if (typeof left !== 'object' || typeof right !== 'object') {
+    return left === right
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => jsonEqual(value, right[index]!))
+    )
+  }
+  const leftRecord = left as Record<string, JsonValue>
+  const rightRecord = right as Record<string, JsonValue>
+  const leftKeys = Object.keys(leftRecord).sort(compareStrings)
+  const rightKeys = Object.keys(rightRecord).sort(compareStrings)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) =>
+        key === rightKeys[index] &&
+        jsonEqual(leftRecord[key]!, rightRecord[key]!)
+    )
+  )
+}
+
+function assertUuid(value: string, field: string): void {
+  if (typeof value !== 'string' || !UUID_PATTERN.test(value)) {
+    fail('INVALID_ID', `${field} must be a UUID`)
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeUuid(value: string, field: string): string {
+  assertUuid(value, field)
+  return value.toLowerCase()
+}
+
+function assertNonEmpty(value: string, field: string): void {
+  if (typeof value !== 'string' || !value.trim()) {
+    fail('INVALID_MANIFEST', `${field} must not be blank`)
+  }
+}
+
+function assertSafeIdentity(value: string, field: string): void {
+  assertNonEmpty(value, field)
+  if (value.length > 256 || /[\r\n]/.test(value)) {
+    fail('INVALID_MANIFEST', `${field} is not a safe identity`)
+  }
+}
+
+function isEmptyJsonObject(value: JsonValue): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  )
+}
+
+function isSafeSourceAllowedTools(value: JsonValue): boolean {
+  if (value === null) return true
+  if (!Array.isArray(value)) return false
+  return value.every(
+    (tool) =>
+      typeof tool === 'string' &&
+      (tool === DOC_QUERY_TOOL_ALIAS ||
+        (SOURCE_DOC_QUERY_TOOL_NAMES as readonly string[]).includes(tool))
+  )
+}
+
+function assertSafeSourceReceiptFields(
+  allowedTools: JsonValue,
+  parameters: JsonValue
+): void {
+  if (parameters !== null && !isEmptyJsonObject(parameters)) {
+    fail(
+      'SOURCE_SHAPE_UNSUPPORTED',
+      'source parameters are not safe to persist in a receipt'
+    )
+  }
+  if (!isSafeSourceAllowedTools(allowedTools)) {
+    fail(
+      'SOURCE_SHAPE_UNSUPPORTED',
+      'source allowlist is not safe to persist in a receipt'
+    )
+  }
+}
+
+function assertSafeSourceReceiptShape(
+  config: CohortActivationConfigRecord
+): void {
+  assertSafeSourceReceiptFields(config.allowedTools, config.parameters)
+}
+
+function snapshotConfig(
+  config: CohortActivationConfigRecord
+): SafeConfigSnapshot {
+  return {
+    id: config.id,
+    chatbotId: config.chatbotId,
+    mcpServerId: config.mcpServerId,
+    chatMode: config.chatMode,
+    allowedTools: cloneJson(config.allowedTools),
+    priority: config.priority,
+    isEnabled: config.isEnabled,
+    parameters: cloneJson(config.parameters),
+    updatedAt: config.updatedAt.toISOString(),
+  }
+}
+
+function snapshotServer(
+  server: CohortActivationServerRecord
+): SafeServerSnapshot {
+  return {
+    id: server.id,
+    name: server.name,
+    description: server.description,
+    url: server.url,
+    authType: server.authType,
+    passChatbotId: server.passChatbotId,
+    chatbotIdHeader: server.chatbotIdHeader,
+    hasAuthSecret: server.hasAuthSecret,
+    parameters: cloneJson(server.parameters),
+    isActive: server.isActive,
+    updatedAt: server.updatedAt.toISOString(),
+  }
+}
+
+function configContentEqual(
+  config: CohortActivationConfigRecord,
+  snapshot: SafeConfigSnapshot
+): boolean {
+  return (
+    config.id === snapshot.id &&
+    config.chatbotId === snapshot.chatbotId &&
+    config.mcpServerId === snapshot.mcpServerId &&
+    config.chatMode === snapshot.chatMode &&
+    jsonEqual(config.allowedTools, snapshot.allowedTools) &&
+    config.priority === snapshot.priority &&
+    config.isEnabled === snapshot.isEnabled &&
+    jsonEqual(config.parameters, snapshot.parameters)
+  )
+}
+
+function configSnapshotEqual(
+  config: CohortActivationConfigRecord,
+  snapshot: SafeConfigSnapshot
+): boolean {
+  return (
+    configContentEqual(config, snapshot) &&
+    config.updatedAt.toISOString() === snapshot.updatedAt
+  )
+}
+
+function configShapeEqual(
+  config: CohortActivationConfigRecord,
+  snapshot: SafeConfigSnapshot
+): boolean {
+  return (
+    config.id === snapshot.id &&
+    config.chatbotId === snapshot.chatbotId &&
+    config.mcpServerId === snapshot.mcpServerId &&
+    config.chatMode === snapshot.chatMode &&
+    jsonEqual(config.allowedTools, snapshot.allowedTools) &&
+    config.priority === snapshot.priority &&
+    jsonEqual(config.parameters, snapshot.parameters)
+  )
+}
+
+function serverSnapshotEqual(
+  server: CohortActivationServerRecord,
+  snapshot: SafeServerSnapshot
+): boolean {
+  return (
+    server.id === snapshot.id &&
+    server.name === snapshot.name &&
+    server.description === snapshot.description &&
+    server.url === snapshot.url &&
+    server.authType === snapshot.authType &&
+    server.passChatbotId === snapshot.passChatbotId &&
+    server.chatbotIdHeader === snapshot.chatbotIdHeader &&
+    server.hasAuthSecret === snapshot.hasAuthSecret &&
+    jsonEqual(server.parameters, snapshot.parameters) &&
+    server.isActive === snapshot.isActive &&
+    server.updatedAt.toISOString() === snapshot.updatedAt
+  )
+}
+
+function exclusionValues(
+  manifest: Pick<CohortActivationManifest, 'excludedCorpora' | 'exclusions'>
+): string[] {
+  if (manifest.excludedCorpora && manifest.exclusions) {
+    if (
+      JSON.stringify(manifest.excludedCorpora) !==
+      JSON.stringify(manifest.exclusions)
+    ) {
+      fail('EXCLUSION_CONTRACT_MISMATCH', 'manifest exclusion aliases differ')
+    }
+  }
+  const values = manifest.excludedCorpora ?? manifest.exclusions
+  if (!values) fail('EXCLUSIONS_MISSING', 'manifest exclusions are required')
+  if (
+    !Array.isArray(values) ||
+    values.some((value) => typeof value !== 'string')
+  ) {
+    fail('EXCLUSION_CONTRACT_MISMATCH', 'manifest exclusions are malformed')
+  }
+  return [...values]
+}
+
+function canonicalExclusion(value: string): string {
+  return value.trim().replaceAll('_', ' ').replaceAll(/\s+/g, ' ').toLowerCase()
+}
+
+function excludedConfigValues(
+  manifest: Pick<CohortActivationManifest, 'excludedConfigIds'>
+): string[] {
+  if (
+    manifest.excludedConfigIds !== undefined &&
+    (!Array.isArray(manifest.excludedConfigIds) ||
+      manifest.excludedConfigIds.some((value) => typeof value !== 'string'))
+  ) {
+    fail('INVALID_MANIFEST', 'excluded config ids are malformed')
+  }
+  return [...(manifest.excludedConfigIds ?? [])]
+}
+
+function entryCorpusIdentity(entry: CohortActivationManifestEntry): string {
+  if (
+    entry.corpusIdentity !== undefined &&
+    entry.corpusId !== undefined &&
+    entry.corpusIdentity !== entry.corpusId
+  ) {
+    fail('CORPUS_IDENTITY_CONFLICT', 'corpus identity aliases differ')
+  }
+  const identity = entry.corpusIdentity ?? entry.corpusId
+  const normalized = identity ?? ''
+  assertSafeIdentity(normalized, 'entry.corpusIdentity')
+  return normalized.trim()
+}
+
+function entryCorpusOwner(entry: CohortActivationManifestEntry): string {
+  if (
+    entry.corpusOwner !== undefined &&
+    entry.corpusOwnerId !== undefined &&
+    entry.corpusOwner !== entry.corpusOwnerId
+  ) {
+    fail('CORPUS_OWNER_CONFLICT', 'corpus owner aliases differ')
+  }
+  const owner = entry.corpusOwner ?? entry.corpusOwnerId
+  const normalized = owner ?? ''
+  assertSafeIdentity(normalized, 'entry.corpusOwner')
+  return normalized.trim()
+}
+
+function entryTargetTool(entry: CohortActivationManifestEntry): string {
+  return entry.targetTool ?? DOC_QUERY_TOOL_ALIAS
+}
+
+function canonicalManifest(
+  manifest: Omit<CohortActivationManifest, 'fingerprint'>
+) {
+  return {
+    target: manifest.target,
+    entries: [...manifest.entries]
+      .sort((left, right) => compareStrings(left.configId, right.configId))
+      .map((entry) => ({
+        configId: entry.configId,
+        chatbotId: entry.chatbotId,
+        chatMode: entry.chatMode,
+        sourceServerId: entry.sourceServerId,
+        targetTool: entryTargetTool(entry),
+        kbId:
+          typeof entry.kbId === 'string'
+            ? entry.kbId.toLowerCase()
+            : entry.kbId,
+        corpusIdentity: entry.corpusIdentity ?? entry.corpusId,
+        corpusOwner: entry.corpusOwner ?? entry.corpusOwnerId,
+      })),
+    heldConfigIds: [...manifest.heldConfigIds].sort(compareStrings),
+    excludedCorpora: canonicalExclusionValues(manifest),
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+  }
+}
+
+function assertNamedExclusions(manifest: CohortActivationManifest): string[] {
+  const actual = canonicalExclusionValues(manifest)
+  const expected = [...COHORT_ACTIVATION_EXCLUDED_CORPORA]
+    .map(canonicalExclusion)
+    .sort(compareStrings)
+  if (
+    actual.length !== expected.length ||
+    actual.some((value, index) => value !== expected[index])
+  ) {
+    fail('EXCLUSION_CONTRACT_MISMATCH', 'manifest exclusions are not fixed')
+  }
+  return actual
+}
+
+function canonicalExclusionValues(
+  manifest: Pick<CohortActivationManifest, 'excludedCorpora' | 'exclusions'>
+): string[] {
+  return exclusionValues(manifest).map(canonicalExclusion).sort(compareStrings)
+}
+
+function canonicalExcludedConfigIds(
+  manifest: CohortActivationManifest
+): string[] {
+  return excludedConfigValues(manifest)
+    .map((value) => normalizeUuid(value, 'excludedConfigIds'))
+    .sort(compareStrings)
+}
+
+function assertCorpusOwnership(manifest: CohortActivationManifest): void {
+  const ownership = new Map<string, string>()
+  for (const entry of manifest.entries) {
+    const kbId = normalizeUuid(entry.kbId, 'entry.kbId')
+    const ownerKey = `${entryCorpusIdentity(entry)}\u0000${entryCorpusOwner(entry)}`
+    const prior = ownership.get(kbId)
+    if (prior && prior !== ownerKey) {
+      fail(
+        'KB_ID_OWNERSHIP_CONFLICT',
+        'repeated kb id has conflicting ownership'
+      )
+    }
+    ownership.set(kbId, ownerKey)
+  }
+}
+
+function assertEntryNotExcluded(entry: CohortActivationManifestEntry): void {
+  const identity = canonicalExclusion(entryCorpusIdentity(entry))
+  if (
+    [...COHORT_ACTIVATION_EXCLUDED_CORPORA].some(
+      (excluded) => canonicalExclusion(excluded) === identity
+    )
+  ) {
+    fail('EXCLUDED_CORPUS_INCLUDED', 'manifest includes an excluded corpus')
+  }
+}
+
+function chatbotIds(entries: CohortActivationManifestEntry[]): string[] {
+  return [
+    ...new Set(
+      entries.map((entry) => normalizeUuid(entry.chatbotId, 'entry.chatbotId'))
+    ),
+  ].sort(compareStrings)
+}
+
+function groupEntriesByChatbot(
+  entries: CohortActivationReceiptEntry[]
+): Array<[string, CohortActivationReceiptEntry[]]> {
+  const groups = new Map<string, CohortActivationReceiptEntry[]>()
+  for (const entry of entries) {
+    const chatbotId = normalizeUuid(entry.manifest.chatbotId, 'entry.chatbotId')
+    const group = groups.get(chatbotId) ?? []
+    group.push(entry)
+    groups.set(chatbotId, group)
+  }
+  return [...groups.entries()].sort(([left], [right]) =>
+    compareStrings(left, right)
+  )
+}
+
+function makeReceiptFrom(
+  receipt: CohortActivationReceipt,
+  input: Pick<
+    CohortActivationReceipt,
+    'entries' | 'state' | 'switchedChatbotIds'
+  >
+): CohortActivationReceipt {
+  return makeReceipt({
+    manifestFingerprint: receipt.manifestFingerprint,
+    target: receipt.target,
+    targetServer: receipt.targetServer,
+    heldConfigIds: receipt.heldConfigIds,
+    excludedCorpora: receipt.excludedCorpora,
+    excludedConfigIds: receipt.excludedConfigIds,
+    entries: input.entries,
+    switchedChatbotIds: input.switchedChatbotIds,
+    state: input.state,
+  })
+}
+
+export function fingerprintManifest(
+  manifest: Omit<CohortActivationManifest, 'fingerprint'>
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalManifest(manifest)))
+    .digest('hex')
+}
+
+type ManifestValidationState = {
+  configIds: Set<string>
+  chatbotModes: Set<string>
+  sourceServersByChatbot: Map<string, string>
+}
+
+function assertManifestShape(manifest: CohortActivationManifest): void {
+  if (!manifest || typeof manifest !== 'object') {
+    fail('INVALID_MANIFEST', 'manifest is malformed')
+  }
+  if (!manifest.target || typeof manifest.target !== 'object') {
+    fail('TARGET_CONTRACT_MISMATCH', 'manifest target is malformed')
+  }
+  if (
+    manifest.target.serverName !== DOC_QUERY_TARGET_SERVER_NAME ||
+    manifest.target.routePath !== DOC_QUERY_ROUTE_PATH ||
+    manifest.target.scope !== DOC_QUERY_TARGET_SCOPE ||
+    manifest.target.url !== DOC_QUERY_TARGET_URL
+  ) {
+    fail('TARGET_CONTRACT_MISMATCH', 'manifest target is not the PRD contract')
+  }
+  if (!Array.isArray(manifest.entries) || manifest.entries.length === 0) {
+    fail('EMPTY_MANIFEST', 'manifest entries are required')
+  }
+  if (!Array.isArray(manifest.heldConfigIds)) {
+    fail('INVALID_MANIFEST', 'held config ids must be an array')
+  }
+}
+
+function validateManifestEntry(
+  entry: CohortActivationManifestEntry,
+  state: ManifestValidationState
+): void {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    fail('INVALID_MANIFEST', 'manifest entry is malformed')
+  }
+  const configId = normalizeUuid(entry.configId, 'entry.configId')
+  const chatbotId = normalizeUuid(entry.chatbotId, 'entry.chatbotId')
+  const sourceServerId = normalizeUuid(
+    entry.sourceServerId,
+    'entry.sourceServerId'
+  )
+  assertNonEmpty(entry.chatMode, 'entry.chatMode')
+  if (entry.targetTool !== undefined && typeof entry.targetTool !== 'string') {
+    fail('INVALID_TARGET_SHAPE', 'target tool is malformed')
+  }
+  const targetTool = entryTargetTool(entry)
+  if (!TOOL_PATTERN.test(targetTool)) {
+    fail('INVALID_TARGET_SHAPE', 'target tool contains unsafe characters')
+  }
+  if (targetTool !== DOC_QUERY_TOOL_ALIAS) {
+    fail(
+      'UNKNOWN_TARGET_TOOL',
+      'target tool is not the multi-tenant reader tool'
+    )
+  }
+  normalizeUuid(entry.kbId, 'entry.kbId')
+  entryCorpusIdentity(entry)
+  entryCorpusOwner(entry)
+  assertEntryNotExcluded(entry)
+  if (state.configIds.has(configId)) {
+    fail('DUPLICATE_CONFIG', 'manifest contains a duplicate config')
+  }
+  state.configIds.add(configId)
+  const priorSourceServer = state.sourceServersByChatbot.get(chatbotId)
+  if (priorSourceServer && priorSourceServer !== sourceServerId) {
+    fail('MIXED_MODE_COVERAGE', 'one chatbot uses more than one source server')
+  }
+  state.sourceServersByChatbot.set(chatbotId, sourceServerId)
+  const chatbotMode = `${chatbotId}:${entry.chatMode}`
+  if (state.chatbotModes.has(chatbotMode)) {
+    fail('DUPLICATE_TARGET_CONFIG', 'manifest targets one chatbot mode twice')
+  }
+  state.chatbotModes.add(chatbotMode)
+}
+
+function validateManifestEntries(
+  manifest: CohortActivationManifest
+): Set<string> {
+  const state: ManifestValidationState = {
+    configIds: new Set<string>(),
+    chatbotModes: new Set<string>(),
+    sourceServersByChatbot: new Map<string, string>(),
+  }
+  for (const entry of manifest.entries) {
+    validateManifestEntry(entry, state)
+  }
+  return state.configIds
+}
+
+function validateHeldConfigIds(
+  manifest: CohortActivationManifest,
+  configIds: Set<string>
+): Set<string> {
+  const held = new Set<string>()
+  for (const configId of manifest.heldConfigIds) {
+    const normalizedId = normalizeUuid(configId, 'heldConfigIds')
+    if (held.has(normalizedId) || configIds.has(normalizedId)) {
+      fail('HELD_CONFIG_INCLUDED', 'held config overlaps the activation')
+    }
+    held.add(normalizedId)
+  }
+  return held
+}
+
+function validateExcludedConfigIds(
+  manifest: CohortActivationManifest,
+  configIds: Set<string>,
+  held: Set<string>
+): void {
+  const excluded = new Set<string>()
+  for (const configId of canonicalExcludedConfigIds(manifest)) {
+    if (
+      excluded.has(configId) ||
+      held.has(configId) ||
+      configIds.has(configId)
+    ) {
+      fail(
+        'EXCLUDED_CONFIG_INCLUDED',
+        'excluded config overlaps the activation'
+      )
+    }
+    excluded.add(configId)
+  }
+}
+
+export function validateManifest(manifest: CohortActivationManifest): void {
+  assertManifestShape(manifest)
+  assertNamedExclusions(manifest)
+  const configIds = validateManifestEntries(manifest)
+  const held = validateHeldConfigIds(manifest, configIds)
+  validateExcludedConfigIds(manifest, configIds, held)
+  assertCorpusOwnership(manifest)
+
+  const expectedFingerprint = fingerprintManifest(manifest)
+  if (manifest.fingerprint !== expectedFingerprint) {
+    fail('MANIFEST_DRIFT', 'manifest fingerprint does not match its contents')
+  }
+}
+
+export function validatePinnedManifest(
+  manifest: CohortActivationManifest,
+  approvedFingerprint = process.env[COHORT_ACTIVATION_MANIFEST_FINGERPRINT_ENV]
+): void {
+  validateManifest(manifest)
+  const configuredFingerprint = approvedFingerprint
+  if (
+    !configuredFingerprint ||
+    !/^[0-9a-f]{64}$/i.test(configuredFingerprint) ||
+    manifest.fingerprint !== configuredFingerprint
+  ) {
+    fail('MANIFEST_NOT_PINNED', 'manifest is not explicitly approved')
+  }
+}
+
+export function assertReceiptMatchesManifest(
+  receipt: CohortActivationReceipt,
+  manifest: CohortActivationManifest
+): void {
+  validateReceipt(receipt)
+  if (receipt.manifestFingerprint !== manifest.fingerprint) {
+    fail('RECEIPT_MANIFEST_MISMATCH', 'receipt does not match the manifest')
+  }
+}
+
+function assertTargetServer(
+  server: CohortActivationServerRecord | null,
+  target: CohortActivationTargetContract
+): asserts server is CohortActivationServerRecord {
+  if (!server) fail('TARGET_SERVER_MISSING', 'target server is missing')
+  if (server.description !== DOC_QUERY_TARGET_DESCRIPTION) {
+    fail('TARGET_OWNERSHIP_UNKNOWN', 'target server ownership is not proven')
+  }
+  if (
+    server.name !== target.serverName ||
+    server.url !== target.url ||
+    server.authType !== 'bearer' ||
+    server.passChatbotId !== true ||
+    server.chatbotIdHeader !== 'Chatbot-ID' ||
+    server.hasAuthSecret !== true ||
+    !isEmptyJsonObject(server.parameters) ||
+    server.isActive !== true
+  ) {
+    fail('TARGET_SERVER_MISMATCH', 'target server contract does not match')
+  }
+}
+
+function targetConfigData(
+  entry: CohortActivationManifestEntry,
+  targetServerId: string,
+  priority: number,
+  isEnabled: false
+): CohortActivationConfigCreate
+function targetConfigData(
+  entry: CohortActivationManifestEntry,
+  targetServerId: string,
+  priority: number,
+  isEnabled: true
+): CohortActivationConfigUpdate
+function targetConfigData(
+  entry: CohortActivationManifestEntry,
+  targetServerId: string,
+  priority: number,
+  isEnabled: boolean
+): CohortActivationConfigCreate | CohortActivationConfigUpdate {
+  return {
+    chatbotId: normalizeUuid(entry.chatbotId, 'entry.chatbotId'),
+    mcpServerId: targetServerId,
+    chatMode: entry.chatMode,
+    allowedTools: [DOC_QUERY_TOOL_ALIAS],
+    priority,
+    isEnabled,
+    parameters: {
+      required: true,
+      toolAlias: DOC_QUERY_TOOL_ALIAS,
+      kb_id: normalizeUuid(entry.kbId, 'entry.kbId'),
+    },
+  }
+}
+
+function sourceConfigData(
+  snapshot: SafeConfigSnapshot,
+  isEnabled: boolean
+): CohortActivationConfigUpdate {
+  return {
+    chatbotId: snapshot.chatbotId,
+    mcpServerId: snapshot.mcpServerId,
+    chatMode: snapshot.chatMode,
+    allowedTools: cloneJson(snapshot.allowedTools),
+    priority: snapshot.priority,
+    isEnabled,
+    parameters: cloneJson(snapshot.parameters),
+  }
+}
+
+async function findTargetServer(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationManifest,
+  encryptedBearer: string | undefined,
+  targetServerId: string | null
+): Promise<CohortActivationServerRecord> {
+  const existing = await tx.findServerByName(manifest.target.serverName)
+  if (existing) {
+    assertTargetServer(existing, manifest.target)
+    if (
+      targetServerId !== null &&
+      normalizeUuid(targetServerId, 'targetServerId') !==
+        normalizeUuid(existing.id, 'targetServer.id')
+    ) {
+      fail('TARGET_SERVER_DRIFT', 'target server does not belong to the intent')
+    }
+    return existing
+  }
+  if (!encryptedBearer) {
+    fail(
+      'TARGET_AUTH_MISSING',
+      'creating the target requires an encrypted bearer'
+    )
+  }
+  const created = await tx.createServer({
+    id: targetServerId
+      ? normalizeUuid(targetServerId, 'targetServerId')
+      : randomUUID(),
+    name: manifest.target.serverName,
+    description: DOC_QUERY_TARGET_DESCRIPTION,
+    url: manifest.target.url,
+    authType: 'bearer',
+    encryptedBearer,
+    passChatbotId: true,
+    chatbotIdHeader: 'Chatbot-ID',
+    parameters: {},
+    isActive: true,
+  })
+  assertTargetServer(created, manifest.target)
+  return created
+}
+
+async function assertTargetConfigAvailable(
+  tx: CohortActivationTransactionStore,
+  targetServer: CohortActivationServerRecord,
+  entry: CohortActivationManifestEntry
+): Promise<void> {
+  const existing = await tx.findConfigByChatbotServer(
+    normalizeUuid(entry.chatbotId, 'entry.chatbotId'),
+    targetServer.id,
+    entry.chatMode
+  )
+  if (existing) {
+    fail(
+      'DUPLICATE_TARGET_CONFIG',
+      'target config already exists for the chatbot mode'
+    )
+  }
+}
+
+async function assertCompleteModeCoverage(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationManifest
+): Promise<void> {
+  const held = new Set(
+    manifest.heldConfigIds.map((id) => normalizeUuid(id, 'heldConfigIds'))
+  )
+  const excluded = new Set(canonicalExcludedConfigIds(manifest))
+  const groups = new Map<string, CohortActivationManifestEntry[]>()
+  for (const entry of manifest.entries) {
+    const chatbotId = normalizeUuid(entry.chatbotId, 'entry.chatbotId')
+    const group = groups.get(chatbotId) ?? []
+    group.push(entry)
+    groups.set(chatbotId, group)
+  }
+
+  for (const [chatbotId, group] of groups) {
+    const sourceServerId = normalizeUuid(
+      group[0]!.sourceServerId,
+      'entry.sourceServerId'
+    )
+    const sourceConfigs = await tx.findConfigsByServerId(sourceServerId)
+    const expected = new Set(
+      group.map((entry) => normalizeUuid(entry.configId, 'entry.configId'))
+    )
+    const active = sourceConfigs.filter(
+      (config) =>
+        config.chatbotId.toLowerCase() === chatbotId &&
+        config.isEnabled &&
+        !held.has(config.id.toLowerCase()) &&
+        !excluded.has(config.id.toLowerCase())
+    )
+    if (
+      active.length !== expected.size ||
+      active.some((config) => !expected.has(config.id.toLowerCase()))
+    ) {
+      fail(
+        'PARTIAL_MODE_COVERAGE',
+        'manifest does not cover every enabled source mode'
+      )
+    }
+  }
+}
+
+async function readSourceEntries(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationManifest
+): Promise<
+  Array<{ manifest: CohortActivationManifestEntry; prior: SafeConfigSnapshot }>
+> {
+  const entries: Array<{
+    manifest: CohortActivationManifestEntry
+    prior: SafeConfigSnapshot
+  }> = []
+  for (const entry of manifest.entries) {
+    const source = await tx.findConfigById(entry.configId)
+    if (!source) fail('CONFIG_MISSING', 'manifest config is missing')
+    if (
+      source.chatbotId.toLowerCase() !== entry.chatbotId.toLowerCase() ||
+      source.chatMode !== entry.chatMode ||
+      source.mcpServerId.toLowerCase() !== entry.sourceServerId.toLowerCase() ||
+      source.isEnabled !== true
+    ) {
+      fail('SOURCE_MISMATCH', 'source config no longer matches manifest')
+    }
+    const sourceServer = await tx.findServerById(entry.sourceServerId)
+    if (!sourceServer) fail('SOURCE_SERVER_MISSING', 'source server is missing')
+    if (!sourceServer.isActive) {
+      fail('SOURCE_SERVER_INACTIVE', 'source server is inactive')
+    }
+    assertSafeSourceReceiptShape(source)
+    if (
+      sourceServer.url === manifest.target.url ||
+      sourceServer.url.endsWith(DOC_QUERY_ROUTE_PATH)
+    ) {
+      fail(
+        'SOURCE_IS_TARGET',
+        'test-route source cannot enter this cohortActivation'
+      )
+    }
+    entries.push({ manifest: entry, prior: snapshotConfig(source) })
+  }
+  await assertCompleteModeCoverage(tx, manifest)
+  return entries
+}
+
+function makeReceipt(
+  input: Omit<CohortActivationReceipt, 'receiptVersion' | 'payloadDigest'>
+): CohortActivationReceipt {
+  const withoutDigest = {
+    receiptVersion: COHORT_ACTIVATION_RECEIPT_VERSION,
+    ...input,
+  }
+  return {
+    ...withoutDigest,
+    payloadDigest: createHash('sha256')
+      .update(JSON.stringify(withoutDigest))
+      .digest('hex'),
+  }
+}
+
+export function makeCohortActivationReceiptIntent(
+  manifest: CohortActivationManifest,
+  targetServerId: string | null = null
+): CohortActivationReceiptIntent {
+  validateManifest(manifest)
+  const targetConfigIds = Object.fromEntries(
+    manifest.entries.map((entry) => [entry.configId, randomUUID()])
+  )
+  const withoutDigest = {
+    receiptVersion: COHORT_ACTIVATION_RECEIPT_VERSION,
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    targetServerId,
+    targetConfigIds,
+    heldConfigIds: manifest.heldConfigIds,
+    excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    state: 'preparing' as const,
+  }
+  return {
+    ...withoutDigest,
+    payloadDigest: createHash('sha256')
+      .update(JSON.stringify(withoutDigest))
+      .digest('hex'),
+  }
+}
+
+function assertReceiptIntentHeader(
+  intent: CohortActivationReceiptIntent
+): void {
+  if (!isRecord(intent)) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent is malformed')
+  }
+  if (!isRecord(intent.target)) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent target is malformed')
+  }
+  if (intent.receiptVersion !== COHORT_ACTIVATION_RECEIPT_VERSION) {
+    fail('RECEIPT_INVALID', 'unsupported cohortActivation receipt version')
+  }
+  if (intent.state !== 'preparing') {
+    fail('RECEIPT_INVALID', 'cohortActivation intent state is malformed')
+  }
+  if (
+    intent.target.serverName !== DOC_QUERY_TARGET_SERVER_NAME ||
+    intent.target.routePath !== DOC_QUERY_ROUTE_PATH ||
+    intent.target.scope !== DOC_QUERY_TARGET_SCOPE ||
+    intent.target.url !== DOC_QUERY_TARGET_URL ||
+    typeof intent.manifestFingerprint !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(intent.manifestFingerprint)
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent target is malformed')
+  }
+}
+
+function validateReceiptIntentHeldIds(
+  intent: CohortActivationReceiptIntent
+): void {
+  if (!Array.isArray(intent.heldConfigIds)) {
+    fail('RECEIPT_INVALID', 'cohortActivation held ids are malformed')
+  }
+  const heldIds = new Set<string>()
+  for (const configId of intent.heldConfigIds) {
+    const normalized = normalizeUuid(configId, 'heldConfigIds')
+    if (heldIds.has(normalized)) {
+      fail('RECEIPT_INVALID', 'cohortActivation held ids repeat')
+    }
+    heldIds.add(normalized)
+  }
+}
+
+function validateReceiptIntentExclusions(
+  intent: CohortActivationReceiptIntent
+): void {
+  const expected = [...COHORT_ACTIVATION_EXCLUDED_CORPORA]
+    .map(canonicalExclusion)
+    .sort(compareStrings)
+  if (
+    !Array.isArray(intent.excludedCorpora) ||
+    intent.excludedCorpora.some((value) => typeof value !== 'string') ||
+    intent.excludedCorpora.length !== expected.length ||
+    intent.excludedCorpora
+      .map(canonicalExclusion)
+      .sort(compareStrings)
+      .some((value, index) => value !== expected[index])
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation exclusions are malformed')
+  }
+}
+
+function validateReceiptIntentTargetConfigIds(
+  intent: CohortActivationReceiptIntent
+): void {
+  if (
+    !intent.targetConfigIds ||
+    typeof intent.targetConfigIds !== 'object' ||
+    Array.isArray(intent.targetConfigIds) ||
+    Object.keys(intent.targetConfigIds).length === 0
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent target ids are malformed')
+  }
+  const targetConfigIds = Object.entries(intent.targetConfigIds)
+  const targetIds = new Set<string>()
+  for (const [configId, targetConfigId] of targetConfigIds) {
+    assertUuid(configId, 'targetConfigIds.configId')
+    assertUuid(targetConfigId, 'targetConfigIds.targetConfigId')
+    if (targetIds.has(targetConfigId)) {
+      fail(
+        'RECEIPT_INVALID',
+        'cohortActivation intent repeats a target config id'
+      )
+    }
+    targetIds.add(targetConfigId)
+  }
+}
+
+function assertReceiptIntentDigest(
+  intent: CohortActivationReceiptIntent
+): void {
+  if (
+    typeof intent.payloadDigest !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(intent.payloadDigest)
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent digest is malformed')
+  }
+  const { payloadDigest: _ignored, ...withoutDigest } = intent
+  const expected = createHash('sha256')
+    .update(JSON.stringify(withoutDigest))
+    .digest('hex')
+  if (expected !== intent.payloadDigest) {
+    fail('RECEIPT_INVALID', 'cohortActivation intent digest does not match')
+  }
+}
+
+export function validateCohortActivationReceiptIntent(
+  intent: CohortActivationReceiptIntent
+): void {
+  assertReceiptIntentHeader(intent)
+  validateReceiptIntentHeldIds(intent)
+  if (intent.targetServerId !== null) {
+    assertUuid(intent.targetServerId, 'targetServerId')
+  }
+  validateReceiptIntentExclusions(intent)
+  if (!Array.isArray(intent.excludedConfigIds)) {
+    fail('RECEIPT_INVALID', 'cohortActivation excluded ids are malformed')
+  }
+  const excludedIds = new Set<string>()
+  for (const configId of intent.excludedConfigIds) {
+    const normalized = normalizeUuid(configId, 'excludedConfigIds')
+    if (excludedIds.has(normalized)) {
+      fail('RECEIPT_INVALID', 'cohortActivation excluded ids repeat')
+    }
+    excludedIds.add(normalized)
+  }
+  validateReceiptIntentTargetConfigIds(intent)
+  assertReceiptIntentDigest(intent)
+}
+
+function assertIntentMatchesManifest(
+  manifest: CohortActivationManifest,
+  intent: CohortActivationReceiptIntent
+): void {
+  if (intent.manifestFingerprint !== manifest.fingerprint) {
+    fail(
+      'RECEIPT_MANIFEST_MISMATCH',
+      'cohortActivation intent does not match manifest'
+    )
+  }
+  const expectedHeldConfigIds = manifest.heldConfigIds
+    .map((configId) => normalizeUuid(configId, 'heldConfigIds'))
+    .sort(compareStrings)
+  const actualHeldConfigIds = intent.heldConfigIds
+    .map((configId) => normalizeUuid(configId, 'heldConfigIds'))
+    .sort(compareStrings)
+  const expectedExcludedConfigIds = canonicalExcludedConfigIds(manifest)
+  const actualExcludedConfigIds = intent.excludedConfigIds
+    .map((configId) => normalizeUuid(configId, 'excludedConfigIds'))
+    .sort(compareStrings)
+  if (
+    JSON.stringify(actualHeldConfigIds) !==
+      JSON.stringify(expectedHeldConfigIds) ||
+    JSON.stringify(actualExcludedConfigIds) !==
+      JSON.stringify(expectedExcludedConfigIds)
+  ) {
+    fail(
+      'RECEIPT_INVALID',
+      'cohortActivation intent holds do not match manifest'
+    )
+  }
+  if (
+    Object.keys(intent.targetConfigIds).length !== manifest.entries.length ||
+    manifest.entries.some((entry) => !intent.targetConfigIds[entry.configId])
+  ) {
+    fail(
+      'RECEIPT_INVALID',
+      'cohortActivation intent does not cover the manifest'
+    )
+  }
+}
+
+function assertReceiptShape(receipt: CohortActivationReceipt): void {
+  if (!isRecord(receipt)) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt is malformed')
+  }
+  if (receipt.receiptVersion !== COHORT_ACTIVATION_RECEIPT_VERSION) {
+    fail('RECEIPT_INVALID', 'unsupported cohortActivation receipt version')
+  }
+  if (!isRecord(receipt.target) || !isRecord(receipt.targetServer)) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt target is malformed')
+  }
+  if (!Array.isArray(receipt.entries)) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt entries are malformed')
+  }
+  if (
+    !Array.isArray(receipt.switchedChatbotIds) ||
+    receipt.switchedChatbotIds.some(
+      (chatbotId) => typeof chatbotId !== 'string'
+    )
+  ) {
+    fail('RECEIPT_INVALID', 'switched chatbot checkpoint is malformed')
+  }
+  const receiptStates: CohortActivationReceiptState[] = [
+    'prepared',
+    'switching',
+    'switched',
+    'rolling_back',
+    'rolled_back',
+  ]
+  if (!receiptStates.includes(receipt.state)) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt state is malformed')
+  }
+  for (const item of receipt.entries) {
+    if (
+      !isRecord(item) ||
+      !isRecord(item.manifest) ||
+      !isRecord(item.prior) ||
+      !isRecord(item.target)
+    ) {
+      fail('RECEIPT_INVALID', 'cohortActivation receipt entry is malformed')
+    }
+  }
+}
+
+function assertReceiptTargetServer(receipt: CohortActivationReceipt): void {
+  assertUuid(receipt.targetServer.id, 'targetServer.id')
+  if (
+    typeof receipt.targetServer.updatedAt !== 'string' ||
+    Number.isNaN(Date.parse(receipt.targetServer.updatedAt))
+  ) {
+    fail('RECEIPT_INVALID', 'target server timestamp is malformed')
+  }
+  if (
+    receipt.targetServer.name !== receipt.target.serverName ||
+    receipt.targetServer.description !== DOC_QUERY_TARGET_DESCRIPTION ||
+    receipt.targetServer.url !== receipt.target.url ||
+    receipt.targetServer.authType !== 'bearer' ||
+    receipt.targetServer.passChatbotId !== true ||
+    receipt.targetServer.chatbotIdHeader !== 'Chatbot-ID' ||
+    receipt.targetServer.hasAuthSecret !== true ||
+    !isEmptyJsonObject(receipt.targetServer.parameters) ||
+    receipt.targetServer.isActive !== true
+  ) {
+    fail('RECEIPT_INVALID', 'target server snapshot is malformed')
+  }
+}
+
+function validateSwitchedChatbotIds(
+  receipt: CohortActivationReceipt,
+  manifestChatbotIds: Set<string>
+): Set<string> {
+  const switchedChatbotIds = new Set(
+    receipt.switchedChatbotIds.map((chatbotId) => chatbotId.toLowerCase())
+  )
+  if (
+    receipt.switchedChatbotIds.some(
+      (chatbotId) =>
+        !UUID_PATTERN.test(chatbotId) ||
+        !manifestChatbotIds.has(chatbotId.toLowerCase())
+    ) ||
+    switchedChatbotIds.size !== receipt.switchedChatbotIds.length
+  ) {
+    fail('RECEIPT_INVALID', 'switched chatbot checkpoint is malformed')
+  }
+  if (receipt.state === 'prepared' && receipt.switchedChatbotIds.length > 0) {
+    fail('RECEIPT_INVALID', 'prepared receipt has switched chatbot ids')
+  }
+  if (
+    receipt.state === 'switched' &&
+    switchedChatbotIds.size !== manifestChatbotIds.size
+  ) {
+    fail('RECEIPT_INVALID', 'switched receipt is incomplete')
+  }
+  if (
+    receipt.state === 'rolled_back' &&
+    receipt.switchedChatbotIds.length > 0
+  ) {
+    fail('RECEIPT_INVALID', 'rolled-back receipt has switched chatbot ids')
+  }
+  return switchedChatbotIds
+}
+
+function validateReceiptEntry(
+  receipt: CohortActivationReceipt,
+  item: CohortActivationReceiptEntry,
+  switchedChatbotIds: Set<string>,
+  targetConfigIds: Set<string>
+): void {
+  assertUuid(item.prior.id, 'receipt.prior.id')
+  assertUuid(item.prior.chatbotId, 'receipt.prior.chatbotId')
+  assertUuid(item.prior.mcpServerId, 'receipt.prior.mcpServerId')
+  assertUuid(item.target.id, 'receipt.target.id')
+  assertUuid(item.target.chatbotId, 'receipt.target.chatbotId')
+  assertUuid(item.target.mcpServerId, 'receipt.target.mcpServerId')
+  if (targetConfigIds.has(item.target.id.toLowerCase())) {
+    fail('RECEIPT_INVALID', 'target config ids repeat')
+  }
+  targetConfigIds.add(item.target.id.toLowerCase())
+  if (
+    typeof item.prior.updatedAt !== 'string' ||
+    Number.isNaN(Date.parse(item.prior.updatedAt)) ||
+    typeof item.target.updatedAt !== 'string' ||
+    Number.isNaN(Date.parse(item.target.updatedAt)) ||
+    typeof item.prior.priority !== 'number' ||
+    !Number.isFinite(item.prior.priority) ||
+    typeof item.target.priority !== 'number' ||
+    !Number.isFinite(item.target.priority)
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation config snapshot is malformed')
+  }
+  if (
+    (item.prior.parameters !== null &&
+      !isEmptyJsonObject(item.prior.parameters)) ||
+    !isSafeSourceAllowedTools(item.prior.allowedTools)
+  ) {
+    fail('RECEIPT_INVALID', 'receipt contains an unsafe source snapshot')
+  }
+  if (
+    !item.prior.isEnabled ||
+    item.target.mcpServerId.toLowerCase() !==
+      receipt.targetServer.id.toLowerCase() ||
+    item.target.chatbotId.toLowerCase() !==
+      item.manifest.chatbotId.toLowerCase() ||
+    item.target.chatMode !== item.manifest.chatMode ||
+    item.prior.id.toLowerCase() !== item.manifest.configId.toLowerCase() ||
+    item.prior.mcpServerId.toLowerCase() !==
+      item.manifest.sourceServerId.toLowerCase() ||
+    item.target.priority !== item.prior.priority ||
+    item.prior.chatbotId.toLowerCase() !==
+      item.manifest.chatbotId.toLowerCase() ||
+    item.prior.chatMode !== item.manifest.chatMode ||
+    !jsonEqual(item.target.allowedTools, [DOC_QUERY_TOOL_ALIAS]) ||
+    !jsonEqual(item.target.parameters, {
+      required: true,
+      toolAlias: DOC_QUERY_TOOL_ALIAS,
+      kb_id: normalizeUuid(item.manifest.kbId, 'entry.kbId'),
+    })
+  ) {
+    fail('RECEIPT_INVALID', 'target config snapshot is malformed')
+  }
+  const expectedTargetEnabled = switchedChatbotIds.has(
+    item.manifest.chatbotId.toLowerCase()
+  )
+  if (item.target.isEnabled !== expectedTargetEnabled) {
+    fail('RECEIPT_INVALID', 'target config state does not match checkpoint')
+  }
+}
+
+function validateReceiptEntries(
+  receipt: CohortActivationReceipt,
+  switchedChatbotIds: Set<string>
+): void {
+  const targetConfigIds = new Set<string>()
+  for (const item of receipt.entries) {
+    validateReceiptEntry(receipt, item, switchedChatbotIds, targetConfigIds)
+  }
+}
+
+function assertReceiptDigest(receipt: CohortActivationReceipt): void {
+  if (
+    typeof receipt.payloadDigest !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(receipt.payloadDigest)
+  ) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt digest is malformed')
+  }
+  const { payloadDigest: _ignored, ...withoutDigest } = receipt
+  const expected = createHash('sha256')
+    .update(JSON.stringify(withoutDigest))
+    .digest('hex')
+  if (expected !== receipt.payloadDigest) {
+    fail('RECEIPT_INVALID', 'cohortActivation receipt digest does not match')
+  }
+}
+
+export function validateReceipt(receipt: CohortActivationReceipt): void {
+  assertReceiptShape(receipt)
+  validateManifest({
+    fingerprint: receipt.manifestFingerprint,
+    target: receipt.target,
+    entries: receipt.entries.map(({ manifest }) => manifest),
+    heldConfigIds: receipt.heldConfigIds,
+    excludedCorpora: receipt.excludedCorpora,
+    excludedConfigIds: receipt.excludedConfigIds,
+  })
+  assertReceiptTargetServer(receipt)
+  const manifestChatbotIds = new Set(
+    chatbotIds(receipt.entries.map(({ manifest }) => manifest))
+  )
+  const switchedChatbotIds = validateSwitchedChatbotIds(
+    receipt,
+    manifestChatbotIds
+  )
+  validateReceiptEntries(receipt, switchedChatbotIds)
+  assertReceiptDigest(receipt)
+}
+
+function validateReceiptFile(receipt: CohortActivationReceiptFile): void {
+  if (receipt.state === 'preparing')
+    validateCohortActivationReceiptIntent(receipt)
+  else validateReceipt(receipt)
+}
+
+export function receiptExpectation(
+  receipt: CohortActivationReceiptFile | null
+): CohortActivationReceiptExpectation {
+  return receipt
+    ? {
+        manifestFingerprint: receipt.manifestFingerprint,
+        payloadDigest: receipt.payloadDigest,
+        state: receipt.state,
+      }
+    : null
+}
+
+const RECEIPT_STATE_TRANSITIONS: Record<
+  CohortActivationReceiptFile['state'],
+  readonly CohortActivationReceiptFile['state'][]
+> = {
+  preparing: ['prepared'],
+  prepared: ['switching', 'switched', 'rolling_back', 'rolled_back'],
+  switching: ['switching', 'switched', 'rolling_back', 'rolled_back'],
+  switched: ['rolling_back', 'rolled_back'],
+  rolling_back: ['rolling_back', 'rolled_back'],
+  rolled_back: [],
+}
+
+/**
+ * Validate the receipt compare-and-swap contract before replacing the file.
+ * The runner holds the session lock while calling this function, but the
+ * expected digest and state also reject stale or out-of-order writes.
+ */
+export function assertReceiptTransition(
+  expected: CohortActivationReceiptExpectation,
+  current: CohortActivationReceiptFile | null,
+  next: CohortActivationReceiptFile
+): void {
+  validateReceiptFile(next)
+  if (expected === null) {
+    if (current !== null) {
+      fail(
+        'RECEIPT_CONCURRENT_WRITE',
+        'receipt was created before the expected initial write'
+      )
+    }
+    if (next.state !== 'preparing') {
+      fail(
+        'RECEIPT_STATE_TRANSITION',
+        'an initial receipt must be a preparing intent'
+      )
+    }
+    return
+  }
+  if (current === null) {
+    fail(
+      'RECEIPT_CONCURRENT_WRITE',
+      'receipt disappeared before the expected transition'
+    )
+  }
+  validateReceiptFile(current)
+  if (
+    current.manifestFingerprint !== expected.manifestFingerprint ||
+    current.payloadDigest !== expected.payloadDigest ||
+    current.state !== expected.state
+  ) {
+    fail(
+      'RECEIPT_CONCURRENT_WRITE',
+      'receipt changed before the expected transition'
+    )
+  }
+  if (current.manifestFingerprint !== next.manifestFingerprint) {
+    fail('RECEIPT_MANIFEST_MISMATCH', 'receipt transition changed the manifest')
+  }
+  if (current.payloadDigest === next.payloadDigest) return
+  if (!RECEIPT_STATE_TRANSITIONS[current.state].includes(next.state)) {
+    fail(
+      'RECEIPT_STATE_TRANSITION',
+      'receipt transition is not allowed from the current state'
+    )
+  }
+}
+
+export async function dryRunCohortActivation(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest
+): Promise<CohortActivationDryRunResult> {
+  validateManifest(manifest)
+  const result = await store.transaction(async (tx) => {
+    const target = await tx.findServerByName(manifest.target.serverName)
+    if (target) assertTargetServer(target, manifest.target)
+    const entries = await readSourceEntries(tx, manifest)
+    if (target) {
+      for (const { manifest: entry } of entries) {
+        await assertTargetConfigAvailable(tx, target, entry)
+      }
+    }
+    return {
+      wouldCreateServer: target === null,
+      wouldCreateConfigs: entries.length,
+      wouldSwitch: entries.length,
+    }
+  })
+  return {
+    status: 'dry-run',
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    entryCount: manifest.entries.length,
+    heldCount: manifest.heldConfigIds.length,
+    ...result,
+    wouldPreserveSourceRows: true,
+  }
+}
+
+export async function prepareCohortActivation(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  options: CohortActivationPrepareOptions
+): Promise<CohortActivationReceipt> {
+  validateManifest(manifest)
+  const intent = options.intent ?? makeCohortActivationReceiptIntent(manifest)
+  validateCohortActivationReceiptIntent(intent)
+  assertIntentMatchesManifest(manifest, intent)
+  const prepared = await store.transaction(async (tx) => {
+    const sourceEntries = await readSourceEntries(tx, manifest)
+    const targetServer = await findTargetServer(
+      tx,
+      manifest,
+      options.encryptedBearer,
+      intent.targetServerId
+    )
+    const entries: CohortActivationReceiptEntry[] = []
+    for (const { manifest: entry, prior } of sourceEntries) {
+      await assertTargetConfigAvailable(tx, targetServer, entry)
+      const created = await tx.createConfig({
+        ...targetConfigData(entry, targetServer.id, prior.priority, false),
+        id: intent.targetConfigIds[entry.configId],
+      })
+      const target = snapshotConfig(created)
+      if (
+        target.id !== intent.targetConfigIds[entry.configId] ||
+        target.isEnabled ||
+        target.mcpServerId !== targetServer.id ||
+        !jsonEqual(target.allowedTools, [DOC_QUERY_TOOL_ALIAS]) ||
+        !jsonEqual(target.parameters, {
+          required: true,
+          toolAlias: DOC_QUERY_TOOL_ALIAS,
+          kb_id: normalizeUuid(entry.kbId, 'entry.kbId'),
+        })
+      ) {
+        fail('TARGET_CONFIG_MISMATCH', 'created target config is not strict')
+      }
+      entries.push({ manifest: entry, prior, target })
+    }
+    return { targetServer: snapshotServer(targetServer), entries }
+  })
+  return makeReceipt({
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    targetServer: prepared.targetServer,
+    heldConfigIds: manifest.heldConfigIds,
+    excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    entries: prepared.entries,
+    switchedChatbotIds: [],
+    state: 'prepared',
+  })
+}
+
+export async function assertCohortActivationNotPrepared(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  intent: CohortActivationReceiptIntent
+): Promise<void> {
+  validateManifest(manifest)
+  validateCohortActivationReceiptIntent(intent)
+  assertIntentMatchesManifest(manifest, intent)
+
+  await store.transaction(async (tx) => {
+    await readSourceEntries(tx, manifest)
+    const targetByName = await tx.findServerByName(manifest.target.serverName)
+    let targetServer: CohortActivationServerRecord | null = null
+
+    if (intent.targetServerId === null) {
+      if (targetByName) {
+        fail(
+          'CLEAR_AMBIGUOUS',
+          'target server appeared after the preparing intent was written'
+        )
+      }
+    } else {
+      const targetById = await tx.findServerById(intent.targetServerId)
+      if (
+        !targetByName ||
+        !targetById ||
+        targetByName.id.toLowerCase() !== intent.targetServerId.toLowerCase() ||
+        targetById.id.toLowerCase() !== intent.targetServerId.toLowerCase()
+      ) {
+        fail(
+          'CLEAR_AMBIGUOUS',
+          'the pre-existing target server no longer matches the intent'
+        )
+      }
+      assertTargetServer(targetByName, manifest.target)
+      assertTargetServer(targetById, manifest.target)
+      targetServer = targetByName
+    }
+
+    for (const entry of manifest.entries) {
+      const targetConfigId = intent.targetConfigIds[entry.configId]
+      if (!targetConfigId || (await tx.findConfigById(targetConfigId))) {
+        fail(
+          'CLEAR_AMBIGUOUS',
+          'a deterministic target config may have been prepared'
+        )
+      }
+      if (
+        targetServer &&
+        (await tx.findConfigByChatbotServer(
+          normalizeUuid(entry.chatbotId, 'entry.chatbotId'),
+          targetServer.id,
+          entry.chatMode
+        ))
+      ) {
+        fail('CLEAR_AMBIGUOUS', 'a target chatbot mode may have been prepared')
+      }
+    }
+  })
+}
+
+export async function recoverPreparedCohortActivation(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  intent: CohortActivationReceiptIntent
+): Promise<CohortActivationReceipt> {
+  validateManifest(manifest)
+  validateCohortActivationReceiptIntent(intent)
+  assertIntentMatchesManifest(manifest, intent)
+  const recovered = await store.transaction(async (tx) => {
+    const targetServer = await tx.findServerByName(manifest.target.serverName)
+    if (!targetServer) {
+      fail('RECOVERY_NOT_PREPARED', 'prepare transaction was not committed')
+    }
+    if (
+      intent.targetServerId !== null &&
+      targetServer.id.toLowerCase() !== intent.targetServerId.toLowerCase()
+    ) {
+      fail('RECOVERY_AMBIGUOUS', 'target server does not belong to the intent')
+    }
+    assertTargetServer(targetServer, manifest.target)
+    const targetConfigs = await tx.findConfigsByServerId(targetServer.id)
+    if (targetConfigs.length === 0) {
+      fail('RECOVERY_NOT_PREPARED', 'prepare configs were not committed')
+    }
+    const expectedTargetConfigIds = new Set(
+      manifest.entries.map((entry) =>
+        intent.targetConfigIds[entry.configId]?.toLowerCase()
+      )
+    )
+    if (
+      expectedTargetConfigIds.size !== manifest.entries.length ||
+      manifest.entries.some(
+        (entry) =>
+          !intent.targetConfigIds[entry.configId] ||
+          !targetConfigs.some(
+            (target) =>
+              target.id.toLowerCase() ===
+              intent.targetConfigIds[entry.configId]!.toLowerCase()
+          )
+      )
+    ) {
+      fail('RECOVERY_AMBIGUOUS', 'target config set is incomplete')
+    }
+    const sourceEntries = await readSourceEntries(tx, manifest)
+    const entries: CohortActivationReceiptEntry[] = []
+    for (const { manifest: entry, prior } of sourceEntries) {
+      const targetConfigId = intent.targetConfigIds[entry.configId]
+      const target = targetConfigId
+        ? await tx.findConfigById(targetConfigId)
+        : null
+      if (
+        !target ||
+        target.id !== targetConfigId ||
+        target.isEnabled ||
+        target.mcpServerId !== targetServer.id ||
+        !jsonEqual(target.allowedTools, [DOC_QUERY_TOOL_ALIAS]) ||
+        !jsonEqual(target.parameters, {
+          required: true,
+          toolAlias: DOC_QUERY_TOOL_ALIAS,
+          kb_id: normalizeUuid(entry.kbId, 'entry.kbId'),
+        })
+      ) {
+        fail('RECOVERY_AMBIGUOUS', 'target config state is not prepared')
+      }
+      entries.push({ manifest: entry, prior, target: snapshotConfig(target) })
+    }
+    return { targetServer: snapshotServer(targetServer), entries }
+  })
+  return makeReceipt({
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    targetServer: recovered.targetServer,
+    heldConfigIds: manifest.heldConfigIds,
+    excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    entries: recovered.entries,
+    switchedChatbotIds: [],
+    state: 'prepared',
+  })
+}
+
+function requireState(
+  receipt: CohortActivationReceipt,
+  expected: CohortActivationReceiptState | CohortActivationReceiptState[]
+): void {
+  validateReceipt(receipt)
+  const allowed = Array.isArray(expected) ? expected : [expected]
+  if (!allowed.includes(receipt.state)) {
+    fail('INVALID_STATE', `cohortActivation receipt has an invalid state`)
+  }
+}
+
+export type CohortActivationReceiptCheckpoint = (
+  receipt: CohortActivationReceipt
+) => Promise<void>
+
+export async function switchCohortActivation(
+  store: CohortActivationStore,
+  receipt: CohortActivationReceipt,
+  checkpoint?: CohortActivationReceiptCheckpoint
+): Promise<CohortActivationReceipt> {
+  requireState(receipt, 'prepared')
+  let current = receipt
+  const groups = groupEntriesByChatbot(receipt.entries)
+  for (const [chatbotId, group] of groups) {
+    await checkpoint?.(
+      makeReceiptFrom(current, {
+        entries: current.entries,
+        state: 'switching',
+        switchedChatbotIds: current.switchedChatbotIds,
+      })
+    )
+    // Keep every mode for one chatbot in the same serializable transaction.
+    const switchedEntries = await store.transaction(async (tx) => {
+      const targetServer = await tx.findServerById(current.targetServer.id)
+      if (
+        !targetServer ||
+        !serverSnapshotEqual(targetServer, current.targetServer)
+      ) {
+        fail('TARGET_SERVER_DRIFT', 'target server changed after prepare')
+      }
+      const entries: CohortActivationReceiptEntry[] = []
+      for (const item of group) {
+        const source = await tx.findConfigById(item.manifest.configId)
+        if (!source || !configSnapshotEqual(source, item.prior)) {
+          fail('SOURCE_DRIFT', 'source config changed after prepare')
+        }
+        const target = await tx.findConfigById(item.target.id)
+        if (!target || !configSnapshotEqual(target, item.target)) {
+          fail('TARGET_DRIFT', 'target config changed after prepare')
+        }
+        const disabledSource = await tx.updateConfig(
+          source.id,
+          source.updatedAt,
+          sourceConfigData(item.prior, false)
+        )
+        if (!disabledSource || disabledSource.isEnabled) {
+          fail('CONCURRENT_EDIT', 'source config compare-and-set failed')
+        }
+        const enabledTarget = await tx.updateConfig(
+          target.id,
+          target.updatedAt,
+          targetConfigData(
+            item.manifest,
+            targetServer.id,
+            item.prior.priority,
+            true
+          )
+        )
+        if (!enabledTarget || !enabledTarget.isEnabled) {
+          fail('CONCURRENT_EDIT', 'target config compare-and-set failed')
+        }
+        entries.push({ ...item, target: snapshotConfig(enabledTarget) })
+      }
+      return entries
+    })
+    const changed = new Map(
+      switchedEntries.map((entry) => [entry.manifest.configId, entry])
+    )
+    const switchedChatbotIds = [
+      ...new Set([...current.switchedChatbotIds, chatbotId]),
+    ].sort(compareStrings)
+    const entries = current.entries.map(
+      (entry) => changed.get(entry.manifest.configId) ?? entry
+    )
+    current = makeReceiptFrom(current, {
+      entries,
+      state:
+        switchedChatbotIds.length === groups.length ? 'switched' : 'switching',
+      switchedChatbotIds,
+    })
+    await checkpoint?.(current)
+  }
+  return current
+}
+
+type RollbackTransactionState = {
+  item: CohortActivationReceiptEntry
+  source: CohortActivationConfigRecord
+  target: CohortActivationConfigRecord
+  state: 'old' | 'new'
+}
+
+function rollbackItemState(
+  source: CohortActivationConfigRecord,
+  target: CohortActivationConfigRecord
+): 'old' | 'new' {
+  if (source.isEnabled && !target.isEnabled) return 'old'
+  if (!source.isEnabled && target.isEnabled) return 'new'
+  fail('READBACK_STATE_MISMATCH', 'chatbot group is partially switched')
+}
+
+async function readRollbackStates(
+  tx: CohortActivationTransactionStore,
+  receipt: CohortActivationReceipt,
+  group: CohortActivationReceiptEntry[]
+): Promise<{
+  targetServer: CohortActivationServerRecord
+  states: RollbackTransactionState[]
+}> {
+  const targetServer = await tx.findServerById(receipt.targetServer.id)
+  if (
+    !targetServer ||
+    !serverSnapshotEqual(targetServer, receipt.targetServer)
+  ) {
+    fail('TARGET_SERVER_DRIFT', 'target server changed before rollback')
+  }
+  const states: RollbackTransactionState[] = []
+  for (const item of group) {
+    const source = await tx.findConfigById(item.manifest.configId)
+    const target = await tx.findConfigById(item.target.id)
+    if (!source || !target)
+      fail('CONFIG_MISSING', 'cohortActivation config is missing')
+    if (!configShapeEqual(source, item.prior)) {
+      fail('SOURCE_DRIFT', 'source config changed before rollback')
+    }
+    if (!configShapeEqual(target, item.target)) {
+      fail('TARGET_DRIFT', 'target config changed before rollback')
+    }
+    states.push({
+      item,
+      source,
+      target,
+      state: rollbackItemState(source, target),
+    })
+  }
+  const hasOld = states.some(({ state }) => state === 'old')
+  const hasNew = states.some(({ state }) => state === 'new')
+  if (hasOld && hasNew) {
+    fail('READBACK_STATE_MISMATCH', 'chatbot group is partially switched')
+  }
+  return { targetServer, states }
+}
+
+async function restoreRollbackStates(
+  tx: CohortActivationTransactionStore,
+  targetServer: CohortActivationServerRecord,
+  states: RollbackTransactionState[]
+): Promise<CohortActivationReceiptEntry[]> {
+  const entries: CohortActivationReceiptEntry[] = []
+  for (const { item, source, target, state } of states) {
+    if (state === 'old') {
+      entries.push({
+        ...item,
+        target: { ...item.target, isEnabled: false },
+      })
+      continue
+    }
+    const disabledTarget = await tx.updateConfig(
+      target.id,
+      target.updatedAt,
+      targetConfigData(
+        item.manifest,
+        targetServer.id,
+        item.prior.priority,
+        false
+      )
+    )
+    if (!disabledTarget || disabledTarget.isEnabled) {
+      fail('ROLLBACK_FAILED', 'target config was not disabled')
+    }
+    const enabledSource = await tx.updateConfig(
+      source.id,
+      source.updatedAt,
+      sourceConfigData(item.prior, true)
+    )
+    if (!enabledSource || !configContentEqual(enabledSource, item.prior)) {
+      fail('ROLLBACK_FAILED', 'source config was not restored')
+    }
+    entries.push({ ...item, target: snapshotConfig(disabledTarget) })
+  }
+  return entries
+}
+
+async function rollbackChatbotGroup(
+  tx: CohortActivationTransactionStore,
+  receipt: CohortActivationReceipt,
+  group: CohortActivationReceiptEntry[]
+): Promise<CohortActivationReceiptEntry[]> {
+  const { targetServer, states } = await readRollbackStates(tx, receipt, group)
+  return restoreRollbackStates(tx, targetServer, states)
+}
+
+function rollbackReceiptState(
+  groupIndex: number,
+  groupCount: number
+): 'rolled_back' | 'rolling_back' {
+  return groupIndex === groupCount - 1 ? 'rolled_back' : 'rolling_back'
+}
+
+export async function rollbackCohortActivation(
+  store: CohortActivationStore,
+  receipt: CohortActivationReceipt,
+  checkpoint?: CohortActivationReceiptCheckpoint
+): Promise<CohortActivationReceipt> {
+  requireState(receipt, ['prepared', 'switching', 'switched', 'rolling_back'])
+  let current = receipt
+  const groups = groupEntriesByChatbot(receipt.entries)
+  for (const [groupIndex, [chatbotId, group]] of groups.entries()) {
+    await checkpoint?.(
+      makeReceiptFrom(current, {
+        entries: current.entries,
+        state: 'rolling_back',
+        switchedChatbotIds: current.switchedChatbotIds,
+      })
+    )
+    // Roll back one chatbot at a time so another chatbot cannot be half-restored.
+    const restoredEntries = await store.transaction((tx) =>
+      rollbackChatbotGroup(tx, current, group)
+    )
+    const changed = new Map(
+      restoredEntries.map((entry) => [entry.manifest.configId, entry])
+    )
+    const switchedChatbotIds = current.switchedChatbotIds.filter(
+      (id) => id !== chatbotId
+    )
+    const entries = current.entries.map(
+      (entry) => changed.get(entry.manifest.configId) ?? entry
+    )
+    current = makeReceiptFrom(current, {
+      entries,
+      state: rollbackReceiptState(groupIndex, groups.length),
+      switchedChatbotIds,
+    })
+    await checkpoint?.(current)
+  }
+  return current
+}
+
+function readbackItemState(
+  source: CohortActivationConfigRecord,
+  target: CohortActivationConfigRecord
+): 'prepared' | 'switched' {
+  if (source.isEnabled && !target.isEnabled) return 'prepared'
+  if (!source.isEnabled && target.isEnabled) return 'switched'
+  fail('READBACK_STATE_MISMATCH', 'chatbot group is partially switched')
+}
+
+async function readReceiptStateItem(
+  tx: CohortActivationTransactionStore,
+  item: CohortActivationReceiptEntry
+): Promise<{
+  source: CohortActivationConfigRecord
+  target: CohortActivationConfigRecord
+  state: 'prepared' | 'switched'
+}> {
+  const source = await tx.findConfigById(item.manifest.configId)
+  const target = await tx.findConfigById(item.target.id)
+  if (!source || !target)
+    fail('CONFIG_MISSING', 'cohortActivation config is missing')
+  const sourceShapeMatches = configShapeEqual(source, item.prior)
+  const targetShapeMatches = configShapeEqual(target, item.target)
+  if (!sourceShapeMatches) {
+    fail('SOURCE_READBACK_MISMATCH', 'source config differs from receipt')
+  }
+  if (!targetShapeMatches) {
+    fail('TARGET_READBACK_MISMATCH', 'target config differs from receipt')
+  }
+  return { source, target, state: readbackItemState(source, target) }
+}
+
+function makeReadbackResult(
+  receipt: CohortActivationReceipt,
+  targetServer: CohortActivationServerRecord
+): CohortActivationReadback {
+  return {
+    state: receipt.state,
+    entryCount: receipt.entries.length,
+    chatbotCount: chatbotIds(receipt.entries.map(({ manifest }) => manifest))
+      .length,
+    switchedChatbotCount: 0,
+    sourceEnabled: 0,
+    sourceDisabled: 0,
+    targetEnabled: 0,
+    targetDisabled: 0,
+    targetServerActive: targetServer.isActive,
+  }
+}
+
+function recordReadbackItem(
+  result: CohortActivationReadback,
+  actualChatbotStates: Map<string, 'prepared' | 'switched'>,
+  item: CohortActivationReceiptEntry,
+  source: CohortActivationConfigRecord,
+  target: CohortActivationConfigRecord,
+  state: 'prepared' | 'switched'
+): void {
+  const chatbotId = normalizeUuid(item.manifest.chatbotId, 'entry.chatbotId')
+  const priorState = actualChatbotStates.get(chatbotId)
+  if (priorState && priorState !== state) {
+    fail('READBACK_STATE_MISMATCH', 'chatbot group is partially switched')
+  }
+  actualChatbotStates.set(chatbotId, state)
+  if (source.isEnabled) result.sourceEnabled += 1
+  else result.sourceDisabled += 1
+  if (target.isEnabled) result.targetEnabled += 1
+  else result.targetDisabled += 1
+}
+
+function finalizeReadback(
+  result: CohortActivationReadback,
+  receipt: CohortActivationReceipt,
+  actualChatbotStates: Map<string, 'prepared' | 'switched'>
+): void {
+  const actualStates = new Set(actualChatbotStates.values())
+  if (actualStates.size > 1) result.state = 'partial'
+  else if (actualStates.has('switched')) result.state = 'switched'
+  else if (actualStates.has('prepared')) {
+    result.state = receipt.state === 'rolled_back' ? 'rolled_back' : 'prepared'
+  }
+  result.switchedChatbotCount = [...actualChatbotStates.values()].filter(
+    (state) => state === 'switched'
+  ).length
+  if (receipt.state === 'switched' && result.state !== 'switched') {
+    fail('READBACK_STATE_MISMATCH', 'switched state is not active')
+  }
+  if (receipt.state === 'rolled_back' && result.state !== 'rolled_back') {
+    fail('READBACK_STATE_MISMATCH', 'rolled-back state is not restored')
+  }
+}
+
+async function readCohortActivationStateInTransaction(
+  tx: CohortActivationTransactionStore,
+  receipt: CohortActivationReceipt
+): Promise<CohortActivationReadback> {
+  const targetServer = await tx.findServerById(receipt.targetServer.id)
+  if (
+    !targetServer ||
+    !serverSnapshotEqual(targetServer, receipt.targetServer)
+  ) {
+    fail('TARGET_SERVER_DRIFT', 'target server differs from receipt')
+  }
+  const result = makeReadbackResult(receipt, targetServer)
+  const actualChatbotStates = new Map<string, 'prepared' | 'switched'>()
+  for (const item of receipt.entries) {
+    const { source, target, state } = await readReceiptStateItem(tx, item)
+    recordReadbackItem(result, actualChatbotStates, item, source, target, state)
+  }
+  finalizeReadback(result, receipt, actualChatbotStates)
+  return result
+}
+
+export async function readCohortActivationState(
+  store: CohortActivationStore,
+  receipt: CohortActivationReceipt
+): Promise<CohortActivationReadback> {
+  validateReceipt(receipt)
+  return store.transaction((tx) =>
+    readCohortActivationStateInTransaction(tx, receipt)
+  )
+}

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
@@ -702,6 +702,7 @@ type ManifestValidationState = {
   configIds: Set<string>
   chatbotModes: Set<string>
   sourceServersByChatbot: Map<string, string>
+  kbIdsByChatbot: Map<string, string>
 }
 
 function assertManifestShape(manifest: CohortActivationManifest): void {
@@ -754,7 +755,7 @@ function validateManifestEntry(
       'target tool is not the multi-tenant reader tool'
     )
   }
-  normalizeUuid(entry.kbId, 'entry.kbId')
+  const kbId = normalizeUuid(entry.kbId, 'entry.kbId')
   entryCorpusIdentity(entry)
   entryCorpusOwner(entry)
   assertEntryNotExcluded(entry)
@@ -767,6 +768,11 @@ function validateManifestEntry(
     fail('MIXED_MODE_COVERAGE', 'one chatbot uses more than one source server')
   }
   state.sourceServersByChatbot.set(chatbotId, sourceServerId)
+  const priorKbId = state.kbIdsByChatbot.get(chatbotId)
+  if (priorKbId && priorKbId !== kbId) {
+    fail('MIXED_KB_COVERAGE', 'one chatbot uses more than one knowledge base')
+  }
+  state.kbIdsByChatbot.set(chatbotId, kbId)
   const chatbotMode = `${chatbotId}:${entry.chatMode}`
   if (state.chatbotModes.has(chatbotMode)) {
     fail('DUPLICATE_TARGET_CONFIG', 'manifest targets one chatbot mode twice')
@@ -781,6 +787,7 @@ function validateManifestEntries(
     configIds: new Set<string>(),
     chatbotModes: new Set<string>(),
     sourceServersByChatbot: new Map<string, string>(),
+    kbIdsByChatbot: new Map<string, string>(),
   }
   for (const entry of manifest.entries) {
     validateManifestEntry(entry, state)

--- a/project/2026-09-03-doc-query-v3-activation-stack-plan.md
+++ b/project/2026-09-03-doc-query-v3-activation-stack-plan.md
@@ -237,6 +237,9 @@ a blocker.
 - [x] Layer 2 activation extraction and local verification: all 37 focused
   tests, Prisma-data checks, formatting, and diff checks pass. Prisma-data has
   no package-local ESLint configuration.
-- [ ] Layer 2 activation simplification and data-integrity review.
+- [x] Layer 2 activation review passed with no integrity defect. The proposed
+  helper extractions were rejected because they add concepts without reducing
+  the state machine. The final retry guard and exact expected-state comparison
+  remain as fail-closed invariants rather than dead-code cleanup.
 - [ ] Layer 3 proof implementation and review.
 - [ ] Draft publication, exact-head CI/reviews, and coverage-ledger completion.

--- a/project/2026-09-03-doc-query-v3-activation-stack-plan.md
+++ b/project/2026-09-03-doc-query-v3-activation-stack-plan.md
@@ -234,6 +234,9 @@ a blocker.
   reductions landed in `08af40bc8`; the security correction review passed.
   Production preflight must still confirm the five-minute token lifetime is
   sufficient for supported turns, and Layer 3 must prove the consumer contract.
-- [ ] Layer 2 activation implementation and review.
+- [x] Layer 2 activation extraction and local verification: all 37 focused
+  tests, Prisma-data checks, formatting, and diff checks pass. Prisma-data has
+  no package-local ESLint configuration.
+- [ ] Layer 2 activation simplification and data-integrity review.
 - [ ] Layer 3 proof implementation and review.
 - [ ] Draft publication, exact-head CI/reviews, and coverage-ledger completion.


### PR DESCRIPTION
## What This Adds

This is layer 2 of the three-PR replacement for #5709. It adds an inert, configuration-only operator for activating the reviewed Doc Query chatbot cohort after a separately authorized invocation.

- Applies one chatbot's configuration changes atomically.
- Binds each transaction to a frozen manifest, compatibility server, explicit exclusions, and protected digests.
- Persists compare-and-swap receipts across prepare, switch, rollback, and recovery.
- Fails closed on concurrency, manifest drift, ambiguous writes, or postcondition mismatch.
- Rejects a manifest that assigns more than one knowledge base to the same chatbot while allowing different chatbots to use different knowledge bases.

The operator is not invoked by this PR. This branch does not change production configuration or access production data.

## Stack Position

- Base: #5736 (`fix/doc-query-v3-runtime-scope`), which adds the scoped Chat runtime.
- This PR: the configuration activation operator.
- Next: #5738 (`test/doc-query-v3-cutover-proof`), which adds the sealed cutover proof.
- Replaces the activation-operator portion of #5709; the source PR remains unchanged.

## Branch Coverage

- Base: `46e8a4b7aa0e51d52ff0106eb98c8163795e8f3d`.
- Current head: `3ac1ddb45ec7c2d7deb8c263ac1e34f6f69d6a22`.
- Three commits are included: the activation operator, its shared-plan evidence update, and the chatbot knowledge-base consistency correction.
- The branch contains 4,155 substantive additions across four activation source/test files, excluding the committed shared-plan metadata change of 8 additions and 1 deletion.
- Covered surfaces are the activation domain, Prisma adapter, command runner, durable receipt lifecycle, concurrency exclusion, rollback/readback, and focused tests.

The state machine, persistence adapter, runner, and tests remain one package because they jointly define the restart-safe transaction contract.

## Review Focus

- Verify receipt durability and compare-and-swap ordering across every lifecycle transition.
- Verify recovery evidence cannot be lost under concurrency.
- Verify the frozen manifest is bound to the intended compatibility server and explicit exclusions.
- Verify every chatbot has one source server and one knowledge base, while different chatbots may use independent knowledge bases.
- Verify failure paths stop without broadening writes beyond the named chatbot.

## Verification

### Current head

- Focused activation suite: 38 tests passed, including the mixed-knowledge-base regression.
- `@klicker-uzh/prisma-data` package checks passed.
- Biome checks for both changed source files and `git diff --check` passed.
- The publication pre-push hook completed 23 workspace build tasks successfully.
- The dedicated data-integrity and operations correction review passed for `78fcc5698055dcf41b8304b4c712987f738e6e39..3ac1ddb45ec7c2d7deb8c263ac1e34f6f69d6a22`.
- Exact-head GitHub checks passed for codebase checks, fallback build, secret scanning, CodeQL, GraphQL, SonarCloud, ARM build, Playwright preparation/build, all eight public-PR shards, the Playwright aggregate, and supporting policy checks.

### Earlier branch verification

- The pre-correction activation implementation had 37 focused tests and a prior local integrity review. The current 38-test result supersedes that count.

### Failed / Warning

- The first commit pre-hook could not complete the repository-wide check because the fresh worktree lacked unrelated generated package build outputs; package-local checks passed, and the later publication pre-push build completed successfully.
- The `final-ai-review` commit status is `error` because this non-default, non-designated stack member is outside that workflow's allowed target set. The corresponding Final AI review workflow run completed successfully; this is a repository-policy status, not a source-test failure.
- OpenCodeReview was skipped by its authorization gate. No new source finding is pending from that workflow.
- Local checks ran on Node 26 while the repository pins Node 24; remote CI is the current-head source of truth.

## Security / Privacy

- No secret values, bearer tokens, production content, or personal data are committed.
- Tests use synthetic values; receipts are designed to remain values-free.
- The source package is inert and performs no database mutation.

## Blocking Before Merge

- [ ] Accept #5736 first because this PR is stacked on that runtime layer.
- [ ] Repository owners must disposition the non-applicable `final-ai-review` policy status for this stack member, or use the repository's designated consolidation path.
- [ ] Merge remains separately gated.

## Follow-Up After Merge

- [ ] Review and merge #5738 separately.
- [ ] Production invocation, configuration writes, rollback, and readback remain separately authorized operational work.

## Local Session Artifacts

- Machine: local macOS host.
- Worktree: `trees/doc-query-v3-activation-operator-fix` in repository `klicker-uzh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a controlled cohort activation workflow for the `doc_query` reader, including dry runs, migration, recovery, rollback, and state readback.
  - Added manifest validation and fingerprint checks to detect configuration drift, unsupported targets, and invalid cohort assignments.
- Added durable activation receipts with progress tracking, integrity checks, and safe recovery after interrupted operations.

- **Bug Fixes**
  - Prevented conflicting activation sessions and rejected unsafe concurrent or out-of-sequence changes.
  - Added automatic handling for transient transaction conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
