### PR TITLE
style(chat): format evaluation target files

### DIFF
--- a/apps/chat/scripts/klicker-evaluation-target.mjs
+++ b/apps/chat/scripts/klicker-evaluation-target.mjs
@@ -6,8 +6,7 @@ import { createServer } from 'node:http'
 import { basename, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export const DEFAULT_CHATBOT_ID =
-  '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
+export const DEFAULT_CHATBOT_ID = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
 export const DEFAULT_MODEL_ID = 'gpt-5.6-luna'
 export const DEFAULT_MAX_STREAM_BYTES = 8 * 1024 * 1024
 export const DEFAULT_POLL_INTERVAL_MS = 250
@@ -86,12 +85,16 @@ function yamlScalar(value) {
 export function parseGroundTruthFrontmatter(text, filePath = 'unknown') {
   const normalized = text.replaceAll('\r\n', '\n')
   if (!normalized.startsWith('---\n')) {
-    throw evaluationError(`ground_truth_frontmatter_missing:${basename(filePath)}`)
+    throw evaluationError(
+      `ground_truth_frontmatter_missing:${basename(filePath)}`
+    )
   }
 
   const end = normalized.indexOf('\n---', 4)
   if (end < 0) {
-    throw evaluationError(`ground_truth_frontmatter_unclosed:${basename(filePath)}`)
+    throw evaluationError(
+      `ground_truth_frontmatter_unclosed:${basename(filePath)}`
+    )
   }
 
   const values = new Map()
@@ -99,7 +102,9 @@ export function parseGroundTruthFrontmatter(text, filePath = 'unknown') {
     const match = /^(question|mode):\s*(.*)$/.exec(line)
     if (!match) continue
     if (values.has(match[1])) {
-      throw evaluationError(`ground_truth_duplicate_field:${basename(filePath)}`)
+      throw evaluationError(
+        `ground_truth_duplicate_field:${basename(filePath)}`
+      )
     }
     values.set(match[1], yamlScalar(match[2]))
   }
@@ -148,7 +153,10 @@ export async function loadCanaryFixture(filePath) {
   ) {
     throw evaluationError('canary_fixture_invalid')
   }
-  if (!Number.isInteger(fixture.maxStreamBytes) || fixture.maxStreamBytes <= 0) {
+  if (
+    !Number.isInteger(fixture.maxStreamBytes) ||
+    fixture.maxStreamBytes <= 0
+  ) {
     throw evaluationError('canary_fixture_max_stream_invalid')
   }
   return {
@@ -287,7 +295,11 @@ async function drainResponse(response, maxBytes) {
       } catch {
         throw evaluationError('chat_stream_invalid')
       }
-      if (!event || typeof event !== 'object' || typeof event.type !== 'string') {
+      if (
+        !event ||
+        typeof event !== 'object' ||
+        typeof event.type !== 'string'
+      ) {
         throw evaluationError('chat_stream_invalid')
       }
       if (event.type === 'finish') streamState.finished = true
@@ -303,7 +315,11 @@ async function drainResponse(response, maxBytes) {
         if (done) {
           buffer += decoder.decode()
           if (buffer) inspectLine(buffer)
-          if (!streamState.done || !streamState.finished || streamState.events === 0) {
+          if (
+            !streamState.done ||
+            !streamState.finished ||
+            streamState.events === 0
+          ) {
             throw evaluationError('chat_stream_incomplete')
           }
           completed = true
@@ -536,7 +552,14 @@ export class KlickerEvaluationTarget {
     return body.id
   }
 
-  async submitTurn({ question, mode, threadId, userMessageId, assistantMessageId, maxStreamBytes }) {
+  async submitTurn({
+    question,
+    mode,
+    threadId,
+    userMessageId,
+    assistantMessageId,
+    maxStreamBytes,
+  }) {
     const response = await fetchWithTimeout(
       urlFor(this.chatOrigin, `/api/chatbots/${this.chatbotId}/chat`),
       {
@@ -585,7 +608,8 @@ export class KlickerEvaluationTarget {
         ? body.find((candidate) => candidate?.id === assistantMessageId)
         : null
       if (message) {
-        if (message.chatMode !== mode) throw evaluationError('chat_mode_mismatch')
+        if (message.chatMode !== mode)
+          throw evaluationError('chat_mode_mismatch')
         if (message.modelId !== this.modelId) {
           throw evaluationError('chat_model_mismatch')
         }
@@ -628,7 +652,8 @@ export class KlickerEvaluationTarget {
   }
 
   async complete(body) {
-    if (!body || typeof body !== 'object') throw evaluationError('request_invalid')
+    if (!body || typeof body !== 'object')
+      throw evaluationError('request_invalid')
     if (body.model !== this.modelId) throw evaluationError('model_mismatch')
     if (body.stream === true) throw evaluationError('stream_must_be_false')
     if (!Array.isArray(body.messages) || body.messages.length !== 1) {
@@ -774,9 +799,14 @@ export async function main() {
   })
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   main().catch((error) => {
-    process.stderr.write(`klicker-evaluation-target: ${error?.code || 'startup_failed'}\n`)
+    process.stderr.write(
+      `klicker-evaluation-target: ${error?.code || 'startup_failed'}\n`
+    )
     process.exitCode = 1
   })
 }

--- a/apps/chat/test/klicker-evaluation-target.test.mjs
+++ b/apps/chat/test/klicker-evaluation-target.test.mjs
@@ -14,7 +14,8 @@ import {
 } from '../scripts/klicker-evaluation-target.mjs'
 
 test('frontmatter projection contains only target-safe question metadata', () => {
-  const metadata = parseGroundTruthFrontmatter(`---
+  const metadata = parseGroundTruthFrontmatter(
+    `---
 question: What is CAPM?
 mode: tutor
 expected_tools_by_profile:
@@ -22,7 +23,9 @@ expected_tools_by_profile:
 ---
 
 Expected answer must never be projected.
-`, 'fixture.md')
+`,
+    'fixture.md'
+  )
 
   assert.deepEqual(metadata, {
     question: 'What is CAPM?',
@@ -51,10 +54,9 @@ test('local origin validation rejects non-local target routes', () => {
     validateLocalOrigin('https://chat.klicker.worktree.localhost/', 'chat'),
     'https://chat.klicker.worktree.localhost'
   )
-  assert.throws(
-    () => validateLocalOrigin('https://example.test', 'chat'),
-    { code: 'chat_non_local' }
-  )
+  assert.throws(() => validateLocalOrigin('https://example.test', 'chat'), {
+    code: 'chat_non_local',
+  })
 })
 
 test('persisted assistant content converts to answer and tool names', () => {
@@ -138,7 +140,11 @@ test('target uses participant gates and reads back one persisted turn', async ()
     if (requestUrl.endsWith('/disclaimer') && method === 'GET') {
       return Response.json({
         disclaimer: { id: 'disclaimer-1' },
-        status: { required: true, accepted: false, disclaimerId: 'disclaimer-1' },
+        status: {
+          required: true,
+          accepted: false,
+          disclaimerId: 'disclaimer-1',
+        },
       })
     }
     if (requestUrl.endsWith('/disclaimer') && method === 'POST') {
@@ -229,7 +235,10 @@ test('target uses participant gates and reads back one persisted turn', async ()
       },
     ])
     assert.equal(requests[0].method, 'POST')
-    assert.equal(requests.filter(({ requestUrl }) => requestUrl.endsWith('/chat')).length, 1)
+    assert.equal(
+      requests.filter(({ requestUrl }) => requestUrl.endsWith('/chat')).length,
+      1
+    )
     assert.equal(
       requests.every(({ body }) => !body.includes(expectedAnswer)),
       true
@@ -237,7 +246,10 @@ test('target uses participant gates and reads back one persisted turn', async ()
     assert.equal(
       requests
         .filter(({ requestUrl }) => !requestUrl.endsWith('/api/graphql'))
-        .every(({ headers }) => headers.Cookie === 'participant_token=participant-jwt'),
+        .every(
+          ({ headers }) =>
+            headers.Cookie === 'participant_token=participant-jwt'
+        ),
       true
     )
   } finally {
@@ -458,7 +470,9 @@ test('adapter requires bearer auth and exposes only the configured model', async
     },
   }
   const server = createEvaluationServer({ target, apiKey: 'test-key' })
-  await new Promise((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise))
+  await new Promise((resolvePromise) =>
+    server.listen(0, '127.0.0.1', resolvePromise)
+  )
   const address = server.address()
   assert.notEqual(typeof address, 'string')
   const baseUrl = `http://127.0.0.1:${address.port}`
@@ -486,7 +500,10 @@ test('adapter requires bearer auth and exposes only the configured model', async
       }),
     })
     assert.equal(completion.status, 200)
-    assert.equal(completion.headers.get('x-klicker-evaluation-source'), 'canary')
+    assert.equal(
+      completion.headers.get('x-klicker-evaluation-source'),
+      'canary'
+    )
     assert.equal((await completion.json()).choices[0].message.content, 'ok')
   } finally {
     await new Promise((resolvePromise, rejectPromise) =>


### PR DESCRIPTION
## Summary

The PR `check` job currently fails on v3 tip: `biome format .` rejects `apps/chat/scripts/klicker-evaluation-target.mjs` and `apps/chat/test/klicker-evaluation-target.test.mjs`, which arrived with #5734. Push runs on v3 do not execute the PR-only format gate, so any new PR into v3 fails on these files until they are formatted. This PR restores the gate.

Formatting only, produced with the repo-pinned `@biomejs/biome@2.5.2 format --write` on exactly these two files. No semantic changes.

## Verification

- `pnpm dlx @biomejs/biome@2.5.2 format .`: 1833 files checked, no fixes needed after this change.
- `git diff` touches only the two files named above.

Unblocks merge delivery of the CI review-harness work (see #5741, already merged).