### PR TITLE
fix(evaluation): fetch judge key via standard Infisical CLI

### DIFF
--- a/.agents/skills/klicker-testing-verification/SKILL.md
+++ b/.agents/skills/klicker-testing-verification/SKILL.md
@@ -44,19 +44,24 @@ For the external synthetic evaluation wrapper, run
 `bash util/test-klicker-eval-wrapper.sh` before any credentialed smoke test.
 Then validate all FineCo Markdown cases against
 `evaluation/data/tools/klicker_fineco.yaml` without a provider request. Use the
-approved secret manager or masked CI variables for live judge checks and stop
-unless caller-provided `LITELLM_API_BASE` and `LITELLM_API_KEY` are present and
-the namespaced model is visible first. Require the wrapper to reject a missing
-or empty key before starting the evaluator, and require its metrics, tools, and
-ground-truth preflights to fail before invoking the evaluator. Eval mode judges
-an existing QA artifact; it does not query Klicker's authenticated AI-SDK chat
-route and is not live product-quality evidence.
+approved secret manager or masked CI variables for live judge checks. Require
+caller-provided `LITELLM_API_BASE` and a visible namespaced model first;
+`LITELLM_API_KEY` is optional because the wrapper fetches
+`PIPELINES_LITELLM_API_KEY` with the standard Infisical CLI (klicker-uzh
+project, `stg` environment; targets CLI 0.43.x flags) when it is unset, and the
+wrapper test suite covers that fetch path. Require the wrapper to fail fast on
+a missing CLI, a failed fetch, or an empty key before starting the evaluator,
+and require its metrics, tools, and ground-truth preflights to fail before
+invoking the evaluator. Eval mode judges an existing QA artifact; it does not
+query Klicker's authenticated AI-SDK chat route and is not live
+product-quality evidence.
 
 For local Klicker target evaluation, start the exact worktree after the VPN is
 active. Map the developer Foundry values to `UPSTREAM_OPENAI_API_KEY` and
-`UPSTREAM_OPENAI_BASE_URL` with the approved secret manager. The repository
-wrapper does not depend on a personal operator or fetch secrets itself. Native
-Infisical and CI examples are documented in `evaluation/README.md`.
+`UPSTREAM_OPENAI_BASE_URL` with the approved secret manager. The wrapper
+fetches its own judge key via the standard Infisical CLI when
+`LITELLM_API_KEY` is unset, so no personal operator is needed; the Infisical
+and CI examples are documented in `evaluation/README.md`.
 
 If the LiteLLM container already exists with different upstream values, stop
 the exact checkout and rerun this command. Run the wrapper fake-runtime test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,8 +71,8 @@ EXPERT_df_fineco_expert is already available through an authorized synthetic
 binding with a finite response bound; otherwise record delivery_pending and
 do not substitute the canary or establish a tunnel. Keep the existing
 judge-only path separate: caller-provided `LITELLM_API_BASE` and
-`LITELLM_API_KEY` are not the developer-Foundry values injected into the local
-Chat container.
+`LITELLM_API_KEY` (the wrapper fetches the key from Infisical when unset) are
+not the developer-Foundry values injected into the local Chat container.
 
 For OpenAI-compatible request-policy or prompt-cache changes, also run
 `apps/chat/test/openai-cache-policy.test.ts` and

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -18,47 +18,47 @@ UZH-internal users with GitLab access can materialize the framework explicitly:
 git submodule update --init --checkout evaluation/framework
 ```
 
-The root wrapper reads `LITELLM_API_BASE` and `LITELLM_API_KEY` from its
-invoking environment. It does not depend on a specific secret manager or local
-operator. The wrapper selects Klicker's namespaced Azure deployment and points
+The root wrapper reads `LITELLM_API_BASE` from its invoking environment and
+resolves the judge key itself: a caller-provided `LITELLM_API_KEY` wins as-is;
+otherwise the wrapper fetches `PIPELINES_LITELLM_API_KEY` with the standard
+Infisical CLI from the klicker-uzh project (environment `stg`) and exports the
+value only to the evaluator child. The fetch path targets Infisical CLI 0.43.x
+flag syntax and is covered by the wrapper test suite. The wrapper selects
+Klicker's namespaced Azure deployment and points
 the framework at the FineCo ground truth and tool catalogue. Caller-provided
 model and framework settings win over these defaults. Changing only
 `EVAL_MODEL` leaves the Luna capability mapping unset, so a different model
 uses its own metadata; set both variables when a different deployment alias
 needs explicit capability metadata. Set `LITELLM_API_BASE` to an approved
 reachable proxy route; the public repository does not store an internal
-hostname. The wrapper rejects a missing key before starting the evaluator and
-checks that the selected metrics, tool file, and ground-truth directories are
-readable.
+hostname. The wrapper fails fast when neither a caller-provided key nor the
+Infisical CLI can supply one — a missing CLI, a failed fetch, and an empty
+secret each name the missing piece — and it checks that the selected metrics,
+tool file, and ground-truth directories are readable before any credential
+fetch happens.
 
-Inject the two judge variables with the team's approved secret manager or as
-masked CI variables. For example, the native Infisical CLI can map the stored
-judge key in a short-lived child process without writing a dotenv file:
+After `infisical login` with access to the klicker-uzh project, the default
+fetch path needs no key in the invoking environment:
 
 ```bash
 export LITELLM_API_BASE="https://<approved-litellm-route>"
 
-infisical run \
-  --domain="https://<infisical-host>" \
-  --projectId="<project-id>" \
-  --env="<environment>" \
-  --path="<secret-path>" -- \
-  sh -c '
-    export LITELLM_API_KEY="${PIPELINES_LITELLM_API_KEY:?missing judge key}"
-    exec pnpm run eval:klicker -- "$@"
-  ' klicker-eval \
+pnpm run eval:klicker -- \
   --mode eval \
   --qa-file /absolute/path/to/synthetic-qa.json \
   --limit 1
 ```
 
-Use a read-only scope containing only the required evaluation secret where
-possible. Never print the key or place it in a command argument, dotenv file,
-or committed artifact.
+Callers with a LiteLLM virtual key or a CI-masked variable can still export
+`LITELLM_API_KEY` directly; the wrapper then uses it as-is and never invokes
+the Infisical CLI. Never print the key or place it in a command argument,
+dotenv file, or committed artifact.
 
-On GitLab, configure `LITELLM_API_BASE` and `LITELLM_API_KEY` as masked CI/CD
-variables and invoke `pnpm run eval:klicker` directly. The job does not need
-Infisical or `rs-infisical-operator` when those variables are already present.
+On GitLab, configure `LITELLM_API_BASE` as a masked CI/CD variable. Pre-setting
+`LITELLM_API_KEY` (for example a per-person LiteLLM virtual key) keeps the job
+free of any Infisical dependency; when it is unset, the job needs the Infisical
+CLI installed and authenticated against the klicker-uzh project so the wrapper
+can fetch `PIPELINES_LITELLM_API_KEY`.
 
 Eval mode judges an existing synthetic QA artifact; it does not query Klicker:
 

--- a/util/_run_klicker_eval.sh
+++ b/util/_run_klicker_eval.sh
@@ -6,6 +6,36 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FRAMEWORK_ROOT="$REPO_ROOT/evaluation/framework"
 FRAMEWORK_RUNNER="$FRAMEWORK_ROOT/scripts/_run_eval.sh"
 
+# Judge credential contract: a caller-provided LITELLM_API_KEY wins as-is;
+# otherwise the key is fetched with the standard Infisical CLI from the
+# klicker-uzh project (stg environment). The value is only exported to the
+# evaluator child and is stripped from the target-adapter environment.
+LITELLM_KEY_SECRET_NAME='PIPELINES_LITELLM_API_KEY'
+INFISICAL_PROJECT_ID='d071be96-5136-4f23-a6cb-e0c7f9b9a6c8'
+INFISICAL_ENV_SLUG='stg'
+
+resolve_litellm_api_key() {
+  if [ -n "${LITELLM_API_KEY:-}" ]; then
+    return 0
+  fi
+  if ! command -v infisical >/dev/null 2>&1; then
+    echo "Error: LITELLM_API_KEY is not set and the infisical CLI is required to fetch ${LITELLM_KEY_SECRET_NAME}" >&2
+    exit 1
+  fi
+  local fetched
+  if ! fetched="$(infisical secrets get "$LITELLM_KEY_SECRET_NAME" \
+    --plain --silent --expand=false \
+    --projectId "$INFISICAL_PROJECT_ID" --env "$INFISICAL_ENV_SLUG" </dev/null)"; then
+    echo "Error: could not fetch ${LITELLM_KEY_SECRET_NAME} from the Infisical project ${INFISICAL_PROJECT_ID} (environment ${INFISICAL_ENV_SLUG}); check infisical login and project access" >&2
+    exit 1
+  fi
+  if [ -z "$fetched" ]; then
+    echo "Error: fetched ${LITELLM_KEY_SECRET_NAME} is empty" >&2
+    exit 1
+  fi
+  export LITELLM_API_KEY="$fetched"
+}
+
 if [ "${1:-}" = "--" ]; then
   shift
 fi
@@ -29,11 +59,6 @@ fi
 
 if [ -z "${LITELLM_API_BASE:-}" ]; then
   echo "Error: LITELLM_API_BASE must point to the approved LiteLLM proxy" >&2
-  exit 1
-fi
-
-if [ -z "${LITELLM_API_KEY:-}" ]; then
-  echo "Error: LITELLM_API_KEY must be provided by the invoking environment" >&2
   exit 1
 fi
 
@@ -98,6 +123,10 @@ if [ "$LOCAL_TARGET" = true ]; then
   require_readable_directory KLICKER_EVAL_GT_DIR "$EFFECTIVE_LOCAL_GT_DIR"
   require_readable_file KLICKER_EVAL_CANARY_FILE "${KLICKER_EVAL_CANARY_FILE:-$REPO_ROOT/evaluation/data/canaries/klicker_local_mcp.json}"
 fi
+
+# Secret retrieval happens after all preflights so input failures never
+# trigger a credential fetch.
+resolve_litellm_api_key
 
 ADAPTER_PID=""
 ADAPTER_TMP_DIR=""

--- a/util/test-klicker-eval-wrapper.sh
+++ b/util/test-klicker-eval-wrapper.sh
@@ -30,6 +30,7 @@ assert_line() {
 FAKE_BIN="$TEST_ROOT/bin"
 FAKE_REPO="$TEST_ROOT/repo"
 CHILD_LOG="$TEST_ROOT/child.log"
+INFISICAL_LOG="$TEST_ROOT/infisical.log"
 mkdir -p "$FAKE_BIN"
 
 write_file "$FAKE_BIN/node" '#!/usr/bin/env bash
@@ -82,8 +83,28 @@ if [ "${KLICKER_TEST_EXEC_RUNNER:-false}" = "true" ]; then
   exec "$4"
 fi'
 
-chmod +x "$FAKE_BIN/node" "$FAKE_BIN/uv"
+write_file "$FAKE_BIN/infisical" '#!/usr/bin/env bash
+if [ -n "${KLICKER_TEST_INFISICAL_LOG:-}" ]; then
+  printf "%s\n" "$*" >>"$KLICKER_TEST_INFISICAL_LOG"
+fi
+if [ -n "${KLICKER_TEST_INFISICAL_STATUS:-}" ] && [ "$KLICKER_TEST_INFISICAL_STATUS" != "0" ]; then
+  printf "%s\n" "synthetic infisical failure" >&2
+  exit "$KLICKER_TEST_INFISICAL_STATUS"
+fi
+if [ -n "${KLICKER_TEST_EMPTY_SECRET:-}" ]; then
+  exit 0
+fi
+printf "%s" "synthetic-test-key"
+exit 0'
+
+chmod +x "$FAKE_BIN/node" "$FAKE_BIN/uv" "$FAKE_BIN/infisical"
 TEST_PATH="$FAKE_BIN:$(dirname "$(command -v bash)"):/usr/bin:/bin"
+# Minimal path for the missing-CLI case: it must contain no infisical, so it
+# cannot reuse TEST_PATH (the bash directory may itself ship a real CLI).
+MIN_BIN="$TEST_ROOT/min-bin"
+mkdir -p "$MIN_BIN"
+ln -s "$(command -v bash)" "$MIN_BIN/bash"
+ln -s "$(command -v dirname)" "$MIN_BIN/dirname"
 if PATH="$TEST_PATH" command -v rs-infisical-operator >/dev/null 2>&1; then
   fail 'portable wrapper test path must not contain rs-infisical-operator'
 fi
@@ -108,6 +129,7 @@ env -i \
   PATH="$TEST_PATH" \
   KLICKER_TEST_REPO_ROOT="$FAKE_REPO" \
   KLICKER_TEST_CHILD_LOG="$CHILD_LOG" \
+  KLICKER_TEST_INFISICAL_LOG="$INFISICAL_LOG" \
   "$WRAPPER" -- --mode eval --qa-file synthetic-qa.json
 
 assert_line 'LITELLM_API_BASE=https://litellm.example.test' "$CHILD_LOG"
@@ -126,6 +148,21 @@ assert_line 'ARG=--mode' "$CHILD_LOG"
 assert_line 'ARG=eval' "$CHILD_LOG"
 assert_line 'ARG=--qa-file' "$CHILD_LOG"
 assert_line 'ARG=synthetic-qa.json' "$CHILD_LOG"
+
+[ ! -s "$INFISICAL_LOG" ] || fail 'caller-provided judge key must not invoke the infisical CLI'
+
+: >"$CHILD_LOG"
+: >"$INFISICAL_LOG"
+env -i \
+  LITELLM_API_BASE='https://litellm.example.test' \
+  PATH="$TEST_PATH" \
+  KLICKER_TEST_REPO_ROOT="$FAKE_REPO" \
+  KLICKER_TEST_CHILD_LOG="$CHILD_LOG" \
+  KLICKER_TEST_INFISICAL_LOG="$INFISICAL_LOG" \
+  "$WRAPPER" -- --mode eval --qa-file synthetic-qa.json
+
+assert_line 'secrets get PIPELINES_LITELLM_API_KEY --plain --silent --expand=false --projectId d071be96-5136-4f23-a6cb-e0c7f9b9a6c8 --env stg' "$INFISICAL_LOG"
+assert_line 'LITELLM_API_KEY_PRESENT=yes' "$CHILD_LOG"
 
 : >"$CHILD_LOG"
 env -i \
@@ -175,14 +212,45 @@ assert_line 'EVAL_MODEL_CAPABILITY_MODEL_STATE=unset' "$CHILD_LOG"
 status=0
 env -i \
   LITELLM_API_BASE='https://litellm.example.test' \
+  PATH="$MIN_BIN" \
+  KLICKER_TEST_REPO_ROOT="$FAKE_REPO" \
+  KLICKER_TEST_CHILD_LOG="$CHILD_LOG" \
+  "$WRAPPER" --mode eval >"$TEST_ROOT/missing-cli.out" 2>&1 || status=$?
+
+[ "$status" -eq 1 ] || fail "missing infisical CLI returned $status instead of 1"
+assert_line 'Error: LITELLM_API_KEY is not set and the infisical CLI is required to fetch PIPELINES_LITELLM_API_KEY' "$TEST_ROOT/missing-cli.out"
+[ ! -s "$CHILD_LOG" ] || fail 'missing infisical CLI must not invoke uv'
+
+: >"$CHILD_LOG"
+status=0
+env -i \
+  LITELLM_API_BASE='https://litellm.example.test' \
+  KLICKER_TEST_INFISICAL_STATUS='73' \
   PATH="$TEST_PATH" \
   KLICKER_TEST_REPO_ROOT="$FAKE_REPO" \
   KLICKER_TEST_CHILD_LOG="$CHILD_LOG" \
-  "$WRAPPER" --mode eval >"$TEST_ROOT/empty-key.out" 2>&1 || status=$?
+  KLICKER_TEST_INFISICAL_LOG="$INFISICAL_LOG" \
+  "$WRAPPER" --mode eval >"$TEST_ROOT/infisical-failure.out" 2>&1 || status=$?
 
-[ "$status" -eq 1 ] || fail "missing judge key returned $status instead of 1"
-assert_line 'Error: LITELLM_API_KEY must be provided by the invoking environment' "$TEST_ROOT/empty-key.out"
-[ ! -s "$CHILD_LOG" ] || fail 'missing judge key must not invoke uv'
+[ "$status" -eq 1 ] || fail "infisical CLI failure returned $status instead of 1"
+assert_line 'Error: could not fetch PIPELINES_LITELLM_API_KEY from the Infisical project d071be96-5136-4f23-a6cb-e0c7f9b9a6c8 (environment stg); check infisical login and project access' "$TEST_ROOT/infisical-failure.out"
+grep -Fq -- 'synthetic infisical failure' "$TEST_ROOT/infisical-failure.out" || fail 'infisical CLI stderr must pass through'
+[ ! -s "$CHILD_LOG" ] || fail 'infisical CLI failure must not invoke uv'
+
+: >"$CHILD_LOG"
+status=0
+env -i \
+  LITELLM_API_BASE='https://litellm.example.test' \
+  KLICKER_TEST_EMPTY_SECRET='true' \
+  PATH="$TEST_PATH" \
+  KLICKER_TEST_REPO_ROOT="$FAKE_REPO" \
+  KLICKER_TEST_CHILD_LOG="$CHILD_LOG" \
+  KLICKER_TEST_INFISICAL_LOG="$INFISICAL_LOG" \
+  "$WRAPPER" --mode eval >"$TEST_ROOT/empty-secret.out" 2>&1 || status=$?
+
+[ "$status" -eq 1 ] || fail "empty fetched judge key returned $status instead of 1"
+assert_line 'Error: fetched PIPELINES_LITELLM_API_KEY is empty' "$TEST_ROOT/empty-secret.out"
+[ ! -s "$CHILD_LOG" ] || fail 'empty fetched judge key must not invoke uv'
 
 status=0
 env -i \


### PR DESCRIPTION
## What This Adds

The eval wrapper no longer requires `LITELLM_API_KEY` in the invoking environment. A caller-provided key still wins as-is (CI, pre-injected keys, per-person LiteLLM virtual keys); when it is unset, the wrapper fetches `PIPELINES_LITELLM_API_KEY` itself with the standard `infisical` CLI from the klicker-uzh project (`d071be96-5136-4f23-a6cb-e0c7f9b9a6c8`, environment `stg`) and exports the value only to the evaluator child.

- Fail-fast errors name the missing piece: CLI not installed, fetch failed (with CLI stderr passed through), or empty secret.
- The fetch runs after all input preflights, so input failures never trigger a credential fetch.
- The key stays stripped from the local-target adapter and keygen environments (unchanged from #5734).
- The fetch path targets Infisical CLI 0.43.x flag syntax; the wrapper test suite pins the exact CLI arguments.

Context: #5734 already landed the eval adapter, data, and docs with an env-only key contract. The earlier branch `rs/klicker-live-target-evaluation` that carried an operator-based version of this change is superseded and left untouched; this PR contains only the CLI-fetch delta on a fresh branch off the current `v3` tip.

## Branch Coverage

- Base: `v3`
- Head: `a0646365d9`
- Reviewed: 1 commit, 5 files changed, +148/−46 (no lockfiles or generated output) — a small cohesive package shipped as a single PR per repo convention.

## Security / Privacy

- The secret value is only exported into the evaluator child process; the wrapper never prints it, logs it, or writes it to disk.
- `TARGET_HELPER_PREFIX` already unsets `LITELLM_API_KEY` (plus the Azure and upstream keys) for the adapter and keygen children; unchanged here.
- The Infisical project ID is non-secret metadata and already public in `.infisical.json`.
- Test fixtures use a synthetic key value only.

## Verification

Current head:

- `bash util/test-klicker-eval-wrapper.sh` → PASS (env-key pass-through without CLI invocation; fetch path with exact CLI arguments asserted; missing-CLI, CLI-failure, and empty-secret fail-fast each before `uv` runs)
- `git show HEAD | gitleaks detect --stdin` → no leaks
- `pnpm run build` (pre-push gate) → 23/23 tasks green
- `pnpm run check:all` → 25/25 tasks green
- Live fail-fast with the real, unauthenticated `infisical` CLI → exit 1 with the named fetch error (CLI's "No valid login session found" surfaced, wrapper error printed)

Not run:

- A live successful fetch: the plain Infisical CLI on this machine is not logged in; requires `infisical login` with klicker-uzh project access.

## Blocking Before Merge

None.

## Follow-Up After Merge

- Optional: a CI job that pins Infisical CLI 0.43.x for the fetch path (no CI job currently runs the wrapper tests).
- GitLab jobs can keep pre-setting `LITELLM_API_KEY` as a masked variable to stay Infisical-free.

## Local Session Artifacts

Machine: local workstation (rschlae)

- Worktree `trees/rs/eval-judge-key-infisical-fetch` in the klicker-uzh repository (this branch)
