### PR TITLE
docs: add practice overview sharing guidance

### DIFF
--- a/apps/docs/docs/tutorials/practice_quiz.mdx
+++ b/apps/docs/docs/tutorials/practice_quiz.mdx
@@ -100,7 +100,26 @@ Beyond opening the editing wizard from the actions menu on any Practice Quiz act
    - **Scheduled publication:** With the scheduled publication, you can choose a future date and time at which the Practice Quiz will be automatically published. This allows you to prepare the quiz in advance and ensure that it is available to students at the right time without manual intervention. While the Practice Quiz is still in the scheduled state (before the scheduled publication date), it can still be unpublished and edited.
 3. Once a **published** Practice Quiz becomes available, all participants who joined your KlickerUZH course can access it through the KlickerUZH app. Alternatively, you can always also share the direct access link to the Practice Quiz.
 
-Independent of the publication mode, when switching the activity to the "Published" state, all stacks contained in the Practice Quiz will be automatically appended to the course practice pool available to all your students through the KlickerUZH app. This pool allows students to practice the content of all published Practice Quizzes efficiently, making use of an established spaced repetition algorithm.
+Independent of the publication mode, when switching the activity to the "Published" state, all stacks contained in the Practice Quiz will be automatically appended to the course practice pool available to all your students through the KlickerUZH app. This pool allows students to practice the content of all published Practice Quizzes efficiently, making use of an established spaced repetition algorithm. For guidance on sharing this overview with your students, see [how to share the practice overview](#how-can-i-share-the-practice-overview-with-my-students).
+
+## How can I share the practice overview with my students?
+
+You do not need to share every Practice Quiz individually. The **course practice overview** combines the **Practice Pool** with the list of individual Practice Quizzes on one page. The pool draws up to 25 question sets from all published Practice Quizzes and orders them using spaced repetition, which makes the overview a good fit for weekly course materials, self-study sections, and exam preparation.
+
+**Where to find the link:**
+
+- For learning management systems such as OLAT or Moodle, copy the LTI link labeled **Practice Pool & Practice Quizzes** from your course overview. Embedding it in your course is described in the [LTI integration tutorial](/tutorials/lti_integration/).
+- For direct sharing (for example in a course news item or on a handout), use the overview link of your course: `https://pwa.klicker.com/{language}/course/{courseId}/practiceQuizzes/overview`. You can copy the `{courseId}` from the URL of the corresponding course in the lecturer application.
+
+:::note
+The Practice Pool is available to students who are logged in as participants of your course. Students who are not logged in see the individual Practice Quizzes on the overview, which can also be used anonymously. Students who have not yet joined your course can do so via the course link or QR code (see the [course management tutorial](/tutorials/course_management/#how-can-i-join-a-course-as-a-participant)).
+:::
+
+**Optional invitation text** that you can adapt and share with your course:
+
+> **English:** Want to keep practicing beyond the classroom? The practice overview of our course on KlickerUZH combines all published practice quizzes in one place. The practice pool at the top selects up to 25 question sets from all quizzes and orders them using spaced repetition - your previous answers can influence the order. Log in to KlickerUZH and practice as often as you like: [link]
+
+> **Deutsch:** Du möchtest den Stoff aus der Veranstaltung weiter üben? Die Übungsübersicht unseres Kurses auf KlickerUZH bündelt alle veröffentlichten Übungs-Quizzes an einem Ort. Der Übungspool wählt bis zu 25 Fragensets aus allen Quizzes aus und ordnet sie nach Spaced Repetition - deine bisherigen Antworten können die Reihenfolge beeinflussen. Melde dich bei KlickerUZH an und übe so oft du möchtest: [Link]
 
 KlickerUZH allows you to inspect the results of a Practice Quiz through the **activity evaluation** as soon as it is published and thereby accessible to students. For more details, please check out the section on the [practice quiz evaluation](/tutorials/practice_quiz/#how-can-i-see-the-results-of-a-practice-quiz), since this functionality is shared between these two activity types.
 


### PR DESCRIPTION
## Summary

- Adds a "How can I share the practice overview with my students?" section to the lecturer practice quiz tutorial (`apps/docs/docs/tutorials/practice_quiz.mdx`) and links to it from the existing practice pool paragraph.
- The section explains where to find the course practice overview link (the "Practice Pool & Practice Quizzes" LTI link, or the direct `/{language}/course/{courseId}/practiceQuizzes/overview` URL) and where to place it (weekly course materials, self-study sections, exam preparation).
- States the participant-experience caveats: the Practice Pool requires course-participant login, while individual Practice Quizzes remain available anonymously; links to the join-course flow.
- Provides copy-ready invitation text in English and German that describes the mechanism (up to 25 question sets from all published quizzes, ordered by spaced repetition, previous answers can influence the order) without promising learning outcomes. No automated messages and no UI changes are introduced.

Implements W3 — Help lecturers distribute the course entry point from [project/2026-09-02-practice-pool-discovery-and-adoption-roadmap.md](https://github.com/uzh-bf/klicker-uzh/blob/v3/project/2026-09-02-practice-pool-discovery-and-adoption-roadmap.md) as a light-path package.

## Substantive Size

- 1 commit, 1 file: 20 insertions, 1 deletion (`git diff --numstat origin/v3...HEAD`), all documentation. Complete package under the ~50-line packaging floor; light path (no architecture, security, data-integrity, or public-contract surfaces).

## Verification Evidence

- Current head: `pnpm exec prettier --check apps/docs/docs/tutorials/practice_quiz.mdx` passed.
- Current head: `pnpm --filter @klicker-uzh/docs build:docs` (docusaurus production build) passed. The reported broken-link/anchor warnings are pre-existing on `v3` and none involve the changed page or its new links.
- CI: not yet run (draft); exact-head checks run on this PR.

## Plan Summary (Light Path)

- Authority: local edits, focused checks, one local commit; push and draft-PR creation approved for this boundary. Merge remains withheld.
- Terminal: docs slice committed and verified locally.
- Pause: an in-product copy affordance for invitation text would be a separate UI package.

## Blocking Before Merge

None.

## Follow-Up After Merge

- Reconcile the roadmap Progress entry for W3 — Help lecturers distribute the course entry point (roadmap Phase 5).
- Unrelated follow-up worth a separate PR: the `playwright-selector` test fixture leaks `GIT_DIR` into the real repository when pre-commit hooks run from linked worktrees, which corrupts the shared config.

## Local Session Artifacts

Machine: rschlae local Mac

- Worktree: `trees/practice-pool-lecturer-guidance` in the klicker-uzh repository — this branch's checkout with installed dependencies.
