### PR TITLE
style: format klicker-graphql-api skill doc

### DIFF
--- a/.agents/skills/klicker-graphql-api/SKILL.md
+++ b/.agents/skills/klicker-graphql-api/SKILL.md
@@ -26,7 +26,10 @@ Facts (auth ladder, layering, error conventions): [docs/graphql-api-layer.md](..
        (args) => ({ courseId: args.id }), // -> PermissionCheck key for the target object
        DB.PermissionLevel.ADMIN, // READ | EXECUTE | WRITE | ADMIN, per operation severity
        async (_, args, ctx) => {
-         const request = await CourseDeletionService.requestCourseDeletion(args, ctx)
+         const request = await CourseDeletionService.requestCourseDeletion(
+           args,
+           ctx
+         )
          return { courseId: request.courseId }
        }
      ),


### PR DESCRIPTION
## Context

`check` (codebase/check) currently fails on every PR merge-ref because the file `.agents/skills/klicker-graphql-api/SKILL.md` on `v3` (introduced in 98845290c7) is not Prettier-formatted.

## Change

Formatting-only fix for that one file (4 insertions, 1 deletion, no content change).

## Evidence

- `prettier --check` fails at base `3c99fa26b9`, passes at head `eebd2615f`.
- Full pre-commit hook suite green at this head (25/25 tasks) after a fresh ordered build of the workspace.

## Why now

Unblocks the Doc Query activation stack PRs #5736 / #5737 / #5738, whose CI currently fails only on this baseline formatting issue.