### PR TITLE
enhance(chat): add deterministic KlickerUZH docs manifest

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -49,9 +49,11 @@
     "dev:docs": "docusaurus start --port 5500",
     "docusaurus": "docusaurus",
     "examples": "docusaurus-examples",
+    "generate:docs-manifest": "node scripts/generate-docs-manifest.mjs",
     "rename-version": "docusaurus-rename-version",
     "serve": "docusaurus serve",
     "swizzle": "docusaurus swizzle",
+    "test:run": "node --test scripts/",
     "version": "docusaurus-version",
     "write-translations": "docusaurus-write-translations"
   },

--- a/apps/docs/scripts/generate-docs-manifest.mjs
+++ b/apps/docs/scripts/generate-docs-manifest.mjs
@@ -1,0 +1,387 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const SCHEMA_VERSION = 1
+const APP_ROOT = path.resolve(import.meta.dirname, '..')
+const DOCS_DIR = path.join(APP_ROOT, 'docs')
+const STATIC_DIR = path.join(APP_ROOT, 'static')
+const CONSTANTS_PATH = path.join(APP_ROOT, 'src', 'constants.tsx')
+const VERSIONS_PATH = path.join(APP_ROOT, 'versions.json')
+const MANIFEST_PATH = path.join(
+  APP_ROOT,
+  'src',
+  'generated',
+  'docs-manifest.json'
+)
+
+const VIDEO_HOST_ALLOWLIST = new Set([
+  'www.youtube.com',
+  'youtube.com',
+  'youtu.be',
+  'player.vimeo.com',
+])
+
+const LEGAL_PAGE_NAMES = new Set([
+  'datenschutz',
+  'nutzungsbedingungen',
+  'privacy_policy',
+  'terms_of_service',
+])
+
+const require = createRequire(import.meta.url)
+
+function stripFences(body) {
+  return body.replace(/^(```|~~~)[\s\S]*?^\1.*$/gm, '')
+}
+
+export function parseFrontmatter(source) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source)
+  if (!match) {
+    return { data: {}, body: source }
+  }
+  const data = {}
+  let currentListKey = null
+  for (const line of match[1].split(/\r?\n/)) {
+    if (/^\s*-\s+/.test(line) && currentListKey) {
+      data[currentListKey].push(line.replace(/^\s*-\s+/, '').trim())
+      continue
+    }
+    const pair = /^([a-zA-Z_-]+):\s*(.*)$/.exec(line)
+    if (!pair) {
+      currentListKey = null
+      continue
+    }
+    const key = pair[1]
+    const value = pair[2].trim()
+    if (value === '') {
+      data[key] = []
+      currentListKey = key
+    } else {
+      currentListKey = null
+      data[key] = value.replace(/^['"]|['"]$/g, '')
+    }
+  }
+  return { data, body: source.slice(match[0].length) }
+}
+
+export function deriveRoute(relativePath) {
+  const withoutExt = relativePath.replace(/\.mdx?$/, '')
+  const segments = withoutExt.split('/')
+  const base = segments.pop()
+  const cleaned = segments
+    .map((segment) => segment.replace(/^\d+-/, ''))
+    .concat(
+      /^(index|readme)$/i.test(base.replace(/^\d+-/, ''))
+        ? []
+        : [base.replace(/^\d+-/, '')]
+    )
+  return `/${cleaned.join('/')}/`
+}
+
+export function categorizeDoc(relativePath) {
+  const segments = relativePath.split('/')
+  if (segments.length === 1) {
+    return LEGAL_PAGE_NAMES.has(segments[0].replace(/\.mdx?$/, ''))
+      ? 'legal'
+      : 'general'
+  }
+  if (segments[0] === 'student_tutorials') {
+    return 'student'
+  }
+  return segments[0]
+}
+
+export function extractHeadings(body) {
+  const headings = []
+  for (const line of stripFences(body).split(/\r?\n/)) {
+    const match = /^#{2,3}\s+(.+)$/.exec(line)
+    if (match) {
+      headings.push(
+        match[1]
+          .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+          .replace(/`/g, '')
+          .trim()
+      )
+    }
+  }
+  return headings
+}
+
+export function extractSummary(body) {
+  const maxLength = 240
+  for (const line of stripFences(body).split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('#') ||
+      trimmed.startsWith('<') ||
+      trimmed.startsWith('import ') ||
+      trimmed.startsWith('export ') ||
+      trimmed.startsWith('![')
+    ) {
+      continue
+    }
+    const text = trimmed
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      .replace(/[*_`]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (text === '') {
+      continue
+    }
+    if (text.length <= maxLength) {
+      return text
+    }
+    return `${text.slice(0, text.lastIndexOf(' ', maxLength))}…`
+  }
+  return ''
+}
+
+export function extractMedia(body, staticDir) {
+  const content = stripFences(body)
+  const media = []
+  const skipped = []
+  const seen = new Set()
+  const add = (item) => {
+    if (seen.has(item.url)) {
+      return
+    }
+    seen.add(item.url)
+    media.push(item)
+  }
+  for (const match of content.matchAll(/!\[([^\]]*)\]\(([^)\s]+)[^)]*\)/g)) {
+    classifyMediaUrl(match[2], staticDir, add, skipped)
+  }
+  for (const tag of content.matchAll(/<img\b([\s\S]*?)>/g)) {
+    const src = /src=["']([^"']+)["']/.exec(tag[1])
+    if (src) {
+      classifyMediaUrl(src[1], staticDir, add, skipped)
+    }
+  }
+  media.sort((a, b) => a.url.localeCompare(b.url))
+  return { media, skipped }
+}
+
+function classifyMediaUrl(url, staticDir, add, skipped) {
+  if (url.startsWith('/')) {
+    const localPath = path.join(staticDir, url)
+    if (!fs.existsSync(localPath)) {
+      throw new Error(`Missing local media for ${url}`)
+    }
+    add({ type: 'image', url })
+    return
+  }
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    skipped.push(url)
+    return
+  }
+  if (
+    parsed.protocol === 'https:' &&
+    VIDEO_HOST_ALLOWLIST.has(parsed.hostname)
+  ) {
+    add({ type: 'video', url })
+    return
+  }
+  skipped.push(url)
+}
+
+export function parseUseCases(constantsPath, ts, staticDir = STATIC_DIR) {
+  const source = ts.createSourceFile(
+    constantsPath,
+    fs.readFileSync(constantsPath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  let declaration = null
+  for (const statement of source.statements) {
+    if (
+      ts.isVariableStatement(statement) &&
+      statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+      )
+    ) {
+      for (const binding of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(binding.name) &&
+          binding.name.text === 'USE_CASES' &&
+          binding.initializer &&
+          ts.isObjectLiteralExpression(binding.initializer)
+        ) {
+          declaration = binding.initializer
+        }
+      }
+    }
+  }
+  if (!declaration) {
+    throw new Error('USE_CASES export not found in constants')
+  }
+  const useCases = []
+  for (const property of declaration.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
+      continue
+    }
+    if (!ts.isObjectLiteralExpression(property.initializer)) {
+      continue
+    }
+    const id = property.name.text
+    const scalars = {}
+    const lists = {}
+    for (const field of property.initializer.properties) {
+      if (!ts.isPropertyAssignment(field) || !ts.isIdentifier(field.name)) {
+        continue
+      }
+      const value = field.initializer
+      if (ts.isStringLiteralLike(value)) {
+        scalars[field.name.text] = value.text
+      } else if (
+        ts.isArrayLiteralExpression(value) &&
+        value.elements.every((element) => ts.isStringLiteralLike(element))
+      ) {
+        lists[field.name.text] = value.elements.map((element) => element.text)
+      }
+    }
+    const media = []
+    if (scalars.headerImgSrc) {
+      const staticPath = path.join(staticDir, scalars.headerImgSrc)
+      if (!fs.existsSync(staticPath)) {
+        throw new Error(
+          `Missing local media for use case ${id}: ${scalars.headerImgSrc}`
+        )
+      }
+      media.push({ type: 'image', url: scalars.headerImgSrc })
+    }
+    useCases.push({
+      id,
+      route: `/use_cases/${id}/`,
+      title: scalars.title ?? id,
+      summary: scalars.abstract ?? '',
+      tags: lists.tags ?? [],
+      goals: lists.goals ?? [],
+      media,
+      sourceCategory: 'use_case',
+    })
+  }
+  return useCases
+}
+
+function readDocsVersion() {
+  const versions = JSON.parse(fs.readFileSync(VERSIONS_PATH, 'utf8'))
+  return Array.isArray(versions) && versions.length > 0
+    ? versions[0]
+    : 'current'
+}
+
+export function buildManifest(options = {}) {
+  const docsDir = options.docsDir ?? DOCS_DIR
+  const staticDir = options.staticDir ?? STATIC_DIR
+  const constantsPath = options.constantsPath ?? CONSTANTS_PATH
+  const ts = options.ts ?? require('typescript')
+  const skippedUnsupported = []
+  const mdxFiles = fs
+    .readdirSync(docsDir, { recursive: true })
+    .filter((file) => file.endsWith('.mdx'))
+    .sort()
+  const pages = mdxFiles.map((relativePath) => {
+    const source = fs.readFileSync(path.join(docsDir, relativePath), 'utf8')
+    const { data, body } = parseFrontmatter(source)
+    const route = deriveRoute(relativePath)
+    const { media, skipped } = extractMedia(body, staticDir)
+    skippedUnsupported.push(...skipped.map((url) => ({ route, url })))
+    const headingMatch = /^#\s+(.+)$/m.exec(stripFences(body))
+    const title =
+      data.title ??
+      (headingMatch ? headingMatch[1].trim() : undefined) ??
+      relativePath.replace(/\.mdx?$/, '').replace(/[-_]/g, ' ')
+    return {
+      route,
+      title,
+      headings: extractHeadings(body),
+      summary: extractSummary(body),
+      tags: Array.isArray(data.tags) ? data.tags : [],
+      media,
+      sourcePath: `docs/${relativePath}`,
+      sourceCategory: categorizeDoc(relativePath),
+    }
+  })
+  const routes = new Set()
+  for (const page of pages) {
+    if (routes.has(page.route)) {
+      throw new Error(`Duplicate docs route: ${page.route}`)
+    }
+    routes.add(page.route)
+  }
+  const useCases = parseUseCases(constantsPath, ts).sort((a, b) =>
+    a.id.localeCompare(b.id)
+  )
+  const useCaseRoutes = new Set()
+  for (const useCase of useCases) {
+    if (routes.has(useCase.route) || useCaseRoutes.has(useCase.route)) {
+      throw new Error(`Duplicate docs route: ${useCase.route}`)
+    }
+    useCaseRoutes.add(useCase.route)
+  }
+  const docsVersion = readDocsVersion()
+  const withoutDigest = {
+    schemaVersion: SCHEMA_VERSION,
+    docsVersion,
+    pages,
+    useCases,
+  }
+  const digest = createHash('sha256')
+    .update(JSON.stringify(withoutDigest))
+    .digest('hex')
+  return {
+    ...withoutDigest,
+    contentDigest: `sha256:${digest}`,
+    _skippedUnsupportedMedia: skippedUnsupported,
+  }
+}
+
+export function renderManifest(manifest) {
+  const { _skippedUnsupportedMedia, ...published } = manifest
+  return `${JSON.stringify(published, null, 2)}\n`
+}
+
+function main() {
+  const checkOnly = process.argv.includes('--check')
+  const manifest = buildManifest()
+  const rendered = renderManifest(manifest)
+  if (checkOnly) {
+    const current = fs.existsSync(MANIFEST_PATH)
+      ? fs.readFileSync(MANIFEST_PATH, 'utf8')
+      : ''
+    if (current !== rendered) {
+      console.error(
+        'Docs manifest is drifted. Run: pnpm --filter @klicker-uzh/docs generate:docs-manifest'
+      )
+      process.exitCode = 1
+      return
+    }
+    console.log('Docs manifest is up to date.')
+    return
+  }
+  fs.mkdirSync(path.dirname(MANIFEST_PATH), { recursive: true })
+  fs.writeFileSync(MANIFEST_PATH, rendered)
+  console.log(
+    `Docs manifest written: ${manifest.pages.length} pages, ${manifest.useCases.length} use cases, ${rendered.split('\n').length} lines.`
+  )
+  if (manifest._skippedUnsupportedMedia.length > 0) {
+    console.log(
+      `Omitted ${manifest._skippedUnsupportedMedia.length} unsupported media reference(s).`
+    )
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main()
+}

--- a/apps/docs/scripts/generate-docs-manifest.test.mjs
+++ b/apps/docs/scripts/generate-docs-manifest.test.mjs
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'node:test'
+import {
+  buildManifest,
+  categorizeDoc,
+  deriveRoute,
+  extractHeadings,
+  extractMedia,
+  extractSummary,
+  parseFrontmatter,
+  parseUseCases,
+  renderManifest,
+} from './generate-docs-manifest.mjs'
+
+const require = createRequire(import.meta.url)
+const ts = require('typescript')
+
+function makeFixture(additions = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-manifest-'))
+  const docsDir = path.join(root, 'docs')
+  const staticDir = path.join(root, 'static')
+  fs.mkdirSync(docsDir, { recursive: true })
+  fs.mkdirSync(staticDir, { recursive: true })
+  fs.mkdirSync(path.join(staticDir, 'img'), { recursive: true })
+  fs.writeFileSync(path.join(staticDir, 'img', 'picture.png'), 'png')
+  const files = {
+    'tutorials/live_quiz.mdx':
+      '---\ntitle: Live Quizzes\n---\n\nFirst paragraph here.\n\n## Setup\n\nText.\n\n![Shot](/img/picture.png)\n',
+    ...additions,
+  }
+  for (const [relativePath, content] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(docsDir, relativePath)), {
+      recursive: true,
+    })
+    fs.writeFileSync(path.join(docsDir, relativePath), content)
+  }
+  return { root, docsDir, staticDir }
+}
+
+function writeConstants(root, body) {
+  const constantsPath = path.join(root, 'constants.tsx')
+  fs.writeFileSync(constantsPath, body)
+  return constantsPath
+}
+
+test('parseFrontmatter reads scalars and lists', () => {
+  const { data, body } = parseFrontmatter(
+    '---\ntitle: FAQ\ntags:\n  - a\n  - b\n---\n\nBody.'
+  )
+  assert.equal(data.title, 'FAQ')
+  assert.deepEqual(data.tags, ['a', 'b'])
+  assert.equal(body, '\nBody.')
+})
+
+test('parseFrontmatter passes through sources without frontmatter', () => {
+  const { data, body } = parseFrontmatter('Plain body.')
+  assert.deepEqual(data, {})
+  assert.equal(body, 'Plain body.')
+})
+
+test('deriveRoute strips numeric prefixes and index files', () => {
+  assert.equal(
+    deriveRoute('01-tutorials/02-live_quiz.mdx'),
+    '/tutorials/live_quiz/'
+  )
+  assert.equal(deriveRoute('getting_started/index.mdx'), '/getting_started/')
+  assert.equal(deriveRoute('faq.mdx'), '/faq/')
+})
+
+test('categorizeDoc separates legal, student, and section pages', () => {
+  assert.equal(categorizeDoc('datenschutz.mdx'), 'legal')
+  assert.equal(categorizeDoc('terms_of_service.mdx'), 'legal')
+  assert.equal(categorizeDoc('student_tutorials/chatbot.mdx'), 'student')
+  assert.equal(categorizeDoc('gamification/awards.mdx'), 'gamification')
+  assert.equal(categorizeDoc('faq.mdx'), 'general')
+})
+
+test('extractHeadings skips fenced blocks and cleans markup', () => {
+  const body =
+    '## Real [heading](/x)\n\n~~~md\n## Fake heading\n~~~\n### Deep topic'
+  assert.deepEqual(extractHeadings(body), ['Real heading', 'Deep topic'])
+})
+
+test('extractSummary takes the first prose paragraph and truncates cleanly', () => {
+  const summary = extractSummary(
+    '# Title\n\n![img](/img/picture.png)\n\nShort summary text.'
+  )
+  assert.equal(summary, 'Short summary text.')
+  const long = extractSummary('A '.repeat(200))
+  assert.ok(long.length <= 241)
+  assert.ok(long.endsWith('…'))
+})
+
+test('extractMedia keeps same-site images and allowlisted videos, omits other schemes', () => {
+  const { docsDir, staticDir } = makeFixture()
+  const body = fs.readFileSync(
+    path.join(docsDir, 'tutorials/live_quiz.mdx'),
+    'utf8'
+  )
+  const extended =
+    body +
+    '\n![Remote](https://example.org/x.png)' +
+    '\n![Clip](https://www.youtube.com/watch?v=abc)' +
+    '\n![Legacy](upload://abc.png)\n'
+  const { media, skipped } = extractMedia(extended, staticDir)
+  assert.deepEqual(media, [
+    { type: 'image', url: '/img/picture.png' },
+    { type: 'video', url: 'https://www.youtube.com/watch?v=abc' },
+  ])
+  assert.deepEqual(skipped, ['https://example.org/x.png', 'upload://abc.png'])
+})
+
+test('extractMedia rejects missing local media', () => {
+  const { staticDir } = makeFixture()
+  assert.throws(
+    () => extractMedia('![Ghost](/img/missing.png)', staticDir),
+    /Missing local media/
+  )
+})
+
+test('parseUseCases extracts declared scalar and list metadata only', () => {
+  const { root, staticDir } = makeFixture()
+  const constantsPath = writeConstants(
+    root,
+    [
+      "const ACK_STANDARD = 'ack'",
+      'export const USE_CASES = {',
+      '  live_quiz: {',
+      '    acknowledgements: ACK_STANDARD,',
+      "    title: 'Live Quizzes',",
+      "    headerImgSrc: '/img/picture.png',",
+      "    tags: ['gamified', 'feedback'],",
+      "    goals: ['Engage students.'],",
+      "    abstract: 'A summary.',",
+      '    introduction: (',
+      '      <>',
+      '        <p>Rendered prose that must never be extracted.</p>',
+      '      </>',
+      '    ),',
+      '  },',
+      '}',
+    ].join('\n')
+  )
+  const useCases = parseUseCases(constantsPath, ts, staticDir)
+  assert.deepEqual(useCases, [
+    {
+      id: 'live_quiz',
+      route: '/use_cases/live_quiz/',
+      title: 'Live Quizzes',
+      summary: 'A summary.',
+      tags: ['gamified', 'feedback'],
+      goals: ['Engage students.'],
+      media: [{ type: 'image', url: '/img/picture.png' }],
+      sourceCategory: 'use_case',
+    },
+  ])
+})
+
+test('parseUseCases rejects missing use-case media', () => {
+  const { root, staticDir } = makeFixture()
+  const constantsPath = writeConstants(
+    root,
+    "export const USE_CASES = { broken: { title: 'X', headerImgSrc: '/img/missing.png' } }"
+  )
+  assert.throws(
+    () => parseUseCases(constantsPath, ts, staticDir),
+    /Missing local media/
+  )
+})
+
+test('buildManifest rejects duplicate routes', () => {
+  const { docsDir, staticDir } = makeFixture({
+    'tutorials/live_quiz/index.mdx': '---\ntitle: Tutorials\n---\n\nIntro.\n',
+  })
+  assert.throws(
+    () => buildManifest({ docsDir, staticDir }),
+    /Duplicate docs route/
+  )
+})
+
+test('real docs tree produces a deterministic, drift-free manifest', () => {
+  const first = buildManifest()
+  const second = buildManifest()
+  assert.equal(renderManifest(first), renderManifest(second))
+  assert.match(first.contentDigest, /^sha256:[0-9a-f]{64}$/)
+  const realDocsDir = path.resolve(import.meta.dirname, '..', 'docs')
+  const mdxCount = fs
+    .readdirSync(realDocsDir, { recursive: true })
+    .filter((file) => file.endsWith('.mdx')).length
+  assert.equal(first.pages.length, mdxCount)
+  assert.ok(first.useCases.length >= 11)
+  const checkedIn = fs.readFileSync(
+    path.resolve(
+      import.meta.dirname,
+      '..',
+      'src',
+      'generated',
+      'docs-manifest.json'
+    ),
+    'utf8'
+  )
+  assert.equal(renderManifest(first), checkedIn)
+})

--- a/apps/docs/src/generated/docs-manifest.json
+++ b/apps/docs/src/generated/docs-manifest.json
@@ -1,0 +1,1538 @@
+{
+  "schemaVersion": 1,
+  "docsVersion": "current",
+  "pages": [
+    {
+      "route": "/about/project/",
+      "title": "About KlickerUZH",
+      "headings": [],
+      "summary": "",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/about/project.mdx",
+      "sourceCategory": "about"
+    },
+    {
+      "route": "/about/roadmap/",
+      "title": "Roadmap",
+      "headings": [],
+      "summary": "",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/about/roadmap.mdx",
+      "sourceCategory": "about"
+    },
+    {
+      "route": "/about/whats_new/",
+      "title": "What's New",
+      "headings": [],
+      "summary": "> COMING SOON",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/about/whats_new.mdx",
+      "sourceCategory": "about"
+    },
+    {
+      "route": "/datenschutz/",
+      "title": "Datenschutzerklärung",
+      "headings": [
+        "1. Grundsätze",
+        "2. Umfang und Zweck der Bearbeitung von Personendaten",
+        "Erfasste Datenelemente",
+        "Umgang mit besonders schützenswerten Personendaten",
+        "3. Kontaktadressen",
+        "4. Begriffe und Rechtsgrundlagen",
+        "4.1 Begriffe",
+        "4.2 Rechtsgrundlagen",
+        "5. Art, Umfang und Zweck",
+        "6. Personendaten im Ausland",
+        "7. Rechte von betroffenen Personen",
+        "7.1 Datenschutzrechtliche Ansprüche",
+        "7.2 Recht auf Beschwerde",
+        "8. Datensicherheit",
+        "9. Nutzung der Website",
+        "9.1 Cookies",
+        "9.2 Server-Logdateien",
+        "10. Benachrichtigungen und Mitteilungen",
+        "10.1 Erfolgs- und Reichweitenmessung",
+        "10.2 Einwilligung und Widerspruch",
+        "10.3 Dienstleister für Benachrichtigungen und Mitteilungen",
+        "11. Social Media",
+        "12. Dienste von Dritten",
+        "10.1 Digitale Infrastruktur",
+        "10.2 Automatisierung und Integration von Apps und Diensten",
+        "10.3 Terminplanung",
+        "10.4 Audio- und Video-Konferenzen",
+        "10.6 Digitale Audio- und Video-Inhalte",
+        "11. Erfolgs- und Reichweitenmessung",
+        "12. Schlussbestimmungen"
+      ],
+      "summary": "Aktualisiert am 26. August 2023",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/datenschutz.mdx",
+      "sourceCategory": "legal"
+    },
+    {
+      "route": "/faq/",
+      "title": "Frequently Asked Questions",
+      "headings": [],
+      "summary": "",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/faq.mdx",
+      "sourceCategory": "general"
+    },
+    {
+      "route": "/gamification/achievements/",
+      "title": "Achievements",
+      "headings": [],
+      "summary": "> COMING SOON",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/gamification/achievements.mdx",
+      "sourceCategory": "gamification"
+    },
+    {
+      "route": "/gamification/awards/",
+      "title": "Awards",
+      "headings": [],
+      "summary": "> COMING SOON",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/gamification/awards.mdx",
+      "sourceCategory": "gamification"
+    },
+    {
+      "route": "/gamification/experience/",
+      "title": "XP and Levels",
+      "headings": [],
+      "summary": "While participants collect points for correct answers on a course level, experience points (XP) are collected across courses and allow students to level up. This represents an important part of our gamification concept, making sure that…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/gamification/xp_vs_level.jpg"
+        }
+      ],
+      "sourcePath": "docs/gamification/experience.mdx",
+      "sourceCategory": "gamification"
+    },
+    {
+      "route": "/gamification/grading_logic/",
+      "title": "Grading Logic",
+      "headings": [
+        "Grading by Element Type",
+        "Multiplier",
+        "Grading Single Choice Questions",
+        "Grading Multiple Choice Questions",
+        "Grading KPRIM Questions",
+        "Grading Numerical Questions",
+        "Grading Free Text Questions",
+        "Grading Selection Questions",
+        "Grading Case Study Questions",
+        "Grading in Live Quizzes",
+        "Advanced: Customized Grading"
+      ],
+      "summary": "In order to distribute points, XP and achievements based on the performance of the participants in various activities, an automated grading logic has been implemented in KlickerUZH. This chapter provides a detailed explanation of the…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/gamification/KPRIM_awarded_points.svg"
+        },
+        {
+          "type": "image",
+          "url": "/img/gamification/live_quiz_awarded_points.svg"
+        },
+        {
+          "type": "image",
+          "url": "/img/gamification/live_quiz_customized_grading.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/gamification/MC_awarded_points.svg"
+        }
+      ],
+      "sourcePath": "docs/gamification/grading_logic.mdx",
+      "sourceCategory": "gamification"
+    },
+    {
+      "route": "/gamification/overview/",
+      "title": "Overview",
+      "headings": [
+        "Goals of Gamification",
+        "Gamified Activities and Competition",
+        "Groups and Collaboration",
+        "Participant Experience"
+      ],
+      "summary": ":::info",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/gamification/overview.mdx",
+      "sourceCategory": "gamification"
+    },
+    {
+      "route": "/getting_started/core_concepts/",
+      "title": "Core Concepts",
+      "headings": [
+        "Elements",
+        "Learning Activities",
+        "Live Quiz (and Live Q&A)",
+        "Microlearning",
+        "Practice Quiz",
+        "Group Activity",
+        "Courses",
+        "Gamification"
+      ],
+      "summary": "id=\"kmsembed-0ugtkafd3\"",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/getting_started/core_concepts.mdx",
+      "sourceCategory": "getting_started"
+    },
+    {
+      "route": "/getting_started/welcome/",
+      "title": "Welcome",
+      "headings": [
+        "User Guide",
+        "Official KlickerUZH",
+        "Deployment",
+        "Contributing",
+        "Support & Community"
+      ],
+      "summary": "KlickerUZH is a web application that supports the interaction between lecturers and their audience in various ways. In a KlickerUZH live quiz (e.g., during a lecture), a speaker may pose questions to be answered by participants over their…",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/getting_started/welcome.mdx",
+      "sourceCategory": "getting_started"
+    },
+    {
+      "route": "/nutzungsbedingungen/",
+      "title": "Nutzungsbedingungen",
+      "headings": [
+        "Lizenz",
+        "Laufzeit",
+        "Gebühren",
+        "Datenschutz",
+        "Kein Recht auf Gewährleistung / Entschädigung",
+        "Allgemeines"
+      ],
+      "summary": "Aktualisiert am 26. August 2023",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/nutzungsbedingungen.mdx",
+      "sourceCategory": "legal"
+    },
+    {
+      "route": "/privacy_policy/",
+      "title": "Privacy policy",
+      "headings": [
+        "1. principles",
+        "2. scope and purpose of the processing of personal data",
+        "Data elements collected",
+        "Handling of particularly sensitive personal data",
+        "3. contact addresses",
+        "4. terms and legal basis",
+        "4.1 Terms",
+        "4.2 Legal basis",
+        "5. type, scope and purpose",
+        "6. personal data abroad",
+        "7. rights of data subjects",
+        "7.1 Data protection rights",
+        "7.2 Right of complaint",
+        "8. data security",
+        "9. use of the website",
+        "9.1 Cookies",
+        "9.2 Server log files",
+        "10. notifications and communications",
+        "10.1 Performance and Reach Measurement.",
+        "10.2 Consent and objection",
+        "10.3 Service providers for notifications and communications",
+        "11. social media",
+        "12. Services of third parties",
+        "10.1 Digital Infrastructure",
+        "10.2 Automation and integration of apps and services.",
+        "10.3 Scheduling",
+        "10.4 Audio and video conferencing",
+        "10.6 Digital audio and video content.",
+        "11. performance and reach measurement",
+        "12. final provisions"
+      ],
+      "summary": "Updated on August 26, 2023",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/privacy_policy.mdx",
+      "sourceCategory": "legal"
+    },
+    {
+      "route": "/private-preview/",
+      "title": "Private Preview Features",
+      "headings": [
+        "What is Private Preview?",
+        "Current Private Preview Features"
+      ],
+      "summary": "Some features in KlickerUZH are initially released as \"Private Preview\" features. This means they are available for testing with selected users before being made generally available.",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/private-preview.mdx",
+      "sourceCategory": "general"
+    },
+    {
+      "route": "/student_tutorials/chatbot/",
+      "title": "Course Chatbot",
+      "headings": [
+        "What is the course chatbot?",
+        "How do I get access?",
+        "How do I chat with the assistant?",
+        "How do I choose a model and reasoning effort?",
+        "How do credits work?",
+        "How do I rate an answer?",
+        "Does the chatbot show sources?",
+        "In which language does the chatbot answer?",
+        "What happens with my data?"
+      ],
+      "summary": "The course chatbot is an AI assistant for a specific course. You can ask it questions about the course content and receive answers in a chat interface. Depending on how your lecturer has set it up, the chatbot can guide you with questions,…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/chatbot/chat_overview.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/chatbot/chat_settings.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/chatbot.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/course_leaderboard/",
+      "title": "Courses and Leaderboards",
+      "headings": [],
+      "summary": "After a student has created a KlickerUZH account and joined a course as outlined in the account section, they can access all available course-related resources. To participate in the leaderboard and other course challenges and collect…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/leaderboard/course_leaderboard.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/leaderboard/join_leaderboard.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/leaderboard/joined_leaderboard.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/course_leaderboard.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/groups_activities/",
+      "title": "Groups and Group Activities",
+      "headings": [
+        "Creating / Joining Groups and Group Activities",
+        "Solve a Group Activity",
+        "View Group Activity Results"
+      ],
+      "summary": "While students compete on leaderboards against each other when collecting points from live quizzes, practice quizzes, and microlearnings, KlickerUZH also covers efforts to promote collaboration and teamwork. This section describes the…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/group_activity/ga_graded_students.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/group_activity/ga_student_view.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/group/group_student_view.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/groups_activities.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/klickeruzh_app/",
+      "title": "KlickerUZH App",
+      "headings": [
+        "Android",
+        "iOS"
+      ],
+      "summary": "To access KlickerUZH from anywhere, there's a KlickerUZH app. This app allows you to easily manage and access the learning content of your courses (using KlickerUZH), as well as add important elements to your private repetition library and…",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/student_tutorials/klickeruzh_app.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/live_quiz/",
+      "title": "Live Quiz",
+      "headings": [],
+      "summary": "Live quizzes are one of the core functionalities of KlickerUZH. In the following, you find an overview of the student view components of live quiz and live Q&A. For more information on how to use these components as a lecturer, check out…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/live_quiz/lq_student_view.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/live_quiz.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/microlearning/",
+      "title": "Microlearning",
+      "headings": [],
+      "summary": "src=\"/img/microlearning/mlstudentview.png\"",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/microlearning/ml_student_view.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/microlearning.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/practice_quiz/",
+      "title": "Practice Quiz",
+      "headings": [],
+      "summary": "In addition to live quizzes, KlickerUZH also offers a variety of asynchronous learning activities. One of them is the practice quiz. Practice quizzes are a great way to repeat the course content and to prepare for an exam. This section…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/practice_quiz/pq_olat_view.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/practice_quiz.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/student_tutorials/student_accounts/",
+      "title": "Participant Accounts",
+      "headings": [
+        "Courses with LMS integration (e.g., OLAT)",
+        "Courses without LMS integration",
+        "Anonymous participation",
+        "Updating the account"
+      ],
+      "summary": "If students are participating in KlickerUZH activities for the first time, they can register for a KlickerUZH participant account. A KlickerUZH participant account allows them to easily manage and access the learning content of courses…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/account/create_account.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/account/edit_profile.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/account/join_course.png"
+        }
+      ],
+      "sourcePath": "docs/student_tutorials/student_accounts.mdx",
+      "sourceCategory": "student"
+    },
+    {
+      "route": "/terms_of_service/",
+      "title": "Terms of Service",
+      "headings": [
+        "License",
+        "Term",
+        "Fees",
+        "Data Protection",
+        "No Warranty / Indemnification",
+        "General"
+      ],
+      "summary": "Updated on August 26, 2023",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/terms_of_service.mdx",
+      "sourceCategory": "legal"
+    },
+    {
+      "route": "/tutorials/activity_batch_operations/",
+      "title": "Batch Operations (Activities)",
+      "headings": [
+        "What are activity batch operations?",
+        "What changes can be applied as batch operations?"
+      ],
+      "summary": ":::info",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/review/activity_batch_operations.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/review/activity_list_batch_operations.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/activity_batch_operations.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/activity_templates/",
+      "title": "Activity Templates",
+      "headings": [],
+      "summary": "Activity Templates allow lecturers to save the structure and content of a Live Quiz or a collection of elements as a reusable template. This facilitates the quick creation of new activities or the sharing of standardized question sets.",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/tutorials/activity_templates.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/ai_assistant/",
+      "title": "AI Assistant",
+      "headings": [
+        "What is the KlickerUZH Assistant?",
+        "What can the assistant help me with?",
+        "How are questions created — the proposal principle",
+        "How do I start a new conversation?",
+        "Can I attach images to my messages?",
+        "What should I keep in mind when using the assistant?"
+      ],
+      "summary": "The KlickerUZH Assistant is an AI chat companion built into the lecturer interface. You open it with the Assistant button in the bottom right corner of any page and it appears as a chat panel next to your work, so you do not have to leave…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/ai_assistant/manage_assistant_drawer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/ai_assistant/manage_assistant_response.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/ai_assistant.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/answer_collections/",
+      "title": "Answer Collections",
+      "headings": [
+        "Creating and Managing Answer Collections",
+        "Accessing Answer Collections",
+        "Creating a New Answer Collection",
+        "Editing and Extending Answer Collections",
+        "Deleting an Entire Collection",
+        "Using Answer Collections in Questions",
+        "For Selection (SE) Questions",
+        "For Case Study (CS) Questions",
+        "Sharing Answer Collections"
+      ],
+      "summary": "Answer Collections are reusable lists of predefined text items (e.g., diagnoses, symptoms, keywords, options). They serve as the source pool for answers in Selection (SE) questions and the evaluable items for Case Study (CS) questions,…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_create.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_edit.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_edit2.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_edit3.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_overview.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_share.jpeg"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_usage_cs.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/answer_collections/answer_collection_usage.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/answer_collections.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/catalog_sharing/",
+      "title": "Sharing via Catalog",
+      "headings": [],
+      "summary": ":::warning",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/tutorials/catalog_sharing.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/chatbot/",
+      "title": "Course Chatbot",
+      "headings": [
+        "What is the Course Chatbot?",
+        "How do I get a chatbot for my course?",
+        "How do I manage my chatbot?",
+        "How do students access the chatbot?",
+        "What do students see?",
+        "How do credits work?",
+        "Can the chatbot cite course materials?",
+        "What about data protection and the disclaimer?"
+      ],
+      "summary": "The course chatbot is an AI assistant that you can offer to the students of a specific course. Students open it through a course-specific link, ask questions about the course content and receive answers in a familiar chat interface. Every…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/chatbot/chat_overview.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/chatbot/chat_settings.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/chatbot.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/course_ai_tutor/",
+      "title": "Course AI Tutor",
+      "headings": [
+        "What is the course AI tutor?",
+        "How do I get a chatbot for my course?",
+        "What do students have to accept before using the tutor?",
+        "How is usage limited (credits)?",
+        "What should I tell my students?"
+      ],
+      "summary": "The course AI tutor is a course-specific chatbot that your students can use inside the KlickerUZH student app. Students open it with the AI tutor button on the course overview and while working on practice quizzes and microlearnings. The…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/ai_assistant/course_ai_tutor_response.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/course_ai_tutor.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/course_management/",
+      "title": "Course Management",
+      "headings": [
+        "What are Courses?",
+        "How can I create a Course?",
+        "How can I duplicate a course?",
+        "How can I join a course as a participant?"
+      ],
+      "summary": "Courses serve as a framework within KlickerUZH, facilitating the integration of learning activities into a structured lecture format. They enable lecturers to effectively manage various activities and challenges over a specific period,…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/courses/course_overview.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/course_management.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/delegated_access/",
+      "title": "Delegated Access",
+      "headings": [
+        "What is delegated access for?",
+        "How can I create a delegated access login for my account?",
+        "Access levels for delegated access"
+      ],
+      "summary": "The login to KlickerUZH v3.0 is only possible using Edu-ID credentials, which are personal and should not be passed on to other persons. The option to create a separate login with username and password from KlickerUZH v2.0 is not available…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/account/delegated_access_settings.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/delegated_access.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/direct_sharing/",
+      "title": "Direct Sharing & Access Requests",
+      "headings": [],
+      "summary": ":::warning",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/tutorials/direct_sharing.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/element_batch_operations/",
+      "title": "Batch Operations (Elements)",
+      "headings": [
+        "What are element batch operations?",
+        "What changes can be applied as batch operations?"
+      ],
+      "summary": ":::info",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/review/element_batch_operations.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/review/element_list_batch_operations.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/element_batch_operations.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/element_management/",
+      "title": "Element Management",
+      "headings": [
+        "What is an Element?",
+        "How can I create an Element?",
+        "How can I modify an Element?",
+        "Editing an Element",
+        "Duplicating an Element",
+        "Sharing an Element <PrivatePreviewTag />",
+        "Deleting an Element",
+        "How can I organize my Element Library?"
+      ],
+      "summary": "Elements serve as the fundamental building blocks of KlickerUZH. The element library builds the home screen of KlickerUZH, providing a central hub for creating and editing elements. To gain a basic understanding of the role of elements in…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/elements/element_deletion.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/elements/element_duplication.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/elements/element_editing.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/elements/element_sharing.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/elements/MC_element_editor.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/element_management.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/element_stacks/",
+      "title": "Element Stacks",
+      "headings": [
+        "What are Element Stacks / Blocks?",
+        "How can I create an Element Stack?",
+        "How do Element Stacks look for Students?"
+      ],
+      "summary": "Most KlickerUZH activities group elements into stacks or blocks. The set of elements is then either shown all at once in practice quizzes and microlearnings or sequentially in live quizzes. To supplement the set of questions in a stack,…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/stacks/stack_creation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/stacks/stack_description_title.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/stacks/stack_student_view.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/element_stacks.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/element_updates_activities/",
+      "title": "Element Updates in Activities",
+      "headings": [
+        "How can elements become outdated in activities?",
+        "How can I make sure that changes to an element are reflected in activities?",
+        "How can I update elements in specific activities?"
+      ],
+      "summary": "As mentioned in our section on the core concepts, all activities in KlickerUZH are centered around re-usable elements. This functionality is designed to minimize the effort required for you as a lecturer to conduct similar quizzes in…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/element_updates/activity_editor_updates.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/element_updates/element_edit_dialog_updates.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/element_updates/outdated_activity_notification.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/element_updates_activities.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/group_activity/",
+      "title": "Group Activity",
+      "headings": [
+        "What is a Group Activity?",
+        "How can I create a Group Activity?",
+        "How can I edit a Group Activity?",
+        "How can I publish a Group Activity and make it accessible to participants?",
+        "How can I grade the submissions to a Group Activity?"
+      ],
+      "summary": "Group activities are one of the collaborative learning activities in KlickerUZH. They are designed to promote teamwork and collaboration among students. Group activities consist of a set of questions, explanation texts, and hints that are…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/group_activity/creation_settings.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/group_activity/creation_stack.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/group_activity/ga_grading_view.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/group_activity.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/live_qa/",
+      "title": "Live Q&A and Feedback",
+      "headings": [
+        "What is Live Q&A?",
+        "What is Live Feedback?",
+        "How can I activate and use Live Q&A and Live Feedback?"
+      ],
+      "summary": "Live Quizzes in KlickerUZH can be coupled with a Live Q&A that enables students to ask questions anonymously. Lecturers can answer either in writing or orally. This facilitates the immediate clarification of questions and fosters…",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/tutorials/live_qa.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/live_quiz/",
+      "title": "Live Quiz",
+      "headings": [
+        "What is a Live Quiz?",
+        "How can I create a Live Quiz?",
+        "How can I edit a Live Quiz?",
+        "How can I execute a Live Quiz?",
+        "How can participants join a Live Quiz?",
+        "What functionalities become available through gamified Live Quizzes?"
+      ],
+      "summary": "Live Quizzes in KlickerUZH involve real-time interaction during lectures to foster engagement between the lecturer and students. Multiple question blocks are activated at different intervals, allowing students to provide answers in…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/live_quiz/lq_evaluation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/live_quiz/lq_gamification_choice.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/live_quiz/lq_gamification_gamified_course.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/live_quiz/lq_gamification_nongamified_course.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/live_quiz.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/lti_integration/",
+      "title": "Integration with LTI",
+      "headings": [
+        "How should I structure my KlickerUZH elements?",
+        "How can I set the language for KlickerUZH activities embedded in OLAT?",
+        "How can I configure Moodle with a system-wide LTI tool?",
+        "How can I integrate KlickerUZH pages into my OLAT course?",
+        "Course Overview and Student Documentation",
+        "Activity Lists (including Live Quiz and Live Q&A)",
+        "Leaderboard",
+        "Account Management",
+        "Individual Activity Links"
+      ],
+      "summary": ":::info",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/lti_olat/lti_link_account_management.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/lti_link_documentation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/lti_link_leaderboard.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/lti_link_live_quizzes.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/olat_account_management.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/olat_dropdown.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/olat_pq_integration_link.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/lti_olat/olat_structure.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/lti_integration.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/microlearning/",
+      "title": "Microlearning",
+      "headings": [
+        "What is a Microlearning?",
+        "How can I create a Microlearning?",
+        "How can I edit a Microlearning?",
+        "How can I publish a Microlearning and access the results?",
+        "How can I inspect a Microlearning before it is available to participants (activity preview)?"
+      ],
+      "summary": "Microlearning offers short learning units with a limited number of questions, available to participants only during pre-defined intervals to counteract the forgetting curve. Students can test themselves, refresh their knowledge, and…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/microlearning/ml_activity_preview.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/microlearning.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/participant_group_management/",
+      "title": "Participant Group Management",
+      "headings": [
+        "How do Students form Groups?",
+        "(Randomized) Student Groups"
+      ],
+      "summary": "Participant groups in KlickerUZH are a course-specific concept, where logged-in students can form groups with their peers when the functionality has been enabled by the lecturer in the course settings. In gamified courses, groups appear on…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/group/random_groups_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/group/random_groups_student.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/participant_group_management.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/permissions_groups/",
+      "title": "Permissions & User Groups",
+      "headings": [],
+      "summary": ":::warning",
+      "tags": [],
+      "media": [],
+      "sourcePath": "docs/tutorials/permissions_groups.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/ppt_integration/",
+      "title": "Integration with PowerPoint",
+      "headings": [
+        "Why should I integrate the live quiz evaluation into my PowerPoint presentation and what settings are available?",
+        "How can I integrate the evaluation view into my PowerPoint presentation?",
+        "How can I use the PowerPoint Add-In outside of UZH?"
+      ],
+      "summary": ":::info",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/ppt_integration/embedding_modal.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/ppt_integration/ppt_add_in.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/ppt_integration.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/practice_quiz/",
+      "title": "Practice Quiz",
+      "headings": [
+        "What is a Practice Quiz?",
+        "How can I create a Practice Quiz?",
+        "How can I edit a Practice Quiz?",
+        "How can I publish a Practice Quiz and access the results?",
+        "How can I see the results of a Practice Quiz?",
+        "How can I inspect a Practice Quiz before it is available to participants (activity preview)?"
+      ],
+      "summary": "Practice Quizzes are designed to contain longer question sets that specifically target modules or topics and that can be embedded within Learning Management Systems (LMS) like OpenOLAT or Moodle. These learning activities have no…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/practice_quiz/activity_evaluation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/practice_quiz/pq_activity_preview.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/practice_quiz/pq_olat_view.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/practice_quiz.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/review/",
+      "title": "Review Functionalities",
+      "headings": [
+        "How can I inspect an activity's content?",
+        "How can I mark an activity as reviewed to keep track?"
+      ],
+      "summary": "An activity's content can be inspected through the activity details view, accessible from the activity list or course overview. Simply select the corresponding \"Activity Information\" entry from the activity actions dropdown (three dots) or…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/review/activity_review_status.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/review/live_quiz_details_modal.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/review.mdx",
+      "sourceCategory": "tutorials"
+    },
+    {
+      "route": "/tutorials/supported_element_types/",
+      "title": "Element Types",
+      "headings": [
+        "Single Choice (SC)",
+        "Multiple Choice (MC)",
+        "KPRIM (KP)",
+        "Numerical Response (NR)",
+        "Free Text (FT)",
+        "Selection (SE)",
+        "Case Study (CS)",
+        "Content Element (CT)",
+        "Flashcard (FC)"
+      ],
+      "summary": "Based on learning settings or learning goals, you can choose from nine different element types in KlickerUZH (i.e., seven types of questions, content elements, and flashcards). Questions support the definition of a sample solution, which is…",
+      "tags": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CS_evaluation_histogram.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CS_evaluation_scatter.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CS_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CS_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CT_evaluation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CT_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/CT_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FC_evaluation_barChart.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FC_evaluation_table.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FC_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FC_student_sol.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FC_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FT_evaluation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FT_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/FT_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/KP_evaluation_barChart.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/KP_evaluation_table.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/KP_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/KP_student_sol.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/KP_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/MC_evaluation_barChart.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/MC_evaluation_table.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/MC_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/MC_student_sol.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/MC_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/NR_evaluation_histogram.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/NR_evaluation_table.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/NR_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/NR_student_sol.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/NR_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SC_evaluation_barChart.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SC_evaluation_table.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SC_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SC_student_sol.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SC_student.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SE_evaluation.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SE_lecturer.png"
+        },
+        {
+          "type": "image",
+          "url": "/img/supported_element_types/SE_student.png"
+        }
+      ],
+      "sourcePath": "docs/tutorials/supported_element_types.mdx",
+      "sourceCategory": "tutorials"
+    }
+  ],
+  "useCases": [
+    {
+      "id": "ai_formative_feedback",
+      "route": "/use_cases/ai_formative_feedback/",
+      "title": "AI-assisted Formative Feedback",
+      "summary": "Provide personalized, AI-powered feedback on student work to support continuous improvement and understanding.",
+      "tags": [
+        "Formative feedback",
+        "AI-assisted grading",
+        "Personalized feedback"
+      ],
+      "goals": [
+        "Use AI to deliver detailed, personalized feedback on open-ended questions, tailored to individual student needs",
+        "Provide immediate AI-generated feedback around the clock to minimize learning process interruptions. ",
+        "Encourage self-regulated learning by offering iterative feedback that helps students refine responses and understand complex concepts",
+        "Reducing educator workload while ensuring consistent, high-quality feedback for large groups",
+        "Guide students toward deeper inquiry and understanding by using AI feedback to promote critical thinking and problem-solving skills"
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/glenn-carstens-peters-RLw-UC03Gwc-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "ai_practice_content",
+      "route": "/use_cases/ai_practice_content/",
+      "title": "AI-generated Practice Content",
+      "summary": "Leverage artificial intelligence to automatically generate diverse practice questions tailored to your course content and student needs.",
+      "tags": [
+        "Content generation",
+        "Bloom’s taxonomy",
+        "Constructive alignment"
+      ],
+      "goals": [
+        "Generate comprehensive and pedagogically sound practice materials by leveraging existing teaching resources, thereby significantly reducing the workload for lecturers in developing practice content",
+        "Ensure complete coverage of lecture content through systematic question generation that aligns with different cognitive levels of Bloom's taxonomy",
+        "Support diverse learning needs through varied question types and adaptation of content difficulty",
+        "Maintain high educational quality through AI-assisted validation while preserving lecturer control over final materials"
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/simon-kadula-8gr6bObQLOI-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "chatbot_tutoring",
+      "route": "/use_cases/chatbot_tutoring/",
+      "title": "Chatbots for Individual Tutoring",
+      "summary": "Provide students with personalized, AI-powered tutoring support that is available 24/7, offering immediate assistance and guidance tailored to individual learning needs.",
+      "tags": [
+        "Individual tutoring",
+        "Self-directed learning",
+        "Interactive engagement",
+        "Personalized feedback"
+      ],
+      "goals": [
+        "Enhance the educational experience by supporting on-demand learning and practice",
+        "Support personalized learning by tailoring responses to course-specific materials and individual student needs",
+        "Enhance student engagement by promoting active problem-solving and critical thinking",
+        "Reduce lecturers’ workload by automating responses to frequently asked questions while providing actionable insights through analytics",
+        "Ensure seamless integration into existing teaching workflows through compatibility with platforms like OLAT"
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/possessed-photography-JjGXjESMxOY-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "flipped_classroom",
+      "route": "/use_cases/flipped_classroom/",
+      "title": "Flipped Classroom",
+      "summary": "Implement the flipped classroom model by providing students with pre-class materials and focusing on interactive discussions during class time.",
+      "tags": [
+        "Interactive lecture",
+        "Self-paced learning",
+        "Application and practice",
+        "Timely feedback",
+        "Increased student engagement",
+        "Effective learning outcomes",
+        "Individual learning styles",
+        "Inclusive learning environment"
+      ],
+      "goals": [
+        "Gain time to explore content in greater depth.",
+        "Promote application and enable students to apply and practice the knowledge they have gained through their self-study, allowing for a more hands-on learning experience.",
+        "Promote individual learning styles.",
+        "Provide timely feedback and help students understand where they stand and address any concerns they may have.",
+        "Foster stronger interaction between the lecturer and students during the lecture and encourage active participation."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/icons8-team-yTwXpLO5HAA-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "gamification",
+      "route": "/use_cases/gamification/",
+      "title": "Gamification",
+      "summary": "Boost student motivation and engagement through game-like elements including points, achievements, and competitive challenges in educational activities.",
+      "tags": [
+        "Engagement and motivation",
+        "Active participation",
+        "Playful learning",
+        "Challenge/reward system",
+        "Competition and prizes",
+        "Immediate feedback and recognition",
+        "Increased interest and achievement",
+        "Dynamic and enriching educational experience"
+      ],
+      "goals": [
+        "Enhance engagement and motivation by incorporating game elements into learning experience.",
+        "Encourage active participation and involvement of students in the lecture.",
+        "Increase motivation by incorporating a challenge/reward system throughout the lecture including points, groups and group activities, badges / achievements, levels, and prizes.",
+        "Enhance the learning experience by creating a dynamic and immersive learning environment where students can interact with the course material in a more engaging way.",
+        "Provide opportunities for healthy competition, encouraging students to strive for achievements, rewards, or higher scores, which can drive their learning progress.",
+        "Offer immediate feedback, rewards, and recognition for accomplishments, supporting students' progress and growth."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/brands-people-ZdqSuxl3Lak-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "group_activity",
+      "route": "/use_cases/group_activity/",
+      "title": "Group Activities",
+      "summary": "Foster collaborative learning through structured group activities that encourage peer interaction and knowledge sharing.",
+      "tags": [
+        "Group collaborations",
+        "Teamwork skills",
+        "Cooperative learning",
+        "Real-world application",
+        "Practical insights",
+        "Interpersonal relationships",
+        "Problem-solving skills",
+        "Effective communication",
+        "Successful professional development"
+      ],
+      "goals": [
+        "Promote and strengthen group collaborations among students, encouraging them to work together as a team and profit from each other's skills and perspectives.",
+        "Offer practical insights and provide students with real-world scenarios where they can apply their knowledge, skills, and teamwork outside of the traditional lecture setting.",
+        "Enable students to develop (transversal) teamwork skills and learn to collaborate efficiently as a group.",
+        "Prepare students for future professional challenges requiring collaboration and teamwork."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/marvin-meyer-SYTO3xs06fU-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "learning_analytics",
+      "route": "/use_cases/learning_analytics/",
+      "title": "Learning Analytics",
+      "summary": "Leverage data analytics to gain insights into student learning patterns, identify areas for improvement, and make informed decisions to enhance educational outcomes.",
+      "tags": [
+        "Educational engagement",
+        "Data-driven pedagogy",
+        "Student performance insights",
+        "Student progress",
+        "Self-regulated learning",
+        "Learning patterns"
+      ],
+      "goals": [],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/dawid-zawila-OCMcTCu97EE-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "live_qa",
+      "route": "/use_cases/live_qa/",
+      "title": "Live Q&A",
+      "summary": "Enable real-time student questions and interactions during lectures while maintaining focus and organization.",
+      "tags": [
+        "Large class",
+        "Interactive lecture",
+        "Anonymous Channel",
+        "Quick feedback",
+        "Continuous dialogue",
+        "Encourage student participation",
+        "Efficient Q&A workflow",
+        "Identfying common questions and problems"
+      ],
+      "goals": [
+        "Encourage students to ask questions by providing them with an anonymous channel.",
+        "Enable students to get answers to questions as soon as they come up instead of postponing them (e.g., to forum posts).",
+        "Make remote participants feel included by allowing them to ask questions during lectures.",
+        "Enable lecturers and their team to provide rapid feedback on incoming questions.",
+        "Improve the efficiency of the Q&A workflow by batching questions (in sessions, with upvotes, etc.)."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/volodymyr-hryshchenko-V5vqWC9gyEU-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "live_quiz",
+      "route": "/use_cases/live_quiz/",
+      "title": "(Gamified) Live Quizzes",
+      "summary": "Enhance student engagement and participation in large courses through interactive polling and gamified elements, providing a safe and inclusive learning environment.",
+      "tags": [
+        "Interactive lecture",
+        "Student engagement",
+        "Interaction in teaching",
+        "Immediate feedback",
+        "Surveys and opinions",
+        "Estimation questions",
+        "Knowledge evaluation",
+        "Gamification"
+      ],
+      "goals": [
+        "Activate and encourage student engagement by incorporating interactive questions and surveys during the lecture.",
+        "Make courses more relaxed, interactive and adaptive.",
+        "Improve motivation by incorporating interactive gamification elements.",
+        "Evaluate feedback from your students (e.g., opinions or level of knowledge)."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/towfiqu-barbhuiya-oZuBNC-6E2s-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "microlearning",
+      "route": "/use_cases/microlearning/",
+      "title": "Microlearning",
+      "summary": "Break down complex topics into bite-sized learning units that students can easily digest and review at their own pace.",
+      "tags": [
+        "Mobile learning",
+        "Repetition opportunity",
+        "Active learning",
+        "Long-term knowledge retention",
+        "Compact learning units",
+        "Accessible repetition",
+        "Efficient knowledge transfer",
+        "Flexible and informal learning"
+      ],
+      "goals": [
+        "Make studying more accessible for students by encouraging mobile learning.",
+        "Encourage active learning and student engagement beyond the classroom by integrating it into students’ everyday lives.",
+        "Improve accessibility and availability of learning content.",
+        "Promote long-term knowledge-retention.",
+        "Provide timely feedback and help students understand where they stand and address any concerns they may have."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/markus-winkler-afW1hht0NSs-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    },
+    {
+      "id": "practice_quiz",
+      "route": "/use_cases/practice_quiz/",
+      "title": "Practice Quiz, Flashcards, and Spaced Repetition",
+      "summary": "Provide students with a comprehensive practice environment featuring quizzes, flashcards, and spaced repetition to reinforce learning.",
+      "tags": [
+        "Repeated learning",
+        "Sustained memoriation",
+        "Individual needs",
+        "Student engagement",
+        "Regular and spaced learning",
+        "Flashcards",
+        "Immediate feedback",
+        "Active learning"
+      ],
+      "goals": [
+        "Provide an opportunity for students to engage in asynchronous learning, allowing them to learn at their own pace.",
+        "Assess and monitor learning progress and helping students assess the understanding of the course material and monitor the progress in learning over time. By completing the practice quizzes, students can identify areas of strength and areas that require further study.",
+        "Provides a streamlined and familiar interface for students to access and complete the quizzes in the LMS."
+      ],
+      "media": [
+        {
+          "type": "image",
+          "url": "/img/use_cases/dan-freeman-WHPsxhB4mWQ-unsplash.jpg"
+        }
+      ],
+      "sourceCategory": "use_case"
+    }
+  ],
+  "contentDigest": "sha256:b3e4325e550318df6b7e803a6eb7785555884f0d20e0779523577915a0a4f709"
+}

--- a/biome.json
+++ b/biome.json
@@ -18,6 +18,7 @@
       "!packages/graphql/instrumented/**",
       "!packages/markdown/components.css",
       "!packages/markdown/utilities.css",
+      "!apps/docs/src/generated/**",
       "!**/public/**",
       "!**/static/**"
     ]

--- a/project/2026-08-29-pr-5637-manage-assistant-integration-ux-plan.md
+++ b/project/2026-08-29-pr-5637-manage-assistant-integration-ux-plan.md
@@ -627,7 +627,7 @@ follow_up_stacks:
 
 ## Progress
 
-- Status: `a4_gate_3_ready`
+- Status: `stack_b_b0_in_progress`
 - Baseline: PR #5637 exact head `85ffe927774b44b7a1b0759fa4fdbfeae81c5a96`
   and PR #5670 exact head `c0d71a444dce3b9b4c83ee94db9e0fd5a27f3e53`
   are open, non-draft, and mergeable after the user-managed stack rebase. All
@@ -1114,3 +1114,32 @@ follow_up_stacks:
   browser execution remains deferred at this stacked layer, where the browser
   jobs are filtered. This receipt is documentation-only; PR #5704 stays a
   draft and no merge or deployment is included in this Gate 3 handoff.
+- S6 integration (user-directed, 2026-09-03): The stack was rebased onto the
+  latest `v3-ai` (`36f43eed037`) after review. The single real conflict
+  (`_app.tsx`, responsive layer) merged the parent's
+  `appContent`/`GenerationStatusProvider` structure with this stack's
+  assistant app-content wrapper. The top layer added `429de085f` fixing the
+  Azurite `devrouter` base/profile service overlap created by v3-ai's new
+  profile contract: Azurite stays a managed base service and left the opt-in
+  `profileServices` list and the redundant `manage` profile selection; the
+  real-planner contract test passes 15/15. Exact-top-head local verification:
+  full build 26/26 and complete `check:all` (all lanes, Playwright contract
+  suites 9/9 and 63/63) pass. All five PR bodies record the new heads and the
+  integration receipts; per-head pre-rebase evidence above stays historical.
+  S6 is complete with this reconciliation; the dated-log requirement is
+  satisfied by this dated Progress record and the repository-reserved
+  `docs/log/` path stays absent.
+- Stack A landed: The user merged PR #5637, #5670, #5679, #5702, and #5704 at
+  2026-09-03T16:45Z. S0-S5 are delivered; wiki and skill updates for the
+  landed behavior shipped inside the layers.
+- S7 start: Stack B uses its own repo-local worktree
+  `trees/rs/manage-assistant-docs-manifest` on branch
+  `rs/manage-assistant-docs-manifest` created from the merged `v3-ai`
+  (`fa7e707bdf`). Survey of the authoritative sources: 49 MDX pages under
+  `apps/docs/docs/` (frontmatter carries only `title` and occasional
+  `hide_title`), and the `USE_CASES` catalogue in
+  `apps/docs/src/constants.tsx` currently holds 11 records with matching
+  `src/pages/use_cases/` routes (the plan sketch said twelve; the generator
+  covers the live catalogue). Media references are same-site `/img/...`
+  paths plus `upload://` schemes, which the contract omits. B0 implements the
+  deterministic manifest generator, drift guard, and tests next.

--- a/project/2026-08-29-pr-5637-manage-assistant-integration-ux-plan.md
+++ b/project/2026-08-29-pr-5637-manage-assistant-integration-ux-plan.md
@@ -627,7 +627,7 @@ follow_up_stacks:
 
 ## Progress
 
-- Status: `stack_b_b0_in_progress`
+- Status: `stack_b_b0_committed_local`
 - Baseline: PR #5637 exact head `85ffe927774b44b7a1b0759fa4fdbfeae81c5a96`
   and PR #5670 exact head `c0d71a444dce3b9b4c83ee94db9e0fd5a27f3e53`
   are open, non-draft, and mergeable after the user-managed stack rebase. All
@@ -1143,3 +1143,14 @@ follow_up_stacks:
   covers the live catalogue). Media references are same-site `/img/...`
   paths plus `upload://` schemes, which the contract omits. B0 implements the
   deterministic manifest generator, drift guard, and tests next.
+- B0 (2026-09-03): Commit `3662ec22b3` adds the deterministic manifest
+  generator (`apps/docs/scripts/generate-docs-manifest.mjs`), 12 unit tests,
+  the checked-in 49-page / 11-use-case manifest, the `generate:docs-manifest`
+  and `test:run` package scripts, and a Biome ignore for the generated
+  artifact (repo convention for generated files; the byte-identity drift test
+  pins its exact content). Double-run equality, `--check` drift mode, and
+  duplicate-route/missing-media failures verified. Complete `check:all` passed
+  in the pre-commit hook. Simplifier disclosure: no subagent dispatch exists in
+  this session, so a main-session simplification pass covered the committed
+  scope; it removed one dead parameter and found no other reductions. Push and
+  draft-PR publication remain withheld pending explicit authority.


### PR DESCRIPTION
## What This Adds

This PR adds the deterministic KlickerUZH docs manifest (layer B0 of the manage-assistant integration plan):

1. A generator (`apps/docs/scripts/generate-docs-manifest.mjs`) that walks all 49 MDX pages under `apps/docs/docs/`, parses frontmatter, headings, summaries, tags, and media, classifies each page (legal, student, section), and extracts the 11 use cases from the `USE_CASES` catalogue in `apps/docs/src/constants.tsx` via the TypeScript AST.
2. The checked-in artifact `apps/docs/src/generated/docs-manifest.json` with schema version, docs version, sha256 content digest, and deterministic ordering — no timestamps.
3. A drift guard: `--check` exits nonzero when the artifact diverges from regenerated output, with visible failures on duplicate routes and missing local media; unsupported schemes such as `upload://` are omitted and reported.

B1 (docs search integration) consumes this manifest and follows in this stack.

## How It Works

- Routes derive Docusaurus-style: numeric prefixes stripped, `index`/`readme` collapse to the directory, trailing slash per site config.
- Media: same-site `/img/...` paths must exist under `apps/docs/static/` (generation fails otherwise); https video URLs are allowlisted (YouTube, Vimeo player); other schemes are counted and omitted.
- Use-case extraction reads only literal scalar/list fields (title, abstract, headerImgSrc, tags, goals); JSX and identifier references are ignored.
- `contentDigest` is a sha256 over the canonical manifest JSON, so any source change changes the digest.

## Important Details

- The generated artifact is excluded from Biome formatting (`biome.json`, matching the repo's generated-files convention); the byte-identity drift test pins its exact content instead.
- `pnpm --filter @klicker-uzh/docs generate:docs-manifest` regenerates; the new `test:run` script joins the repo CI test lane via turbo.
- Live catalogue facts: 49 pages, 11 use cases (the plan sketch said twelve; the generator covers the live catalogue), 1 omitted `upload://` reference.
- Substantive size: 597 lines across generator, tests, package scripts, and formatter config; the remaining diff is the 1538-line generated artifact and plan/progress metadata.

## Branch Coverage

- Base: `v3-ai`
- Head: `fba9d54a9d`
- Reviewed: 3 commits (`1058a3f350` S6 reconciliation receipt, `3662ec22b3` B0 manifest, `fba9d54a9d` plan progress), 6 files, 2176 insertions
- Covered: generator, tests, generated artifact, package scripts, formatter exclusion; plan/progress files are metadata, not review scope

## Review Focus

- Use-case extraction is AST-based and deliberately narrow; confirm the declared-field allowlist matches what the assistant integration should expose.
- The generated JSON is committed; do not hand-edit — regenerate instead.

## Verification

Current head:
- `node --test apps/docs/scripts/` -> 12/12 pass
- `node apps/docs/scripts/generate-docs-manifest.mjs --check` -> up to date (double-run equality)
- `pnpm exec biome check` / `biome format .` -> clean (2223 files)
- Complete `check:all` pre-commit hook -> pass; pre-push `pnpm run build` -> 26/26 tasks

Not run:
- Hosted CI on this exact head -> triggered by this PR; results pending.

## Security / Privacy

- Review: not applicable (no auth, secrets, permissions, or data movement; the generator reads repo-local public docs sources only).
- Sensitive data: none; the manifest carries public docs metadata (titles, headings, summaries, media URLs, use-case copy).

## Blocking Before Merge

None.

## Follow-Up After Merge

- [ ] B1: docs search integration consumes this manifest (next layer in this stack).

## Local Session Artifacts

Machine: `MacBook-Pro.local`

- Worktree: `~/Git/klicker/klicker-uzh/trees/rs/manage-assistant-docs-manifest` in repository `klicker-uzh`
