### PR TITLE
fix(ci): include feature flags in Playwright artifacts

### DIFF
--- a/.github/actions/playwright-build/action.yml
+++ b/.github/actions/playwright-build/action.yml
@@ -178,6 +178,7 @@ runs:
           apps/olat-api/dist
           apps/response-api/dist
           packages/export/dist
+          packages/feature-flags/dist
           packages/grading/dist
           packages/graphql/dist
           packages/hatchet/dist

--- a/.github/scripts/validate-public-playwright-workflow.test.cjs
+++ b/.github/scripts/validate-public-playwright-workflow.test.cjs
@@ -37,6 +37,7 @@ test('the current public workflow satisfies the runner trust boundary', () => {
   assert.match(sources[1], /playwright-shard@refs\/heads\/v3/)
   assert.match(sources[2], /repository: \$\{\{ job\.workflow_repository \}\}/)
   assert.match(sources[2], /ref: \$\{\{ job\.workflow_sha \}\}/)
+  assert.match(sources[2], /packages\/feature-flags\/dist/)
   assert.match(sources[2], /packages\/knowledge-graph\/dist/)
   assert.match(sources[3], /repository: \$\{\{ job\.workflow_repository \}\}/)
   assert.match(sources[3], /ref: \$\{\{ job\.workflow_sha \}\}/)


### PR DESCRIPTION
## Summary

- include `packages/feature-flags/dist` in the reusable Playwright build artifact
- assert the artifact contract so future package additions cannot silently break shard startup

## Why

PR #5756 exposed that every Playwright shard restored the backend bundle without `@klicker-uzh/feature-flags/dist/node.js`, so the backend exited before tests started.

## Verification

- Node 24 reusable-workflow and cache-contract tests: 5/5 passed
- Prettier check for the composite action passed
- Biome check for the validator test passed
- `git diff --check` passed

## Exact-head CI

- The shared Playwright artifact build passed at `d33d9959c7810c3b625429e64991481481044de9`, and all eight hosted shards started with the restored artifact.
- Repository check, CodeQL, gitleaks, GitGuardian, trusted policy, and fallback builds passed at the exact head.
- OpenCodeReview failed before reviewing source: both provider requests returned HTTP 403 authentication, with zero tokens and zero findings.
- Hosted Playwright shards remain in progress.

## Reviewer notes

This is a two-line reusable-CI restoration on `v3`. It does not modify application behavior, PR #5756, `v3-ai`, deployments, or runtimes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Included feature flag build output in Playwright build artifacts.
  * Added validation to ensure the feature flag output remains included in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->