### PR TITLE
chore(deploy): promote 688c6ab17783 to stg [skip ci]

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -41,7 +41,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '916728a53282'
+        rollout.klicker.uzh.ch/release: '688c6ab17783'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: Always
@@ -66,7 +66,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '916728a53282'
+        rollout.klicker.uzh.ch/release: '688c6ab17783'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -88,7 +88,7 @@ hatchet:
       replicaCount: 1
       priorityClassName: staging-workload
       podAnnotations:
-        rollout.klicker.uzh.ch/release: '916728a53282'
+        rollout.klicker.uzh.ch/release: '688c6ab17783'
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
@@ -122,7 +122,7 @@ hatchet:
 auth:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -177,7 +177,7 @@ chat:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   openai:
     baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
@@ -348,7 +348,7 @@ chat:
 mcpStudent:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -425,7 +425,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch https://moodle.fernuni.ch https://*.localhost'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -478,7 +478,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -532,7 +532,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -586,7 +586,7 @@ backendGraphql:
   betaSavedGroupId: grp_2CeKcuxYw3c567fSV7CPPQ
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -686,7 +686,7 @@ backendGraphql:
 olatApi:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -739,7 +739,7 @@ olatApi:
 lti:
   priorityClassName: staging-workload
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
   replicaCount: 1
 
   affinity:
@@ -788,7 +788,7 @@ responseApi:
   priorityClassName: staging-workload
 
   podAnnotations:
-    rollout.klicker.uzh.ch/release: '916728a53282'
+    rollout.klicker.uzh.ch/release: '688c6ab17783'
 
   replicaCount: 1
 
@@ -842,7 +842,7 @@ assessment:
   frontendPWA:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '916728a53282'
+      rollout.klicker.uzh.ch/release: '688c6ab17783'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -906,7 +906,7 @@ assessment:
   backendGraphql:
     priorityClassName: staging-workload
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '916728a53282'
+      rollout.klicker.uzh.ch/release: '688c6ab17783'
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -984,7 +984,7 @@ assessment:
     priorityClassName: staging-workload
 
     podAnnotations:
-      rollout.klicker.uzh.ch/release: '916728a53282'
+      rollout.klicker.uzh.ch/release: '688c6ab17783'
     replicaCount: 1
 
     autoscaling:


### PR DESCRIPTION
Automated staging promotion of `688c6ab1778352626f41c1a211b67d8af02b76d2`.

Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD
detects drift, runs the PreSync migration hook, and rolls the stg pods.
Opened only after every `v3_*-stg.yml` image build succeeded for this
commit. See ADR-0003.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment rollout identifiers across application components.
  * No user-facing functionality or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->