### PR TITLE
fix(chat): restore chatbot owner preview

### DIFF
--- a/apps/chat/src/components/owner-preview-assistant.tsx
+++ b/apps/chat/src/components/owner-preview-assistant.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo } from 'react'
 import { resolveSelectedMode } from '@/src/lib/config/modes'
 import { useSettingsStore } from '@/src/stores/settingsStore'
 import { ChatUiProvider } from './chat-ui-context'
+import { ModeOptionsProvider } from './mode-options-context'
 import { Thread } from './thread'
 
 type OwnerPreviewAssistantProps = {
@@ -79,12 +80,14 @@ export function OwnerPreviewAssistant({
           </header>
 
           <main id="main-content" className="flex min-h-0 flex-1 flex-col">
-            <Thread
-              chatbotAvatar={chatbot.avatar ?? ''}
-              chatbotName={chatbot.name}
-              initialModeOptions={initialModeOptions}
-              maxImageAttachments={0}
-            />
+            <ModeOptionsProvider modeOptions={initialModeOptions}>
+              <Thread
+                chatbotAvatar={chatbot.avatar ?? ''}
+                chatbotName={chatbot.name}
+                initialModeOptions={initialModeOptions}
+                maxImageAttachments={0}
+              />
+            </ModeOptionsProvider>
           </main>
         </div>
       </AssistantRuntimeProvider>

--- a/playwright/profiles.json
+++ b/playwright/profiles.json
@@ -3,10 +3,7 @@
   "groups": [
     {
       "profile": "manage",
-      "specs": [
-        "T-chatbot-authoring.spec.ts",
-        "Y-question-generation-review.spec.ts"
-      ]
+      "specs": ["Y-question-generation-review.spec.ts"]
     },
     {
       "profile": "manage,pwa",
@@ -37,6 +34,7 @@
       "profile": "manage,chat",
       "specs": [
         "A-login.spec.ts",
+        "T-chatbot-authoring.spec.ts",
         "Y-ai-beta-management-gate.spec.ts",
         "Y-chat.spec.ts",
         "Y-kb-management-ux.spec.ts",

--- a/playwright/tests/T-chatbot-authoring.spec.ts
+++ b/playwright/tests/T-chatbot-authoring.spec.ts
@@ -3,7 +3,12 @@ import { getPrisma } from '../global-setup.js'
 import { test } from '../util/fixtures.js'
 import { selectOption } from '../util/fixtures/activities.js'
 import { fillEditorField } from '../util/fixtures/elements.js'
-import { COURSE_ID_TEST, URL_MANAGE, USER_ID_TEST } from '../util/constants.js'
+import {
+  COURSE_ID_TEST,
+  URL_CHAT,
+  URL_MANAGE,
+  USER_ID_TEST,
+} from '../util/constants.js'
 
 const CHATBOT_PREFIX = 'E2E Authoring'
 const FIRST_CHATBOT = `${CHATBOT_PREFIX} One`
@@ -166,6 +171,25 @@ test.describe.serial('Lecturer chatbot draft authoring', () => {
 
   test.afterEach(async () => {
     await cleanupAuthoringChatbots()
+  })
+
+  test('opens a draft owner preview with its effective modes', async ({
+    page,
+  }) => {
+    const chatbotId = await createChatbot(page, FIRST_CHATBOT)
+    const previewPagePromise = page.context().waitForEvent('page')
+
+    await page.getByTestId('chatbot-owner-preview-link').click()
+    const previewPage = await previewPagePromise
+
+    await expect(previewPage).toHaveURL(
+      `${process.env.URL_CHAT ?? URL_CHAT}/preview/${chatbotId}`
+    )
+    await expect(previewPage.getByTestId('chat-error')).toHaveCount(0)
+    await expect(previewPage.getByTestId('chat-welcome-message')).toBeVisible()
+    await expect(previewPage.getByTestId('chat-welcome-mode')).toContainText(
+      'Tutor'
+    )
   })
 
   test('locks chatbot creation fields while the request is pending', async ({


### PR DESCRIPTION
## What This Fixes

This PR restores the chatbot owner preview on staging. `Thread` now receives the `ModeOptionsProvider` required by `useEffectiveModeOptions`, so the preview renders its effective chatbot modes instead of falling into the generic unavailable state.

It also adds a focused browser regression that creates a draft chatbot, opens its owner preview, and verifies the welcome screen and Tutor mode. The authoring spec now selects the `manage,chat` Playwright runtime profile required by that path.

## Branch Coverage

- Base: `v3-ai`
- Head: `57d8048646`
- Reviewed: 1 commit and 3 changed files
- Substantive size: 47 changed lines: 36 additions and 11 deletions
- Packaging: below the normal floor, but exempt as an isolated staging regression fix that restores an existing owner workflow

## Review Focus

- Confirm `ModeOptionsProvider` is scoped around the owner-preview `Thread` without changing participant chat behavior.
- Confirm the Playwright profile includes both Manage and Chat for the cross-app preview path.

## Screenshots

Not attached because this restores the existing owner-preview layout rather than changing its visuals. The isolated Browser check rendered the owner badge, welcome screen, Tutor mode, and composer without console errors; the same path is covered by the new Playwright regression.

## Verification

Current head:

- `pnpm run build` in the repository DevPod -> 26 Turbo tasks passed, including the Chat and Manage production builds
- `pnpm run check` in the repository DevPod -> 29 Turbo tasks passed
- Non-analytics Turbo lint -> 6 tasks passed; analytics `ruff check` and `ruff format --check` passed in a temporary Python 3.12 environment
- Focused Playwright owner-preview regression -> 1 passed
- Chat Vitest suite -> 91 files passed, 2 skipped; 909 tests passed, 22 skipped
- Chat and Playwright package checks, staged formatting, and `git diff --check` -> pass
- `gitleaks git --redact --no-banner --log-opts='origin/v3-ai..HEAD'` -> no leaks
- Isolated Browser -> local owner preview rendered with Tutor mode and no console errors

Failed / warning:

- The monolithic `pnpm run check:all` selected Python 3.14 for analytics, then failed because pandas 2.2.2 has no matching wheel and the devcontainer has no C compiler. Its remaining checks were run separately, including analytics lint under Python 3.12.

## Blocking Before Merge

- [ ] Complete exact-head GitHub CI and final AI review.
- [ ] Obtain explicit merge approval.

## Follow-Up After Merge

- [ ] Promote and deploy the merged `v3-ai` revision through the separately approved staging path.
- [ ] Recheck the affected owner preview on staging after deployment.

## Local Session Artifacts

Machine-local pointer for resuming this branch; it is not review evidence.

- Machine: `MacBook-Pro`
- Worktree: `trees/fix-chatbot-owner-preview-context` in repository `klicker-uzh`
- DevPod workspace: `rs-fix-chatbot-owner-preview-con`, stopped after verification with zero routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Draft chatbots now open in the chat-based owner preview with the expected welcome message and Tutor mode.
  - Owner previews now apply the configured mode options when displaying a chatbot thread.

- **Tests**
  - Added end-to-end coverage for opening newly created draft chatbots and verifying their initial preview experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->