### PR TITLE
ci: promote qualified staging builds through a release ref

### DIFF
--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -34,7 +34,6 @@ const FINAL_REVIEW_CLEAN_STATUS_PREFIX = `${FINAL_REVIEW_MODEL} final review cle
 const FINAL_REVIEW_REQUIRED_DESCRIPTION = `Manual ${FINAL_REVIEW_MODEL} final review required for this head`
 const FINAL_REVIEW_CLEAN_EVIDENCE_SCHEMA = 'final-ai-clean-evidence/v1'
 const FINAL_REVIEW_CLEAN_EVIDENCE_CHECK_NAME = 'Final AI clean evidence'
-const GENERATED_PROMOTION_STATUS = 'Verified generated staging promotion'
 const OCR_RUN_MANIFEST_SCHEMA = 'ocr.run-manifest/v1'
 // Long-lived consolidation branches (for example, v3-ai) that staging
 // deployments are cut from. Individual final reviews treat open ready pull
@@ -67,7 +66,6 @@ const OPENROUTER_TOOL_CANARY_MARKER = 'KLICKER_FINAL_REVIEW_TOOL_CANARY'
 const OPENROUTER_TOOL_CANARY_NAME = 'final_review_probe'
 const OPENROUTER_TOOL_CANARY_TIMEOUT_MS = 30_000
 const OCR_MAX_COMPLETION_TOKENS = 16_384
-const PROMOTION_FILE = 'deploy/env-uzh-stg/values.yaml'
 const REPORT_LIMIT = 55_000
 const MAX_INCREMENTAL_PATHS = 20
 const MAX_INCREMENTAL_LINES = 1_000
@@ -657,264 +655,6 @@ function removeOCRConfig(configPath = defaultOCRConfigPath()) {
   fs.rmSync(configPath, { force: true })
 }
 
-function promotionBody(targetSha) {
-  return [
-    `Automated staging promotion of \`${targetSha}\`.`,
-    '',
-    'Writes the built commit into `rollout.klicker.uzh.ch/release` so ArgoCD',
-    'detects drift, runs the PreSync migration hook, and rolls the stg pods.',
-    'Opened only after every `v3_*-stg.yml` image build succeeded for this',
-    'commit. See ADR-0003.',
-    '',
-  ].join('\n')
-}
-
-function parsePromotionTarget(body) {
-  const match = String(body ?? '').match(
-    /^Automated staging promotion of `([0-9a-f]{40})`\.\n\n/
-  )
-  return match?.[1] ?? ''
-}
-
-function isPromotionCandidate(headRef) {
-  return /^chore\/promote-stg-[0-9a-f]{12}$/.test(headRef)
-}
-
-function buildExpectedPromotionContent(baseContent, shortSha, sourceBranch) {
-  let releaseCount = 0
-  let tagCount = 0
-
-  const withRelease = baseContent.replace(
-    /^([ \t]*rollout\.klicker\.uzh\.ch\/release: ).*$/gm,
-    (_line, prefix) => {
-      releaseCount += 1
-      return `${prefix}'${shortSha}'`
-    }
-  )
-  const content = withRelease.replace(
-    /^([ \t]+tag: ).*$/gm,
-    (_line, prefix) => {
-      tagCount += 1
-      return `${prefix}${sourceBranch}`
-    }
-  )
-
-  return { content, releaseCount, tagCount }
-}
-
-function invalidPromotion(reason) {
-  return { valid: false, reason }
-}
-
-async function verifyPromotionBuilds({
-  github,
-  context,
-  sourceBranch,
-  targetSha,
-  trustedSha,
-}) {
-  if (!/^[0-9a-f]{40}$/.test(trustedSha ?? '')) {
-    return invalidPromotion('trusted promotion workflow commit is missing')
-  }
-  if (
-    typeof github.paginate !== 'function' ||
-    typeof github.rest.actions?.listWorkflowRunsForRepo !== 'function'
-  ) {
-    return invalidPromotion('staging build evidence is unavailable')
-  }
-  const response = await github.rest.repos.getContent({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    path: '.github/workflows',
-    ref: trustedSha,
-  })
-  const workflowPaths = Array.isArray(response.data)
-    ? response.data
-        .filter(
-          (entry) =>
-            entry?.type === 'file' &&
-            /^v3_.*-stg\.yml$/.test(String(entry.name ?? ''))
-        )
-        .map((entry) => String(entry.path ?? ''))
-        .filter(Boolean)
-        .sort()
-    : []
-  if (workflowPaths.length === 0) {
-    return invalidPromotion('no staging build workflows were found')
-  }
-
-  const results = await Promise.all(
-    workflowPaths.map(async (workflowPath) => {
-      let trustedDefinition
-      let targetDefinition
-      try {
-        const definitions = await Promise.all([
-          getFileText(github, context, workflowPath, trustedSha),
-          getFileText(github, context, workflowPath, targetSha),
-        ])
-        trustedDefinition = definitions[0]
-        targetDefinition = definitions[1]
-      } catch {
-        return {
-          reason: 'workflow definition could not be verified',
-          verified: false,
-          workflowPath,
-        }
-      }
-      if (sha256(trustedDefinition) !== sha256(targetDefinition)) {
-        return {
-          reason: 'workflow definition differs from trusted policy',
-          verified: false,
-          workflowPath,
-        }
-      }
-      const runs = await github.paginate(
-        github.rest.actions.listWorkflowRunsForRepo,
-        {
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          workflow_id: workflowPath,
-          event: 'push',
-          head_sha: targetSha,
-          status: 'completed',
-          per_page: 100,
-        }
-      )
-      const verified = Array.isArray(runs)
-        ? runs.some(
-            (run) =>
-              run?.path === workflowPath &&
-              run?.event === 'push' &&
-              run?.head_branch === sourceBranch &&
-              run?.head_sha === targetSha &&
-              run?.status === 'completed' &&
-              run?.conclusion === 'success' &&
-              run?.repository?.full_name === repositoryName(context)
-          )
-        : false
-      return {
-        reason: verified ? '' : 'successful exact-SHA run is missing',
-        verified,
-        workflowPath,
-      }
-    })
-  )
-  const failures = results.filter(({ verified }) => !verified)
-  if (failures.length > 0) {
-    return invalidPromotion(
-      `staging build evidence or trusted workflow definition is missing for ${failures
-        .map(({ reason, workflowPath }) => `${workflowPath} (${reason})`)
-        .join(', ')}`
-    )
-  }
-  return {
-    valid: true,
-    reason: `verified ${workflowPaths.length} staging build runs for the target SHA`,
-    sourceBranch,
-    targetSha,
-    workflowPaths,
-  }
-}
-
-function validatePromotionContract(input) {
-  const {
-    pull,
-    permission,
-    repository,
-    sourceBranch,
-    commits,
-    files,
-    baseContent,
-    headContent,
-    targetIsAncestor,
-    buildEvidence,
-  } = input
-
-  if (pull.state !== 'open' || pull.draft) {
-    return invalidPromotion('promotion PR must be open and ready')
-  }
-  if (
-    pull.baseRef !== sourceBranch ||
-    pull.baseRepo !== repository ||
-    pull.headRepo !== repository
-  ) {
-    return invalidPromotion('promotion PR repository or base does not match')
-  }
-  if (!isTrustedPermission(permission)) {
-    return invalidPromotion('promotion author lacks write permission')
-  }
-  if (!/^[A-Za-z0-9_.-]+$/.test(sourceBranch)) {
-    return invalidPromotion('staging source branch is invalid')
-  }
-
-  const branchMatch = pull.headRef.match(/^chore\/promote-stg-([0-9a-f]{12})$/)
-  if (!branchMatch) {
-    return invalidPromotion('promotion head branch does not match')
-  }
-  const shortSha = branchMatch[1]
-  if (pull.title !== `chore(deploy): promote ${shortSha} to stg [skip ci]`) {
-    return invalidPromotion('promotion title does not match')
-  }
-
-  const targetSha = parsePromotionTarget(pull.body)
-  if (
-    !targetSha?.startsWith(shortSha) ||
-    pull.body !== promotionBody(targetSha)
-  ) {
-    return invalidPromotion('promotion body or target SHA does not match')
-  }
-  if (!targetIsAncestor) {
-    return invalidPromotion('promotion target is not on the staging source')
-  }
-  if (
-    !buildEvidence?.valid ||
-    buildEvidence.targetSha !== targetSha ||
-    buildEvidence.sourceBranch !== sourceBranch
-  ) {
-    return invalidPromotion(
-      'exact successful staging build evidence is missing'
-    )
-  }
-
-  if (commits.length !== 1) {
-    return invalidPromotion('promotion PR must contain one commit')
-  }
-  const [commit] = commits
-  if (
-    commit.message !== `chore(deploy): promote ${shortSha} to stg` ||
-    commit.parents.length !== 1 ||
-    commit.parents[0] !== pull.baseSha
-  ) {
-    return invalidPromotion('promotion commit or parent does not match')
-  }
-
-  if (
-    files.length !== 1 ||
-    files[0].filename !== PROMOTION_FILE ||
-    files[0].status !== 'modified'
-  ) {
-    return invalidPromotion('promotion changed an unexpected file')
-  }
-
-  const expected = buildExpectedPromotionContent(
-    baseContent,
-    shortSha,
-    sourceBranch
-  )
-  if (expected.releaseCount === 0 || expected.tagCount === 0) {
-    return invalidPromotion('base promotion file has unexpected structure')
-  }
-  if (headContent !== expected.content) {
-    return invalidPromotion('promotion content exceeds generated replacements')
-  }
-
-  return {
-    valid: true,
-    reason: 'verified generated staging promotion',
-    targetSha,
-  }
-}
-
 async function setCommitStatus({ github, context, sha, state, description }) {
   await github.rest.repos.createCommitStatus({
     owner: context.repo.owner,
@@ -1219,88 +959,6 @@ async function latestVerifiedCleanFinalReviewEvidence({
   })
 }
 
-async function getStagingSourceBranch({ github, context, defaultBranch }) {
-  if (typeof github.rest.actions?.getRepoVariable !== 'function') {
-    return defaultBranch
-  }
-  try {
-    const response = await github.rest.actions.getRepoVariable({
-      name: 'STG_SOURCE_BRANCH',
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-    })
-    const value = response.data?.value
-    return /^[A-Za-z0-9_.-]+$/.test(value ?? '') ? value : defaultBranch
-  } catch (error) {
-    if (
-      error?.status === 404 ||
-      /\b404\b|not found/i.test(String(error?.stderr ?? ''))
-    ) {
-      return defaultBranch
-    }
-    throw error
-  }
-}
-
-async function hasVerifiedGeneratedPromotionStatus({
-  github,
-  context,
-  pull,
-  sourceBranch,
-  trustedSha,
-}) {
-  const status = await getLatestFinalReviewStatus(
-    github,
-    context,
-    pull.head.sha
-  )
-  if (
-    status?.state !== 'success' ||
-    status.description !== GENERATED_PROMOTION_STATUS
-  ) {
-    return false
-  }
-  const workflowRunId = workflowRunIdFromUrl(context, status.target_url)
-  if (
-    workflowRunId == null ||
-    typeof github.rest.actions?.getWorkflowRun !== 'function'
-  ) {
-    return false
-  }
-  const workflow = (
-    await github.rest.actions.getWorkflowRun({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      run_id: workflowRunId,
-    })
-  )?.data
-  if (
-    !workflow ||
-    workflow.id !== workflowRunId ||
-    workflow.path !== FINAL_REVIEW_WORKFLOW_PATH ||
-    workflow.event !== 'pull_request_target' ||
-    workflow.head_branch !== context.payload.repository.default_branch ||
-    workflow.conclusion !== 'success' ||
-    workflow.repository?.full_name !== repositoryName(context) ||
-    !(await hasSuccessfulFinalReview(
-      github,
-      context,
-      pull.head.sha,
-      workflowRunId
-    ))
-  ) {
-    return false
-  }
-  const promotion = await inspectPromotion({
-    github,
-    context,
-    pull,
-    sourceBranch,
-    trustedSha,
-  })
-  return promotion.valid === true
-}
-
 async function getFileText(github, context, filePath, ref) {
   const response = await github.rest.repos.getContent({
     owner: context.repo.owner,
@@ -1340,7 +998,6 @@ function reviewPolicySettings() {
     model: FINAL_REVIEW_MODEL,
     ocr: buildOCRPolicy(),
     openrouter_url: OPENROUTER_URL,
-    promotion_file: PROMOTION_FILE,
     report_limit: REPORT_LIMIT,
     review_schemas: {
       individual: FINAL_REVIEW_SCHEMA,
@@ -1372,81 +1029,6 @@ async function getReviewPolicyDigest({ github, context, trustedSha }) {
       settings: reviewPolicySettings(),
     })
   )
-}
-
-async function inspectPromotion({
-  github,
-  context,
-  pull,
-  sourceBranch,
-  trustedSha,
-}) {
-  const permission = await getPermission(github, context, pull.user.login)
-  const targetSha = parsePromotionTarget(pull.body)
-  if (!targetSha) {
-    return invalidPromotion('promotion target SHA is missing')
-  }
-
-  const [commits, files, baseContent, headContent, comparison, buildEvidence] =
-    await Promise.all([
-      github.paginate(github.rest.pulls.listCommits, {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        pull_number: pull.number,
-        per_page: 100,
-      }),
-      github.paginate(github.rest.pulls.listFiles, {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        pull_number: pull.number,
-        per_page: 100,
-      }),
-      getFileText(github, context, PROMOTION_FILE, pull.base.sha),
-      getFileText(github, context, PROMOTION_FILE, pull.head.sha),
-      github.rest.repos.compareCommitsWithBasehead({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        basehead: `${targetSha}...${sourceBranch}`,
-      }),
-      verifyPromotionBuilds({
-        github,
-        context,
-        sourceBranch,
-        targetSha,
-        trustedSha,
-      }),
-    ])
-
-  return validatePromotionContract({
-    pull: {
-      state: pull.state,
-      draft: pull.draft,
-      baseRef: pull.base.ref,
-      baseSha: pull.base.sha,
-      baseRepo: pull.base.repo.full_name,
-      headRef: pull.head.ref,
-      headRepo: pull.head.repo.full_name,
-      title: pull.title,
-      body: pull.body ?? '',
-    },
-    permission,
-    repository: `${context.repo.owner}/${context.repo.repo}`,
-    sourceBranch,
-    commits: commits.map((commit) => ({
-      message: commit.commit.message,
-      parents: commit.parents.map((parent) => parent.sha),
-    })),
-    files: files.map((file) => ({
-      filename: file.filename,
-      status: file.status,
-    })),
-    baseContent,
-    headContent,
-    targetIsAncestor:
-      comparison.data.status === 'ahead' ||
-      comparison.data.status === 'identical',
-    buildEvidence,
-  })
 }
 
 function parseReviewMetadata(body) {
@@ -2221,13 +1803,7 @@ async function buildReviewPlan({ github, context, pull, trustedSha }) {
   }
 }
 
-async function initializeFinalReview({
-  github,
-  context,
-  core,
-  sourceBranch,
-  trustedSha,
-}) {
+async function initializeFinalReview({ github, context, core }) {
   const pull = context.payload.pull_request
   let state = 'pending'
   let description = FINAL_REVIEW_REQUIRED_DESCRIPTION
@@ -2235,32 +1811,6 @@ async function initializeFinalReview({
   if (pull.state !== 'open') {
     state = 'error'
     description = 'Final review is unavailable for a closed pull request'
-  } else if (isPromotionCandidate(pull.head.ref)) {
-    try {
-      const promotion = await inspectPromotion({
-        github,
-        context,
-        pull,
-        sourceBranch,
-        trustedSha,
-      })
-      core.info(`Promotion exemption: ${promotion.reason}`)
-      if (promotion.valid) {
-        state = 'success'
-        description = 'Verified generated staging promotion'
-      }
-    } catch (error) {
-      state = 'error'
-      description = 'Promotion validation failed; use /final-review'
-      await setCommitStatus({
-        github,
-        context,
-        sha: pull.head.sha,
-        state,
-        description,
-      })
-      throw error
-    }
   } else if (!pull.draft) {
     try {
       const eligibility = await resolvePullEligibility({
@@ -3632,23 +3182,9 @@ async function verifyCurrentIndividualFinalReview({ repository, prNumber }) {
   }
   const pull = await getPull(github, context, prNumber)
   const plan = await buildReviewPlan({ github, context, pull, trustedSha })
-  const promotion = isPromotionCandidate(pull.head?.ref)
-    ? await hasVerifiedGeneratedPromotionStatus({
-        github,
-        context,
-        pull,
-        sourceBranch: await getStagingSourceBranch({
-          github,
-          context,
-          defaultBranch,
-        }),
-        trustedSha,
-      })
-    : false
   const current =
-    promotion ||
-    (plan.eligible &&
-      (await hasCurrentSuccessfulFinalReview({ github, context, pull, plan })))
+    plan.eligible &&
+    (await hasCurrentSuccessfulFinalReview({ github, context, pull, plan }))
   return {
     current,
     head_sha: pull.head?.sha ?? '',
@@ -3764,7 +3300,6 @@ module.exports = {
   FINAL_REVIEW_CLEAN_EVIDENCE_CHECK_NAME,
   FINAL_REVIEW_CLEAN_EVIDENCE_SCHEMA,
   FINAL_REVIEW_CLEAN_STATUS_PREFIX,
-  GENERATED_PROMOTION_STATUS,
   FINAL_REVIEW_MODEL,
   FINAL_REVIEW_POLICY_SCHEMA,
   FINAL_REVIEW_SCHEMA,
@@ -3773,12 +3308,10 @@ module.exports = {
   OCR_RUN_MANIFEST_SCHEMA,
   MAX_INCREMENTAL_LINES,
   MAX_INCREMENTAL_PATHS,
-  PROMOTION_FILE,
   authorizeFinalReview,
   buildFinalReviewEvidenceDigest,
   buildIndividualCleanReviewEvidenceDigest,
   buildIndividualCleanEvidenceMetadata,
-  buildExpectedPromotionContent,
   buildOCRPolicy,
   buildOCRConfig,
   buildOpenRouterToolCanaryRequest,
@@ -3793,13 +3326,10 @@ module.exports = {
   finalizeFinalReviewFailure,
   initializeFinalReview,
   isFinalReviewCommand,
-  isPromotionCandidate,
   isTrustedPermission,
   getReviewPolicyDigest,
-  getStagingSourceBranch,
   ghRepositoryPath,
   hasCurrentSuccessfulFinalReview,
-  hasVerifiedGeneratedPromotionStatus,
   verifyCurrentIndividualFinalReview,
   mergeOCRResumeResults,
   normalizeTitle,
@@ -3808,8 +3338,6 @@ module.exports = {
   listReviewArtifacts,
   parseDispositionRecord,
   parseReviewMetadata,
-  parsePromotionTarget,
-  promotionBody,
   publishFinalReview,
   removeOCRConfig,
   resolveFinalReviewLockKey,
@@ -3820,9 +3348,7 @@ module.exports = {
   startFinalReview,
   validateDispositionRecord,
   validateOCRResult,
-  validatePromotionContract,
   validateFinding,
-  verifyPromotionBuilds,
   verifyOpenRouterToolAccess,
   writeOCRConfig,
 }

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -11,12 +11,9 @@ const {
   FINAL_REVIEW_CLEAN_STATUS_PREFIX,
   FINAL_REVIEW_CLEAN_EVIDENCE_CHECK_NAME,
   FINAL_REVIEW_CLEAN_EVIDENCE_SCHEMA,
-  GENERATED_PROMOTION_STATUS,
-  PROMOTION_FILE,
   authorizeFinalReview,
   buildIndividualCleanReviewEvidenceDigest,
   buildIndividualCleanEvidenceMetadata,
-  buildExpectedPromotionContent,
   buildOCRConfig,
   buildOpenRouterToolCanaryRequest,
   buildReviewPlan,
@@ -26,10 +23,7 @@ const {
   decideFinalStatus,
   encodeMetadata,
   finalizeFinalReview,
-  getStagingSourceBranch,
-  verifyPromotionBuilds,
   hasCurrentSuccessfulFinalReview,
-  hasVerifiedGeneratedPromotionStatus,
   isFinalReviewCommand,
   isTrustedPermission,
   initializeFinalReview,
@@ -40,14 +34,12 @@ const {
   parseReviewMetadata,
   planOCRResume,
   publishFinalReview,
-  promotionBody,
   removeOCRConfig,
   resolveFinalReviewLockKey,
   renderFinalReviewChunks,
   resolveCleanReviewRange,
   requiresColdIncrementalReview,
   startFinalReview,
-  validatePromotionContract,
   validateOCRResult,
   verifyOpenRouterToolAccess,
   writeOCRConfig,
@@ -2539,8 +2531,6 @@ test('keeps the pending status for a consolidation-branch pull request', async (
     github,
     context,
     core: { info: () => {}, notice: () => {}, setOutput: () => {} },
-    sourceBranch: 'v3-ai',
-    trustedSha: 'd'.repeat(40),
   })
 
   assert.equal(statuses.length, 1)
@@ -2589,8 +2579,6 @@ test('rejects a pull request targeting an unlisted integration branch', async ()
     github,
     context,
     core: { info: () => {}, notice: () => {}, setOutput: () => {} },
-    sourceBranch: 'v3',
-    trustedSha: 'd'.repeat(40),
   })
 
   assert.equal(statuses.length, 1)
@@ -3423,445 +3411,58 @@ test('rejects duplicate disposition markers as ambiguous', () => {
   assert.equal(parseDispositionRecord(`${marker}\n${marker}`), null)
 })
 
-function promotionFile(release, tag = 'v3-ai') {
-  const tags = Array.from(
-    { length: 17 },
-    (_, index) => `service${index}:\n  tag: ${tag}`
-  )
-  const annotations = Array.from(
-    { length: 16 },
-    (_, index) =>
-      `rollout${index}:\n  podAnnotations:\n    rollout.klicker.uzh.ch/release: '${release}'`
-  )
-  return [...tags, ...annotations].join('\n')
-}
-
-function validPromotionInput(sourceBranch = 'v3-ai') {
-  const targetSha = '123456789abc'.padEnd(40, 'd')
-  const shortSha = targetSha.slice(0, 12)
-  const baseContent = promotionFile('aaaaaaaaaaaa')
-  const expected = buildExpectedPromotionContent(
-    baseContent,
-    shortSha,
-    sourceBranch
-  )
-
-  return {
-    pull: {
-      state: 'open',
-      draft: false,
-      baseRef: sourceBranch,
-      baseSha: 'b'.repeat(40),
-      baseRepo: 'uzh-bf/klicker-uzh',
-      headRef: `chore/promote-stg-${shortSha}`,
-      headRepo: 'uzh-bf/klicker-uzh',
-      title: `chore(deploy): promote ${shortSha} to stg [skip ci]`,
-      body: promotionBody(targetSha),
-    },
-    permission: 'write',
-    repository: 'uzh-bf/klicker-uzh',
-    defaultBranch: 'v3',
-    sourceBranch,
-    commits: [
-      {
-        message: `chore(deploy): promote ${shortSha} to stg`,
-        parents: ['b'.repeat(40)],
-      },
-    ],
-    files: [{ filename: PROMOTION_FILE, status: 'modified' }],
-    baseContent,
-    headContent: expected.content,
-    targetIsAncestor: true,
-    buildEvidence: {
-      valid: true,
-      sourceBranch,
-      targetSha,
-    },
-  }
-}
-
-test('accepts current and source-switch generated promotions', () => {
-  assert.equal(validatePromotionContract(validPromotionInput()).valid, true)
-  assert.equal(
-    validatePromotionContract(validPromotionInput('release-candidate')).valid,
-    true
-  )
-})
-
-test('requires non-empty dynamic promotion inventories', () => {
-  const noTags = validPromotionInput()
-  noTags.baseContent = noTags.baseContent.replace(/^([ \t]+tag: ).*$/gm, '')
-  noTags.headContent = buildExpectedPromotionContent(
-    noTags.baseContent,
-    noTags.buildEvidence.targetSha.slice(0, 12),
-    noTags.sourceBranch
-  ).content
-  assert.equal(validatePromotionContract(noTags).valid, false)
-
-  const noAnnotations = validPromotionInput()
-  noAnnotations.baseContent = noAnnotations.baseContent.replace(
-    /^([ \t]*rollout\.klicker\.uzh\.ch\/release: ).*$/gm,
-    ''
-  )
-  noAnnotations.headContent = buildExpectedPromotionContent(
-    noAnnotations.baseContent,
-    noAnnotations.buildEvidence.targetSha.slice(0, 12),
-    noAnnotations.sourceBranch
-  ).content
-  assert.equal(validatePromotionContract(noAnnotations).valid, false)
-})
-
-test('staging promoter targets the selected source without fixed value counts', () => {
-  const workflow = fs.readFileSync(
-    path.join(__dirname, '../workflows/deploy-stg-promote.yml'),
-    'utf8'
-  )
-
-  assert.match(workflow, /Build Docker image for mcp-lecturer \(stg\)/)
-  assert.match(workflow, /Build Docker image for mcp-student \(stg\)/)
-  assert.match(
-    workflow,
-    /ref: \$\{\{ steps\.target\.outputs\.source_branch \}\}/
-  )
-  assert.ok(workflow.includes('--base "$SOURCE_BRANCH"'))
-  assert.ok(workflow.includes('Verified generated staging promotion'))
-  assert.doesNotMatch(workflow, /expected 15/)
-})
-
-test('requires every trusted exact-SHA staging build run for a promotion', async () => {
-  const workflowPaths = [
-    '.github/workflows/v3_auth-stg.yml',
-    '.github/workflows/v3_chat-stg.yml',
-  ]
-  const targetSha = 'a'.repeat(40)
-  const trustedSha = 'd'.repeat(40)
-  const context = reviewContext()
-  const workflowDefinitions = new Map(
-    workflowPaths.map((workflowPath) => [
-      `${workflowPath}:${trustedSha}`,
-      `name: ${workflowPath}`,
-    ])
-  )
-  for (const workflowPath of workflowPaths) {
-    workflowDefinitions.set(
-      `${workflowPath}:${targetSha}`,
-      `name: ${workflowPath}`
-    )
-  }
-  const github = {
-    rest: {
-      repos: {
-        getContent: async ({ path: filePath, ref }) =>
-          filePath === '.github/workflows'
-            ? {
-                data: workflowPaths.map((workflowPath) => ({
-                  name: workflowPath.split('/').at(-1),
-                  path: workflowPath,
-                  type: 'file',
-                })),
-              }
-            : {
-                data: {
-                  type: 'file',
-                  encoding: 'base64',
-                  content: Buffer.from(
-                    workflowDefinitions.get(`${filePath}:${ref}`) ?? ''
-                  ).toString('base64'),
-                },
-              },
-      },
-      actions: {
-        listWorkflowRunsForRepo: async (params) => ({
-          data: {
-            workflow_runs: [
-              {
-                conclusion: 'success',
-                event: 'push',
-                head_branch: 'v3',
-                head_sha: targetSha,
-                path: params.workflow_id,
-                repository: { full_name: 'uzh-bf/klicker-uzh' },
-                status: 'completed',
-              },
-            ],
-          },
-        }),
-      },
-    },
-    paginate: async (endpoint, params) =>
-      (await endpoint(params)).data.workflow_runs,
-  }
-
-  const evidence = await verifyPromotionBuilds({
-    github,
-    context,
-    sourceBranch: 'v3',
-    targetSha,
-    trustedSha,
-  })
-
-  assert.equal(evidence.valid, true)
-  assert.deepEqual(evidence.workflowPaths, workflowPaths)
-
-  workflowDefinitions.set(
-    `${workflowPaths[1]}:${targetSha}`,
-    'name: changed on the target'
-  )
-  const changedDefinition = await verifyPromotionBuilds({
-    github,
-    context,
-    sourceBranch: 'v3',
-    targetSha,
-    trustedSha,
-  })
-  assert.equal(changedDefinition.valid, false)
-  assert.match(changedDefinition.reason, /definition/)
-})
-
-test('CLI verifier adapter covers promotion pagination and missing variables', async () => {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'final-review-gh-'))
-  const executable = path.join(directory, 'gh')
-  fs.writeFileSync(
-    executable,
-    `#!/usr/bin/env node
-const endpoint = process.argv.at(-1)
-if (endpoint.includes('/actions/variables/')) {
-  process.stderr.write('gh: 404 Not Found')
-  process.exit(1)
-}
-if (endpoint.includes('/pulls/42/commits')) {
-  process.stdout.write(JSON.stringify([[{ sha: 'commit' }]]))
-} else if (endpoint.includes('/pulls/42/files')) {
-  process.stdout.write(JSON.stringify([[{ filename: 'deploy/env-uzh-stg/values.yaml' }]]))
-} else if (endpoint.includes('/actions/workflows/v3_auth-stg.yml/runs')) {
-  process.stdout.write(JSON.stringify([{ workflow_runs: [{ conclusion: 'success', head_sha: 'a'.repeat(40) }] }]))
-} else {
-  process.stdout.write(JSON.stringify({ ok: true }))
-}
-`,
-    { mode: 0o700 }
-  )
-  const originalPath = process.env.PATH
-  process.env.PATH = `${directory}:${originalPath ?? ''}`
-  try {
-    const { github } = createGhGithub({
-      repository: 'uzh-bf/klicker-uzh',
-      defaultBranch: 'v3',
-    })
-    assert.deepEqual(
-      await github.paginate(github.rest.pulls.listCommits, {
-        pull_number: 42,
-      }),
-      [{ sha: 'commit' }]
-    )
-    assert.deepEqual(
-      await github.paginate(github.rest.pulls.listFiles, { pull_number: 42 }),
-      [{ filename: 'deploy/env-uzh-stg/values.yaml' }]
-    )
-    assert.deepEqual(
-      await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
-        workflow_id: '.github/workflows/v3_auth-stg.yml',
-        event: 'push',
-        head_sha: 'a'.repeat(40),
-        status: 'completed',
-      }),
-      [{ conclusion: 'success', head_sha: 'a'.repeat(40) }]
-    )
-    assert.equal(
-      await getStagingSourceBranch({
-        github,
-        context: reviewContext(),
-        defaultBranch: 'v3',
-      }),
-      'v3'
-    )
-  } finally {
-    if (originalPath == null) delete process.env.PATH
-    else process.env.PATH = originalPath
-    fs.rmSync(directory, { recursive: true, force: true })
-  }
-})
-
-test('verifies the generated-promotion no-report status through the repository verifier', async () => {
-  const input = validPromotionInput()
+test('treats chore/promote-stg-* as ordinary final-review policy', async () => {
   const pull = {
     number: 42,
-    state: input.pull.state,
-    draft: input.pull.draft,
-    title: input.pull.title,
-    body: input.pull.body,
-    user: { login: 'reviewer' },
+    state: 'open',
+    draft: false,
+    title: 'Legacy-named staging change',
     base: {
-      ref: input.pull.baseRef,
-      repo: { full_name: input.pull.baseRepo },
-      sha: input.pull.baseSha,
+      ref: 'v3',
+      sha: 'b'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
     },
     head: {
-      ref: input.pull.headRef,
-      repo: { full_name: input.pull.headRepo },
+      ref: 'chore/promote-stg-123456789abc',
       sha: 'a'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
     },
   }
-  const trustedSha = 'd'.repeat(40)
-  const workflowPath = '.github/workflows/v3_auth-stg.yml'
-  const statusEndpoint = async () => ({ data: [] })
-  const commitsEndpoint = {}
-  const filesEndpoint = {}
-  const workflowRunsEndpoint = async () => ({ data: { workflow_runs: [] } })
-  const workflow = {
-    conclusion: 'success',
-    event: 'push',
-    head_branch: input.sourceBranch,
-    head_sha: input.buildEvidence.targetSha,
-    path: workflowPath,
-    repository: { full_name: input.repository },
-    status: 'completed',
-  }
+  const statuses = []
   const github = {
     rest: {
-      actions: {
-        listWorkflowRunsForRepo: workflowRunsEndpoint,
-        getWorkflowRun: async () => ({
-          data: {
-            conclusion: 'success',
-            event: 'pull_request_target',
-            head_branch: 'v3',
-            id: 123,
-            path: '.github/workflows/check-ocr-final-review.yml',
-            repository: { full_name: input.repository },
-          },
-        }),
-      },
-      pulls: {
-        listCommits: commitsEndpoint,
-        listFiles: filesEndpoint,
-      },
       repos: {
-        compareCommitsWithBasehead: async () => ({
-          data: { status: 'ahead' },
-        }),
-        getCollaboratorPermissionLevel: async () => ({
-          data: { user: { permission: 'write' } },
-        }),
-        getContent: async ({ path: filePath, ref }) => {
-          if (filePath === '.github/workflows') {
-            return {
-              data: [
-                {
-                  name: 'v3_auth-stg.yml',
-                  path: workflowPath,
-                  type: 'file',
-                },
-              ],
-            }
-          }
-          if (filePath === workflowPath) {
-            return {
-              data: {
-                content: Buffer.from('trusted workflow').toString('base64'),
-                encoding: 'base64',
-                type: 'file',
-              },
-            }
-          }
-          return {
-            data: {
-              content: Buffer.from(
-                filePath === PROMOTION_FILE
-                  ? ref === pull.base.sha
-                    ? input.baseContent
-                    : input.headContent
-                  : ''
-              ).toString('base64'),
-              encoding: 'base64',
-              type: 'file',
-            },
-          }
-        },
-        listCommitStatusesForRef: statusEndpoint,
+        createCommitStatus: async (status) => statuses.push(status),
       },
     },
-    paginate: async (endpoint) => {
-      if (endpoint === statusEndpoint) {
-        return [
-          {
-            context: 'final-ai-review',
-            description: GENERATED_PROMOTION_STATUS,
-            state: 'success',
-            target_url:
-              'https://github.com/uzh-bf/klicker-uzh/actions/runs/123',
-          },
-        ]
-      }
-      if (endpoint === commitsEndpoint) {
-        return [
-          {
-            commit: { message: input.commits[0].message },
-            parents: [{ sha: input.commits[0].parents[0] }],
-          },
-        ]
-      }
-      if (endpoint === filesEndpoint) return input.files
-      if (endpoint === workflowRunsEndpoint) return [workflow]
-      throw new Error('unexpected pagination endpoint')
+  }
+  const context = {
+    ...reviewContext(),
+    payload: {
+      ...reviewContext().payload,
+      pull_request: pull,
     },
   }
 
+  await initializeFinalReview({
+    github,
+    context,
+    core: { info: () => {}, notice: () => {}, setOutput: () => {} },
+  })
+
+  assert.equal(statuses.length, 1)
+  assert.equal(statuses[0].state, 'pending')
   assert.equal(
-    await hasVerifiedGeneratedPromotionStatus({
-      github,
-      context: reviewContext(),
-      pull,
-      sourceBranch: input.sourceBranch,
-      trustedSha,
-    }),
-    true
+    statuses[0].description,
+    `Manual ${FINAL_REVIEW_MODEL} final review required for this head`
   )
-})
 
-test('rejects every material promotion-contract deviation', () => {
-  const mutations = [
-    (input) => {
-      input.pull.draft = true
-    },
-    (input) => {
-      input.permission = 'read'
-    },
-    (input) => {
-      input.pull.headRepo = 'attacker/fork'
-    },
-    (input) => {
-      input.pull.baseRef = 'v3'
-    },
-    (input) => {
-      input.pull.title = 'chore(deploy): bypass review'
-    },
-    (input) => {
-      input.pull.body = `${input.pull.body}extra`
-    },
-    (input) => {
-      input.commits.push(input.commits[0])
-    },
-    (input) => {
-      input.commits[0].parents[0] = 'c'.repeat(40)
-    },
-    (input) => {
-      input.files.push({ filename: 'extra.txt', status: 'added' })
-    },
-    (input) => {
-      input.headContent += '\nuntrusted: true\n'
-    },
-    (input) => {
-      input.targetIsAncestor = false
-    },
-    (input) => {
-      input.buildEvidence.valid = false
-    },
-  ]
-
-  for (const mutate of mutations) {
-    const input = validPromotionInput()
-    mutate(input)
-    assert.equal(validatePromotionContract(input).valid, false)
-  }
+  const source = fs.readFileSync(
+    path.join(__dirname, 'final-ai-review.js'),
+    'utf8'
+  )
+  assert.doesNotMatch(
+    source,
+    /Generated staging promotion|isPromotionCandidate|validatePromotionContract/
+  )
 })

--- a/.github/scripts/stg-release-promoter-fixtures.js
+++ b/.github/scripts/stg-release-promoter-fixtures.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const crypto = require('node:crypto')
+
+const OCI_MANIFEST_CONTENT_TYPE = 'application/vnd.oci.image.manifest.v1+json'
+
 const FIXTURE_WORKFLOW_PATHS = Object.freeze([
   '.github/workflows/v3_auth-stg.yml',
   '.github/workflows/v3_backend-docker-stg.yml',
@@ -174,10 +178,48 @@ function workflowJobs({
   }))
 }
 
+function registryManifestResponse({
+  body = '{"schemaVersion":2}',
+  contentType = OCI_MANIFEST_CONTENT_TYPE,
+  digest,
+  includeDigest = true,
+  includeReader = true,
+  redirected = false,
+} = {}) {
+  const bytes = Buffer.isBuffer(body) ? body : Buffer.from(body)
+  const resolvedDigest =
+    digest ??
+    `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`
+  const values = new Map(
+    Object.entries({
+      'content-type': contentType,
+      ...(includeDigest ? { 'docker-content-digest': resolvedDigest } : {}),
+    })
+  )
+  return {
+    ...(includeReader ? { arrayBuffer: async () => bytes } : {}),
+    headers: {
+      get: (name) => values.get(String(name).toLowerCase()) ?? null,
+    },
+    ok: true,
+    redirected,
+    status: 200,
+  }
+}
+
+function transientReadbackFailure(status = 503) {
+  const error = new Error('synthetic readback unavailable')
+  error.status = status
+  return error
+}
+
 module.exports = {
   FIXTURE_STAGING_WORKFLOWS,
   FIXTURE_WORKFLOW_PATHS,
+  OCI_MANIFEST_CONTENT_TYPE,
   fixtureDefinitions,
+  registryManifestResponse,
+  transientReadbackFailure,
   workflowDefinition,
   workflowJobs,
   workflowRun,

--- a/.github/scripts/stg-release-promoter-fixtures.js
+++ b/.github/scripts/stg-release-promoter-fixtures.js
@@ -1,0 +1,184 @@
+'use strict'
+
+const FIXTURE_WORKFLOW_PATHS = Object.freeze([
+  '.github/workflows/v3_auth-stg.yml',
+  '.github/workflows/v3_backend-docker-stg.yml',
+  '.github/workflows/v3_mcp-lecturer-stg.yml',
+])
+const FIXTURE_STAGING_WORKFLOWS = Object.freeze([
+  {
+    jobs: [{ id: 'build-arm', image: 'auth-arm' }],
+    name: 'Build Docker image for auth (stg)',
+    path: FIXTURE_WORKFLOW_PATHS[0],
+  },
+  {
+    jobs: [
+      { id: 'build-arm', image: 'backend-docker-arm' },
+      { id: 'build-migrator-arm', image: 'backend-docker-migrator-arm' },
+    ],
+    name: 'Build Docker image for backend-docker (stg)',
+    path: FIXTURE_WORKFLOW_PATHS[1],
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'mcp-lecturer-arm' }],
+    name: 'Build Docker image for mcp-lecturer (stg)',
+    nonRuntimeJobs: [{ id: 'build-amd', image: 'mcp-lecturer-amd' }],
+    path: FIXTURE_WORKFLOW_PATHS[2],
+  },
+])
+
+function workflowDefinition({
+  activeAmd = false,
+  image,
+  migrator = false,
+  pushBranches = ["'v3'", "'v3*'"],
+  fullShaTag = true,
+}) {
+  const imageEnvironment = migrator
+    ? `  MIGRATOR_IMAGE_NAME: \${{ github.repository }}/${image}-migrator`
+    : ''
+  const tagLines = fullShaTag
+    ? '          type=raw,value=\${{ github.sha }}'
+    : '          type=ref,event=branch'
+  const amdJob = activeAmd
+    ? `  build-amd:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: \${{ env.REGISTRY }}/\${{ env.IMAGE_NAME }}-amd
+          tags: |
+${tagLines}
+      - uses: docker/build-push-action@v5
+        with:
+          push: \${{ github.event_name != 'pull_request' }}
+          tags: \${{ steps.meta.outputs.tags }}
+`
+    : `  build-amd:
+    if: \${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/metadata-action@v4
+`
+  const migratorJobs = migrator
+    ? `  build-migrator-arm:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: \${{ env.REGISTRY }}/\${{ env.MIGRATOR_IMAGE_NAME }}-arm
+          tags: |
+${tagLines}
+      - uses: docker/build-push-action@v5
+        with:
+          push: \${{ github.event_name != 'pull_request' }}
+          tags: \${{ steps.meta.outputs.tags }}
+  build-migrator-amd:
+    if: \${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/metadata-action@v4
+`
+    : ''
+  return `name: Build Docker image for ${image} (stg)
+
+on:
+  push:
+    branches:
+${pushBranches.map((branch) => `      - ${branch}`).join('\n')}
+  pull_request:
+    types: [opened]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: \${{ github.repository }}/${image}
+${imageEnvironment}
+jobs:
+  build-arm:
+    if: github.event.pull_request.draft == false
+${migrator ? '    needs: build-migrator-arm\n' : ''}    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: \${{ env.REGISTRY }}/\${{ env.IMAGE_NAME }}-arm
+          tags: |
+${tagLines}
+      - uses: docker/build-push-action@v5
+        with:
+          push: \${{ github.event_name != 'pull_request' }}
+          tags: \${{ steps.meta.outputs.tags }}
+${amdJob}${migratorJobs}
+`
+}
+
+function fixtureDefinitions(options = {}) {
+  return FIXTURE_WORKFLOW_PATHS.map((path) => {
+    const backend = path.includes('backend-docker')
+    const mcp = path.includes('mcp-lecturer')
+    return {
+      content: workflowDefinition({
+        activeAmd: mcp,
+        image: backend ? 'backend-docker' : mcp ? 'mcp-lecturer' : 'auth',
+        migrator: backend,
+        ...options,
+      }),
+      path,
+    }
+  })
+}
+
+function workflowRun({
+  candidateSha,
+  conclusion = 'success',
+  event = 'push',
+  headBranch = 'v3',
+  id,
+  path,
+  repository = 'uzh-bf/klicker-uzh',
+  status = 'completed',
+}) {
+  return {
+    conclusion,
+    event,
+    head_branch: headBranch,
+    head_sha: candidateSha,
+    html_url: `https://github.com/${repository}/actions/runs/${id}`,
+    id,
+    path,
+    repository: { full_name: repository },
+    status,
+  }
+}
+
+function workflowJobs({
+  candidateSha,
+  includeMigrator = false,
+  jobState = {},
+  path,
+}) {
+  const names = ['build-arm']
+  if (includeMigrator) names.push('build-migrator-arm')
+  return names.map((name, index) => ({
+    conclusion: jobState[name]?.conclusion ?? 'success',
+    head_sha: jobState[name]?.head_sha ?? candidateSha,
+    html_url: `https://github.com/uzh-bf/klicker-uzh/actions/runs/1/job/${index + 1}`,
+    id: index + 1,
+    name,
+    path,
+    status: jobState[name]?.status ?? 'completed',
+  }))
+}
+
+module.exports = {
+  FIXTURE_STAGING_WORKFLOWS,
+  FIXTURE_WORKFLOW_PATHS,
+  fixtureDefinitions,
+  workflowDefinition,
+  workflowJobs,
+  workflowRun,
+}

--- a/.github/scripts/stg-release-promoter.js
+++ b/.github/scripts/stg-release-promoter.js
@@ -12,19 +12,21 @@ const PROMOTION_REF_API = `heads/${PROMOTION_REF_NAME}`
 const SOURCE_BRANCH_VARIABLE = 'STG_SOURCE_BRANCH'
 const PROMOTION_ENABLED_VARIABLE = 'STG_RELEASE_PROMOTION_ENABLED'
 const MANUAL_CONFIRMATION = 'stg-release'
-const DEFAULT_SOURCE_BRANCH = 'v3'
 const DEFAULT_MAX_ATTEMPTS = 6
 const DEFAULT_RETRY_DELAY_MS = 20_000
+const DEFAULT_POST_PUSH_READBACK_ATTEMPTS = 3
+const DEFAULT_POST_PUSH_READBACK_DELAY_MS = 2_000
 const WORKFLOW_PATH_PATTERN = /^\.github\/workflows\/v3_.*-stg\.yml$/
 const APPROVED_PUSH_BRANCHES = Object.freeze(['v3', 'v3*'])
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
 const SHA_PATTERN = /^[0-9a-f]{40}$/
-const REGISTRY_ACCEPT = [
+const REGISTRY_CONTENT_TYPES = Object.freeze([
   'application/vnd.oci.image.index.v1+json',
   'application/vnd.docker.distribution.manifest.list.v2+json',
   'application/vnd.oci.image.manifest.v1+json',
   'application/vnd.docker.distribution.manifest.v2+json',
-].join(', ')
+])
+const REGISTRY_ACCEPT = REGISTRY_CONTENT_TYPES.join(', ')
 
 // Keep this inventory synchronized with the workflow_run names below. A
 // candidate cannot rename, add, remove, or retarget a runtime publisher without
@@ -117,6 +119,10 @@ const STAGING_WORKFLOW_PATHS = Object.freeze(
 
 function sha256(value) {
   return crypto.createHash('sha256').update(String(value)).digest('hex')
+}
+
+function sha256Bytes(value) {
+  return crypto.createHash('sha256').update(value).digest('hex')
 }
 
 function validSha(value) {
@@ -630,27 +636,13 @@ async function getCandidateDefinitions({
   return definitions
 }
 
-async function getSourceBranch({
-  github,
-  context,
-  selectedSourceBranch = undefined,
-}) {
-  if (selectedSourceBranch !== undefined) {
-    return assertSafeSourceBranch(selectedSourceBranch)
+function getSourceBranch(selectedSourceBranch) {
+  if (selectedSourceBranch === undefined) {
+    throw new Error(
+      `${SOURCE_BRANCH_VARIABLE} must be resolved by the trusted workflow`
+    )
   }
-  const getVariable = github.rest.actions?.getRepoVariable
-  if (typeof getVariable !== 'function') return DEFAULT_SOURCE_BRANCH
-  try {
-    const response = await getVariable({
-      name: SOURCE_BRANCH_VARIABLE,
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-    })
-    return assertSafeSourceBranch(response.data?.value)
-  } catch (error) {
-    if (error?.status === 404) return DEFAULT_SOURCE_BRANCH
-    throw error
-  }
+  return assertSafeSourceBranch(selectedSourceBranch)
 }
 
 async function compareRevisions({ github, context, base, head }) {
@@ -686,16 +678,14 @@ async function validateCandidateAncestry({
 }
 
 async function paginate(github, endpoint, params) {
-  if (typeof github.paginate === 'function') {
-    const result = await github.paginate(endpoint, params)
-    return Array.isArray(result) ? result : []
+  if (typeof github.paginate !== 'function') {
+    throw new Error('GitHub pagination is unavailable')
   }
-  const response = await endpoint(params)
-  const data = response?.data
-  if (Array.isArray(data)) return data
-  if (Array.isArray(data?.workflow_runs)) return data.workflow_runs
-  if (Array.isArray(data?.jobs)) return data.jobs
-  return []
+  const result = await github.paginate(endpoint, params)
+  if (!Array.isArray(result)) {
+    throw new Error('GitHub pagination returned an invalid result')
+  }
+  return result
 }
 
 function latestRun(runs, workflowPath, candidateSha) {
@@ -1013,6 +1003,9 @@ async function registryResponse({ repository, tag, fetchImpl }) {
       redirect: 'error',
     })
   let response = await request()
+  if (response.redirected) {
+    throw new Error(`${repository}:${tag} registry response redirected`)
+  }
   if (response.status !== 401) return response
 
   const challenge = parseBearerChallenge(
@@ -1034,6 +1027,9 @@ async function registryResponse({ repository, tag, fetchImpl }) {
   realm.searchParams.set('service', registry)
   realm.searchParams.set('scope', expectedScope)
   const tokenResponse = await fetchImpl(realm, { redirect: 'error' })
+  if (tokenResponse.redirected) {
+    throw new Error(`${repository}:${tag} registry token response redirected`)
+  }
   if (!tokenResponse.ok) {
     throw new Error(
       `${repository}:${tag} registry token response was ${tokenResponse.status}`
@@ -1047,6 +1043,9 @@ async function registryResponse({ repository, tag, fetchImpl }) {
     )
   }
   response = await request(`Bearer ${token}`)
+  if (response.redirected) {
+    throw new Error(`${repository}:${tag} registry response redirected`)
+  }
   return response
 }
 
@@ -1057,10 +1056,37 @@ async function fetchRegistryDigest({ repository, tag, fetchImpl = fetch }) {
       `${repository}:${tag} registry response was ${response.status}`
     )
   }
+  const contentType = String(response.headers.get('content-type') ?? '')
+    .split(';', 1)[0]
+    .trim()
+    .toLowerCase()
+  if (!REGISTRY_CONTENT_TYPES.includes(contentType)) {
+    throw new Error(
+      `${repository}:${tag} registry response has an unexpected content type`
+    )
+  }
   const digest = response.headers.get('docker-content-digest')
   if (!DIGEST_PATTERN.test(digest ?? '')) {
     throw new Error(
-      `${repository}:${tag} registry response has no digest header`
+      `${repository}:${tag} registry response has no valid digest header`
+    )
+  }
+  if (typeof response.arrayBuffer !== 'function') {
+    throw new Error(`${repository}:${tag} registry response was incomplete`)
+  }
+  let body
+  try {
+    body = Buffer.from(await response.arrayBuffer())
+  } catch {
+    throw new Error(`${repository}:${tag} registry response was incomplete`)
+  }
+  if (body.length === 0) {
+    throw new Error(`${repository}:${tag} registry response was incomplete`)
+  }
+  const bodyDigest = `sha256:${sha256Bytes(body)}`
+  if (bodyDigest !== digest) {
+    throw new Error(
+      `${repository}:${tag} registry response body does not match its digest header`
     )
   }
   return digest
@@ -1209,7 +1235,16 @@ async function compareAndSwapReleaseRef({
   repositoryUrl,
   gitRunner,
   workspace,
+  readbackMaxAttempts = DEFAULT_POST_PUSH_READBACK_ATTEMPTS,
+  readbackRetryDelayMs = DEFAULT_POST_PUSH_READBACK_DELAY_MS,
+  sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
 }) {
+  if (!Number.isSafeInteger(readbackMaxAttempts) || readbackMaxAttempts < 1) {
+    throw new Error('post-push readback attempts must be a positive integer')
+  }
+  if (!Number.isSafeInteger(readbackRetryDelayMs) || readbackRetryDelayMs < 0) {
+    throw new Error('post-push readback delay must be a non-negative integer')
+  }
   const observed = await getReleaseRef({ github, context })
   if (observed !== expectedSha) {
     throw new Error('stg-release changed before the compare-and-swap')
@@ -1238,11 +1273,44 @@ async function compareAndSwapReleaseRef({
   } catch (error) {
     throw new Error('stg-release compare-and-swap failed', { cause: error })
   }
-  const result = await getReleaseRef({ github, context })
-  if (result !== candidateSha) {
-    throw new Error('stg-release changed during the compare-and-swap')
+
+  const readbackAttempts = []
+  let observedReleaseSha = null
+  let verification = 'uncertain'
+  for (let attempt = 1; attempt <= readbackMaxAttempts; attempt += 1) {
+    try {
+      observedReleaseSha = await getReleaseRef({ github, context })
+      verification =
+        observedReleaseSha === candidateSha ? 'verified' : 'mismatch'
+      readbackAttempts.push({
+        attempt,
+        observed_release_sha: observedReleaseSha,
+        state: verification,
+      })
+      if (verification === 'verified') break
+    } catch {
+      observedReleaseSha = null
+      verification = 'uncertain'
+      readbackAttempts.push({
+        attempt,
+        observed_release_sha: null,
+        state: 'unavailable',
+      })
+    }
+    if (attempt < readbackMaxAttempts) {
+      try {
+        await sleep(readbackRetryDelayMs)
+      } catch {
+        break
+      }
+    }
   }
-  return result
+  return {
+    observed_release_sha: observedReleaseSha,
+    readback_attempts: readbackAttempts,
+    result: 'push-succeeded',
+    verification,
+  }
 }
 
 function defaultReceiptPath() {
@@ -1282,6 +1350,8 @@ function writeReceiptArtifacts({
         `- Controller run: \`${receipt.controller_run_id}\``,
         `- Decision: \`${receipt.decision.action}\``,
         `- Write mode: \`${receipt.decision.mode}\``,
+        `- Ref update: \`${receipt.update_result.result}\``,
+        `- Ref verification: \`${receipt.update_result.verification}\``,
         `- Workflows: ${receipt.workflows.length}`,
         `- Runtime image digests: ${receipt.images.length}`,
         `- Receipt checksum: \`${checksum}\``,
@@ -1297,17 +1367,12 @@ function setOutput(core, name, value) {
 }
 
 async function resolveInputs({
-  github,
   context,
   sourceBranch,
   candidateSha,
   promotionEnabled = process.env[PROMOTION_ENABLED_VARIABLE],
 }) {
-  const selectedSourceBranch = await getSourceBranch({
-    github,
-    context,
-    selectedSourceBranch: sourceBranch,
-  })
+  const selectedSourceBranch = getSourceBranch(sourceBranch)
   if (context.eventName === 'workflow_run') {
     const workflowRun = context.payload?.workflow_run
     if (
@@ -1334,10 +1399,10 @@ async function resolveInputs({
     const inputs = context.payload?.inputs ?? {}
     const selectedCandidateSha = candidateSha ?? inputs.sha
     const dryRun = inputs.dry_run !== false && inputs.dry_run !== 'false'
-    const confirmation = inputs.confirm ?? ''
+    const confirmation = inputs.confirm_ref_update ?? ''
     if (!dryRun && confirmation !== MANUAL_CONFIRMATION) {
       throw new Error(
-        `manual writes require the exact confirmation ${MANUAL_CONFIRMATION}`
+        `manual writes require confirm_ref_update=${MANUAL_CONFIRMATION}`
       )
     }
     return {
@@ -1364,6 +1429,8 @@ async function runPromotion({
   maxAttempts = DEFAULT_MAX_ATTEMPTS,
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
   sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+  readbackMaxAttempts = DEFAULT_POST_PUSH_READBACK_ATTEMPTS,
+  readbackRetryDelayMs = DEFAULT_POST_PUSH_READBACK_DELAY_MS,
   receiptPath,
   checksumPath,
   summaryPath,
@@ -1373,7 +1440,6 @@ async function runPromotion({
   workspace,
 }) {
   const inputs = await resolveInputs({
-    github,
     context,
     sourceBranch,
     candidateSha,
@@ -1445,12 +1511,17 @@ async function runPromotion({
     currentSha,
     candidateSha: inputs.candidateSha,
   })
-  let appliedSha = null
+  let updateResult = {
+    observed_release_sha: currentSha,
+    readback_attempts: [],
+    result: 'not-attempted',
+    verification: 'not-required',
+  }
   if (
     inputs.allowWrite &&
     ['create', 'fast-forward'].includes(decision.action)
   ) {
-    appliedSha = await compareAndSwapReleaseRef({
+    updateResult = await compareAndSwapReleaseRef({
       github,
       context,
       expectedSha: currentSha,
@@ -1459,8 +1530,13 @@ async function runPromotion({
       repositoryUrl,
       gitRunner,
       workspace,
+      readbackMaxAttempts,
+      readbackRetryDelayMs,
+      sleep,
     })
   }
+  const appliedSha =
+    updateResult.verification === 'verified' ? inputs.candidateSha : null
 
   const receipt = {
     schema_version: 'stg-release-promotion/v1',
@@ -1475,6 +1551,7 @@ async function runPromotion({
       mode: inputs.allowWrite ? 'apply' : 'dry-run',
       ref: PROMOTION_REF,
     },
+    update_result: updateResult,
     attempts: evidence.attempts,
     workflows: evidence.workflows.map((workflow) => ({
       name: workflows.find((entry) => entry.path === workflow.path).name,
@@ -1501,12 +1578,22 @@ async function runPromotion({
   core?.info?.(
     `Staging release promotion ${decision.action}; receipt ${checksum}`
   )
+  if (
+    updateResult.result === 'push-succeeded' &&
+    updateResult.verification !== 'verified'
+  ) {
+    throw new Error(
+      `stg-release push succeeded but post-push verification is ${updateResult.verification}; receipt ${checksum}`
+    )
+  }
   return { ...receipt, checksum, ...artifacts }
 }
 
 module.exports = {
   APPROVED_PUSH_BRANCHES,
   DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_POST_PUSH_READBACK_ATTEMPTS,
+  DEFAULT_POST_PUSH_READBACK_DELAY_MS,
   DEFAULT_RETRY_DELAY_MS,
   DIGEST_PATTERN,
   MANUAL_CONFIRMATION,

--- a/.github/scripts/stg-release-promoter.js
+++ b/.github/scripts/stg-release-promoter.js
@@ -1,0 +1,1538 @@
+'use strict'
+
+const crypto = require('node:crypto')
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const PROMOTION_REF = 'refs/heads/stg-release'
+const PROMOTION_REF_NAME = 'stg-release'
+const PROMOTION_REF_API = `heads/${PROMOTION_REF_NAME}`
+const SOURCE_BRANCH_VARIABLE = 'STG_SOURCE_BRANCH'
+const PROMOTION_ENABLED_VARIABLE = 'STG_RELEASE_PROMOTION_ENABLED'
+const MANUAL_CONFIRMATION = 'stg-release'
+const DEFAULT_SOURCE_BRANCH = 'v3'
+const DEFAULT_MAX_ATTEMPTS = 6
+const DEFAULT_RETRY_DELAY_MS = 20_000
+const WORKFLOW_PATH_PATTERN = /^\.github\/workflows\/v3_.*-stg\.yml$/
+const APPROVED_PUSH_BRANCHES = Object.freeze(['v3', 'v3*'])
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+const REGISTRY_ACCEPT = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ')
+
+// Keep this inventory synchronized with the workflow_run names below. A
+// candidate cannot rename, add, remove, or retarget a runtime publisher without
+// a trusted controller change.
+const STAGING_WORKFLOWS = Object.freeze([
+  {
+    jobs: [{ id: 'build-arm', image: 'analytics-arm' }],
+    name: 'Build Docker image for analytics (stg)',
+    path: '.github/workflows/v3_analytics-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'auth-arm' }],
+    name: 'Build Docker image for auth (stg)',
+    path: '.github/workflows/v3_auth-stg.yml',
+  },
+  {
+    jobs: [
+      { id: 'build-arm', image: 'backend-docker-arm' },
+      { id: 'build-migrator-arm', image: 'backend-docker-migrator-arm' },
+    ],
+    name: 'Build Docker image for backend-docker (stg)',
+    path: '.github/workflows/v3_backend-docker-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'chat-arm' }],
+    name: 'Build Docker image for chat (stg)',
+    path: '.github/workflows/v3_chat-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'frontend-control-arm' }],
+    name: 'Build Docker image for frontend-control (stg)',
+    path: '.github/workflows/v3_frontend-control-docker-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'frontend-manage-arm' }],
+    name: 'Build Docker image for frontend-manage (stg)',
+    path: '.github/workflows/v3_frontend-manage-docker-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'frontend-assessment-arm' }],
+    name: 'Build Docker image for frontend-assessment (stg)',
+    path: '.github/workflows/v3_frontend-pwa-docker-assessment-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'frontend-pwa-arm' }],
+    name: 'Build Docker image for frontend-pwa (stg)',
+    path: '.github/workflows/v3_frontend-pwa-docker-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'hatchet-worker-general-arm' }],
+    name: 'Build Docker image for hatchet-worker-general (stg)',
+    path: '.github/workflows/v3_hatchet-worker-general-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'hatchet-worker-response-processor-arm' }],
+    name: 'Build Docker image for hatchet-worker-response-processor (stg)',
+    path: '.github/workflows/v3_hatchet-worker-response-processor-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'lti-arm' }],
+    name: 'Build Docker image for lti (stg)',
+    path: '.github/workflows/v3_lti-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'mcp-lecturer-arm' }],
+    name: 'Build Docker image for mcp-lecturer (stg)',
+    nonRuntimeJobs: [{ id: 'build-amd', image: 'mcp-lecturer-amd' }],
+    path: '.github/workflows/v3_mcp-lecturer-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'mcp-student-arm' }],
+    name: 'Build Docker image for mcp-student (stg)',
+    nonRuntimeJobs: [{ id: 'build-amd', image: 'mcp-student-amd' }],
+    path: '.github/workflows/v3_mcp-student-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'olat-api-arm' }],
+    name: 'Build Docker image for olat-api (stg)',
+    path: '.github/workflows/v3_olat-api-stg.yml',
+  },
+  {
+    jobs: [{ id: 'build-arm', image: 'response-api-arm' }],
+    name: 'Build Docker image for response-api (stg)',
+    path: '.github/workflows/v3_response-api-stg.yml',
+  },
+])
+const STAGING_WORKFLOW_PATHS = Object.freeze(
+  STAGING_WORKFLOWS.map((workflow) => workflow.path)
+)
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex')
+}
+
+function validSha(value) {
+  return SHA_PATTERN.test(value ?? '')
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])])
+    )
+  }
+  return value
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value))
+}
+
+function checksumReceipt(receipt) {
+  return sha256(canonicalJson(receipt))
+}
+
+function repositoryName(context) {
+  return `${context.repo.owner}/${context.repo.repo}`
+}
+
+function assertSafeSourceBranch(sourceBranch) {
+  if (
+    typeof sourceBranch !== 'string' ||
+    !/^[A-Za-z0-9_.-]+$/.test(sourceBranch) ||
+    !matchesApprovedBranch(sourceBranch)
+  ) {
+    throw new Error(
+      `${SOURCE_BRANCH_VARIABLE} must be a safe branch covered by the approved push triggers`
+    )
+  }
+  return sourceBranch
+}
+
+function matchesApprovedBranch(sourceBranch) {
+  return APPROVED_PUSH_BRANCHES.some((pattern) =>
+    pattern.endsWith('*')
+      ? sourceBranch.startsWith(pattern.slice(0, -1))
+      : sourceBranch === pattern
+  )
+}
+
+function parseScalar(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/^(['"])(.*)\1$/, '$2')
+}
+
+function extractTopLevelBlock(
+  content,
+  key,
+  workflowPath,
+  { optional = false } = {}
+) {
+  const lines = String(content).split(/\r?\n/)
+  const indexes = lines
+    .map((line, index) => (line === `${key}:` ? index : -1))
+    .filter((index) => index >= 0)
+  if (indexes.length === 0 && optional) return []
+  if (indexes.length !== 1) {
+    throw new Error(
+      `${workflowPath} must have exactly one top-level ${key} block`
+    )
+  }
+  const start = indexes[0]
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => line.trim() !== '' && !/^\s/.test(line))
+  const end = relativeEnd < 0 ? lines.length : start + 1 + relativeEnd
+  return lines.slice(start + 1, end)
+}
+
+function extractName(content, workflowPath) {
+  const matches = [...String(content).matchAll(/^name:\s*(.+)$/gm)]
+  if (matches.length !== 1 || !parseScalar(matches[0][1])) {
+    throw new Error(`${workflowPath} must have exactly one workflow name`)
+  }
+  return parseScalar(matches[0][1])
+}
+
+function extractPushBranches(content, workflowPath) {
+  const lines = extractTopLevelBlock(content, 'on', workflowPath)
+  const pushIndex = lines.findIndex((line) => /^  push:\s*$/.test(line))
+  if (pushIndex < 0) {
+    throw new Error(`${workflowPath} has no push trigger`)
+  }
+  const end = lines.slice(pushIndex + 1).findIndex((line) => {
+    return line.trim() !== '' && !/^\s*#/.test(line) && /^  \S/.test(line)
+  })
+  const endIndex = end < 0 ? lines.length : pushIndex + 1 + end
+  const branchesIndex = lines.findIndex(
+    (line, index) =>
+      index > pushIndex && index < endIndex && /^    branches:\s*$/.test(line)
+  )
+  if (branchesIndex < 0) {
+    throw new Error(`${workflowPath} push trigger has no branches`)
+  }
+  const pushKeys = lines
+    .slice(pushIndex + 1, endIndex)
+    .flatMap((line) => line.match(/^    ([A-Za-z0-9_-]+):/)?.[1] ?? [])
+  if (canonicalJson(pushKeys) !== canonicalJson(['branches'])) {
+    throw new Error(`${workflowPath} does not use the approved push triggers`)
+  }
+  const branches = []
+  for (let index = branchesIndex + 1; index < endIndex; index += 1) {
+    const match = lines[index].match(/^      -\s*(.+?)\s*$/)
+    if (match) branches.push(parseScalar(match[1]))
+  }
+  return branches
+}
+
+function extractRootEnvironment(content, workflowPath) {
+  const lines = extractTopLevelBlock(content, 'env', workflowPath, {
+    optional: true,
+  })
+  const values = {}
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const match = line.match(/^  ([A-Z][A-Z0-9_]*)\s*:\s*(.*?)\s*$/)
+    if (match) values[match[1]] = parseScalar(match[2])
+  }
+  return values
+}
+
+function extractJobBlocks(content, workflowPath) {
+  const lines = extractTopLevelBlock(content, 'jobs', workflowPath)
+  const jobs = []
+  let current = null
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const jobMatch = line.match(/^  ([A-Za-z0-9_-]+):\s*$/)
+    if (jobMatch) {
+      if (current) jobs.push(current)
+      current = { id: jobMatch[1], lines: [] }
+      continue
+    }
+    if (current) {
+      if (/^\S/.test(line) && line.trim() !== '') break
+      current.lines.push(line)
+    }
+  }
+  if (current) jobs.push(current)
+  return jobs.map((job) => ({ ...job, content: job.lines.join('\n') }))
+}
+
+function isDisabledJob(job) {
+  return /^    if:\s*\$\{\{\s*false\s*\}\}\s*(?:#.*)?$/m.test(job.content)
+}
+
+function resolveTemplate(value, environment, repository) {
+  let resolved = parseScalar(value)
+  for (let pass = 0; pass < 3; pass += 1) {
+    const next = resolved
+      .replace(/\$\{\{\s*github\.repository\s*\}\}/g, repository)
+      .replace(
+        /\$\{\{\s*env\.([A-Z][A-Z0-9_]*)\s*\}\}/g,
+        (_match, name) => environment[name] ?? ''
+      )
+    if (next === resolved) break
+    resolved = next
+  }
+  return resolved
+}
+
+function extractActionSteps(job, workflowPath) {
+  const lines = job.content.split(/\r?\n/)
+  const stepsIndexes = lines
+    .map((line, index) => (line === '    steps:' ? index : -1))
+    .filter((index) => index >= 0)
+  if (stepsIndexes.length !== 1) {
+    throw new Error(
+      `${workflowPath}/${job.id} must have exactly one steps block`
+    )
+  }
+  const start = stepsIndexes[0]
+  const relativeEnd = lines.slice(start + 1).findIndex((line) => {
+    return (
+      line.trim() !== '' &&
+      !/^\s*#/.test(line) &&
+      /^    [A-Za-z0-9_-]+:/.test(line)
+    )
+  })
+  const end = relativeEnd < 0 ? lines.length : start + 1 + relativeEnd
+  const steps = []
+  let current = null
+  for (const line of lines.slice(start + 1, end)) {
+    if (/^      -\s+/.test(line)) {
+      if (current) steps.push(current.join('\n'))
+      current = [line]
+    } else if (current) {
+      current.push(line)
+    }
+  }
+  if (current) steps.push(current.join('\n'))
+  return steps
+}
+
+function actionStep(job, action, workflowPath) {
+  const matches = extractActionSteps(job, workflowPath).filter((step) =>
+    new RegExp(
+      `^(?:      - uses|        uses):\\s*${action.replace('/', '\\/')}@[^\\s#]+\\s*(?:#.*)?$`,
+      'm'
+    ).test(step)
+  )
+  if (matches.length !== 1) {
+    throw new Error(`${workflowPath}/${job.id} must use exactly one ${action}`)
+  }
+  return matches[0]
+}
+
+function extractImageReference(
+  step,
+  environment,
+  repository,
+  workflowPath,
+  jobId
+) {
+  const matches = [...step.matchAll(/^          images:\s*(.+)$/gm)]
+  if (matches.length !== 1) {
+    throw new Error(
+      `${workflowPath}/${jobId} must declare exactly one metadata image`
+    )
+  }
+  const match = matches[0]
+  if (!match) {
+    throw new Error(`${workflowPath}/${jobId} has no Docker image metadata`)
+  }
+  const image = resolveTemplate(match[1], environment, repository)
+  if (
+    image.includes('${{') ||
+    !/^[A-Za-z0-9.-]+\/[A-Za-z0-9._/-]+$/.test(image)
+  ) {
+    throw new Error(
+      `${workflowPath}/${jobId} has an unresolved image reference`
+    )
+  }
+  return image
+}
+
+function hasFullShaTag(metadataStep) {
+  return (
+    /^\s*type\s*=\s*raw[^\n#]*value\s*=\s*\$\{\{\s*github\.sha\s*\}\}\s*$/m.test(
+      metadataStep
+    ) || /^\s*tags:\s*\$\{\{\s*github\.sha\s*\}\}\s*$/m.test(metadataStep)
+  )
+}
+
+function validateStagingWorkflow({
+  path: workflowPath,
+  content,
+  expectedWorkflow,
+  repository,
+  sourceBranch,
+}) {
+  if (!WORKFLOW_PATH_PATTERN.test(workflowPath)) {
+    throw new Error(`${workflowPath} is not an approved staging workflow path`)
+  }
+  const workflowName = extractName(content, workflowPath)
+  if (workflowName !== expectedWorkflow.name) {
+    throw new Error(`${workflowPath} does not use the trusted workflow name`)
+  }
+  const branches = extractPushBranches(content, workflowPath)
+  if (canonicalJson(branches) !== canonicalJson([...APPROVED_PUSH_BRANCHES])) {
+    throw new Error(`${workflowPath} does not use the approved push triggers`)
+  }
+  if (!matchesApprovedBranch(sourceBranch)) {
+    throw new Error(
+      `${sourceBranch} is not covered by the approved push triggers`
+    )
+  }
+
+  const environment = extractRootEnvironment(content, workflowPath)
+  const jobs = extractJobBlocks(content, workflowPath)
+  if (jobs.length === 0) throw new Error(`${workflowPath} has no jobs`)
+
+  const expectedNonRuntimeJobIds = (expectedWorkflow.nonRuntimeJobs ?? [])
+    .map((job) => job.id)
+    .sort()
+  for (const job of jobs.filter((entry) => entry.id.endsWith('-amd'))) {
+    if (!isDisabledJob(job) && !expectedNonRuntimeJobIds.includes(job.id)) {
+      throw new Error(`${workflowPath}/${job.id} must remain disabled`)
+    }
+  }
+
+  const activeArmJobs = jobs.filter(
+    (job) => job.id.endsWith('-arm') && !isDisabledJob(job)
+  )
+  const expectedJobIds = expectedWorkflow.jobs.map((job) => job.id).sort()
+  const actualJobIds = activeArmJobs.map((job) => job.id).sort()
+  if (canonicalJson(actualJobIds) !== canonicalJson(expectedJobIds)) {
+    throw new Error(`${workflowPath} active ARM job inventory changed`)
+  }
+
+  const activeNonRuntimeJobs = jobs.filter(
+    (job) => expectedNonRuntimeJobIds.includes(job.id) && !isDisabledJob(job)
+  )
+  const actualNonRuntimeJobIds = activeNonRuntimeJobs
+    .map((job) => job.id)
+    .sort()
+  if (
+    canonicalJson(actualNonRuntimeJobIds) !==
+    canonicalJson(expectedNonRuntimeJobIds)
+  ) {
+    throw new Error(`${workflowPath} active non-runtime job inventory changed`)
+  }
+
+  const publisherJobs = [...activeArmJobs, ...activeNonRuntimeJobs]
+  const images = publisherJobs.map((job) => {
+    if (
+      job.id.endsWith('-arm') &&
+      !/^    runs-on:\s*ubuntu-24\.04-arm\s*$/m.test(job.content)
+    ) {
+      throw new Error(
+        `${workflowPath}/${job.id} is not pinned to the ARM runner`
+      )
+    }
+    const metadataStep = actionStep(job, 'docker/metadata-action', workflowPath)
+    const publisherStep = actionStep(
+      job,
+      'docker/build-push-action',
+      workflowPath
+    )
+    const metadataId = metadataStep.match(
+      /^        id:\s*([A-Za-z0-9_-]+)\s*$/m
+    )?.[1]
+    if (!metadataId) {
+      throw new Error(
+        `${workflowPath}/${job.id} metadata action has no stable id`
+      )
+    }
+    if (
+      !/^          push:\s*\$\{\{\s*github\.event_name\s*!=\s*'pull_request'\s*\}\}\s*$/m.test(
+        publisherStep
+      )
+    ) {
+      throw new Error(`${workflowPath}/${job.id} has an unsafe push condition`)
+    }
+    if (
+      !new RegExp(
+        `^          tags:\\s*\\$\\{\\{\\s*steps\\.${metadataId}\\.outputs\\.tags\\s*\\}\\}\\s*$`,
+        'm'
+      ).test(publisherStep)
+    ) {
+      throw new Error(
+        `${workflowPath}/${job.id} does not publish the validated metadata tags`
+      )
+    }
+    if (!hasFullShaTag(metadataStep)) {
+      throw new Error(
+        `${workflowPath}/${job.id} does not publish a full source SHA tag`
+      )
+    }
+    return {
+      id: job.id,
+      image: extractImageReference(
+        metadataStep,
+        environment,
+        repository,
+        workflowPath,
+        job.id
+      ),
+    }
+  })
+
+  const unexpectedPublishers = jobs.filter(
+    (job) =>
+      extractActionSteps(job, workflowPath).some((step) =>
+        /^(?:      - uses|        uses):\s*docker\/build-push-action@[^\s#]+\s*(?:#.*)?$/m.test(
+          step
+        )
+      ) &&
+      !publisherJobs.includes(job) &&
+      !(job.id.endsWith('-amd') && isDisabledJob(job))
+  )
+  if (unexpectedPublishers.length > 0) {
+    throw new Error(`${workflowPath} has an unexpected active image publisher`)
+  }
+
+  const hasMigratorJob = expectedJobIds.includes('build-migrator-arm')
+  if (
+    hasMigratorJob &&
+    !/^    needs:\s*build-migrator-arm\s*$/m.test(
+      activeArmJobs.find((job) => job.id === 'build-arm').content
+    )
+  ) {
+    throw new Error(`${workflowPath}/build-arm does not wait for the migrator`)
+  }
+
+  const expectedImages = [
+    ...expectedWorkflow.jobs,
+    ...(expectedWorkflow.nonRuntimeJobs ?? []),
+  ]
+    .map((job) => ({
+      id: job.id,
+      image: `ghcr.io/${repository}/${job.image}`,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id))
+  const actualImages = images.sort((left, right) =>
+    left.id.localeCompare(right.id)
+  )
+  if (canonicalJson(actualImages) !== canonicalJson(expectedImages)) {
+    throw new Error(`${workflowPath} runtime image inventory changed`)
+  }
+
+  const runtimeJobIds = new Set(expectedJobIds)
+  return {
+    name: workflowName,
+    path: workflowPath,
+    jobs: actualImages.filter((job) => runtimeJobIds.has(job.id)),
+  }
+}
+
+function validateStagingWorkflows({
+  definitions,
+  repository,
+  sourceBranch,
+  expectedWorkflows = STAGING_WORKFLOWS,
+}) {
+  assertSafeSourceBranch(sourceBranch)
+  const paths = definitions.map((definition) => definition.path).sort()
+  const expected = expectedWorkflows.map((workflow) => workflow.path).sort()
+  if (canonicalJson(paths) !== canonicalJson(expected)) {
+    throw new Error(
+      'candidate staging workflow set differs from the trusted set'
+    )
+  }
+  const workflows = definitions
+    .map((definition) => {
+      const expectedWorkflow = expectedWorkflows.find(
+        (workflow) => workflow.path === definition.path
+      )
+      return validateStagingWorkflow({
+        ...definition,
+        expectedWorkflow,
+        repository,
+        sourceBranch,
+      })
+    })
+    .sort((left, right) => left.path.localeCompare(right.path))
+  const jobCount = workflows.reduce(
+    (count, workflow) => count + workflow.jobs.length,
+    0
+  )
+  if (jobCount === 0) throw new Error('candidate has no active ARM image jobs')
+  return workflows
+}
+
+async function getFileText(github, context, filePath, ref) {
+  const response = await github.rest.repos.getContent({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    path: filePath,
+    ref,
+  })
+  const data = response.data
+  if (
+    Array.isArray(data) ||
+    data?.type !== 'file' ||
+    data.encoding !== 'base64'
+  ) {
+    throw new Error(`Expected ${filePath} to be a base64 file at ${ref}`)
+  }
+  return Buffer.from(data.content, 'base64').toString('utf8')
+}
+
+async function getCandidateDefinitions({
+  github,
+  context,
+  candidateSha,
+  expectedWorkflows = STAGING_WORKFLOWS,
+}) {
+  const response = await github.rest.repos.getContent({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    path: '.github/workflows',
+    ref: candidateSha,
+  })
+  if (!Array.isArray(response.data)) {
+    throw new Error('candidate workflow directory is unavailable')
+  }
+  const entries = response.data
+    .filter(
+      (entry) =>
+        entry?.type === 'file' && WORKFLOW_PATH_PATTERN.test(entry.path)
+    )
+    .map((entry) => entry.path)
+    .sort()
+  const expectedPaths = expectedWorkflows
+    .map((workflow) => workflow.path)
+    .sort()
+  if (canonicalJson(entries) !== canonicalJson(expectedPaths)) {
+    throw new Error(
+      'candidate staging workflow set differs from the trusted set'
+    )
+  }
+  const definitions = await Promise.all(
+    entries.map(async (workflowPath) => ({
+      content: await getFileText(github, context, workflowPath, candidateSha),
+      path: workflowPath,
+    }))
+  )
+  return definitions
+}
+
+async function getSourceBranch({
+  github,
+  context,
+  selectedSourceBranch = undefined,
+}) {
+  if (selectedSourceBranch !== undefined) {
+    return assertSafeSourceBranch(selectedSourceBranch)
+  }
+  const getVariable = github.rest.actions?.getRepoVariable
+  if (typeof getVariable !== 'function') return DEFAULT_SOURCE_BRANCH
+  try {
+    const response = await getVariable({
+      name: SOURCE_BRANCH_VARIABLE,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    })
+    return assertSafeSourceBranch(response.data?.value)
+  } catch (error) {
+    if (error?.status === 404) return DEFAULT_SOURCE_BRANCH
+    throw error
+  }
+}
+
+async function compareRevisions({ github, context, base, head }) {
+  if (typeof github.rest.repos?.compareCommitsWithBasehead !== 'function') {
+    throw new Error('remote commit comparison is unavailable')
+  }
+  const response = await github.rest.repos.compareCommitsWithBasehead({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    basehead: `${base}...${head}`,
+  })
+  return response.data
+}
+
+async function validateCandidateAncestry({
+  github,
+  context,
+  candidateSha,
+  sourceBranch,
+}) {
+  const comparison = await compareRevisions({
+    github,
+    context,
+    base: candidateSha,
+    head: sourceBranch,
+  })
+  if (!['ahead', 'identical'].includes(comparison?.status)) {
+    throw new Error(
+      `candidate ${candidateSha} is not an ancestor of selected source ${sourceBranch}`
+    )
+  }
+  return comparison
+}
+
+async function paginate(github, endpoint, params) {
+  if (typeof github.paginate === 'function') {
+    const result = await github.paginate(endpoint, params)
+    return Array.isArray(result) ? result : []
+  }
+  const response = await endpoint(params)
+  const data = response?.data
+  if (Array.isArray(data)) return data
+  if (Array.isArray(data?.workflow_runs)) return data.workflow_runs
+  if (Array.isArray(data?.jobs)) return data.jobs
+  return []
+}
+
+function latestRun(runs, workflowPath, candidateSha) {
+  const exact = runs
+    .filter(
+      (run) => run?.path === workflowPath && run?.head_sha === candidateSha
+    )
+    .sort((left, right) => Number(right.id ?? 0) - Number(left.id ?? 0))
+  return {
+    exact: exact[0],
+    candidateRuns: runs.filter((run) => run?.head_sha === candidateSha),
+  }
+}
+
+function runState(run, sourceBranch, repository) {
+  if (
+    run?.event !== 'push' ||
+    run?.head_branch !== sourceBranch ||
+    run?.repository?.full_name !== repository
+  ) {
+    return 'wrong_evidence'
+  }
+  if (run.status !== 'completed') return 'running'
+  if (run.conclusion === 'success') return 'success'
+  if (run.conclusion === 'skipped') return 'skipped'
+  if (run.conclusion === 'cancelled') return 'cancelled'
+  return 'failed'
+}
+
+function jobState(job, expectedJobId, candidateSha) {
+  if (!job) return 'missing'
+  if (job.name !== expectedJobId || job.head_sha !== candidateSha) {
+    return 'wrong_evidence'
+  }
+  if (job.status !== 'completed') return 'running'
+  if (job.conclusion === 'success') return 'success'
+  if (job.conclusion === 'skipped') return 'skipped'
+  if (job.conclusion === 'cancelled') return 'cancelled'
+  return 'failed'
+}
+
+async function collectWorkflowEvidence({
+  github,
+  context,
+  workflow,
+  candidateSha,
+  sourceBranch,
+  repository,
+}) {
+  const runs = await paginate(github, github.rest.actions.listWorkflowRuns, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    workflow_id: workflow.path,
+    event: 'push',
+    head_sha: candidateSha,
+    per_page: 100,
+  })
+  const { exact, candidateRuns } = latestRun(runs, workflow.path, candidateSha)
+  if (!exact) {
+    return {
+      path: workflow.path,
+      reason: candidateRuns.length > 0 ? 'wrong evidence' : 'no exact-SHA run',
+      status: candidateRuns.length > 0 ? 'wrong_evidence' : 'missing',
+    }
+  }
+  const state = runState(exact, sourceBranch, repository)
+  if (state !== 'success') {
+    return {
+      path: workflow.path,
+      reason:
+        state === 'running'
+          ? 'run is still running'
+          : `run is ${state.replace('_', ' ')}`,
+      run: exact,
+      status: state,
+    }
+  }
+  if (typeof github.rest.actions.listJobsForWorkflowRun !== 'function') {
+    return {
+      path: workflow.path,
+      reason: 'workflow jobs are unavailable',
+      run: exact,
+      status: 'wrong_evidence',
+    }
+  }
+  const jobs = await paginate(
+    github,
+    github.rest.actions.listJobsForWorkflowRun,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: exact.id,
+      per_page: 100,
+    }
+  )
+  const verifiedJobs = []
+  for (const required of workflow.jobs) {
+    const matching = jobs.find((job) => job?.name === required.id)
+    const stateForJob = jobState(matching, required.id, candidateSha)
+    if (stateForJob !== 'success') {
+      return {
+        path: workflow.path,
+        reason: `${required.id} is ${stateForJob.replace('_', ' ')}`,
+        run: exact,
+        status: stateForJob,
+      }
+    }
+    if (!Number.isSafeInteger(matching.id) || matching.id <= 0) {
+      return {
+        path: workflow.path,
+        reason: `${required.id} has no stable job id`,
+        run: exact,
+        status: 'wrong_evidence',
+      }
+    }
+    verifiedJobs.push({
+      id: matching.id,
+      name: matching.name,
+      url: matching.html_url ?? '',
+    })
+  }
+  return {
+    jobs: verifiedJobs,
+    path: workflow.path,
+    run: {
+      branch: exact.head_branch,
+      id: exact.id,
+      sha: exact.head_sha,
+      url: exact.html_url ?? '',
+    },
+    status: 'success',
+  }
+}
+
+function isRetryableEvidenceStatus(status) {
+  return status === 'missing' || status === 'running'
+}
+
+async function collectBuildEvidence({
+  github,
+  context,
+  workflows,
+  candidateSha,
+  sourceBranch,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+}) {
+  const repository = repositoryName(context)
+  const attempts = []
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const results = await Promise.all(
+      workflows.map((workflow) =>
+        collectWorkflowEvidence({
+          github,
+          context,
+          workflow,
+          candidateSha,
+          sourceBranch,
+          repository,
+        })
+      )
+    )
+    const failures = results.filter((result) => result.status !== 'success')
+    attempts.push({
+      attempt,
+      failures: failures.map(({ path, reason, status }) => ({
+        path,
+        reason,
+        status,
+      })),
+    })
+    if (failures.length === 0) {
+      return {
+        attempts,
+        valid: true,
+        workflows: results,
+      }
+    }
+    const retryable = failures.every((failure) =>
+      isRetryableEvidenceStatus(failure.status)
+    )
+    if (!retryable || attempt === maxAttempts) {
+      return {
+        attempts,
+        failures,
+        reason: failures
+          .map(({ path, reason }) => `${path} (${reason})`)
+          .join(', '),
+        valid: false,
+      }
+    }
+    await sleep(retryDelayMs)
+  }
+  throw new Error('bounded evidence collection did not reach a terminal state')
+}
+
+function uniqueImageReferences(evidence, workflows) {
+  const references = []
+  for (const evidenceWorkflow of evidence.workflows) {
+    const workflow = workflows.find(
+      (candidate) => candidate.path === evidenceWorkflow.path
+    )
+    for (const job of evidenceWorkflow.jobs) {
+      const definition = workflow.jobs.find(
+        (candidate) => candidate.id === job.name
+      )
+      references.push({
+        job_id: job.id,
+        job_name: job.name,
+        repository: definition.image,
+        run_id: evidenceWorkflow.run.id,
+        run_url: evidenceWorkflow.run.url,
+        workflow_path: evidenceWorkflow.path,
+        workflow_run_sha: evidenceWorkflow.run.sha,
+      })
+    }
+  }
+  return references.sort((left, right) => {
+    return canonicalJson(left).localeCompare(canonicalJson(right))
+  })
+}
+
+function digestValue(value) {
+  return typeof value === 'string' ? value : value?.digest
+}
+
+async function resolveStableRegistryDigests({
+  candidateSha,
+  evidence,
+  workflows,
+  getRegistryDigest,
+}) {
+  if (typeof getRegistryDigest !== 'function') {
+    throw new Error('registry digest resolver is unavailable')
+  }
+  const references = uniqueImageReferences(evidence, workflows)
+  const unique = [
+    ...new Map(
+      references.map((reference) => [
+        `${reference.repository}:${candidateSha}`,
+        { repository: reference.repository, tag: candidateSha },
+      ])
+    ).values(),
+  ].sort((left, right) =>
+    canonicalJson(left).localeCompare(canonicalJson(right))
+  )
+
+  const read = async () => {
+    const entries = await Promise.all(
+      unique.map(async (reference) => {
+        const digest = digestValue(await getRegistryDigest(reference))
+        if (!DIGEST_PATTERN.test(digest ?? '')) {
+          throw new Error(
+            `${reference.repository}:${reference.tag} has no complete registry digest`
+          )
+        }
+        return { ...reference, digest }
+      })
+    )
+    return entries.sort((left, right) =>
+      canonicalJson(left).localeCompare(canonicalJson(right))
+    )
+  }
+
+  const first = await read()
+  const second = await read()
+  if (canonicalJson(first) !== canonicalJson(second)) {
+    throw new Error('registry SHA-tag digests changed during collection')
+  }
+  const digestByReference = new Map(
+    first.map((entry) => [`${entry.repository}:${entry.tag}`, entry.digest])
+  )
+  return references.map((reference) => ({
+    ...reference,
+    digest: digestByReference.get(`${reference.repository}:${candidateSha}`),
+    tag: candidateSha,
+  }))
+}
+
+function registryManifestUrl(repository, tag) {
+  const parts = repository.split('/')
+  if (parts.length < 2)
+    throw new Error(`invalid registry repository ${repository}`)
+  const registry = parts.shift()
+  return `https://${registry}/v2/${parts.map(encodeURIComponent).join('/')}/manifests/${encodeURIComponent(tag)}`
+}
+
+function parseBearerChallenge(value) {
+  if (!/^Bearer\s+/i.test(value ?? '')) {
+    throw new Error(
+      'registry did not provide a Bearer authentication challenge'
+    )
+  }
+  const parameters = Object.fromEntries(
+    [...String(value).matchAll(/([a-z]+)="([^"]*)"/gi)].map((match) => [
+      match[1].toLowerCase(),
+      match[2],
+    ])
+  )
+  if (!parameters.realm) {
+    throw new Error('registry Bearer challenge has no token realm')
+  }
+  return parameters
+}
+
+async function registryResponse({ repository, tag, fetchImpl }) {
+  const manifestUrl = registryManifestUrl(repository, tag)
+  const request = (authorization = undefined) =>
+    fetchImpl(manifestUrl, {
+      headers: {
+        accept: REGISTRY_ACCEPT,
+        ...(authorization ? { authorization } : {}),
+      },
+      redirect: 'error',
+    })
+  let response = await request()
+  if (response.status !== 401) return response
+
+  const challenge = parseBearerChallenge(
+    response.headers.get('www-authenticate')
+  )
+  const repositoryPath = repository.split('/').slice(1).join('/')
+  const registry = new URL(manifestUrl).hostname
+  const realm = new URL(challenge.realm)
+  if (realm.protocol !== 'https:' || realm.hostname !== registry) {
+    throw new Error('registry Bearer challenge uses an untrusted token realm')
+  }
+  if (challenge.service && challenge.service !== registry) {
+    throw new Error('registry Bearer challenge uses an unexpected service')
+  }
+  const expectedScope = `repository:${repositoryPath}:pull`
+  if (challenge.scope && challenge.scope !== expectedScope) {
+    throw new Error('registry Bearer challenge uses an unexpected scope')
+  }
+  realm.searchParams.set('service', registry)
+  realm.searchParams.set('scope', expectedScope)
+  const tokenResponse = await fetchImpl(realm, { redirect: 'error' })
+  if (!tokenResponse.ok) {
+    throw new Error(
+      `${repository}:${tag} registry token response was ${tokenResponse.status}`
+    )
+  }
+  const tokenPayload = await tokenResponse.json()
+  const token = tokenPayload?.token ?? tokenPayload?.access_token
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error(
+      `${repository}:${tag} registry token response was incomplete`
+    )
+  }
+  response = await request(`Bearer ${token}`)
+  return response
+}
+
+async function fetchRegistryDigest({ repository, tag, fetchImpl = fetch }) {
+  const response = await registryResponse({ repository, tag, fetchImpl })
+  if (!response.ok) {
+    throw new Error(
+      `${repository}:${tag} registry response was ${response.status}`
+    )
+  }
+  const digest = response.headers.get('docker-content-digest')
+  if (!DIGEST_PATTERN.test(digest ?? '')) {
+    throw new Error(
+      `${repository}:${tag} registry response has no digest header`
+    )
+  }
+  return digest
+}
+
+async function getReleaseRef({ github, context }) {
+  if (typeof github.rest.git?.getRef !== 'function') {
+    throw new Error('stg-release remote ref API is unavailable')
+  }
+  try {
+    const response = await github.rest.git.getRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: PROMOTION_REF_API,
+    })
+    const sha = response.data?.object?.sha
+    if (response.data?.object?.type !== 'commit' || !validSha(sha))
+      throw new Error('stg-release does not point to a commit')
+    return sha
+  } catch (error) {
+    if (error?.status === 404) return null
+    throw error
+  }
+}
+
+function releaseRepositoryUrl(
+  context,
+  serverUrl = process.env.GITHUB_SERVER_URL
+) {
+  const owner = context.repo.owner
+  const repository = context.repo.repo
+  if (
+    !/^[A-Za-z0-9_.-]+$/.test(owner ?? '') ||
+    !/^[A-Za-z0-9_.-]+$/.test(repository ?? '')
+  ) {
+    throw new Error('repository identity is unsafe for a ref update')
+  }
+  const server = new URL(serverUrl || 'https://github.com')
+  if (server.protocol !== 'https:') {
+    throw new Error('repository server must use HTTPS')
+  }
+  return new URL(`${owner}/${repository}.git`, `${server.origin}/`).toString()
+}
+
+function gitEnvironment(gitToken, repositoryUrl) {
+  const environment = {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+  }
+  delete environment.GITHUB_TOKEN
+  if (!gitToken) return environment
+
+  const origin = new URL(repositoryUrl).origin
+  const authorization = Buffer.from(`x-access-token:${gitToken}`).toString(
+    'base64'
+  )
+  environment.GIT_CONFIG_COUNT = '1'
+  environment.GIT_CONFIG_KEY_0 = `http.${origin}/.extraheader`
+  environment.GIT_CONFIG_VALUE_0 = `AUTHORIZATION: basic ${authorization}`
+  return environment
+}
+
+function runGit(args, options) {
+  return execFileSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+    ...options,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+function pushReleaseRefWithLease({
+  context,
+  expectedSha,
+  candidateSha,
+  gitToken = process.env.GITHUB_TOKEN,
+  repositoryUrl = releaseRepositoryUrl(context),
+  gitRunner = runGit,
+  workspace = process.cwd(),
+}) {
+  if (!validSha(candidateSha)) throw new Error('candidate SHA is invalid')
+  if (expectedSha != null && !validSha(expectedSha)) {
+    throw new Error('expected release SHA is invalid')
+  }
+  if (!gitToken && /^https:/i.test(repositoryUrl)) {
+    throw new Error('GITHUB_TOKEN is unavailable for the ref update')
+  }
+
+  const options = {
+    cwd: workspace,
+    env: gitEnvironment(gitToken, repositoryUrl),
+  }
+  gitRunner(
+    [
+      'fetch',
+      '--no-tags',
+      '--no-write-fetch-head',
+      repositoryUrl,
+      candidateSha,
+    ],
+    options
+  )
+  gitRunner(
+    [
+      'push',
+      '--porcelain',
+      // GitHub's ref API has no expected-old field. The explicit lease supplies
+      // that compare-and-swap condition after graph validation proved this is
+      // a create or fast-forward, never a history rewrite.
+      `--force-with-lease=${PROMOTION_REF}:${expectedSha ?? ''}`,
+      repositoryUrl,
+      `${candidateSha}:${PROMOTION_REF}`,
+    ],
+    options
+  )
+}
+
+async function planReleaseRef({ github, context, currentSha, candidateSha }) {
+  if (currentSha == null) return { action: 'create', currentSha: null }
+  if (currentSha === candidateSha) {
+    return { action: 'no-op-equal', currentSha }
+  }
+  const comparison = await compareRevisions({
+    github,
+    context,
+    base: currentSha,
+    head: candidateSha,
+  })
+  if (comparison.status === 'ahead') {
+    return { action: 'fast-forward', currentSha }
+  }
+  if (comparison.status === 'behind') {
+    return { action: 'no-op-stale', currentSha }
+  }
+  if (comparison.status === 'identical') {
+    return { action: 'no-op-equal', currentSha }
+  }
+  throw new Error('stg-release diverges from the candidate; refusing promotion')
+}
+
+async function compareAndSwapReleaseRef({
+  github,
+  context,
+  expectedSha,
+  candidateSha,
+  gitToken,
+  repositoryUrl,
+  gitRunner,
+  workspace,
+}) {
+  const observed = await getReleaseRef({ github, context })
+  if (observed !== expectedSha) {
+    throw new Error('stg-release changed before the compare-and-swap')
+  }
+  if (expectedSha != null) {
+    const comparison = await compareRevisions({
+      github,
+      context,
+      base: expectedSha,
+      head: candidateSha,
+    })
+    if (!['ahead', 'identical'].includes(comparison?.status)) {
+      throw new Error('stg-release compare-and-swap is not a fast-forward')
+    }
+  }
+  try {
+    pushReleaseRefWithLease({
+      context,
+      expectedSha,
+      candidateSha,
+      gitToken,
+      repositoryUrl,
+      gitRunner,
+      workspace,
+    })
+  } catch (error) {
+    throw new Error('stg-release compare-and-swap failed', { cause: error })
+  }
+  const result = await getReleaseRef({ github, context })
+  if (result !== candidateSha) {
+    throw new Error('stg-release changed during the compare-and-swap')
+  }
+  return result
+}
+
+function defaultReceiptPath() {
+  return path.join(
+    process.env.RUNNER_TEMP || os.tmpdir(),
+    'stg-release-promotion-receipt.json'
+  )
+}
+
+function defaultChecksumPath() {
+  return path.join(
+    process.env.RUNNER_TEMP || os.tmpdir(),
+    'stg-release-promotion-receipt.sha256'
+  )
+}
+
+function writeReceiptArtifacts({
+  receipt,
+  checksum,
+  receiptPath = defaultReceiptPath(),
+  checksumPath = defaultChecksumPath(),
+  summaryPath = process.env.GITHUB_STEP_SUMMARY,
+}) {
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true })
+  fs.mkdirSync(path.dirname(checksumPath), { recursive: true })
+  const serialized = canonicalJson(receipt)
+  fs.writeFileSync(receiptPath, `${serialized}\n`)
+  fs.writeFileSync(checksumPath, `${checksum}  ${path.basename(receiptPath)}\n`)
+  if (summaryPath) {
+    fs.appendFileSync(
+      summaryPath,
+      [
+        '### Staging release promotion',
+        '',
+        `- Candidate: \`${receipt.candidate_sha}\``,
+        `- Source: \`${receipt.source_branch}\``,
+        `- Controller run: \`${receipt.controller_run_id}\``,
+        `- Decision: \`${receipt.decision.action}\``,
+        `- Write mode: \`${receipt.decision.mode}\``,
+        `- Workflows: ${receipt.workflows.length}`,
+        `- Runtime image digests: ${receipt.images.length}`,
+        `- Receipt checksum: \`${checksum}\``,
+        '',
+      ].join('\n')
+    )
+  }
+  return { checksumPath, receiptPath }
+}
+
+function setOutput(core, name, value) {
+  if (typeof core?.setOutput === 'function') core.setOutput(name, value)
+}
+
+async function resolveInputs({
+  github,
+  context,
+  sourceBranch,
+  candidateSha,
+  promotionEnabled = process.env[PROMOTION_ENABLED_VARIABLE],
+}) {
+  const selectedSourceBranch = await getSourceBranch({
+    github,
+    context,
+    selectedSourceBranch: sourceBranch,
+  })
+  if (context.eventName === 'workflow_run') {
+    const workflowRun = context.payload?.workflow_run
+    if (
+      workflowRun?.event !== 'push' ||
+      workflowRun?.conclusion !== 'success' ||
+      workflowRun?.head_branch !== selectedSourceBranch
+    ) {
+      return {
+        mode: 'automatic',
+        reason: 'workflow completion is not a successful selected-source push',
+        skipped: true,
+      }
+    }
+    return {
+      allowWrite: promotionEnabled === 'true',
+      candidateSha: workflowRun.head_sha,
+      confirmation: '',
+      dryRun: false,
+      mode: 'automatic',
+      sourceBranch: selectedSourceBranch,
+    }
+  }
+  if (context.eventName === 'workflow_dispatch') {
+    const inputs = context.payload?.inputs ?? {}
+    const selectedCandidateSha = candidateSha ?? inputs.sha
+    const dryRun = inputs.dry_run !== false && inputs.dry_run !== 'false'
+    const confirmation = inputs.confirm ?? ''
+    if (!dryRun && confirmation !== MANUAL_CONFIRMATION) {
+      throw new Error(
+        `manual writes require the exact confirmation ${MANUAL_CONFIRMATION}`
+      )
+    }
+    return {
+      allowWrite: !dryRun,
+      candidateSha: selectedCandidateSha,
+      confirmation,
+      dryRun,
+      mode: 'manual',
+      sourceBranch: selectedSourceBranch,
+    }
+  }
+  throw new Error(`unsupported promotion event ${context.eventName}`)
+}
+
+async function runPromotion({
+  github,
+  context,
+  core,
+  sourceBranch,
+  candidateSha,
+  promotionEnabled,
+  expectedWorkflows = STAGING_WORKFLOWS,
+  getRegistryDigest = fetchRegistryDigest,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+  receiptPath,
+  checksumPath,
+  summaryPath,
+  gitToken,
+  repositoryUrl,
+  gitRunner,
+  workspace,
+}) {
+  const inputs = await resolveInputs({
+    github,
+    context,
+    sourceBranch,
+    candidateSha,
+    promotionEnabled,
+  })
+  if (inputs.skipped) {
+    core?.info?.(`Skipping staging release promotion: ${inputs.reason}`)
+    setOutput(core, 'decision', 'skipped')
+    return inputs
+  }
+  if (!validSha(inputs.candidateSha)) {
+    throw new Error('candidate SHA must be 40 lowercase hexadecimal characters')
+  }
+  if (!Number.isSafeInteger(context.runId) || context.runId <= 0) {
+    throw new Error('controller run id is unavailable')
+  }
+  if (inputs.mode === 'automatic' && !inputs.allowWrite) {
+    core?.info?.(
+      `${PROMOTION_ENABLED_VARIABLE} is not true; automatic promotion remains read-only`
+    )
+    setOutput(core, 'decision', 'disabled')
+    return { ...inputs, decision: 'disabled', skipped: true }
+  }
+
+  const repository = repositoryName(context)
+  const definitions = await getCandidateDefinitions({
+    github,
+    context,
+    candidateSha: inputs.candidateSha,
+    expectedWorkflows,
+  })
+  const workflows = validateStagingWorkflows({
+    definitions,
+    repository,
+    sourceBranch: inputs.sourceBranch,
+    expectedWorkflows,
+  })
+  await validateCandidateAncestry({
+    github,
+    context,
+    candidateSha: inputs.candidateSha,
+    sourceBranch: inputs.sourceBranch,
+  })
+
+  const evidence = await collectBuildEvidence({
+    github,
+    context,
+    workflows,
+    candidateSha: inputs.candidateSha,
+    sourceBranch: inputs.sourceBranch,
+    maxAttempts,
+    retryDelayMs,
+    sleep,
+  })
+  if (!evidence.valid) {
+    throw new Error(`staging build evidence is incomplete: ${evidence.reason}`)
+  }
+  const images = await resolveStableRegistryDigests({
+    candidateSha: inputs.candidateSha,
+    evidence,
+    workflows,
+    getRegistryDigest,
+  })
+
+  const currentSha = await getReleaseRef({ github, context })
+  const decision = await planReleaseRef({
+    github,
+    context,
+    currentSha,
+    candidateSha: inputs.candidateSha,
+  })
+  let appliedSha = null
+  if (
+    inputs.allowWrite &&
+    ['create', 'fast-forward'].includes(decision.action)
+  ) {
+    appliedSha = await compareAndSwapReleaseRef({
+      github,
+      context,
+      expectedSha: currentSha,
+      candidateSha: inputs.candidateSha,
+      gitToken,
+      repositoryUrl,
+      gitRunner,
+      workspace,
+    })
+  }
+
+  const receipt = {
+    schema_version: 'stg-release-promotion/v1',
+    controller_run_id: context.runId,
+    repository,
+    source_branch: inputs.sourceBranch,
+    candidate_sha: inputs.candidateSha,
+    previous_release_sha: currentSha,
+    applied_release_sha: appliedSha,
+    decision: {
+      action: decision.action,
+      mode: inputs.allowWrite ? 'apply' : 'dry-run',
+      ref: PROMOTION_REF,
+    },
+    attempts: evidence.attempts,
+    workflows: evidence.workflows.map((workflow) => ({
+      name: workflows.find((entry) => entry.path === workflow.path).name,
+      path: workflow.path,
+      run_id: workflow.run.id,
+      run_sha: workflow.run.sha,
+      run_url: workflow.run.url,
+      jobs: workflow.jobs,
+    })),
+    images,
+  }
+  const checksum = checksumReceipt(receipt)
+  const artifacts = writeReceiptArtifacts({
+    receipt,
+    checksum,
+    receiptPath,
+    checksumPath,
+    summaryPath,
+  })
+  setOutput(core, 'decision', decision.action)
+  setOutput(core, 'receipt_path', artifacts.receiptPath)
+  setOutput(core, 'checksum_path', artifacts.checksumPath)
+  setOutput(core, 'receipt_checksum', checksum)
+  core?.info?.(
+    `Staging release promotion ${decision.action}; receipt ${checksum}`
+  )
+  return { ...receipt, checksum, ...artifacts }
+}
+
+module.exports = {
+  APPROVED_PUSH_BRANCHES,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_DELAY_MS,
+  DIGEST_PATTERN,
+  MANUAL_CONFIRMATION,
+  PROMOTION_ENABLED_VARIABLE,
+  PROMOTION_REF,
+  PROMOTION_REF_API,
+  PROMOTION_REF_NAME,
+  SOURCE_BRANCH_VARIABLE,
+  STAGING_WORKFLOWS,
+  STAGING_WORKFLOW_PATHS,
+  canonicalJson,
+  checksumReceipt,
+  collectBuildEvidence,
+  compareAndSwapReleaseRef,
+  fetchRegistryDigest,
+  getCandidateDefinitions,
+  getReleaseRef,
+  getSourceBranch,
+  isDisabledJob,
+  matchesApprovedBranch,
+  planReleaseRef,
+  pushReleaseRefWithLease,
+  resolveStableRegistryDigests,
+  runPromotion,
+  validateCandidateAncestry,
+  validateStagingWorkflow,
+  validateStagingWorkflows,
+  writeReceiptArtifacts,
+}

--- a/.github/scripts/stg-release-promoter.test.js
+++ b/.github/scripts/stg-release-promoter.test.js
@@ -8,6 +8,8 @@ const test = require('node:test')
 const {
   FIXTURE_STAGING_WORKFLOWS,
   fixtureDefinitions,
+  registryManifestResponse,
+  transientReadbackFailure,
   workflowJobs,
   workflowRun,
 } = require('./stg-release-promoter-fixtures')
@@ -20,6 +22,7 @@ const {
   collectBuildEvidence,
   compareAndSwapReleaseRef,
   fetchRegistryDigest,
+  getSourceBranch,
   planReleaseRef,
   pushReleaseRefWithLease,
   resolveStableRegistryDigests,
@@ -150,8 +153,13 @@ function successfulJobs(workflows) {
   )
 }
 
-function refGithub(initialSha = null, { afterUpdateSha } = {}) {
+function refGithub(
+  initialSha = null,
+  { afterUpdateSha, postPushReadbacks = [] } = {}
+) {
   let currentSha = initialSha
+  let pushed = false
+  let readbackIndex = 0
   const calls = []
   const github = {
     calls,
@@ -159,6 +167,17 @@ function refGithub(initialSha = null, { afterUpdateSha } = {}) {
       git: {
         getRef: async (params) => {
           calls.push({ method: 'getRef', params })
+          if (pushed && readbackIndex < postPushReadbacks.length) {
+            const readback = postPushReadbacks[readbackIndex]
+            readbackIndex += 1
+            if (readback instanceof Error) throw readback
+            if (readback == null) {
+              const error = new Error('reference not found')
+              error.status = 404
+              throw error
+            }
+            return { data: { object: { sha: readback, type: 'commit' } } }
+          }
           if (currentSha == null) {
             const error = new Error('reference not found')
             error.status = 404
@@ -184,6 +203,7 @@ function refGithub(initialSha = null, { afterUpdateSha } = {}) {
     if (currentSha !== expectedSha) throw new Error('stale ref lease')
     const candidateSha = args.at(-1).split(':')[0]
     currentSha = afterUpdateSha ?? candidateSha
+    pushed = true
     return ''
   }
   return {
@@ -196,6 +216,12 @@ function refGithub(initialSha = null, { afterUpdateSha } = {}) {
     },
   }
 }
+
+test('requires the trusted workflow to resolve the selected source branch', () => {
+  assert.equal(getSourceBranch('v3'), 'v3')
+  assert.throws(() => getSourceBranch(), /resolved by the trusted workflow/)
+  assert.throws(() => getSourceBranch('main'), /approved push triggers/)
+})
 
 test('validates the candidate workflow set and only inventories active ARM publishers', () => {
   const workflows = validWorkflows()
@@ -638,6 +664,43 @@ test('fails closed for missing, skipped, failed, cancelled, and wrong evidence',
   }
 })
 
+test('fails closed when Octokit pagination is unavailable or invalid', async () => {
+  const workflows = validWorkflows()
+  const missingPaginator = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+  }).github
+  delete missingPaginator.paginate
+  await assert.rejects(
+    collectBuildEvidence({
+      github: missingPaginator,
+      context: reviewContext(),
+      workflows,
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+      maxAttempts: 1,
+    }),
+    /pagination is unavailable/
+  )
+
+  const invalidPaginator = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+  }).github
+  invalidPaginator.paginate = async () => ({})
+  await assert.rejects(
+    collectBuildEvidence({
+      github: invalidPaginator,
+      context: reviewContext(),
+      workflows,
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+      maxAttempts: 1,
+    }),
+    /pagination returned an invalid result/
+  )
+})
+
 test('resolves stable runtime SHA-tag digests and rejects incomplete or changing results', async () => {
   const workflows = validWorkflows()
   const { github } = evidenceGithub({
@@ -701,7 +764,8 @@ test('resolves stable runtime SHA-tag digests and rejects incomplete or changing
 })
 
 test('resolves a public registry Bearer challenge without exposing credentials', async () => {
-  const digest = `sha256:${'5'.repeat(64)}`
+  const manifestResponse = registryManifestResponse()
+  const digest = manifestResponse.headers.get('docker-content-digest')
   const calls = []
   const responses = [
     {
@@ -717,11 +781,7 @@ test('resolves a public registry Bearer challenge without exposing credentials',
       ok: true,
       status: 200,
     },
-    {
-      headers: new Headers({ 'docker-content-digest': digest }),
-      ok: true,
-      status: 200,
-    },
+    manifestResponse,
   ]
   const fetchImpl = async (url, options = {}) => {
     calls.push({ url: String(url), options })
@@ -741,6 +801,89 @@ test('resolves a public registry Bearer challenge without exposing credentials',
   assert.equal(
     calls[2].options.headers.authorization,
     'Bearer synthetic-registry-token'
+  )
+})
+
+test('verifies registry digest headers against accepted raw manifest bodies', async () => {
+  const contentTypes = [
+    'application/vnd.oci.image.index.v1+json',
+    'application/vnd.docker.distribution.manifest.list.v2+json',
+    'application/vnd.oci.image.manifest.v1+json',
+    'application/vnd.docker.distribution.manifest.v2+json',
+  ]
+  for (const contentType of contentTypes) {
+    const response = registryManifestResponse({
+      contentType: `${contentType}; charset=utf-8`,
+    })
+    assert.equal(
+      await fetchRegistryDigest({
+        repository: 'ghcr.io/uzh-bf/klicker-uzh/auth-arm',
+        tag: CANDIDATE_SHA,
+        fetchImpl: async () => response,
+      }),
+      response.headers.get('docker-content-digest'),
+      contentType
+    )
+  }
+})
+
+test('rejects untrusted or incomplete registry manifest responses', async () => {
+  const cases = [
+    [
+      'unexpected content type',
+      registryManifestResponse({ contentType: 'text/plain' }),
+      /unexpected content type/,
+    ],
+    [
+      'missing digest',
+      registryManifestResponse({ includeDigest: false }),
+      /no valid digest header/,
+    ],
+    [
+      'invalid digest',
+      registryManifestResponse({ digest: 'sha256:not-a-digest' }),
+      /no valid digest header/,
+    ],
+    [
+      'body mismatch',
+      registryManifestResponse({ digest: `sha256:${'f'.repeat(64)}` }),
+      /does not match its digest header/,
+    ],
+    ['redirect', registryManifestResponse({ redirected: true }), /redirected/],
+    [
+      'missing body reader',
+      registryManifestResponse({ includeReader: false }),
+      /incomplete/,
+    ],
+    [
+      'empty body',
+      registryManifestResponse({ body: Buffer.alloc(0) }),
+      /incomplete/,
+    ],
+  ]
+  for (const [label, response, reason] of cases) {
+    await assert.rejects(
+      fetchRegistryDigest({
+        repository: 'ghcr.io/uzh-bf/klicker-uzh/auth-arm',
+        tag: CANDIDATE_SHA,
+        fetchImpl: async () => response,
+      }),
+      reason,
+      label
+    )
+  }
+
+  const interrupted = registryManifestResponse()
+  interrupted.arrayBuffer = async () => {
+    throw new Error('synthetic truncated body')
+  }
+  await assert.rejects(
+    fetchRegistryDigest({
+      repository: 'ghcr.io/uzh-bf/klicker-uzh/auth-arm',
+      tag: CANDIDATE_SHA,
+      fetchImpl: async () => interrupted,
+    }),
+    /incomplete/
   )
 })
 
@@ -806,17 +949,17 @@ test('plans equal, stale, fast-forward, and divergent release refs without force
 test('uses an exact remote lease for create and prevalidated fast-forward updates', async () => {
   const context = reviewContext()
   const create = refGithub()
-  assert.equal(
-    await compareAndSwapReleaseRef({
-      github: create.github,
-      context,
-      expectedSha: null,
-      candidateSha: CANDIDATE_SHA,
-      gitRunner: create.gitRunner,
-      gitToken: 'fixture-token',
-    }),
-    CANDIDATE_SHA
-  )
+  const created = await compareAndSwapReleaseRef({
+    github: create.github,
+    context,
+    expectedSha: null,
+    candidateSha: CANDIDATE_SHA,
+    gitRunner: create.gitRunner,
+    gitToken: 'fixture-token',
+  })
+  assert.equal(created.result, 'push-succeeded')
+  assert.equal(created.verification, 'verified')
+  assert.equal(created.observed_release_sha, CANDIDATE_SHA)
   const createGitCalls = create.calls.filter((call) => call.method === 'git')
   assert.equal(createGitCalls[0].args[0], 'fetch')
   assert.deepEqual(createGitCalls[1].args.slice(0, 3), [
@@ -865,17 +1008,21 @@ test('uses an exact remote lease for create and prevalidated fast-forward update
   )
 
   const raced = refGithub(CURRENT_SHA, { afterUpdateSha: 'd'.repeat(40) })
-  await assert.rejects(
-    compareAndSwapReleaseRef({
-      github: raced.github,
-      context,
-      expectedSha: CURRENT_SHA,
-      candidateSha: NEXT_SHA,
-      gitRunner: raced.gitRunner,
-      gitToken: 'fixture-token',
-    }),
-    /changed during the compare-and-swap/
-  )
+  const racedResult = await compareAndSwapReleaseRef({
+    github: raced.github,
+    context,
+    expectedSha: CURRENT_SHA,
+    candidateSha: NEXT_SHA,
+    gitRunner: raced.gitRunner,
+    gitToken: 'fixture-token',
+    readbackMaxAttempts: 2,
+    readbackRetryDelayMs: 0,
+    sleep: async () => {},
+  })
+  assert.equal(racedResult.result, 'push-succeeded')
+  assert.equal(racedResult.verification, 'mismatch')
+  assert.equal(racedResult.observed_release_sha, 'd'.repeat(40))
+  assert.equal(racedResult.readback_attempts.length, 2)
 
   const notForward = refGithub(CURRENT_SHA)
   notForward.github.rest.repos.compareCommitsWithBasehead = async () => ({
@@ -897,6 +1044,28 @@ test('uses an exact remote lease for create and prevalidated fast-forward update
       (call) => call.method === 'git' && call.args[0] === 'push'
     ),
     false
+  )
+})
+
+test('recovers from a transient post-push ref readback failure', async () => {
+  const refs = refGithub(null, {
+    postPushReadbacks: [transientReadbackFailure(), CANDIDATE_SHA],
+  })
+  const result = await compareAndSwapReleaseRef({
+    github: refs.github,
+    context: reviewContext(),
+    expectedSha: null,
+    candidateSha: CANDIDATE_SHA,
+    gitRunner: refs.gitRunner,
+    gitToken: 'fixture-token',
+    readbackMaxAttempts: 3,
+    readbackRetryDelayMs: 0,
+    sleep: async () => {},
+  })
+  assert.equal(result.verification, 'verified')
+  assert.deepEqual(
+    result.readback_attempts.map((attempt) => attempt.state),
+    ['unavailable', 'verified']
   )
 })
 
@@ -1057,6 +1226,105 @@ test('keeps an out-of-order candidate stale after a newer fast-forward wins', as
   )
 })
 
+test('writes receipts before rejecting uncertain or mismatched post-push readback', async (t) => {
+  const workflows = validWorkflows()
+  const { github: baseGithub } = evidenceGithub({
+    definitions: fixtureDefinitions(),
+    workflows,
+    jobs: successfulJobs(workflows),
+    runs: evidenceRuns(workflows),
+  })
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'stg-release-readback-')
+  )
+  t.after(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }))
+
+  const cases = [
+    {
+      label: 'uncertain',
+      options: {
+        postPushReadbacks: [
+          transientReadbackFailure(),
+          transientReadbackFailure(),
+        ],
+      },
+      reason: /post-push verification is uncertain/,
+      states: ['unavailable', 'unavailable'],
+    },
+    {
+      label: 'mismatch',
+      options: { afterUpdateSha: NEXT_SHA },
+      reason: /post-push verification is mismatch/,
+      states: ['mismatch', 'mismatch'],
+    },
+  ]
+
+  for (const fixture of cases) {
+    const refs = refGithub(null, fixture.options)
+    const github = {
+      ...baseGithub,
+      rest: {
+        ...baseGithub.rest,
+        git: refs.github.rest.git,
+      },
+    }
+    const receiptPath = path.join(
+      temporaryDirectory,
+      `${fixture.label}-receipt.json`
+    )
+    const checksumPath = path.join(
+      temporaryDirectory,
+      `${fixture.label}-receipt.sha256`
+    )
+    const outputs = new Map()
+    await assert.rejects(
+      runPromotion({
+        github,
+        context: reviewContext('workflow_dispatch', {
+          confirm_ref_update: MANUAL_CONFIRMATION,
+          dry_run: false,
+          sha: CANDIDATE_SHA,
+        }),
+        sourceBranch: 'v3',
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        getRegistryDigest: async () => `sha256:${'6'.repeat(64)}`,
+        gitRunner: refs.gitRunner,
+        gitToken: 'fixture-token',
+        maxAttempts: 1,
+        readbackMaxAttempts: 2,
+        readbackRetryDelayMs: 0,
+        sleep: async () => {},
+        receiptPath,
+        checksumPath,
+        core: {
+          setOutput: (name, value) => outputs.set(name, value),
+        },
+      }),
+      fixture.reason,
+      fixture.label
+    )
+
+    assert.equal(fs.existsSync(receiptPath), true, fixture.label)
+    assert.equal(fs.existsSync(checksumPath), true, fixture.label)
+    const receiptText = fs.readFileSync(receiptPath, 'utf8')
+    const receipt = JSON.parse(receiptText)
+    assert.equal(receipt.update_result.result, 'push-succeeded')
+    assert.equal(receipt.update_result.verification, fixture.label)
+    assert.equal(receipt.applied_release_sha, null)
+    assert.deepEqual(
+      receipt.update_result.readback_attempts.map((attempt) => attempt.state),
+      fixture.states
+    )
+    assert.doesNotMatch(receiptText, /synthetic readback unavailable/)
+    const checksum = checksumReceipt(receipt)
+    assert.equal(outputs.get('receipt_checksum'), checksum)
+    assert.equal(
+      fs.readFileSync(checksumPath, 'utf8'),
+      `${checksum}  ${path.basename(receiptPath)}\n`
+    )
+  }
+})
+
 test('keeps manual defaults dry-run and gates automatic writes', async () => {
   const workflows = validWorkflows()
   const runs = evidenceRuns(workflows)
@@ -1096,6 +1364,8 @@ test('keeps manual defaults dry-run and gates automatic writes', async () => {
     })
     assert.equal(result.decision.mode, 'dry-run')
     assert.equal(result.decision.action, 'create')
+    assert.equal(result.update_result.result, 'not-attempted')
+    assert.equal(result.update_result.verification, 'not-required')
     assert.equal(refs.current(), null)
     assert.equal(
       checksumReceipt(JSON.parse(fs.readFileSync(result.receiptPath, 'utf8'))),
@@ -1114,7 +1384,7 @@ test('keeps manual defaults dry-run and gates automatic writes', async () => {
     const rerun = await runPromotion({
       github: rerunGithub,
       context: reviewContext('workflow_dispatch', {
-        confirm: MANUAL_CONFIRMATION,
+        confirm_ref_update: MANUAL_CONFIRMATION,
         dry_run: false,
         sha: CANDIDATE_SHA,
       }),
@@ -1127,6 +1397,7 @@ test('keeps manual defaults dry-run and gates automatic writes', async () => {
       summaryPath,
     })
     assert.equal(rerun.decision.action, 'no-op-equal')
+    assert.equal(rerun.update_result.result, 'not-attempted')
     assert.equal(
       rerunRefs.calls.some((call) => call.method === 'updateRef'),
       false
@@ -1157,25 +1428,32 @@ test('keeps manual defaults dry-run and gates automatic writes', async () => {
     })
     assert.equal(enabled.decision.action, 'create')
     assert.equal(enabled.decision.mode, 'apply')
+    assert.equal(enabled.update_result.result, 'push-succeeded')
+    assert.equal(enabled.update_result.verification, 'verified')
     assert.equal(refs.current(), CANDIDATE_SHA)
   } finally {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true })
   }
 
-  await assert.rejects(
-    runPromotion({
-      github,
-      context: reviewContext('workflow_dispatch', {
-        confirm: 'wrong',
-        dry_run: false,
-        sha: CANDIDATE_SHA,
+  for (const inputs of [
+    { confirm_ref_update: 'wrong' },
+    { confirm: MANUAL_CONFIRMATION },
+  ]) {
+    await assert.rejects(
+      runPromotion({
+        github,
+        context: reviewContext('workflow_dispatch', {
+          ...inputs,
+          dry_run: false,
+          sha: CANDIDATE_SHA,
+        }),
+        sourceBranch: 'v3',
+        candidateSha: CANDIDATE_SHA,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
       }),
-      sourceBranch: 'v3',
-      candidateSha: CANDIDATE_SHA,
-      expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
-    }),
-    new RegExp(`exact confirmation ${MANUAL_CONFIRMATION}`)
-  )
+      new RegExp(`confirm_ref_update=${MANUAL_CONFIRMATION}`)
+    )
+  }
 })
 
 test('uses only trusted controller checkout and has no commit or PR commands', () => {
@@ -1188,7 +1466,8 @@ test('uses only trusted controller checkout and has no commit or PR commands', (
   assert.match(workflow, /SOURCE_BRANCH:.*STG_SOURCE_BRANCH/)
   assert.match(workflow, /sourceBranch: process\.env\.SOURCE_BRANCH/)
   assert.match(workflow, /default: true/)
-  assert.match(workflow, /confirm/)
+  assert.match(workflow, /^ {6}confirm_ref_update:$/m)
+  assert.doesNotMatch(workflow, /^ {6}confirm:$/m)
   assert.match(workflow, /stg-release/)
   assert.match(workflow, /github\.event\.workflow_run\.head_sha/)
   assert.doesNotMatch(workflow, /STG_PROMOTE_TOKEN|git commit|git push|gh pr/)
@@ -1221,6 +1500,7 @@ test('uses only trusted controller checkout and has no commit or PR commands', (
   assert.match(promoter, /--force-with-lease=/)
   assert.doesNotMatch(promoter, /['"]--force['"]|git commit|gh pr/)
   assert.doesNotMatch(promoter, /createRef|updateRef|pulls\.create/)
+  assert.doesNotMatch(promoter, /getRepoVariable/)
 })
 
 test('does not use candidate files as executable workflow inputs', () => {

--- a/.github/scripts/stg-release-promoter.test.js
+++ b/.github/scripts/stg-release-promoter.test.js
@@ -1,0 +1,1241 @@
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  FIXTURE_STAGING_WORKFLOWS,
+  fixtureDefinitions,
+  workflowJobs,
+  workflowRun,
+} = require('./stg-release-promoter-fixtures')
+const {
+  MANUAL_CONFIRMATION,
+  PROMOTION_REF,
+  STAGING_WORKFLOWS,
+  STAGING_WORKFLOW_PATHS,
+  checksumReceipt,
+  collectBuildEvidence,
+  compareAndSwapReleaseRef,
+  fetchRegistryDigest,
+  planReleaseRef,
+  pushReleaseRefWithLease,
+  resolveStableRegistryDigests,
+  runPromotion,
+  validateCandidateAncestry,
+  validateStagingWorkflows,
+} = require('./stg-release-promoter')
+
+const REPOSITORY = 'uzh-bf/klicker-uzh'
+const CANDIDATE_SHA = 'a'.repeat(40)
+const CURRENT_SHA = 'b'.repeat(40)
+const NEXT_SHA = 'c'.repeat(40)
+
+function reviewContext(eventName = 'workflow_dispatch', inputs = {}) {
+  return {
+    eventName,
+    payload: {
+      inputs,
+      repository: { default_branch: 'v3' },
+      workflow_run: {
+        conclusion: 'success',
+        event: 'push',
+        head_branch: 'v3',
+        head_sha: CANDIDATE_SHA,
+      },
+    },
+    repo: { owner: 'uzh-bf', repo: 'klicker-uzh' },
+    runId: 9001,
+  }
+}
+
+function validWorkflows() {
+  return validateStagingWorkflows({
+    definitions: fixtureDefinitions(),
+    expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+    repository: REPOSITORY,
+    sourceBranch: 'v3',
+  })
+}
+
+function evidenceRuns(workflows, overrides = {}) {
+  return Object.fromEntries(
+    workflows.map((workflow, index) => [
+      workflow.path,
+      overrides[workflow.path] ?? [
+        workflowRun({
+          candidateSha: CANDIDATE_SHA,
+          id: 100 + index,
+          path: workflow.path,
+        }),
+      ],
+    ])
+  )
+}
+
+function evidenceGithub({
+  definitions = [],
+  workflows,
+  runs = evidenceRuns(workflows),
+  jobs = {},
+  comparisons = {},
+}) {
+  const runEndpoint = async (params) => ({
+    data: { workflow_runs: runs[params.workflow_id] ?? [] },
+  })
+  const jobEndpoint = async (params) => ({
+    data: { jobs: jobs[params.run_id] ?? [] },
+  })
+  const compareEndpoint = async ({ basehead }) => ({
+    data: comparisons[basehead] ?? { status: 'ahead' },
+  })
+  const github = {
+    rest: {
+      actions: {
+        listJobsForWorkflowRun: jobEndpoint,
+        listWorkflowRuns: runEndpoint,
+      },
+      repos: {
+        compareCommitsWithBasehead: compareEndpoint,
+        getContent: async ({ path: filePath }) => {
+          if (filePath === '.github/workflows') {
+            return {
+              data: definitions.map((definition) => ({
+                name: definition.path.split('/').at(-1),
+                path: definition.path,
+                type: 'file',
+              })),
+            }
+          }
+          const definition = definitions.find(
+            (candidate) => candidate.path === filePath
+          )
+          return {
+            data: {
+              content: Buffer.from(definition?.content ?? '').toString(
+                'base64'
+              ),
+              encoding: 'base64',
+              type: 'file',
+            },
+          }
+        },
+      },
+    },
+    paginate: async (endpoint, params) => {
+      const response = await endpoint(params)
+      return response.data.workflow_runs ?? response.data.jobs ?? []
+    },
+  }
+  return { github, jobEndpoint, runEndpoint }
+}
+
+function successfulJobs(workflows) {
+  return Object.fromEntries(
+    workflows.map((workflow, index) => {
+      const runId = 100 + index
+      return [
+        runId,
+        workflowJobs({
+          candidateSha: CANDIDATE_SHA,
+          includeMigrator: workflow.jobs.some(
+            (job) => job.id === 'build-migrator-arm'
+          ),
+          path: workflow.path,
+        }),
+      ]
+    })
+  )
+}
+
+function refGithub(initialSha = null, { afterUpdateSha } = {}) {
+  let currentSha = initialSha
+  const calls = []
+  const github = {
+    calls,
+    rest: {
+      git: {
+        getRef: async (params) => {
+          calls.push({ method: 'getRef', params })
+          if (currentSha == null) {
+            const error = new Error('reference not found')
+            error.status = 404
+            throw error
+          }
+          return { data: { object: { sha: currentSha, type: 'commit' } } }
+        },
+      },
+      repos: {
+        compareCommitsWithBasehead: async () => ({
+          data: { status: 'ahead' },
+        }),
+      },
+    },
+  }
+  const gitRunner = (args) => {
+    calls.push({ args, method: 'git' })
+    if (args[0] !== 'push') return ''
+    const lease = args.find((argument) =>
+      argument.startsWith('--force-with-lease=')
+    )
+    const expectedSha = lease.slice(lease.lastIndexOf(':') + 1) || null
+    if (currentSha !== expectedSha) throw new Error('stale ref lease')
+    const candidateSha = args.at(-1).split(':')[0]
+    currentSha = afterUpdateSha ?? candidateSha
+    return ''
+  }
+  return {
+    github,
+    calls,
+    current: () => currentSha,
+    gitRunner,
+    set: (sha) => {
+      currentSha = sha
+    },
+  }
+}
+
+test('validates the candidate workflow set and only inventories active ARM publishers', () => {
+  const workflows = validWorkflows()
+  assert.deepEqual(
+    workflows.map((workflow) => workflow.jobs.map((job) => job.id)),
+    [['build-arm'], ['build-arm', 'build-migrator-arm'], ['build-arm']]
+  )
+  assert.equal(
+    workflows.some((workflow) =>
+      workflow.jobs.some((job) => job.id === 'build-amd')
+    ),
+    false
+  )
+  assert.equal(
+    workflows.every((workflow) => workflow.name.endsWith('(stg)')),
+    true
+  )
+})
+
+test('rejects unsafe workflow publication changes', () => {
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: fixtureDefinitions({ pushBranches: ["'v3'"] }),
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /approved push triggers/
+  )
+
+  const filteredPush = fixtureDefinitions()
+  filteredPush[0].content = filteredPush[0].content.replace(
+    "      - 'v3*'\n  pull_request:",
+    "      - 'v3*'\n    paths:\n      - 'apps/auth/**'\n  pull_request:"
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: filteredPush,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /approved push triggers/
+  )
+
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: fixtureDefinitions({ fullShaTag: false }),
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /full source SHA tag/
+  )
+
+  const prefixedSha = fixtureDefinitions()
+  prefixedSha[0].content = prefixedSha[0].content.replace(
+    'type=raw,value=${{ github.sha }}',
+    'type=sha,format=long'
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: prefixedSha,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /full source SHA tag/
+  )
+
+  const definitions = fixtureDefinitions()
+  definitions[0].content = definitions[0].content.replace(
+    'if: ${{ false }}',
+    'if: github.event.pull_request.draft == false'
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /must remain disabled/
+  )
+
+  const misleadingDisabledStep = fixtureDefinitions()
+  misleadingDisabledStep[0].content = misleadingDisabledStep[0].content
+    .replace(
+      '  build-amd:\n    if: ${{ false }}',
+      "  build-amd:\n    if: github.event_name != 'pull_request'"
+    )
+    .replace(
+      '      - uses: docker/metadata-action@v4\n',
+      '      - if: ${{ false }}\n        uses: docker/metadata-action@v4\n'
+    )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: misleadingDisabledStep,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /must remain disabled/
+  )
+
+  const fakePublisherText = fixtureDefinitions()
+  fakePublisherText[0].content = fakePublisherText[0].content.replace(
+    `      - uses: docker/build-push-action@v5
+        with:
+          push: \${{ github.event_name != 'pull_request' }}
+          tags: \${{ steps.meta.outputs.tags }}`,
+    `      - name: Fake publisher text
+        run: |
+          uses: docker/build-push-action@v5
+          push: \${{ github.event_name != 'pull_request' }}
+          tags: \${{ steps.meta.outputs.tags }}`
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: fakePublisherText,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /must use exactly one docker\/build-push-action/
+  )
+
+  const renamed = fixtureDefinitions()
+  renamed[0].content = renamed[0].content.replace(
+    'Build Docker image for auth (stg)',
+    'Build Docker image for renamed-auth (stg)'
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: renamed,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /trusted workflow name/
+  )
+
+  const retargeted = fixtureDefinitions()
+  retargeted[0].content = retargeted[0].content.replace(
+    '${{ github.repository }}/auth',
+    '${{ github.repository }}/other-auth'
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: retargeted,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /runtime image inventory changed/
+  )
+
+  const noMigrator = fixtureDefinitions()
+  noMigrator[1].content = noMigrator[1].content.replace(
+    /^  build-migrator-arm:[\s\S]*?(?=^  build-migrator-amd:)/m,
+    ''
+  )
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: noMigrator,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /active ARM job inventory changed/
+  )
+
+  const extraPublisher = fixtureDefinitions()
+  extraPublisher[0].content += `  publish-extra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/build-push-action@v5
+`
+  assert.throws(
+    () =>
+      validateStagingWorkflows({
+        definitions: extraPublisher,
+        expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+        repository: REPOSITORY,
+        sourceBranch: 'v3',
+      }),
+    /unexpected active image publisher/
+  )
+})
+
+test('requires the candidate to be an ancestor of the selected source', async () => {
+  const context = reviewContext()
+  const github = evidenceGithub({ workflows: validWorkflows() }).github
+  await assert.doesNotReject(
+    validateCandidateAncestry({
+      github,
+      context,
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+    })
+  )
+
+  const staleGithub = evidenceGithub({
+    comparisons: { [`${CANDIDATE_SHA}...v3`]: { status: 'behind' } },
+    workflows: validWorkflows(),
+  }).github
+  await assert.rejects(
+    validateCandidateAncestry({
+      github: staleGithub,
+      context,
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+    }),
+    /not an ancestor/
+  )
+})
+
+test('accepts delayed and running exact-SHA evidence after bounded retries', async () => {
+  const workflows = validWorkflows()
+  let runReads = 0
+  const { github: delayedGithub } = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+  })
+  const delayedEndpoint = delayedGithub.rest.actions.listWorkflowRuns
+  delayedGithub.rest.actions.listWorkflowRuns = async (params) => {
+    runReads += 1
+    if (runReads === 1) return { data: { workflow_runs: [] } }
+    return delayedEndpoint(params)
+  }
+  const delays = []
+  const delayed = await collectBuildEvidence({
+    github: delayedGithub,
+    context: reviewContext(),
+    workflows,
+    candidateSha: CANDIDATE_SHA,
+    sourceBranch: 'v3',
+    maxAttempts: 2,
+    retryDelayMs: 7,
+    sleep: async (delay) => delays.push(delay),
+  })
+  assert.equal(delayed.valid, true)
+  assert.deepEqual(delays, [7])
+  assert.equal(delayed.attempts.length, 2)
+
+  let runningReads = 0
+  const runningGithub = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+  }).github
+  const runningEndpoint = runningGithub.rest.actions.listWorkflowRuns
+  runningGithub.rest.actions.listWorkflowRuns = async (params) => {
+    runningReads += 1
+    if (runningReads === 1) {
+      return {
+        data: {
+          workflow_runs: [
+            workflowRun({
+              candidateSha: CANDIDATE_SHA,
+              id: 100,
+              path: params.workflow_id,
+              status: 'in_progress',
+            }),
+          ],
+        },
+      }
+    }
+    return runningEndpoint(params)
+  }
+  const running = await collectBuildEvidence({
+    github: runningGithub,
+    context: reviewContext(),
+    workflows,
+    candidateSha: CANDIDATE_SHA,
+    sourceBranch: 'v3',
+    maxAttempts: 2,
+    sleep: async () => {},
+  })
+  assert.equal(running.valid, true)
+  assert.equal(running.attempts[0].failures[0].status, 'running')
+})
+
+test('fails closed for missing, skipped, failed, cancelled, and wrong evidence', async () => {
+  const workflows = validWorkflows()
+  const cases = [
+    [
+      'skipped',
+      [
+        workflowRun({
+          candidateSha: CANDIDATE_SHA,
+          conclusion: 'skipped',
+          id: 100,
+          path: workflows[0].path,
+        }),
+      ],
+      /run is skipped/,
+    ],
+    [
+      'failed',
+      [
+        workflowRun({
+          candidateSha: CANDIDATE_SHA,
+          conclusion: 'failure',
+          id: 100,
+          path: workflows[0].path,
+        }),
+      ],
+      /run is failed/,
+    ],
+    [
+      'cancelled',
+      [
+        workflowRun({
+          candidateSha: CANDIDATE_SHA,
+          conclusion: 'cancelled',
+          id: 100,
+          path: workflows[0].path,
+        }),
+      ],
+      /run is cancelled/,
+    ],
+    [
+      'wrong evidence',
+      [
+        workflowRun({
+          candidateSha: CANDIDATE_SHA,
+          headBranch: 'other',
+          id: 100,
+          path: workflows[0].path,
+        }),
+      ],
+      /wrong evidence/,
+    ],
+  ]
+  for (const [label, firstRuns, reason] of cases) {
+    const runs = evidenceRuns(workflows)
+    runs[workflows[0].path] = firstRuns
+    const { github } = evidenceGithub({
+      workflows,
+      jobs: successfulJobs(workflows),
+      runs,
+    })
+    const result = await collectBuildEvidence({
+      github,
+      context: reviewContext(),
+      workflows,
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+      maxAttempts: 3,
+      sleep: async () => {
+        throw new Error(`${label} should not retry`)
+      },
+    })
+    assert.equal(result.valid, false, label)
+    assert.match(result.reason, reason, label)
+    assert.equal(result.attempts.length, 1, label)
+  }
+
+  const missingRuns = evidenceRuns(workflows)
+  missingRuns[workflows[0].path] = []
+  const { github: missingGithub } = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+    runs: missingRuns,
+  })
+  const missing = await collectBuildEvidence({
+    github: missingGithub,
+    context: reviewContext(),
+    workflows,
+    candidateSha: CANDIDATE_SHA,
+    sourceBranch: 'v3',
+    maxAttempts: 2,
+    sleep: async () => {},
+  })
+  assert.equal(missing.valid, false)
+  assert.match(missing.reason, /no exact-SHA run/)
+  assert.equal(missing.attempts.length, 2)
+
+  const runningJobs = successfulJobs(workflows)
+  runningJobs[100] = workflowJobs({
+    candidateSha: CANDIDATE_SHA,
+    jobState: { 'build-arm': { status: 'in_progress' } },
+    path: workflows[0].path,
+  })
+  const { github: runningGithub } = evidenceGithub({
+    workflows,
+    jobs: runningJobs,
+  })
+  const runningResult = await collectBuildEvidence({
+    github: runningGithub,
+    context: reviewContext(),
+    workflows: [workflows[0]],
+    candidateSha: CANDIDATE_SHA,
+    sourceBranch: 'v3',
+    maxAttempts: 1,
+  })
+  assert.match(runningResult.reason, /build-arm is running/)
+
+  const jobCases = [
+    ['skipped', { conclusion: 'skipped' }],
+    ['failed', { conclusion: 'failure' }],
+    ['cancelled', { conclusion: 'cancelled' }],
+    ['wrong evidence', { head_sha: 'd'.repeat(40) }],
+  ]
+  for (const [label, jobState] of jobCases) {
+    const terminalJobs = successfulJobs(workflows)
+    terminalJobs[100] = workflowJobs({
+      candidateSha: CANDIDATE_SHA,
+      jobState: { 'build-arm': jobState },
+      path: workflows[0].path,
+    })
+    const { github: terminalGithub } = evidenceGithub({
+      workflows,
+      jobs: terminalJobs,
+    })
+    const result = await collectBuildEvidence({
+      github: terminalGithub,
+      context: reviewContext(),
+      workflows: [workflows[0]],
+      candidateSha: CANDIDATE_SHA,
+      sourceBranch: 'v3',
+      maxAttempts: 3,
+      sleep: async () => {
+        throw new Error(`${label} job should not retry`)
+      },
+    })
+    assert.equal(result.valid, false, label)
+    assert.match(result.reason, new RegExp(label), label)
+    assert.equal(result.attempts.length, 1, label)
+  }
+})
+
+test('resolves stable runtime SHA-tag digests and rejects incomplete or changing results', async () => {
+  const workflows = validWorkflows()
+  const { github } = evidenceGithub({
+    workflows,
+    jobs: successfulJobs(workflows),
+  })
+  const evidence = await collectBuildEvidence({
+    github,
+    context: reviewContext(),
+    workflows,
+    candidateSha: CANDIDATE_SHA,
+    sourceBranch: 'v3',
+    maxAttempts: 1,
+  })
+  const digest = `sha256:${'1'.repeat(64)}`
+  const receiptImages = await resolveStableRegistryDigests({
+    candidateSha: CANDIDATE_SHA,
+    evidence,
+    workflows,
+    getRegistryDigest: async () => digest,
+  })
+  assert.equal(
+    receiptImages.length,
+    workflows.reduce((count, workflow) => count + workflow.jobs.length, 0)
+  )
+  assert.equal(
+    receiptImages.some((image) => image.repository.endsWith('-amd')),
+    false
+  )
+  assert.equal(
+    receiptImages.every((image) => image.digest === digest),
+    true
+  )
+  assert.equal(
+    checksumReceipt({ images: receiptImages }),
+    checksumReceipt({ images: receiptImages })
+  )
+
+  let reads = 0
+  await assert.rejects(
+    resolveStableRegistryDigests({
+      candidateSha: CANDIDATE_SHA,
+      evidence,
+      workflows,
+      getRegistryDigest: async () => {
+        reads += 1
+        return `sha256:${(reads === 1 ? '2' : '3').repeat(64)}`
+      },
+    }),
+    /changed during collection/
+  )
+  await assert.rejects(
+    resolveStableRegistryDigests({
+      candidateSha: CANDIDATE_SHA,
+      evidence,
+      workflows,
+      getRegistryDigest: async () => undefined,
+    }),
+    /no complete registry digest/
+  )
+})
+
+test('resolves a public registry Bearer challenge without exposing credentials', async () => {
+  const digest = `sha256:${'5'.repeat(64)}`
+  const calls = []
+  const responses = [
+    {
+      headers: new Headers({
+        'www-authenticate':
+          'Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:uzh-bf/klicker-uzh/auth-arm:pull"',
+      }),
+      ok: false,
+      status: 401,
+    },
+    {
+      json: async () => ({ token: 'synthetic-registry-token' }),
+      ok: true,
+      status: 200,
+    },
+    {
+      headers: new Headers({ 'docker-content-digest': digest }),
+      ok: true,
+      status: 200,
+    },
+  ]
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options })
+    return responses.shift()
+  }
+  assert.equal(
+    await fetchRegistryDigest({
+      repository: 'ghcr.io/uzh-bf/klicker-uzh/auth-arm',
+      tag: CANDIDATE_SHA,
+      fetchImpl,
+    }),
+    digest
+  )
+  assert.equal(calls.length, 3)
+  assert.equal(calls[0].options.headers.authorization, undefined)
+  assert.match(calls[1].url, /^https:\/\/ghcr\.io\/token\?/)
+  assert.equal(
+    calls[2].options.headers.authorization,
+    'Bearer synthetic-registry-token'
+  )
+})
+
+test('plans equal, stale, fast-forward, and divergent release refs without force', async () => {
+  const context = reviewContext()
+  const equal = await planReleaseRef({
+    github: evidenceGithub({ workflows: [] }).github,
+    context,
+    currentSha: CANDIDATE_SHA,
+    candidateSha: CANDIDATE_SHA,
+  })
+  assert.equal(equal.action, 'no-op-equal')
+
+  const staleGithub = evidenceGithub({
+    comparisons: {
+      [`${CURRENT_SHA}...${CANDIDATE_SHA}`]: { status: 'behind' },
+    },
+    workflows: [],
+  }).github
+  assert.equal(
+    (
+      await planReleaseRef({
+        github: staleGithub,
+        context,
+        currentSha: CURRENT_SHA,
+        candidateSha: CANDIDATE_SHA,
+      })
+    ).action,
+    'no-op-stale'
+  )
+
+  const forwardGithub = evidenceGithub({
+    comparisons: { [`${CURRENT_SHA}...${NEXT_SHA}`]: { status: 'ahead' } },
+    workflows: [],
+  }).github
+  assert.equal(
+    (
+      await planReleaseRef({
+        github: forwardGithub,
+        context,
+        currentSha: CURRENT_SHA,
+        candidateSha: NEXT_SHA,
+      })
+    ).action,
+    'fast-forward'
+  )
+
+  const divergentGithub = evidenceGithub({
+    comparisons: { [`${CURRENT_SHA}...${NEXT_SHA}`]: { status: 'diverged' } },
+    workflows: [],
+  }).github
+  await assert.rejects(
+    planReleaseRef({
+      github: divergentGithub,
+      context,
+      currentSha: CURRENT_SHA,
+      candidateSha: NEXT_SHA,
+    }),
+    /diverges/
+  )
+})
+
+test('uses an exact remote lease for create and prevalidated fast-forward updates', async () => {
+  const context = reviewContext()
+  const create = refGithub()
+  assert.equal(
+    await compareAndSwapReleaseRef({
+      github: create.github,
+      context,
+      expectedSha: null,
+      candidateSha: CANDIDATE_SHA,
+      gitRunner: create.gitRunner,
+      gitToken: 'fixture-token',
+    }),
+    CANDIDATE_SHA
+  )
+  const createGitCalls = create.calls.filter((call) => call.method === 'git')
+  assert.equal(createGitCalls[0].args[0], 'fetch')
+  assert.deepEqual(createGitCalls[1].args.slice(0, 3), [
+    'push',
+    '--porcelain',
+    `--force-with-lease=${PROMOTION_REF}:`,
+  ])
+  assert.equal(createGitCalls[1].args.includes('--force'), false)
+
+  const update = refGithub(CURRENT_SHA)
+  await compareAndSwapReleaseRef({
+    github: update.github,
+    context,
+    expectedSha: CURRENT_SHA,
+    candidateSha: NEXT_SHA,
+    gitRunner: update.gitRunner,
+    gitToken: 'fixture-token',
+  })
+  const updateCall = update.calls.find(
+    (call) => call.method === 'git' && call.args[0] === 'push'
+  )
+  assert.ok(
+    updateCall.args.includes(
+      `--force-with-lease=${PROMOTION_REF}:${CURRENT_SHA}`
+    )
+  )
+  assert.equal(updateCall.args.at(-1), `${NEXT_SHA}:${PROMOTION_REF}`)
+
+  const preRaced = refGithub(CURRENT_SHA)
+  await assert.rejects(
+    compareAndSwapReleaseRef({
+      github: preRaced.github,
+      context,
+      expectedSha: 'd'.repeat(40),
+      candidateSha: NEXT_SHA,
+      gitRunner: preRaced.gitRunner,
+      gitToken: 'fixture-token',
+    }),
+    /changed before the compare-and-swap/
+  )
+  assert.equal(
+    preRaced.calls.some(
+      (call) => call.method === 'git' && call.args[0] === 'push'
+    ),
+    false
+  )
+
+  const raced = refGithub(CURRENT_SHA, { afterUpdateSha: 'd'.repeat(40) })
+  await assert.rejects(
+    compareAndSwapReleaseRef({
+      github: raced.github,
+      context,
+      expectedSha: CURRENT_SHA,
+      candidateSha: NEXT_SHA,
+      gitRunner: raced.gitRunner,
+      gitToken: 'fixture-token',
+    }),
+    /changed during the compare-and-swap/
+  )
+
+  const notForward = refGithub(CURRENT_SHA)
+  notForward.github.rest.repos.compareCommitsWithBasehead = async () => ({
+    data: { status: 'diverged' },
+  })
+  await assert.rejects(
+    compareAndSwapReleaseRef({
+      github: notForward.github,
+      context,
+      expectedSha: CURRENT_SHA,
+      candidateSha: NEXT_SHA,
+      gitRunner: notForward.gitRunner,
+      gitToken: 'fixture-token',
+    }),
+    /not a fast-forward/
+  )
+  assert.equal(
+    notForward.calls.some(
+      (call) => call.method === 'git' && call.args[0] === 'push'
+    ),
+    false
+  )
+})
+
+test('exercises create, fast-forward, and race rejection against a bare remote', (t) => {
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'stg-release-cas-')
+  )
+  t.after(() => fs.rmSync(temporaryDirectory, { force: true, recursive: true }))
+
+  const remote = path.join(temporaryDirectory, 'remote.git')
+  const client = path.join(temporaryDirectory, 'client')
+  execFileSync('git', ['init', '--bare', '--quiet', remote])
+  execFileSync('git', ['init', '--quiet', client])
+  const fixtureEnvironment = {
+    ...process.env,
+    GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+    GIT_AUTHOR_NAME: 'Fixture',
+    GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+    GIT_COMMITTER_NAME: 'Fixture',
+  }
+  const makeCommit = (label, parent = null) => {
+    const blob = execFileSync(
+      'git',
+      ['--git-dir', remote, 'hash-object', '-w', '--stdin'],
+      { encoding: 'utf8', input: `${label}\n` }
+    ).trim()
+    const tree = execFileSync('git', ['--git-dir', remote, 'mktree'], {
+      encoding: 'utf8',
+      input: `100644 blob ${blob}\tfixture.txt\n`,
+    }).trim()
+    return execFileSync(
+      'git',
+      [
+        '--git-dir',
+        remote,
+        'commit-tree',
+        tree,
+        ...(parent ? ['-p', parent] : []),
+      ],
+      { encoding: 'utf8', env: fixtureEnvironment, input: `${label}\n` }
+    ).trim()
+  }
+  const baseSha = makeCommit('base')
+  const racedSha = makeCommit('raced', baseSha)
+  const candidateSha = makeCommit('candidate', racedSha)
+  const readRemoteRef = () =>
+    execFileSync('git', ['--git-dir', remote, 'rev-parse', PROMOTION_REF], {
+      encoding: 'utf8',
+    }).trim()
+
+  pushReleaseRefWithLease({
+    candidateSha,
+    context: reviewContext(),
+    expectedSha: null,
+    gitToken: '',
+    repositoryUrl: remote,
+    workspace: client,
+  })
+  assert.equal(readRemoteRef(), candidateSha)
+
+  execFileSync('git', [
+    '--git-dir',
+    remote,
+    'update-ref',
+    PROMOTION_REF,
+    baseSha,
+  ])
+  pushReleaseRefWithLease({
+    candidateSha,
+    context: reviewContext(),
+    expectedSha: baseSha,
+    gitToken: '',
+    repositoryUrl: remote,
+    workspace: client,
+  })
+  assert.equal(readRemoteRef(), candidateSha)
+
+  execFileSync('git', [
+    '--git-dir',
+    remote,
+    'update-ref',
+    PROMOTION_REF,
+    baseSha,
+  ])
+  const racingGitRunner = (args, options) => {
+    if (args[0] === 'push') {
+      execFileSync('git', [
+        '--git-dir',
+        remote,
+        'update-ref',
+        PROMOTION_REF,
+        racedSha,
+      ])
+    }
+    return execFileSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+      ...options,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  }
+  assert.throws(
+    () =>
+      pushReleaseRefWithLease({
+        candidateSha,
+        context: reviewContext(),
+        expectedSha: baseSha,
+        gitRunner: racingGitRunner,
+        gitToken: '',
+        repositoryUrl: remote,
+        workspace: client,
+      }),
+    /Command failed/
+  )
+  assert.equal(readRemoteRef(), racedSha)
+})
+
+test('keeps an out-of-order candidate stale after a newer fast-forward wins', async () => {
+  const context = reviewContext()
+  const comparisons = {
+    [`${CURRENT_SHA}...${NEXT_SHA}`]: { status: 'ahead' },
+    [`${NEXT_SHA}...${CANDIDATE_SHA}`]: { status: 'behind' },
+  }
+  const github = evidenceGithub({ comparisons, workflows: [] }).github
+  const remote = refGithub(CURRENT_SHA)
+  const combinedGithub = {
+    ...github,
+    rest: { ...github.rest, git: remote.github.rest.git },
+  }
+
+  const newer = await planReleaseRef({
+    github: combinedGithub,
+    context,
+    currentSha: CURRENT_SHA,
+    candidateSha: NEXT_SHA,
+  })
+  assert.equal(newer.action, 'fast-forward')
+  await compareAndSwapReleaseRef({
+    github: combinedGithub,
+    context,
+    expectedSha: CURRENT_SHA,
+    candidateSha: NEXT_SHA,
+    gitRunner: remote.gitRunner,
+    gitToken: 'fixture-token',
+  })
+
+  const older = await planReleaseRef({
+    github: combinedGithub,
+    context,
+    currentSha: NEXT_SHA,
+    candidateSha: CANDIDATE_SHA,
+  })
+  assert.equal(older.action, 'no-op-stale')
+  assert.equal(remote.current(), NEXT_SHA)
+  assert.equal(
+    remote.calls.filter(
+      (call) => call.method === 'git' && call.args[0] === 'push'
+    ).length,
+    1
+  )
+})
+
+test('keeps manual defaults dry-run and gates automatic writes', async () => {
+  const workflows = validWorkflows()
+  const runs = evidenceRuns(workflows)
+  const { github: baseGithub } = evidenceGithub({
+    definitions: fixtureDefinitions(),
+    workflows,
+    jobs: successfulJobs(workflows),
+    runs,
+  })
+  const refs = refGithub()
+  const github = {
+    ...baseGithub,
+    rest: {
+      ...baseGithub.rest,
+      git: refs.github.rest.git,
+    },
+  }
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'stg-release-promoter-')
+  )
+  const summaryPath = path.join(temporaryDirectory, 'summary.md')
+  try {
+    const result = await runPromotion({
+      github,
+      context: reviewContext('workflow_dispatch', {
+        dry_run: true,
+        sha: CANDIDATE_SHA,
+      }),
+      sourceBranch: 'v3',
+      candidateSha: CANDIDATE_SHA,
+      expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+      getRegistryDigest: async () => `sha256:${'4'.repeat(64)}`,
+      maxAttempts: 1,
+      receiptPath: path.join(temporaryDirectory, 'receipt.json'),
+      checksumPath: path.join(temporaryDirectory, 'receipt.sha256'),
+      summaryPath,
+    })
+    assert.equal(result.decision.mode, 'dry-run')
+    assert.equal(result.decision.action, 'create')
+    assert.equal(refs.current(), null)
+    assert.equal(
+      checksumReceipt(JSON.parse(fs.readFileSync(result.receiptPath, 'utf8'))),
+      result.checksum
+    )
+    assert.match(fs.readFileSync(summaryPath, 'utf8'), /Controller run: `9001`/)
+
+    const rerunRefs = refGithub(CANDIDATE_SHA)
+    const rerunGithub = {
+      ...baseGithub,
+      rest: {
+        ...baseGithub.rest,
+        git: rerunRefs.github.rest.git,
+      },
+    }
+    const rerun = await runPromotion({
+      github: rerunGithub,
+      context: reviewContext('workflow_dispatch', {
+        confirm: MANUAL_CONFIRMATION,
+        dry_run: false,
+        sha: CANDIDATE_SHA,
+      }),
+      sourceBranch: 'v3',
+      expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+      getRegistryDigest: async () => `sha256:${'4'.repeat(64)}`,
+      maxAttempts: 1,
+      receiptPath: path.join(temporaryDirectory, 'rerun-receipt.json'),
+      checksumPath: path.join(temporaryDirectory, 'rerun-receipt.sha256'),
+      summaryPath,
+    })
+    assert.equal(rerun.decision.action, 'no-op-equal')
+    assert.equal(
+      rerunRefs.calls.some((call) => call.method === 'updateRef'),
+      false
+    )
+
+    const automatic = await runPromotion({
+      github,
+      context: reviewContext('workflow_run'),
+      sourceBranch: 'v3',
+      promotionEnabled: 'false',
+    })
+    assert.equal(automatic.decision, 'disabled')
+    assert.equal(refs.current(), null)
+
+    const enabled = await runPromotion({
+      github,
+      context: reviewContext('workflow_run'),
+      sourceBranch: 'v3',
+      promotionEnabled: 'true',
+      expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+      getRegistryDigest: async () => `sha256:${'5'.repeat(64)}`,
+      gitRunner: refs.gitRunner,
+      gitToken: 'fixture-token',
+      maxAttempts: 1,
+      receiptPath: path.join(temporaryDirectory, 'enabled-receipt.json'),
+      checksumPath: path.join(temporaryDirectory, 'enabled-receipt.sha256'),
+      summaryPath,
+    })
+    assert.equal(enabled.decision.action, 'create')
+    assert.equal(enabled.decision.mode, 'apply')
+    assert.equal(refs.current(), CANDIDATE_SHA)
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true })
+  }
+
+  await assert.rejects(
+    runPromotion({
+      github,
+      context: reviewContext('workflow_dispatch', {
+        confirm: 'wrong',
+        dry_run: false,
+        sha: CANDIDATE_SHA,
+      }),
+      sourceBranch: 'v3',
+      candidateSha: CANDIDATE_SHA,
+      expectedWorkflows: FIXTURE_STAGING_WORKFLOWS,
+    }),
+    new RegExp(`exact confirmation ${MANUAL_CONFIRMATION}`)
+  )
+})
+
+test('uses only trusted controller checkout and has no commit or PR commands', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '../workflows/deploy-stg-promote.yml'),
+    'utf8'
+  )
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/)
+  assert.match(workflow, /STG_RELEASE_PROMOTION_ENABLED/)
+  assert.match(workflow, /SOURCE_BRANCH:.*STG_SOURCE_BRANCH/)
+  assert.match(workflow, /sourceBranch: process\.env\.SOURCE_BRANCH/)
+  assert.match(workflow, /default: true/)
+  assert.match(workflow, /confirm/)
+  assert.match(workflow, /stg-release/)
+  assert.match(workflow, /github\.event\.workflow_run\.head_sha/)
+  assert.doesNotMatch(workflow, /STG_PROMOTE_TOKEN|git commit|git push|gh pr/)
+  assert.doesNotMatch(workflow, /promote-stg-writer/)
+  assert.doesNotMatch(workflow, /ref: \$\{\{[^}]*head_sha/)
+  assert.doesNotMatch(workflow, /actions\/cache@|actions\/download-artifact@/)
+  assert.match(workflow, /actions\/upload-artifact@/)
+  assert.match(workflow, /persist-credentials: false/)
+  assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/)
+
+  const workflowRunNames = [
+    ...workflow.matchAll(/^      - '([^']+ \(stg\))'$/gm),
+  ].map((match) => match[1])
+  assert.deepEqual(
+    workflowRunNames.sort(),
+    STAGING_WORKFLOWS.map((entry) => entry.name).sort()
+  )
+
+  const permissions = [
+    ...workflow
+      .match(/\npermissions:\n((?:  [a-z-]+: (?:read|write)\n)+)/)[1]
+      .matchAll(/^  ([a-z-]+): (read|write)$/gm),
+  ].map((match) => match[1])
+  assert.deepEqual([...new Set(permissions)].sort(), ['actions', 'contents'])
+
+  const promoter = fs.readFileSync(
+    `${__dirname}/stg-release-promoter.js`,
+    'utf8'
+  )
+  assert.match(promoter, /--force-with-lease=/)
+  assert.doesNotMatch(promoter, /['"]--force['"]|git commit|gh pr/)
+  assert.doesNotMatch(promoter, /createRef|updateRef|pulls\.create/)
+})
+
+test('does not use candidate files as executable workflow inputs', () => {
+  const promoter = fs.readFileSync(
+    `${__dirname}/stg-release-promoter.js`,
+    'utf8'
+  )
+  assert.match(promoter, /getCandidateDefinitions/)
+  assert.match(promoter, /ref: candidateSha/)
+  assert.doesNotMatch(promoter, /require\([^)]*candidate/)
+  assert.doesNotMatch(promoter, /eval\(|new Function\(/)
+  assert.equal(STAGING_WORKFLOW_PATHS.length, 15)
+  assert.equal(STAGING_WORKFLOWS.length, 15)
+  assert.deepEqual(
+    STAGING_WORKFLOW_PATHS,
+    STAGING_WORKFLOWS.map((workflow) => workflow.path)
+  )
+})

--- a/.github/workflows/check-ocr-final-review.yml
+++ b/.github/workflows/check-ocr-final-review.yml
@@ -112,9 +112,6 @@ jobs:
 
       - name: Initialize final-review status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
-          TRUSTED_SHA: ${{ needs.trusted_policy.outputs.trusted_sha }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -123,8 +120,6 @@ jobs:
               github,
               context,
               core,
-              sourceBranch: process.env.SOURCE_BRANCH,
-              trustedSha: process.env.TRUSTED_SHA,
             })
 
   initialize_stack:

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -35,7 +35,7 @@ on:
         default: true
         required: true
         type: boolean
-      confirm:
+      confirm_ref_update:
         description: 'Required only when applying a manual promotion: stg-release'
         required: false
         type: string

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -1,31 +1,12 @@
 name: Promote to stg
 
-# Staging pulls the floating image tag for the selected source branch, so rebuilding
-# an image never changes the rendered manifest: ArgoCD sees no drift, never syncs,
-# and the new image is only picked up whenever someone happens to restart the pods.
-# This workflow closes that gap by writing the built commit's SHA into the
-# `rollout.klicker.uzh.ch/release` pod annotations. That DOES change the pod
-# template, so ArgoCD detects drift, runs the PreSync migration hook, and rolls the
-# pods -- in that order (see ADR-0003).
-#
-# It promotes only once every stg image for that commit exists, so the rollout can
-# never start against a half-published or stale source tag.
-#
-# INVARIANT: every `.github/workflows/v3_*-stg.yml` must (a) run unconditionally on
-# push to the selected source branch and (b) appear under `workflows:` below. Adding
-# a push-level `paths:` filter to any of them stalls promotion permanently -- the
-# gate would wait forever for a run that is never going to happen.
-#
-# The selected source branch is the repository variable `STG_SOURCE_BRANCH`. It falls
-# back to `v3` until the variable is created. The branch name must also be a valid
-# Docker tag because the stg build workflows publish branch-name tags.
+# This controller is evaluated from the workflow definition commit, never from
+# the candidate source tree. Candidate workflow files, run metadata, jobs, and
+# registry manifests are inputs to validation only; no candidate code, action,
+# cache, or artifact is checked out or executed here.
 
 on:
   workflow_run:
-    # These are workflow *names*, not paths. A typo fails silently: GitHub simply
-    # never fires this workflow for that build. Keep in sync with `name:` in each
-    # `v3_*-stg.yml` (the gate below derives the required set from the files, so a
-    # missing entry here only costs a trigger, never a false promotion).
     workflows:
       - 'Build Docker image for analytics (stg)'
       - 'Build Docker image for auth (stg)'
@@ -46,320 +27,85 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Commit SHA on the selected source branch to promote (break-glass / first run)'
+        description: '40-character commit SHA on the selected source branch'
         required: true
+        type: string
       dry_run:
-        description: 'Evaluate and print the diff only, do not open a PR'
-        type: boolean
+        description: 'Validate and emit the receipt without updating stg-release'
         default: true
+        required: true
+        type: boolean
+      confirm:
+        description: 'Required only when applying a manual promotion: stg-release'
+        required: false
+        type: string
 
-# Must stay `false`: cancelling a promoter mid-publish could leave a branch pushed
-# with no PR. Keep workflow-run groups separate by source branch, so an unrelated
-# `v3*` branch cannot occupy the selected branch's pending slot. Within one branch
-# group, repeated build completions collapse to the latest queued one.
+# Each candidate gets its own serialized controller lane. There is deliberately
+# no global pending writer group: an out-of-order candidate must be evaluated
+# against the remote ref rather than dropped behind another candidate.
 concurrency:
-  group: promote-stg-${{ github.event.workflow_run.head_branch || 'manual' }}
+  group: promote-stg-${{ github.event.workflow_run.head_sha || github.event.inputs.sha || github.run_id }}
   cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: write
 
 jobs:
   promote:
-    # The stg build workflows also fire on `v3*` feature branches, which must never
-    # promote unless selected by STG_SOURCE_BRANCH. `event == 'push'` excludes PR
-    # builds, which do not push images at all.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'push' &&
-       (github.event.workflow_run.head_branch == vars.STG_SOURCE_BRANCH ||
-        (vars.STG_SOURCE_BRANCH == '' && github.event.workflow_run.head_branch == 'v3')) &&
        github.event.workflow_run.conclusion == 'success')
-    # Workflow-level concurrency is branch-specific so skipped, non-selected
-    # completions do not occupy the selected branch's pending slot. This job-level
-    # lock still serializes every real writer, including manual dispatches.
-    concurrency:
-      group: promote-stg-writer
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      actions: read
     steps:
-      - name: Require the promotion token
-        env:
-          TOKEN: ${{ secrets.STG_PROMOTE_TOKEN }}
-        run: |
-          set -euo pipefail
-          # A PR opened with the default GITHUB_TOKEN does not trigger workflows, so
-          # its required checks would never report and auto-merge would never fire.
-          # The promotion therefore needs a token that acts as a real user/app.
-          if [ -z "${TOKEN}" ]; then
-            echo "::error::secrets.STG_PROMOTE_TOKEN is not set - see docs/ci-and-deployment.md"
-            exit 1
-          fi
-
-      - name: Resolve target commit
-        id: target
-        env:
-          WR_SHA: ${{ github.event.workflow_run.head_sha }}
-          IN_SHA: ${{ github.event.inputs.sha }}
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${SOURCE_BRANCH}" =~ ^[A-Za-z0-9_.-]+$ ]]; then
-            echo "::error::STG_SOURCE_BRANCH must be a Docker-safe branch/tag name"
-            exit 1
-          fi
-          # Must be the BUILD's head SHA, never the current tip of the source branch:
-          # the tip may have advanced past the commit whose images are actually green.
-          SHA="${WR_SHA:-$IN_SHA}"
-          [[ "$SHA" =~ ^[0-9a-f]{40}$ ]] \
-            || { echo "::error::target SHA must be 40 lowercase hexadecimal characters"; exit 1; }
-          echo "sha=$SHA" >>"$GITHUB_OUTPUT"
-          echo "source_branch=$SOURCE_BRANCH" >>"$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@v4
+      - name: Checkout the trusted controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # ArgoCD reads the selected source branch, so the promotion must update the
-          # values on that same branch.
-          ref: ${{ steps.target.outputs.source_branch }}
-          fetch-depth: 0 # merge-base needs full history
-          token: ${{ secrets.STG_PROMOTE_TOKEN }}
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/scripts
 
-      - name: Require every stg image for this commit
-        id: gate
+      - name: Verify the trusted checkout
         env:
-          GH_TOKEN: ${{ github.token }}
-          SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          # Matched per workflow *file* via `.path`. Check-runs cannot be used: the stg
-          # workflows name their jobs `build-arm`/`build-amd`, so the names collide.
-          # Re-poll rather than giving up on the first look. This job is only ever
-          # triggered by a build completing, so if the API has not yet indexed the
-          # last run when the surviving promoter evaluates, there is no later trigger
-          # to recover -- staging would stall silently until the next merge.
-          for attempt in 1 2 3 4 5 6; do
-            gh api --paginate --slurp \
-              "/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&event=push&per_page=100" \
-              | jq --arg source "${SOURCE_BRANCH}" \
-                '[.[].workflow_runs[] | select(.head_branch == $source)]' > runs.json
+          test "$(git rev-parse HEAD)" = "${TRUSTED_WORKFLOW_SHA}"
 
-            missing=(); notgreen=()
-            # Required set derived from the checkout, so changing the stg build set
-            # needs no count update here -- only the trigger list above.
-            for wf in .github/workflows/v3_*-stg.yml; do
-              run=$(jq -c --arg p "$wf" \
-                '[.[] | select(.path == $p)] | sort_by(.id) | last // empty' runs.json)
-              if [ -z "$run" ]; then missing+=("$wf [no run]"); continue; fi
-              st=$(jq -r '.status'     <<<"$run")
-              cc=$(jq -r '.conclusion' <<<"$run")
-              if   [ "$st" != "completed" ]; then missing+=("$wf [$st]")
-              # `skipped` is deliberately NOT success: on push every job runs, so a
-              # skipped run means no image was published for that component.
-              elif [ "$cc" != "success"   ]; then notgreen+=("$wf [$cc]")
-              fi
-            done
-
-            # A genuine failure is final -- no amount of waiting fixes it.
-            if [ ${#notgreen[@]} -gt 0 ]; then
-              echo "::notice::not promoting ${SHA}; not green: ${notgreen[*]}"
-              echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
-            fi
-            if [ ${#missing[@]} -eq 0 ]; then
-              echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
-            fi
-            echo "attempt ${attempt}: waiting on ${missing[*]}"
-            [ "$attempt" -eq 6 ] || sleep 20
-          done
-
-          echo "::notice::giving up on ${SHA}; still waiting on: ${missing[*]}"
-          echo "go=false" >>"$GITHUB_OUTPUT"
-
-      - name: Skip if already promoted or superseded
-        id: guard
-        if: steps.gate.outputs.go == 'true'
+      - name: Validate and promote the selected candidate
+        id: promote
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
-        run: |
-          set -euo pipefail
-          F=deploy/env-uzh-stg/values.yaml
-          git merge-base --is-ancestor "$SHA" "origin/${SOURCE_BRANCH}" \
-            || { echo "::error::$SHA is not an ancestor of origin/${SOURCE_BRANCH}"; exit 1; }
+          CANDIDATE_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PROMOTION_ENABLED: ${{ vars.STG_RELEASE_PROMOTION_ENABLED || 'false' }}
+          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
+          RECEIPT_PATH: ${{ runner.temp }}/stg-release-promotion-receipt.json
+          CHECKSUM_PATH: ${{ runner.temp }}/stg-release-promotion-receipt.sha256
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const promoter = require('./.github/scripts/stg-release-promoter.js')
+            await promoter.runPromotion({
+              candidateSha: process.env.CANDIDATE_SHA,
+              context,
+              core,
+              github,
+              promotionEnabled: process.env.PROMOTION_ENABLED,
+              sourceBranch: process.env.SOURCE_BRANCH,
+              receiptPath: process.env.RECEIPT_PATH,
+              checksumPath: process.env.CHECKSUM_PATH,
+            })
 
-          TOTAL_TAGS=$(awk '$1 == "tag:" { count++ } END { print count + 0 }' "$F")
-          SOURCE_TAGS=$(awk -v source="$SOURCE_BRANCH" \
-            '$1 == "tag:" && $2 == source { count++ } END { print count + 0 }' "$F")
-          [ "$TOTAL_TAGS" -gt 0 ] \
-            || { echo "::error::staging values contain no image tags"; exit 1; }
-          if [ "$SOURCE_TAGS" -ne "$TOTAL_TAGS" ]; then
-            echo "::notice::staging source tag is changing to ${SOURCE_BRANCH}"
-            echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
-          fi
-
-          # Never promote a promotion. The `[skip ci]` marker in the PR title normally
-          # stops the squash-merge from rebuilding and re-firing this workflow, but that
-          # depends on the repository's `squash_merge_commit_title` setting, which lives
-          # outside this repo and is not recorded anywhere as load-bearing. This check
-          # does not depend on it, and without it a flipped setting yields a runaway loop
-          # that burns every image build and a full stg rollout per iteration.
-          if git log -1 --format='%s' "$SHA" | grep -q '^chore(deploy): promote '; then
-            echo "::notice::${SHA} is itself a promotion commit"
-            echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
-          fi
-
-          RELEASE_COUNT=$(awk \
-            '/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release:/ { count++ } END { print count + 0 }' "$F")
-          [ "$RELEASE_COUNT" -gt 0 ] \
-            || { echo "::error::staging values contain no rollout annotations"; exit 1; }
-          mapfile -t RELEASES < <(sed -n \
-            "s/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release: '\(.*\)'$/\1/p" "$F")
-          [ "${#RELEASES[@]}" -eq "$RELEASE_COUNT" ] \
-            || { echo "::error::rollout annotations must contain quoted string values"; exit 1; }
-          mapfile -t UNIQUE_RELEASES < <(printf '%s\n' "${RELEASES[@]}" | sort -u)
-          if [ "${#UNIQUE_RELEASES[@]}" -ne 1 ]; then
-            echo "::notice::staging rollout annotations are not uniform"
-            echo "go=true" >>"$GITHUB_OUTPUT"; exit 0
-          fi
-          CUR="${UNIQUE_RELEASES[0]}"
-          # Stale-promotion guard, and the idempotence check for repeated build events:
-          # `--is-ancestor` is true for equal commits. Restricted to hex so a legacy
-          # release-tag value is not silently resolved as a commit -- `v3.4.0-alpha.64`
-          # IS a tag in this repo, and comparing against a tag newer than the target
-          # would skip a promotion that should have happened.
-          if printf '%s' "$CUR" | grep -qE '^[0-9a-f]{7,40}$' \
-             && git cat-file -e "${CUR}^{commit}" 2>/dev/null; then
-            if git merge-base --is-ancestor "$SHA" "$CUR"; then
-              echo "::notice::${CUR} is already promoted and is newer than or equal to ${SHA}"
-              echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
-            fi
-          fi
-          echo "go=true" >>"$GITHUB_OUTPUT"
-
-      - name: Write the release annotation
-        id: write
-        if: steps.gate.outputs.go == 'true' && steps.guard.outputs.go == 'true'
-        env:
-          SHA: ${{ steps.target.outputs.sha }}
-          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
-        run: |
-          set -euo pipefail
-          F=deploy/env-uzh-stg/values.yaml
-          SHORT=$(git rev-parse --short=12 "$SHA")
-
-          TAGS_BEFORE=$(awk '$1 == "tag:" { count++ } END { print count + 0 }' "$F")
-          [ "$TAGS_BEFORE" -gt 0 ] \
-            || { echo "::error::staging values contain no image tags"; exit 1; }
-          sed -i -E "s|^([[:space:]]+tag: ).*$|\1${SOURCE_BRANCH}|" "$F"
-          TAGS_AFTER=$(awk -v source="$SOURCE_BRANCH" \
-            '$1 == "tag:" && $2 == source { count++ } END { print count + 0 }' "$F")
-          [ "$TAGS_AFTER" -eq "$TAGS_BEFORE" ] || { echo "::error::rewrote $TAGS_AFTER of $TAGS_BEFORE image tags"; exit 1; }
-
-          BEFORE=$(awk \
-            '/^[[:space:]]*rollout\.klicker\.uzh\.ch\/release:/ { count++ } END { print count + 0 }' "$F")
-          [ "$BEFORE" -gt 0 ] \
-            || { echo "::error::staging values contain no rollout annotations"; exit 1; }
-
-          # sed, not yq: the file carries comments and hand-chosen quote styles that a
-          # yq round-trip reflows. The value MUST stay quoted -- an unquoted all-digit
-          # short SHA parses as a YAML integer and Kubernetes rejects the annotation.
-          sed -i -E "s|^([[:space:]]*rollout\.klicker\.uzh\.ch/release:).*|\1 '${SHORT}'|" "$F"
-
-          AFTER=$(awk -v release="'${SHORT}'" \
-            '$1 == "rollout.klicker.uzh.ch/release:" && $2 == release { count++ } END { print count + 0 }' "$F")
-          [ "$AFTER" -eq "$BEFORE" ] || { echo "::error::rewrote $AFTER of $BEFORE"; exit 1; }
-
-          git diff -- "$F"
-          echo "short=$SHORT" >>"$GITHUB_OUTPUT"
-
-      - name: Open the promotion PR and auto-merge it
-        if: steps.write.outcome == 'success' && github.event.inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.STG_PROMOTE_TOKEN }}
-          SHA: ${{ steps.target.outputs.sha }}
-          SHORT: ${{ steps.write.outputs.short }}
-          SOURCE_BRANCH: ${{ steps.target.outputs.source_branch }}
-        run: |
-          set -euo pipefail
-          BRANCH="chore/promote-stg-${SHORT}"
-
-          # Supersede any promotion still open: with `strict: true` an older one can
-          # sit un-mergeable behind a newer commit and would otherwise roll stg back.
-          # Exclude the branch we are about to create, so a re-run of a flaky build
-          # within the promotion window cannot close this SHA's own open PR.
-          for n in $(gh pr list --state open --limit 100 --json number,headRefName \
-                       | jq -r --arg b "$BRANCH" \
-                         '.[] | select(.headRefName | startswith("chore/promote-stg-"))
-                              | select(.headRefName != $b) | .number'); do
-            gh pr close "$n" --delete-branch \
-              --comment "Superseded by the promotion of ${SHORT}." || true
-          done
-
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git checkout -b "$BRANCH"
-          git add deploy/env-uzh-stg/values.yaml
-          git commit -m "chore(deploy): promote ${SHORT} to stg"
-          git push origin "$BRANCH"
-
-          # `[skip ci]` in the title becomes the squash commit message, which stops the
-          # merge from re-running every image build and re-firing this workflow. The PR
-          # touches only `deploy/**`, so `Build Fallback` supplies build-amd/build-arm.
-          # The YAML block scalar strips this common indentation, so the heredoc body
-          # and its EOF terminator both land at column 0 in the generated script.
-          cat >/tmp/pr-body.md <<EOF
-          Automated staging promotion of \`${SHA}\`.
-
-          Writes the built commit into \`rollout.klicker.uzh.ch/release\` so ArgoCD
-          detects drift, runs the PreSync migration hook, and rolls the stg pods.
-          Opened only after every \`v3_*-stg.yml\` image build succeeded for this
-          commit. See ADR-0003.
-          EOF
-
-          PR_URL=$(gh pr create \
-            --base "$SOURCE_BRANCH" --head "$BRANCH" \
-            --title "chore(deploy): promote ${SHORT} to stg [skip ci]" \
-            --body-file /tmp/pr-body.md)
-
-          # The selected source branch may not require the generated-promotion
-          # verifier. Wait for its exact success status before allowing an immediate
-          # merge on an unprotected branch.
-          PROMOTION_HEAD=$(git rev-parse HEAD)
-          VERIFIED='false'
-          for attempt in 1 2 3 4 5 6; do
-            STATUS=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${PROMOTION_HEAD}/statuses" \
-              --jq '[.[] | select(.context == "final-ai-review")] | first | [.state, .description] | @tsv')
-            case "$STATUS" in
-              $'success\tVerified generated staging promotion')
-                VERIFIED='true'; break ;;
-              $'failure\t'* | $'error\t'*)
-                echo "::error::generated promotion verification failed: ${STATUS}"; exit 1 ;;
-            esac
-            echo "attempt ${attempt}: waiting for generated promotion verification on ${PR_URL}"
-            [ "$attempt" -eq 6 ] || sleep 20
-          done
-          [ "$VERIFIED" = 'true' ] \
-            || { echo "::error::generated promotion verification did not succeed for ${PR_URL}"; exit 1; }
-
-          gh pr merge "$BRANCH" --squash --auto --delete-branch
-
-          # `--auto` returns immediately, so a PR that can NEVER merge would otherwise
-          # leave a green run, an open PR nobody looks at, and staging exactly as stale
-          # as before -- the silent no-op this whole workflow exists to prevent. Watch
-          # it briefly and fail loudly instead. Still pending after this is fine: that
-          # is auto-merge waiting on checks, which will complete on its own.
-          STATE=''
-          for attempt in 1 2 3 4 5 6; do
-            sleep 20
-            STATE=$(gh pr view "$BRANCH" --json state,mergeStateStatus \
-                      --jq '.state + "/" + .mergeStateStatus')
-            case "$STATE" in
-              MERGED/*)
-                echo "::notice::promotion of ${SHORT} merged"; exit 0 ;;
-              */BLOCKED | */DIRTY)
-                echo "::error::promotion PR for ${SHORT} is ${STATE} and will not merge on its own - staging will NOT update"
-                exit 1 ;;
-            esac
-          done
-          echo "::notice::promotion PR for ${SHORT} is ${STATE}; auto-merge will complete it"
+      - name: Upload the promotion receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          if-no-files-found: ignore
+          name: stg-release-promotion-receipt-${{ github.event.workflow_run.head_sha || github.event.inputs.sha || github.run_id }}
+          path: |
+            ${{ runner.temp }}/stg-release-promotion-receipt.json
+            ${{ runner.temp }}/stg-release-promotion-receipt.sha256

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -1,8 +1,34 @@
 # 3. Promote to staging by writing the built commit into a release annotation
 
-- **Status:** Accepted — 2026-08-04
+- **Status:** Superseded — 2026-09-04
 - **Deciders:** @rschlaefli
 - **Context:** [PR #5183](https://github.com/uzh-bf/klicker-uzh/pull/5183), [PR #5303](https://github.com/uzh-bf/klicker-uzh/pull/5303)
+
+## Supersession
+
+Staging promotion no longer creates a commit or pull request that rewrites
+rollout annotations. A trusted default-branch `workflow_run` controller now
+validates the selected-source workflow definitions, exact-SHA successful runs
+and ARM jobs, and stable full-SHA registry digests. It records that evidence in
+a canonical checksummed receipt before creating or fast-forwarding
+`refs/heads/stg-release`. An explicit expected-old lease makes the remote write
+a compare-and-swap, while prior graph validation permits only creation or a
+fast-forward and never a history rewrite. Equal and stale candidates are
+no-ops; divergence and concurrent ref movement fail closed.
+
+The controller executes only code checked out at `github.workflow_sha`.
+Candidate Git objects, API metadata, and registry manifests are data; candidate
+actions, scripts, caches, and artifacts are never executed or consumed. It uses
+only `actions: read` and `contents: write`. Automatic writes require
+`STG_RELEASE_PROMOTION_ENABLED=true`; manual runs default to dry-run and require
+the exact confirmation `stg-release` before a write.
+
+The companion selected-source and platform work makes staging track
+`stg-release` and render all first-party images with its resolved full commit
+SHA. The immutable registry-digest receipt, rather than a mutable branch tag or
+rollout annotation, is the deployment provenance. Keep automatic promotion
+disabled until the SHA publishers, chart override, platform ref, and an initial
+manual receipt-backed ref creation have all been verified.
 
 ## Context
 

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -9,19 +9,24 @@
 Staging promotion no longer creates a commit or pull request that rewrites
 rollout annotations. A trusted default-branch `workflow_run` controller now
 validates the selected-source workflow definitions, exact-SHA successful runs
-and ARM jobs, and stable full-SHA registry digests. It records that evidence in
-a canonical checksummed receipt before creating or fast-forwarding
-`refs/heads/stg-release`. An explicit expected-old lease makes the remote write
-a compare-and-swap, while prior graph validation permits only creation or a
-fast-forward and never a history rewrite. Equal and stale candidates are
-no-ops; divergence and concurrent ref movement fail closed.
+and ARM jobs, and stable full-SHA registry digests before any ref write. For
+each accepted OCI or Docker manifest response, it hashes the raw body and
+requires that value to equal the validated `Docker-Content-Digest` header. It
+then records the evidence and ref-update result in a canonical checksummed
+receipt. An explicit expected-old lease makes the remote write a
+compare-and-swap, while prior graph validation permits only creation or a
+fast-forward and never a history rewrite. After a successful push, bounded
+readback retries record `verified`, `mismatch`, or `uncertain`; the latter two
+fail only after the receipt and checksum have been written. Equal and stale
+candidates are no-ops; divergence and concurrent pre-push ref movement fail
+closed.
 
 The controller executes only code checked out at `github.workflow_sha`.
 Candidate Git objects, API metadata, and registry manifests are data; candidate
 actions, scripts, caches, and artifacts are never executed or consumed. It uses
 only `actions: read` and `contents: write`. Automatic writes require
 `STG_RELEASE_PROMOTION_ENABLED=true`; manual runs default to dry-run and require
-the exact confirmation `stg-release` before a write.
+the exact input `confirm_ref_update=stg-release` before a write.
 
 The companion selected-source and platform work makes staging track
 `stg-release` and render all first-party images with its resolved full commit

--- a/docs/adr/0028-short-lived-qualified-rc-branch-for-ai-releases.md
+++ b/docs/adr/0028-short-lived-qualified-rc-branch-for-ai-releases.md
@@ -8,22 +8,25 @@ Accepted — 2026-08-29
 
 `v3` is the production mainline and ships alphas continuously. `v3-ai` has
 accumulated a large body of AI work, including exploratory migrations that
-shared staging has already applied. Shared staging follows a floating branch
-selected by `STG_SOURCE_BRANCH`; the promoter accepts only Docker-tag-safe
-branch names, and the staging image workflows build only `v3` and `v3*`
-branches. The AI capabilities must reach production without freezing either
-line, without shipping exploratory schema, and without a database
+shared staging has already applied. `STG_SOURCE_BRANCH` selects the staging
+candidate source; the promoter accepts only Docker-tag-safe branch names, and
+the staging image workflows build only `v3` and `v3*` branches. Under the
+release-ref promotion contract, that variable selects which branch publishes
+candidate images while ArgoCD continues to track `stg-release`. The AI
+capabilities must reach production without freezing
+either line, without shipping exploratory schema, and without a database
 down-migration story that PostgreSQL cannot honestly provide.
 
 ## Decision
 
 Each AI release is cut as a short-lived release-candidate branch named
 `v3.5.0-ai-rc` (pattern `v3*`, Docker-safe — both constraints are load-bearing)
-from a normalized `v3-ai` commit. Shared staging is repointed to the RC
-(repository variable and ArgoCD `targetRevision` together), reset
-destructively, and qualifies that exact tree. After qualification the RC merges
-into `v3`, the resulting tree is tagged and deployed dark, and feature trains
-continue on `v3-ai` throughout.
+from a normalized `v3-ai` commit. The `STG_SOURCE_BRANCH` repository variable
+is repointed to the RC while ArgoCD keeps `targetRevision: stg-release`; the
+receipt-gated controller then advances that ref to the qualified RC commit.
+Shared staging is reset destructively and qualifies that exact tree. After
+qualification the RC merges into `v3`, the resulting tree is tagged and
+deployed dark, and feature trains continue on `v3-ai` throughout.
 
 Three rules bound the release:
 
@@ -49,6 +52,7 @@ Three rules bound the release:
   every RC fix into `v3-ai`.
 - One branch ruleset covers `v3`, `v3-ai`, and the RC. With a single code
   owner, required approvals stay at zero and always-reporting status checks
-  carry the entire gate; the staging promoter identity is a named bypass
-  actor.
+  carry the entire gate. Promotion does not commit to those branches or require
+  a bypass actor; the trusted controller updates only `stg-release` after
+  exact-build and registry-receipt validation.
 - The pattern repeats for future AI releases until `v3-ai` retires into `v3`.

--- a/docs/adr/0028-short-lived-qualified-rc-branch-for-ai-releases.md
+++ b/docs/adr/0028-short-lived-qualified-rc-branch-for-ai-releases.md
@@ -54,5 +54,6 @@ Three rules bound the release:
   owner, required approvals stay at zero and always-reporting status checks
   carry the entire gate. Promotion does not commit to those branches or require
   a bypass actor; the trusted controller updates only `stg-release` after
-  exact-build and registry-receipt validation.
+  exact-build validation and raw-body verification of each registry digest
+  recorded in the receipt.
 - The pattern repeats for future AI releases until `v3-ai` retires into `v3`.

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -2,7 +2,7 @@
 type: Operations
 title: CI & Deployment
 description: PR gates, image builds, the standard-version release flow, Helm deployment reality, and what is NOT in this repo.
-timestamp: '2026-08-30'
+timestamp: '2026-09-04'
 tags:
   - ci
   - deployment
@@ -45,18 +45,19 @@ neither Node nor pnpm.
 - **Manual final review**: After CI and the draft feedback are settled, a collaborator with calculated `write` or `admin` permission posts `/final-review` on an unstacked PR or on one verified native stack layer. The workflow uses `z-ai/glm-5.3-flash` with high reasoning, applies the repository's diff-led operational lenses, and publishes one consolidated review attached to an immutable head. Before review fan-out, one fixed public-safe request must return the expected function call; failure stops the run with bounded provider diagnostics. The manual jobs pin OpenCodeReview 1.11.0 and use its low review-effort preset for one review round; this does not lower the model's high reasoning setting. Each OCR task has a 30-minute deadline, and an individual range has a 750,000-token ceiling. When the first attempt returns structurally valid partial coverage for a non-budget failure, the same job may resume that exact session once with only the unused token allowance. Strict lineage and identity checks protect checkpoint reuse, and combined usage cannot exceed the original range ceiling. Budget exhaustion, an invalid session, or a still-partial resume fails immediately. The job has a 75-minute ceiling and reserves time after OCR for cleanup and finalization. No incomplete result reaches publication. The mode-0600 OpenRouter config lives only at OCR's current-user default path on a fresh GitHub-hosted runner and is removed by the existing always-run cleanup before publication. Do not move these jobs to persistent self-hosted runners without redesigning that secret lifecycle. If no actionable findings exist, it records an evidence-bound clean success status with description `z-ai/glm-5.3-flash final review clean; evidence=<64-hex evidence digest>` and skips the PR comment. The evidence digest covers the exact PR range, review mode, root review, stack identity, dispositions, and policy. A later descendant containing only bounded, declared repairs may be attested incrementally; material scope changes, stale stack identities, missing dispositions, or exceeded bounds require another complete manual review. For a finding-bearing report, a permitted collaborator records the exact machine-readable marker `<!-- final-ai-disposition/v1 {"schema_version":"final-ai-disposition/v1","review_id":"...","root_head":"...","workflow_run_id":123,"entries":[{"finding_id":"...","state":"fixed|follow-up|rejected","reference":"public-safe reference","paths":["path/to/finding"]}]} -->`; every entry must cover exactly one root finding and include its finding path in the explicit remediation paths. Malformed or missing records force a complete review. Findings are advisory: collaborators verify them and record each blocker as fixed, follow-up, or rejected.
 - **Manual stack review**: For a verified native stack, post `/final-review-stack` on the top PR. The workflow uses `z-ai/glm-5.3-flash` with high reasoning to review the cumulative change and stack topology, assigns cross-layer findings to exact layer deltas, and publishes one report on the top PR. Each cumulative OCR task has a 30-minute deadline. A full-stack range has a 20,000,000-token ceiling; each incremental layer range retains its own 750,000-token ceiling. The first eligible partial range in declared order may consume the job's single resume allowance and shares that range's ceiling. A later or ineligible partial fails immediately. The 90-minute job uses an inner code-review deadline to reserve time for cleanup, topology review, publication, and finalization. Partial coverage is never published. The topology request removes derivation-only patch operations before sending evidence and fails closed above its bounded request and output budgets. It receives bounded excerpts of prior code findings, reports only defects that depend on a cross-layer interaction, and suppresses a topology result when it restates an overlapping code finding with the same path and category. Metadata retains both generated and published topology counts for later evaluation. If neither pass produces an actionable finding, it records an evidence-bound clean success status with description `z-ai/glm-5.3-flash stack review clean; evidence=<64-hex evidence digest>` and skips the PR comment. It stores the immutable reviewed-path and rename-alias set in the trusted `Final AI stack clean evidence` check output so an unrelated default-branch advance can be revalidated without recreating a comment. The stack evidence digest covers the ordered layer identities, topology identity, exact range, dispositions, and policy. A later repair in one or more layers may use the same bounded, disposition-backed attestation contract when every changed layer descends from its reviewed head, every upper layer contains the current parent head, and each per-layer remediation range remains within the declared bounds. Topology drift, material scope changes, or missing dispositions require another cumulative review. Any layer drift resets the top `final-ai-stack-review` status, even when the top PR's SHA is unchanged. Neither final status grants merge authority; merge readiness still requires current evidence, green required CI, and terminal dispositions. The repository grants agents and the shared PR babysitter standing approval to post `/final-review` or `/final-review-stack` after exact-head CI and ordinary feedback settle; no per-run approval is required for the configured external OpenRouter request and its usage cost. This standing approval does not cover non-public payloads or grant merge authority. The babysitter still stops after two autonomous head-changing rounds and never guesses a tracker destination. Add `final-ai-review` or `final-ai-stack-review` to branch protection only after a controlled live run has proved its status lifecycle.
 - **Publisher rejection diagnostics**: A failed validation or publisher step keeps its exact rejected JSON input as a one-day workflow artifact. The individual job retains its initial, resumed, or final result JSON as applicable. The stack job normally retains the combined code result and optional topology result. An incremental validation or resume failure may instead retain the exact affected range result JSONs, while a combine failure retains every range result passed to the failed combine step. The workflow never adds stderr, OpenRouter configuration, stack manifests, review-range directories as directories, unrelated wildcard inputs, or runner workspaces to these artifacts. Treat the payloads as public because this repository is public: use them only for offline parser diagnosis, never as authorization to replay or publish a review. The upload runs only after the corresponding validation or publisher step fails and does not change the failed job or final status. Live artifact proof remains a post-merge check because `pull_request_target` uses workflow code from the default branch. See [OpenCodeReview publisher rejection payloads](./solutions/integration/opencodereview-publisher-rejection-payloads.md) for the failure pattern and safe diagnostic boundary.
-- **Generated staging promotion exemption**: A PR that passes the repository's generated staging-promotion contract receives the separate status `Verified generated staging promotion` without a final-review report. The contract verifies every exact-SHA successful `v3_*-stg.yml` push run and requires each executed staging workflow definition to match the trusted default-branch definition. The repository-owned babysitter verifier rechecks the promotion contract, exact status, and trusted workflow provenance before consuming this no-report exemption; it is not a general substitute for `/final-review`.
 - **Offline qualification**: Public-safe synthetic receipts and a dependency-free evaluator live under `.github/open-code-review/qualification/`. The evaluator's strict synthetic contract covers explicit blocker and false-blocker dispositions, prompt-injection text treated as untrusted data, valid and invalid stack topology, exact path ownership, incomplete coverage, and token-counter consistency. It is intentionally separate from the runtime OCR parser and does not claim to validate live provider receipts. Run `node --test .github/open-code-review/qualification/final-review-qualification.test.js` and `node .github/open-code-review/qualification/final-review-qualification.js`; this checks deterministic local contracts and reports offline-only metrics. OpenCodeReview 1.11.0 is also qualified before publication against a fake OpenAI-compatible endpoint with a synthetic one-file diff; that probe checks the released binary's model, high reasoning, tool request, 16,384-token completion cap, automatic provider routing, and one-round effort wiring. Neither offline path qualifies live model behavior, proves first-trigger success, or makes a merge-readiness decision. Real `/final-review` and `/final-review-stack` proof remains a post-merge gate because `pull_request_target` executes trusted default-branch workflow code.
 
 ## Image builds
 
-13 apps × stg + prd workflows (`v3_<app>-{stg,prd}.yml`) push ARM64
-images to ghcr.io through their `-arm` jobs. The legacy `-amd` image jobs stay
-defined but use an always-false job condition, so they publish no AMD64 images.
-Keeping the skipped `build-amd` job preserves the required status context while
-branch protection still requires that name. The no-op `Build Fallback`
-`build-amd` job remains enabled for pull requests that do not start an app image
-workflow.
+The selected staging source currently has 15 `v3_*-stg.yml` workflows with 16
+active ARM64 image jobs, including the backend migrator and the two MCP images.
+They push images to ghcr.io through their `-arm` jobs. Fourteen legacy `-amd`
+jobs remain defined with an always-false condition. The two MCP workflows also
+publish AMD64 variants, but those repositories are not staging-chart runtime
+inputs and are excluded from the release receipt. Keeping the skipped
+`build-amd` job preserves the required status context where branch protection
+still requires that name. The no-op `Build Fallback` `build-amd` job remains
+enabled for pull requests that do not start an app image workflow.
 
 - **stg**: push to `v3`/`v3*` or PR touching the app's paths (PRs build but don't push).
 - **prd**: tags `v*.*.*` only.
@@ -83,7 +84,7 @@ Version bumps are **local and manual** via standard-version: `pnpm run release[:
 
 ## Deployment values (facts, not procedures)
 
-- **stg** (`*.klicker.stg.df-app.ch`): everything rides the floating image tag selected by the `STG_SOURCE_BRANCH` repository variable (the current value and committed values use `v3-ai`; an unset variable defaults to `v3`), so the rendered manifest never changes on a rebuild and ArgoCD would never sync on its own. The promotion workflow aligns the image tags and promotion pull request with the selected branch. The `rollout.klicker.uzh.ch/release` pod annotation is what makes it move — see [Staging promotion](#staging-promotion) below.
+- **stg** (`*.klicker.stg.df-app.ch`): `STG_SOURCE_BRANCH` selects the supported `v3*` branch that publishes staging candidates. The release-ref design makes ArgoCD track `stg-release` and inject its resolved full commit SHA as the first-party image tag. Phase 1 keeps automatic promotion disabled until the selected-source SHA publishers, chart override, and platform configuration are delivered and verified — see [Staging promotion](#staging-promotion) below.
 - **prd** (`*.klicker.uzh.ch`): pinned version tags, `replicaCount: 2` for web/API services.
 - **Secrets are external**: deployments reference `envFrom.secretRef` names, but the chart defines no `Secret` manifests — provision them out-of-band with matching names. GrowthBook-ready Node workloads also reference the optional shared `<rendered-chart-fullname>-secret-growthbook`, which supplies only `GROWTHBOOK_API_HOST` and the server SDK `GROWTHBOOK_CLIENT_KEY`; `GROWTHBOOK_ENV` comes from the global ConfigMap. Separately, only the primary GraphQL backend references optional `<rendered-chart-fullname>-secret-growthbook-management`, containing `GROWTHBOOK_MANAGEMENT_API_URL` and `GROWTHBOOK_MANAGEMENT_API_KEY` for beta enrollment. Its non-secret `GROWTHBOOK_BETA_SAVED_GROUP_ID` renders only from a configured `backendGraphql.betaSavedGroupId`; the chart default is empty. The optional references preserve startup before provisioning. Do not place the write-capable management key in the shared evaluator Secret.
 - **Hatchet endpoint pair**: `hatchet.client.apiUrl` in the environment values renders `HATCHET_API_URL`, while the external secret supplies `HATCHET_CLIENT_HOST_PORT`. They must resolve to the same Hatchet installation; worker health alone does not validate programmatic schedule creation over the HTTP API. Staging uses `app-hatchet-svc-api.stg-hatchet-svc.svc.cluster.local:8080`, and production uses `app-hatchet-svc-api.prd-hatchet-svc.svc.cluster.local:8080` (see [Async & Workers](./async-and-workers.md)).
@@ -99,25 +100,66 @@ Why this shape (ArgoCD-native hook, dedicated migrator image, manual demoted to 
 
 ## Staging promotion
 
-**ArgoCD auto-syncs on git change** (prune + selfHeal, app `app-klicker`), but only when the _rendered manifest_ differs. Two things therefore do **not** trigger a sync, and both have bitten us:
+`.github/workflows/deploy-stg-promote.yml` is a trusted default-branch
+`workflow_run` controller. It checks out only `github.workflow_sha`, executes
+only the promoter script from that checkout, and treats candidate workflow
+files, run and job metadata, and registry responses as untrusted data. It does
+not check out or execute candidate actions or scripts and does not consume
+candidate caches or artifacts.
 
-- **A rebuilt floating tag.** stg pulls the selected source tag (currently `:v3-ai`), so a new image leaves the Deployment spec byte-identical. `pullPolicy: Always` means a restart _would_ pick it up, but nothing asks for a restart.
-- **A hook-only change.** ArgoCD excludes hook manifests from the OutOfSync comparison, so a commit touching only the PreSync migration Job shows as "Synced" at the new revision with the hook never executed (this is why the hook in [ADR-0001](./adr/0001-automate-db-migrations-via-argocd-presync-hook.md) needed one manual sync to fire the first time).
+For each candidate, the controller validates all of these before considering a
+ref update:
 
-The `rollout.klicker.uzh.ch/release` annotation exists to break that tie: it lands in the **pod template**, so changing it is a real manifest change. The promoter discovers every occurrence in `deploy/env-uzh-stg/values.yaml`; prd has no such annotation because its pinned tags change on every release.
+- `STG_SOURCE_BRANCH` is a safe supported `v3*` source and the candidate is its
+  ancestor.
+- The candidate has the exact trusted staging workflow names, paths, push
+  triggers, active ARM jobs, runtime image repositories, and backend migrator
+  ordering. Intentionally disabled AMD jobs are excluded.
+- Every required workflow and job has a successful push run for the exact
+  candidate SHA. Only missing or still-running evidence is retried, for a
+  bounded interval; skipped, failed, cancelled, or mismatched evidence fails
+  immediately.
+- Every expected runtime repository exposes the full candidate SHA tag with a
+  complete digest. The controller reads the registry inventory twice and fails
+  if any digest is absent or changes during collection.
 
-`.github/workflows/deploy-stg-promote.yml` resolves `STG_SOURCE_BRANCH` once, checks out that branch, aligns every discovered image tag, and writes the built commit's short SHA into every discovered rollout annotation once **every** `v3_*-stg.yml` image build for the selected commit has succeeded. Both inventories must be non-empty, but their sizes are intentionally independent. A rollout can therefore never start against a half-published source tag, and the PreSync migration hook runs before the new pods. The workflow publishes a pull request to the selected source branch rather than pushing directly. Before enabling auto-merge it waits for the exact `Verified generated staging promotion` status, which also protects an unprotected source branch from merging before the generated-content and exact-build checks finish. `[skip ci]` in the title prevents the squash commit from rebuilding every image and re-firing the promoter.
+The sorted evidence becomes a canonical JSON receipt with the controller run,
+source and candidate revisions, workflow/run/job identities, registry tags and
+digests, retry history, ref decision, and previous/applied release revisions.
+Its SHA-256 checksum is written beside the receipt, and both are uploaded as a
+workflow artifact; the job summary records the same checksum and run identity.
+
+`refs/heads/stg-release` is the only write target. An explicit expected-old
+lease provides the remote compare-and-swap after the controller has proved the
+candidate is a fast-forward. Initial creation and fast-forward are the only
+accepted updates; equal and stale candidates are no-ops, while divergence and
+any concurrent ref movement fail. Candidate-SHA concurrency serializes
+duplicate evaluation of one commit without suppressing a different, possibly
+newer candidate.
 
 Operational notes.
 
-- Set the repository variable `STG_SOURCE_BRANCH` to select the active supported `v3*` branch; it falls back to `v3` when unset. Set it explicitly to `v3-ai` for the current staging source. The branch name must be a Docker-safe image tag because the build workflows publish branch-name tags.
-- **Default-branch activation:** GitHub evaluates `workflow_run` from the repository default branch. A promoter correction merged only to `v3-ai` is available for a branch-selected manual dispatch but does not change automatic fan-in until the same executable correction reaches default branch `v3`. Activate it with a focused pull request; do not repeat a broad `v3` to `v3-ai` merge for that purpose.
-- **Already-built commits:** a build set started before a promoter correction keeps the old behavior. After the correction is active, first require every exact-head staging image build to succeed, inspect and resolve any stale wrong-base promotion pull request, then dispatch `Promote to stg` on the selected source ref with the full commit SHA and `dry_run=false`. Dispatch and rollout remain separate authorized actions. Merging the correction alone does not redeploy an existing image set.
-- Before changing ArgoCD `targetRevision`, render the staging chart from the branch ArgoCD will track and verify every workload image tag uses that branch. After an authorized sync, require both `Synced` and `Healthy`; a successful sync alone can still leave workloads in `ImagePullBackOff` or `OOMKilled`.
-- It needs `secrets.STG_PROMOTE_TOKEN`, a repository-owned PAT with `contents: write` and `pull-requests: write`, plus permission to merge into the selected source branch. A pull request opened with the default `GITHUB_TOKEN` does not trigger workflows, so the generated verifier would never report and the promoter would fail closed.
-- Two settings outside this repo are load-bearing. `squash_merge_commit_title` must stay `PR_TITLE`, or the `[skip ci]` marker never reaches the squash commit and every promotion rebuilds all staging images. The workflow does not rely on it alone — the guard also refuses to promote any commit whose subject starts with `chore(deploy): promote ` — but the belt is worth keeping. Auto-merge must be enabled on the repository.
-- The annotation records which commit _triggered_ the rollout, not which bits are in the image: two merges minutes apart cancel the first build (`cancel-in-progress: true`) and the selected source tag then holds the later images. Immutable per-commit tags are the fix if that ever matters.
+- Set `STG_SOURCE_BRANCH` to the active supported `v3*` source. It falls back to
+  `v3` when unset, but promotion fails closed unless that branch has the exact
+  trusted publisher inventory and full-SHA tags.
+- GitHub evaluates `workflow_run` from the default branch. A correction on a
+  selected-source branch does not change the privileged controller. Candidate
+  source may contain an identical mirror for manual diagnostics, but the
+  automatic run executes only the default-branch revision.
+- Keep `STG_RELEASE_PROMOTION_ENABLED` absent or `false` during Phase 1. A
+  manual dispatch defaults to dry-run; a write requires `dry_run=false` and the
+  exact confirmation `stg-release`. Initial ref creation, repository-variable
+  changes, and activation remain separate operations.
+- Before activation, prove every full-SHA image and retain the receipt, create
+  `stg-release` through the confirmed manual path, then update only the private
+  staging ArgoCD Application to track that ref and pass
+  `global.imageTag=$ARGOCD_APP_REVISION` as a forced string. Preview, apply,
+  runtime health, and acceptance remain separate evidence and approvals.
+- The controller uses the repository `GITHUB_TOKEN`; no promotion PAT,
+  pull-request permission, source-branch bypass actor, auto-merge setting, or
+  squash-title behavior is part of the new path.
 
-Rationale and rejected alternatives: [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).
+The superseded annotation-write-back rationale remains in
+[ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).
 
 Prd is unaffected — it promotes by hand-editing pinned tags in `deploy/env-uzh-prd/values.yaml`.

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -120,14 +120,21 @@ ref update:
   bounded interval; skipped, failed, cancelled, or mismatched evidence fails
   immediately.
 - Every expected runtime repository exposes the full candidate SHA tag with a
-  complete digest. The controller reads the registry inventory twice and fails
-  if any digest is absent or changes during collection.
+  complete digest. Each accepted OCI or Docker manifest response must be
+  redirect-free, complete, and have raw body bytes whose SHA-256 equals its
+  validated `Docker-Content-Digest` header. The controller reads the registry
+  inventory twice and fails if any digest is absent or changes during
+  collection.
 
 The sorted evidence becomes a canonical JSON receipt with the controller run,
 source and candidate revisions, workflow/run/job identities, registry tags and
-digests, retry history, ref decision, and previous/applied release revisions.
-Its SHA-256 checksum is written beside the receipt, and both are uploaded as a
-workflow artifact; the job summary records the same checksum and run identity.
+digests, retry history, ref decision, update result, post-push verification
+state, and previous/applied release revisions. Its SHA-256 checksum is written
+beside the receipt, and both are uploaded as a workflow artifact; the job
+summary records the same checksum and run identity. A successful Git push is
+followed by bounded ref readback retries. If readback remains unavailable or
+reports another ref, the controller writes the receipt and checksum with
+`uncertain` or `mismatch` verification before failing the run.
 
 `refs/heads/stg-release` is the only write target. An explicit expected-old
 lease provides the remote compare-and-swap after the controller has proved the
@@ -140,16 +147,18 @@ newer candidate.
 Operational notes.
 
 - Set `STG_SOURCE_BRANCH` to the active supported `v3*` source. It falls back to
-  `v3` when unset, but promotion fails closed unless that branch has the exact
-  trusted publisher inventory and full-SHA tags.
+  `v3` in the trusted workflow expression when unset. The promoter requires
+  that resolved input and does not query repository variables itself. Promotion
+  fails closed unless the branch has the exact trusted publisher inventory and
+  full-SHA tags.
 - GitHub evaluates `workflow_run` from the default branch. A correction on a
   selected-source branch does not change the privileged controller. Candidate
   source may contain an identical mirror for manual diagnostics, but the
   automatic run executes only the default-branch revision.
 - Keep `STG_RELEASE_PROMOTION_ENABLED` absent or `false` during Phase 1. A
   manual dispatch defaults to dry-run; a write requires `dry_run=false` and the
-  exact confirmation `stg-release`. Initial ref creation, repository-variable
-  changes, and activation remain separate operations.
+  exact input `confirm_ref_update=stg-release`. Initial ref creation,
+  repository-variable changes, and activation remain separate operations.
 - Before activation, prove every full-SHA image and retain the receipt, create
   `stg-release` through the confirmed manual path, then update only the private
   staging ArgoCD Application to track that ref and pass

--- a/project/2026-09-04-stg-release-controller-plan.md
+++ b/project/2026-09-04-stg-release-controller-plan.md
@@ -131,8 +131,10 @@ and document the new release-ref contract.
 
 ## Progress
 
-- `Current:` the accepted controller correction is implemented and verified on
-  exact local baseline `3079761289a4e0bb54380bfc7792c7c0295dbf11`.
+- `Current:` the accepted controller is rebased onto exact target
+  `origin/v3@468f05b91503b133670dda235be9a4b38bba2155`; implementation head
+  `0f643e48b99a512ca225b0826f6d3e00ec023d0a` is six commits ahead and zero
+  behind that target.
 - `Correction:` preserve a receipt after every successful Git push, add bounded
   post-push readback retries and explicit verification state, verify registry
   digest headers against raw manifest bytes and accepted content types, remove
@@ -151,12 +153,18 @@ and document the new release-ref contract.
   checks pass. Deterministic tests write and verify canonical fixture receipts
   and checksums before rejecting exhausted or mismatched post-push readback.
   Staged Gitleaks and focused personal-data review complete before commit.
-- `Review:` the execution owner completed a bounded trust-boundary and diff
-  review. The global integration owner still owns the independent cross-branch
-  review and contract matrix after all Phase 1 worktrees are available.
-- `Remaining:` no implementation remains in this assigned worktree. Activation
-  still requires the separately owned selected-source SHA publishers, chart
-  override and runtime mirror, the private platform change, a receipt-backed
-  initial ref creation, runtime proof, and separate authorization of
-  `STG_RELEASE_PROMOTION_ENABLED=true`.
+- `Review:` the independent final review passed on pre-rebase head
+  `4a81e8e10bb5f1b8b8c3b7af275e7b14425767dc`. `git range-diff` confirms all
+  executable controller commits replayed unchanged. The documentation commit
+  only retained the newer target-branch GrowthBook beta-enrollment wording, so
+  the content-based review remains valid.
+- `Integration:` the approved one-time rebase completed without a conflict.
+  Promoter tests pass 20/20, final-review tests pass 56/56, and the seven
+  mirrored runtime and policy blobs still match the selected-source branch
+  7/7.
+- `Remaining:` no implementation remains in this assigned worktree. Phase 1
+  selected-source publishers, chart override, and runtime mirror are complete
+  locally. Activation still requires the private platform change, a
+  receipt-backed initial ref creation, runtime proof, and separate
+  authorization of `STG_RELEASE_PROMOTION_ENABLED=true`.
 - `External state:` unchanged.

--- a/project/2026-09-04-stg-release-controller-plan.md
+++ b/project/2026-09-04-stg-release-controller-plan.md
@@ -131,9 +131,24 @@ and document the new release-ref contract.
 
 ## Progress
 
-- `Current:` approved controller scope copied into this branch-local plan;
-  implementation has not started.
-- `Completed:` none.
-- `Remaining:` controller, final-review policy, documentation, verification,
-  and final local commits.
+- `Current:` all assigned Phase 1 controller work is implemented, verified,
+  and committed locally.
+- `Completed:` `e7743d2c57` replaces the generated commit/pull-request promoter
+  with the trusted exact-build release-ref controller; `2edaec3a37` removes the
+  generated-promotion final-review bypass; `553b1f131a` supersedes ADR 0003,
+  narrowly amends ADR 0028, and updates the CI guide.
+- `Verification:` Node 24 syntax checks passed; promoter tests pass 14/14;
+  final-review tests pass 56/56; the selected-source fixture commit validates
+  15 workflow definitions and 16 runtime ARM jobs; workflow YAML parsing,
+  extracted-shell `bash -n`, ShellCheck, Biome and Prettier formatting checks,
+  and Git diff checks pass. Each staged slice passed Gitleaks and a focused
+  personal-data scan.
+- `Review:` the execution owner completed a bounded trust-boundary and diff
+  review. The global integration owner still owns the independent cross-branch
+  review and contract matrix after all Phase 1 worktrees are available.
+- `Remaining:` no implementation remains in this assigned worktree. Activation
+  still requires the separately owned selected-source SHA publishers, chart
+  override and runtime mirror, the private platform change, a receipt-backed
+  initial ref creation, runtime proof, and separate authorization of
+  `STG_RELEASE_PROMOTION_ENABLED=true`.
 - `External state:` unchanged.

--- a/project/2026-09-04-stg-release-controller-plan.md
+++ b/project/2026-09-04-stg-release-controller-plan.md
@@ -57,7 +57,7 @@ and document the new release-ref contract.
   candidate code, actions, caches, and artifacts are never executed or used.
 - Workflow permissions are only `actions: read` and `contents: write`.
 - Automatic writes require `STG_RELEASE_PROMOTION_ENABLED=true`. Manual runs
-  default to dry-run and require exact confirmation `stg-release` before a
+  default to dry-run and require `confirm_ref_update=stg-release` before a
   write.
 - Candidate-scoped concurrency permits different candidates to race; remote
   compare-and-swap allows create or fast-forward only. Equal and stale
@@ -131,18 +131,26 @@ and document the new release-ref contract.
 
 ## Progress
 
-- `Current:` all assigned Phase 1 controller work is implemented, verified,
-  and committed locally.
+- `Current:` the accepted controller correction is implemented and verified on
+  exact local baseline `3079761289a4e0bb54380bfc7792c7c0295dbf11`.
+- `Correction:` preserve a receipt after every successful Git push, add bounded
+  post-push readback retries and explicit verification state, verify registry
+  digest headers against raw manifest bytes and accepted content types, remove
+  dead source-branch and pagination fallbacks, and rename the manual input to
+  `confirm_ref_update`.
 - `Completed:` `e7743d2c57` replaces the generated commit/pull-request promoter
   with the trusted exact-build release-ref controller; `2edaec3a37` removes the
   generated-promotion final-review bypass; `553b1f131a` supersedes ADR 0003,
-  narrowly amends ADR 0028, and updates the CI guide.
-- `Verification:` Node 24 syntax checks passed; promoter tests pass 14/14;
-  final-review tests pass 56/56; the selected-source fixture commit validates
-  15 workflow definitions and 16 runtime ARM jobs; workflow YAML parsing,
-  extracted-shell `bash -n`, ShellCheck, Biome and Prettier formatting checks,
-  and Git diff checks pass. Each staged slice passed Gitleaks and a focused
-  personal-data scan.
+  narrowly amends ADR 0028, and updates the CI guide. The correction preserves
+  receipts for uncertain or mismatched successful pushes, validates manifest
+  bodies against digest headers, removes dead fallbacks, and uses the exact
+  `confirm_ref_update` input.
+- `Verification:` Node 24 syntax checks pass; promoter tests pass 20/20 and
+  final-review tests pass 56/56. Workflow YAML parsing, extracted-shell
+  `bash -n`, ShellCheck, Biome and Prettier formatting checks, and Git diff
+  checks pass. Deterministic tests write and verify canonical fixture receipts
+  and checksums before rejecting exhausted or mismatched post-push readback.
+  Staged Gitleaks and focused personal-data review complete before commit.
 - `Review:` the execution owner completed a bounded trust-boundary and diff
   review. The global integration owner still owns the independent cross-branch
   review and contract matrix after all Phase 1 worktrees are available.

--- a/project/2026-09-04-stg-release-controller-plan.md
+++ b/project/2026-09-04-stg-release-controller-plan.md
@@ -1,0 +1,139 @@
+# Default-controller Phase 1 implementation
+
+## Goal
+
+Replace the generated staging-promotion commit and pull-request path with a
+trusted default-branch `workflow_run` controller that advances
+`refs/heads/stg-release` only after exact-SHA staging builds and registry
+digest evidence pass. Remove the generated-promotion final-review exemption
+and document the new release-ref contract.
+
+## Scope
+
+- `.github/workflows/deploy-stg-promote.yml`
+- New focused promoter scripts, deterministic fixtures, and tests under
+  `.github/scripts`
+- Generated-promotion-specific code and tests in
+  `.github/scripts/final-ai-review.js` and
+  `.github/scripts/final-ai-review.test.js`
+- Related inputs in `.github/workflows/check-ocr-final-review.yml`
+- `docs/adr/0003-promote-stg-via-release-annotation-write-back.md`
+- `docs/adr/0028-short-lived-qualified-rc-branch-for-ai-releases.md`
+- `docs/ci-and-deployment.md`
+- This branch-local plan under `project/`
+
+## Non-goals
+
+- No platform-helper, selected-source workflow, chart, runtime mirror, or
+  production-values changes.
+- No registry queries during this local task; tests use synthetic fixtures.
+- No push, pull request creation or update, merge, rebase, deployment, ref
+  movement, secret or repository-setting change, or live verification.
+- No changes outside the named paths and no cleanup of unrelated work.
+
+## Execution contract
+
+- `Owner:` this session, in the assigned physical worktree only.
+- `Baseline:` branch `rs/stg-release-controller` at
+  `c5aeaee2fdc1bedc82d9080085a8d1aeba1c08b7`; do not integrate the later
+  `origin/v3` movement observed during the required remote refresh.
+- `Granted:` edit the named paths, use synthetic fixtures, run focused local
+  Node/shell/workflow/format/diff checks, and make local conventional commits.
+- `Withheld:` all external state changes and all credentials, private data,
+  registry access, candidate-code execution, and worktree operations outside
+  this worktree.
+- `Terminal:` the controller, final-review policy, ADRs, CI guide, tests, and
+  plan are committed locally with exact verification evidence and no staged
+  unrelated changes.
+- `Pause:` stop for credentials, secret-bearing configuration, private or
+  production data, missing policy decisions, destructive actions, or a need to
+  alter any path outside this assignment.
+
+## Decisions and invariants
+
+- The privileged workflow checks out only its own trusted default-branch
+  `github.workflow_sha` and executes only that checked-out script. Candidate
+  SHA, workflow definitions, API responses, and registry metadata are data;
+  candidate code, actions, caches, and artifacts are never executed or used.
+- Workflow permissions are only `actions: read` and `contents: write`.
+- Automatic writes require `STG_RELEASE_PROMOTION_ENABLED=true`. Manual runs
+  default to dry-run and require exact confirmation `stg-release` before a
+  write.
+- Candidate-scoped concurrency permits different candidates to race; remote
+  compare-and-swap allows create or fast-forward only. Equal and stale
+  candidates are no-ops. Divergence and races fail without force.
+- The controller validates selected-source and candidate ancestry, candidate
+  staging workflow triggers, required active ARM jobs including migrator,
+  disabled AMD exclusions, exact-SHA successful runs/jobs, complete stable
+  full-SHA registry digests, and a canonical receipt checksum before any ref
+  write.
+- Promotion never invokes commit, pull-request, merge, branch-delete, force,
+  or unrelated GitHub mutation commands.
+- The old generated-promotion status, parser, exporter, build verifier, and
+  workflow input are removed. A legacy `chore/promote-stg-*` pull request
+  follows ordinary final-review policy.
+
+## Feature-wide test portfolio
+
+| Risk or behavior | Existing evidence | Test obligation | Stable seam | Slice |
+| --- | --- | --- | --- | --- |
+| Trusted workflow execution and least privilege | Existing workflow only | Add | YAML and static workflow fixture assertions | Controller |
+| Candidate/source ancestry and workflow inventory | Existing promoter shell is incomplete | Add | Synthetic candidate repository/API fixtures | Controller |
+| Exact run/job evidence and bounded retries | Existing promoter checks runs only | Add | Deterministic delayed, missing, running, skipped, failed, cancelled, and wrong-evidence fixtures | Controller |
+| Digest receipt completeness and immutability | No existing receipt contract | Add | Synthetic registry responses and canonical JSON/checksum | Controller |
+| Compare-and-swap ref behavior | Existing local branch guard only | Add | Fake remote compare/update adapter covering create, fast-forward, equality, stale, divergence, and races | Controller |
+| Manual/automatic gates and no mutation commands | Existing workflow token/manual path | Add | Entry-point fixture matrix and command recorder | Controller |
+| Generated-promotion exemption removal | Existing exemption tests | Replace/consolidate | Final-review policy parser and legacy branch-name regression | Final review |
+| Durable release policy documentation | Existing ADRs and CI guide | Extend | Markdown/ADR text and formatting checks | Documentation |
+
+## Slices
+
+### Controller: trusted exact-build promotion and remote ref CAS
+
+- `Route:` main session; architecture, trust-boundary, and remote-write logic
+  remain here.
+- `Do:` replace the workflow, add the smallest repository script and synthetic
+  fixtures/tests, and remove the old commit/PR path.
+- `Check:` focused Node tests, workflow YAML/static assertions, shell syntax,
+  shellcheck, formatting, and `git diff --check`.
+- `Commit:` `ci: replace staging promotion with trusted release controller`.
+
+### Final-review policy: remove generated-promotion bypass
+
+- `Route:` main session; policy and generated-input coupling are critical-path
+  seams in the assigned files.
+- `Do:` remove generated-promotion-specific status/parser/build-verifier/
+  exporter/workflow inputs and add the ordinary-policy regression.
+- `Check:` focused final-review tests, workflow checks, formatting, and diff
+  hygiene.
+- `Commit:` `ci: remove generated staging promotion review bypass`.
+
+### Documentation: record the release-ref controller contract
+
+- `Route:` main session; docs are coupled to the implemented security and
+  release behavior.
+- `Do:` supersede ADR 0003, narrowly amend ADR 0028 while preserving its RC,
+  clean-schema, merge-hold, and forward-only migration decisions, and update
+  the CI guide.
+- `Check:` Markdown formatting, targeted stale-term searches, and diff hygiene.
+- `Commit:` `docs: document staging release-ref promotion`.
+
+## Verification and delivery
+
+- Run focused Node tests for the promoter and final-review policy.
+- Run shell syntax checks, ShellCheck, workflow/config checks, formatter
+  checks, and `git diff --check`.
+- Inspect every changed hunk and staged content for secrets, credentials,
+  personal data, unrelated changes, candidate-code execution, and forbidden
+  mutation commands.
+- Keep all commits local. Do not push, create or update a PR, merge, rebase,
+  move refs, query a registry, or change external state.
+
+## Progress
+
+- `Current:` approved controller scope copied into this branch-local plan;
+  implementation has not started.
+- `Completed:` none.
+- `Remaining:` controller, final-review policy, documentation, verification,
+  and final local commits.
+- `External state:` unchanged.


### PR DESCRIPTION
## Summary

Replace generated staging deployment commits and PRs with a trusted release-ref controller. Successful builds qualify an existing source commit; promotion advances `stg-release` without rebuilding or adding commits. Production release tags remain unchanged.

## Whole-branch coverage

- Validate exact workflow/job results and immutable image manifest digests before lease-protected, create-or-fast-forward ref updates.
- Run trusted default-branch scripts, never candidate code; retain canonical receipts even when post-push verification fails.
- Remove the generated-promotion review exemption and document the release-ref contract.

Substantive diff: 3,601 additions and 1,274 deletions, excluding project artifacts. This is one cohesive controller/policy change; deterministic fixtures and tests account for much of the size.

## Verification

After the approved integration: Node 24 promoter tests pass 20/20; final-review policy tests pass 56/56. Seven shared runtime/policy files match the selected-source implementation. Syntax, workflow parsing, ShellCheck, formatting, and diff checks passed. Independent final review accepted the implementation; executable commits replayed unchanged. Publication-time Gitleaks scanned all seven commits with no findings.

## Security and activation boundary

Automatic promotion remains disabled unless `STG_RELEASE_PROMOTION_ENABLED=true`. Manual runs default to dry-run and require explicit confirmation for writes. Candidate execution, redirects, unverified digest headers, divergent refs, and races fail closed. No variables, secrets, cluster state, or release refs have been changed by this publication.

## Blocking before merge

- Complete human review and exact-head/merged-result CI. The target advanced two commits after the approved integration; this draft preserves the reviewed head rather than integrating again.
- Coordinate the selected-source publisher/chart change and companion platform configuration. Merge is not authorization to activate promotion.

## Follow-up

Separately approve platform wiring, receipt-backed initial ref creation, runtime verification, and enabling automatic promotion. Production remains on its existing release-tag path.

## Local artifacts

`project/2026-09-04-stg-release-controller-plan.md` records implementation and verification. Its local-only delivery boundary was subsequently extended by explicit user approval to publish this draft.
