### PR TITLE
fix(ci): preserve pnpm caches across task script changes

### DIFF
--- a/.github/scripts/playwright-cache-contract.cjs
+++ b/.github/scripts/playwright-cache-contract.cjs
@@ -98,7 +98,7 @@ function dependencyFingerprint({
   const hash = crypto.createHash('sha256')
   hash.update(
     JSON.stringify({
-      schema: 1,
+      schema: 2,
       node: NODE_VERSION,
       pnpm: PNPM_VERSION,
       buildImageDigest,
@@ -119,9 +119,30 @@ function dependencyFingerprint({
     hash.update('\0')
     hash.update(file)
     hash.update('\0')
-    hash.update(fs.readFileSync(path.join(root, file)))
+    let contents = fs.readFileSync(path.join(root, file))
+    if (isPackageManifest(file)) {
+      const manifest = JSON.parse(contents.toString('utf8'))
+      // The pnpm store is reused before a fresh frozen install, not as node_modules.
+      // Keep installation hooks and all other fields; omit routine task scripts.
+      manifest.scripts = Object.fromEntries(
+        Object.entries(manifest.scripts ?? {}).filter(([name]) =>
+          [
+            'pnpm:devPreinstall',
+            'preinstall',
+            'install',
+            'postinstall',
+            'prepublish',
+            'preprepare',
+            'prepare',
+            'postprepare',
+          ].includes(name)
+        )
+      )
+      contents = JSON.stringify(manifest)
+    }
+    hash.update(contents)
   }
-  return `v1-${hash.digest('hex').slice(0, 32)}`
+  return `v2-${hash.digest('hex').slice(0, 32)}`
 }
 
 function main(argv = process.argv.slice(2)) {

--- a/.github/scripts/playwright-cache-contract.test.cjs
+++ b/.github/scripts/playwright-cache-contract.test.cjs
@@ -78,10 +78,49 @@ test('dependency cache survives orchestration changes but tracks installation in
   }
   assert.equal(original, dependencyFingerprint(input))
   for (const file of Object.keys(files).slice(0, 6)) {
-    fs.writeFileSync(path.join(root, file), `${files[file]}\nchanged`)
+    fs.writeFileSync(
+      path.join(root, file),
+      file === 'package.json'
+        ? '{"dependencies":{"example":"2.0.0"}}'
+        : `${files[file]}\nchanged`
+    )
     assert.notEqual(original, dependencyFingerprint(input), file)
     fs.writeFileSync(path.join(root, file), files[file])
   }
+})
+
+test('task scripts preserve the store key while installation hooks invalidate it', (t) => {
+  const root = fixtureRoot({ 'package.json': '{}' })
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const input = { root, files: ['package.json'] }
+  const original = dependencyFingerprint(input)
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'test:dev-runtime': 'node test.mjs' } })
+  )
+  assert.equal(dependencyFingerprint(input), original)
+  const build = buildFingerprint(input)
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'test:dev-runtime': 'node other-test.mjs' } })
+  )
+  assert.equal(dependencyFingerprint(input), original)
+  assert.notEqual(buildFingerprint(input), build)
+  for (const hook of [
+    'preinstall',
+    'install',
+    'postinstall',
+    'prepare',
+    'pnpm:devPreinstall',
+  ]) {
+    fs.writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({ scripts: { [hook]: 'node install.mjs' } })
+    )
+    assert.notEqual(dependencyFingerprint(input), original, hook)
+  }
+  fs.writeFileSync(path.join(root, 'package.json'), '{invalid')
+  assert.throws(() => dependencyFingerprint(input), SyntaxError)
 })
 
 test('the fingerprint is deterministic and includes the image digest', (t) => {


### PR DESCRIPTION
## Summary

Fix unnecessary pnpm cache misses found while evaluating #5783 on PR #5790. A test-script-only manifest change invalidated the dependency store key despite unchanged dependencies.

- Exclude routine task scripts from the pnpm fingerprint; retain installation lifecycle hooks and every other manifest field.
- Preserve lockfile, workspace, patch, toolchain and image inputs. Turbo fingerprinting and restore-only PR cache permissions are unchanged.
- Bump the pnpm key schema to v2 and add focused regression coverage.

Scope: one commit, two files, 64 additions and 4 deletions. This is a bounded follow-up to the cache-key defect observed in the previous rollout.

## Verification

Current head: six cache-contract and telemetry tests pass; Biome and `git diff --check` pass; staged gitleaks scan reports no leaks. Main-session diff inspection completed.

Application-wide build/check hooks were not run for this standalone helper change; focused checks replaced them using `HUSKY=0`. Hosted CI and live cache-hit performance are pending.

## Blocking Before Merge

- Exact-head CI and review feedback.
- Merge approval; this PR is draft.

## Follow-Up After Merge

- Allow one fresh v2 cache seed, then verify actual reuse on an eligible PR canary. No speedup is claimed from local tests.
- Keep global PR cache rollout off until measured. This PR changes no runner settings or repository variables.

## Local Session Artifacts

- On the originating Codex host: worktree `trees/rs/pnpm-cache-manifest-inputs` in `klicker-uzh`.
