### PR TITLE
ci(final-review): accept native stacks rooted on consolidation branches

### DIFF
--- a/.github/scripts/final-ai-review-shared.js
+++ b/.github/scripts/final-ai-review-shared.js
@@ -31,6 +31,30 @@ async function listCheckRunsForRef({ github, context, ref }) {
   return Array.isArray(checkRuns) ? checkRuns : []
 }
 
+// Consolidation branches are long-lived integration branches named after the
+// default branch with a dash-separated suffix (for example, v3-ai or
+// v3-polls). Staging deployments are cut from them, so pull requests and
+// native stack roots that target one are reviewed exactly like pull requests
+// that target the default branch itself.
+function isConsolidationBaseBranch({ baseRef, defaultBranch }) {
+  if (typeof baseRef !== 'string' || typeof defaultBranch !== 'string') {
+    return false
+  }
+  const prefix = `${defaultBranch}-`
+  return (
+    baseRef.startsWith(prefix) &&
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(baseRef.slice(prefix.length))
+  )
+}
+
+function isEligibleBaseBranch({ baseRef, context }) {
+  const defaultBranch = context.payload.repository.default_branch
+  return (
+    baseRef === defaultBranch ||
+    isConsolidationBaseBranch({ baseRef, defaultBranch })
+  )
+}
+
 function repositoryName(context) {
   return `${context.repo.owner}/${context.repo.repo}`
 }
@@ -68,6 +92,8 @@ function workflowRunUrl(context, runId = context.runId) {
 
 module.exports = {
   getPermission,
+  isConsolidationBaseBranch,
+  isEligibleBaseBranch,
   listCheckRunsForRef,
   repositoryName,
   safeFence,

--- a/.github/scripts/final-ai-review.js
+++ b/.github/scripts/final-ai-review.js
@@ -1,5 +1,6 @@
 const {
   getPermission,
+  isEligibleBaseBranch,
   listCheckRunsForRef,
   repositoryName,
   safeFence,
@@ -36,12 +37,6 @@ const FINAL_REVIEW_CLEAN_EVIDENCE_SCHEMA = 'final-ai-clean-evidence/v1'
 const FINAL_REVIEW_CLEAN_EVIDENCE_CHECK_NAME = 'Final AI clean evidence'
 const GENERATED_PROMOTION_STATUS = 'Verified generated staging promotion'
 const OCR_RUN_MANIFEST_SCHEMA = 'ocr.run-manifest/v1'
-// Long-lived consolidation branches (for example, v3-ai) that staging
-// deployments are cut from. Individual final reviews treat open ready pull
-// requests targeting one of these bases exactly like pull requests targeting
-// the default branch. Stack review and native-stack root validation stay
-// bound to the default branch.
-const CONSOLIDATION_BASE_BRANCHES = Object.freeze(['v3-ai'])
 const FINAL_REVIEW_RULES_PATH =
   '.github/open-code-review/final-review-rules.json'
 const FINAL_STACK_REVIEW_WORKFLOW_PATH =
@@ -934,13 +929,6 @@ async function getPull(github, context, pullNumber) {
     pull_number: pullNumber,
   })
   return response.data
-}
-
-function isEligibleBaseBranch({ baseRef, context }) {
-  return (
-    baseRef === context.payload.repository.default_branch ||
-    CONSOLIDATION_BASE_BRANCHES.includes(baseRef)
-  )
 }
 
 function isEligibleDefaultPull({ pull, context, baseSha, headSha }) {

--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -6,6 +6,11 @@ const path = require('node:path')
 const test = require('node:test')
 
 const {
+  isConsolidationBaseBranch,
+  isEligibleBaseBranch,
+} = require('./final-ai-review-shared')
+
+const {
   FINAL_REVIEW_SCHEMA,
   FINAL_REVIEW_MODEL,
   FINAL_REVIEW_CLEAN_STATUS_PREFIX,
@@ -2464,6 +2469,146 @@ test('authorizes a verified native stack member', async () => {
   )
   assert.equal(outputs.get('scope_kind'), 'native-stack')
   assert.equal(outputs.get('stack_id'), 'stack-42')
+})
+
+test('treats default-branch-prefixed branches as consolidation bases', () => {
+  const context = reviewContext()
+  for (const baseRef of ['v3-ai', 'v3-polls', 'v3-course-qa', 'v3-x.y_z']) {
+    assert.equal(isEligibleBaseBranch({ baseRef, context }), true, baseRef)
+    assert.equal(
+      isConsolidationBaseBranch({ baseRef, defaultBranch: 'v3' }),
+      true,
+      baseRef
+    )
+  }
+  assert.equal(isEligibleBaseBranch({ baseRef: 'v3', context }), true)
+  assert.equal(
+    isConsolidationBaseBranch({ baseRef: 'v3', defaultBranch: 'v3' }),
+    false
+  )
+  for (const baseRef of [
+    'v3-',
+    'v3-ai/feature',
+    'v3--ai',
+    'v4-ai',
+    'xv3-ai',
+    'feature/v3-ai',
+    'main',
+    undefined,
+    null,
+  ]) {
+    assert.equal(
+      isEligibleBaseBranch({ baseRef, context }),
+      false,
+      String(baseRef)
+    )
+  }
+  assert.equal(
+    isEligibleBaseBranch({
+      baseRef: 'main-ai',
+      context: {
+        ...context,
+        payload: { repository: { default_branch: 'main' } },
+      },
+    }),
+    true
+  )
+})
+
+test('authorizes a verified native stack member whose root targets a consolidation branch', async () => {
+  const parentPull = {
+    number: 41,
+    state: 'open',
+    draft: false,
+    title: 'Parent change',
+    base: {
+      ref: 'v3-ai',
+      sha: 'b'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
+    },
+    head: {
+      ref: 'rs/parent-change',
+      sha: 'c'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
+    },
+  }
+  const pull = {
+    number: 42,
+    state: 'open',
+    draft: false,
+    title: 'Stacked change',
+    base: {
+      ref: 'rs/parent-change',
+      sha: 'c'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
+    },
+    head: {
+      ref: 'rs/child-change',
+      sha: 'a'.repeat(40),
+      repo: { full_name: 'uzh-bf/klicker-uzh' },
+    },
+  }
+  const stackResponse = [
+    {
+      id: 'stack-42',
+      pull_requests: [
+        {
+          number: 41,
+          state: 'open',
+          draft: false,
+          head: { sha: 'c'.repeat(40) },
+        },
+        {
+          number: 42,
+          state: 'open',
+          draft: false,
+          head: { sha: 'a'.repeat(40) },
+        },
+      ],
+    },
+  ]
+  const outputs = new Map()
+  const core = {
+    notice: () => {},
+    setOutput: (name, value) => outputs.set(name, value),
+  }
+
+  assert.equal(
+    await authorizeFinalReview({
+      github: reviewGithub({
+        pull,
+        stackResponse,
+        comparison: { status: 'ahead', files: [] },
+        pullsByNumber: { 41: parentPull },
+      }).github,
+      context: reviewContext(),
+      core,
+    }),
+    true
+  )
+  assert.equal(outputs.get('scope_kind'), 'native-stack')
+  assert.equal(outputs.get('stack_id'), 'stack-42')
+
+  const unrelatedRoot = {
+    ...parentPull,
+    base: { ...parentPull.base, ref: 'feature/v3-ai' },
+  }
+  const notices = []
+  assert.equal(
+    await authorizeFinalReview({
+      github: reviewGithub({
+        pull,
+        stackResponse,
+        comparison: { status: 'ahead', files: [] },
+        pullsByNumber: { 41: unrelatedRoot },
+      }).github,
+      context: reviewContext(),
+      core: { ...core, notice: (message) => notices.push(message) },
+    }),
+    false
+  )
+  assert.equal(outputs.get('authorized'), 'false')
+  assert.match(notices.join('\n'), /consolidation branch/)
 })
 
 test('authorizes a pull request targeting a designated consolidation branch', async () => {

--- a/.github/scripts/final-ai-stack-review.js
+++ b/.github/scripts/final-ai-stack-review.js
@@ -1,5 +1,6 @@
 const {
   getPermission,
+  isEligibleBaseBranch,
   listCheckRunsForRef,
   repositoryName,
   safeFence,
@@ -530,8 +531,10 @@ function canUseStackReviewBaseAdvance(membership, context) {
   const rootRange = membership.ranges[0]?.response?.data
   if (
     !['behind', 'diverged'].includes(rootRange?.status) ||
-    membership.members[0].pull.base.ref !==
-      context.payload.repository.default_branch ||
+    !isEligibleBaseBranch({
+      baseRef: membership.members[0].pull.base.ref,
+      context,
+    }) ||
     membership.members[0].pull.base.repo?.full_name !== repositoryName(context)
   ) {
     return false
@@ -1009,7 +1012,7 @@ async function canPreserveStackReviewAcrossBaseAdvance({
     if (
       !['behind', 'diverged'].includes(rootRange?.status) ||
       !upperRanges.every((range) => range.response?.data?.status === 'ahead') ||
-      rootPull.base.ref !== context.payload.repository.default_branch ||
+      !isEligibleBaseBranch({ baseRef: rootPull.base.ref, context }) ||
       rootPull.base.repo?.full_name !== repositoryName(context) ||
       !membership.members.every(({ pull }, index) =>
         index === 0

--- a/.github/scripts/final-ai-stack-review.test.js
+++ b/.github/scripts/final-ai-stack-review.test.js
@@ -646,6 +646,27 @@ test('resolves a four-layer native stack and exact ancestry', async () => {
   assert.match(membership.orderDigest, /^[0-9a-f]{64}$/)
 })
 
+test('resolves a native stack whose root targets a consolidation branch', async () => {
+  const { github, pulls } = stackFixture()
+  pulls[11].base.ref = 'v3-ai'
+  const membership = await resolveStackMembership({
+    github,
+    context: context(),
+    pullNumber: 14,
+  })
+  assert.equal(membership.valid, true)
+  assert.deepEqual(membership.numbers, [11, 12, 13, 14])
+
+  pulls[11].base.ref = 'feature/v3-ai'
+  const rejected = await resolveStackMembership({
+    github,
+    context: context(),
+    pullNumber: 14,
+  })
+  assert.equal(rejected.valid, false)
+  assert.match(rejected.reason, /stack root does not target/)
+})
+
 test('accepts a verified two-layer stack as a distinct topology', async () => {
   const { github } = stackFixture()
   github.request = async () => ({
@@ -1503,6 +1524,123 @@ test('preserves comment-free clean evidence across unrelated default-base advanc
     false
   )
   assert.equal(state.createdStatuses.length, 0)
+})
+
+test('preserves stack evidence across base advancement of a consolidation root', async () => {
+  const { files, github, pulls, responses, state } = stackFixture()
+  pulls[11].base.ref = 'v3-ai'
+  const membership = await resolveStackMembership({
+    github,
+    context: context(),
+    pullNumber: 14,
+  })
+  assert.equal(membership.valid, true)
+  const manifestBundle = await buildStackSnapshot({
+    github,
+    context: context(),
+    membership,
+  })
+  const plan = await buildStackReviewPlan({
+    github,
+    context: context(),
+    membership,
+  })
+  state.reviews = [
+    {
+      body: renderStackReview({
+        codeResult: completeOCRResult([codeFinding()]),
+        headSha: pulls[14].head.sha,
+        manifestBundle,
+        topologyResult: topologyResult(),
+        policyDigest: plan.policyDigest,
+        workflowUrl: 'https://github.com/uzh-bf/klicker-uzh/actions/runs/700',
+        workflowHeadSha: 'a'.repeat(40),
+        trustedPolicySha: 'a'.repeat(40),
+        workflowSha: 'a'.repeat(40),
+        workflowRunId: 700,
+      }),
+      commit_id: pulls[14].head.sha,
+      state: 'COMMENTED',
+      submitted_at: '2026-08-25T00:00:00Z',
+      user: { login: 'github-actions[bot]' },
+    },
+  ]
+  state.comments = []
+  state.workflowRun = {
+    id: 700,
+    path: '.github/workflows/check-ocr-final-review.yml',
+    event: 'issue_comment',
+    head_branch: 'v3',
+    head_sha: 'a'.repeat(40),
+    conclusion: 'success',
+    repository: { full_name: repository },
+  }
+  state.statuses = [
+    {
+      context: 'final-ai-stack-review',
+      state: 'success',
+      target_url: 'https://github.com/uzh-bf/klicker-uzh/actions/runs/700',
+    },
+  ]
+  github.rest.actions = {
+    getWorkflowRun: async () => ({ data: state.workflowRun }),
+  }
+  github.paginate = async (endpoint, params) =>
+    endpoint === github.rest.repos.listCommitStatusesForRef
+      ? (await endpoint(params)).data
+      : endpoint === github.rest.pulls.listReviews
+        ? state.reviews
+        : state.comments
+
+  const advancedBase = '9'.repeat(40)
+  pulls[11].base.sha = advancedBase
+  responses.set('b'.repeat(40), advancedBase)
+  files.set('b'.repeat(40), [
+    { filename: 'docs/base.md', additions: 1, deletions: 0 },
+  ])
+  files.set(advancedBase, [])
+  const eventContext = context(11)
+  eventContext.eventName = 'pull_request_target'
+  eventContext.payload.pull_request = pulls[11]
+
+  assert.equal(
+    await initializeStackReview({ github, context: eventContext }),
+    false
+  )
+  assert.equal(state.createdStatuses.length, 0)
+
+  const reviewContext = context(14)
+  reviewContext.payload.comment.user = { login: 'reviewer' }
+  const notices = []
+  assert.equal(
+    await authorizeStackReview({
+      github,
+      context: reviewContext,
+      core: {
+        notice: (message) => notices.push(message),
+        setOutput: () => {},
+      },
+    }),
+    false
+  )
+  assert.equal(
+    notices.at(-1),
+    'Stack review already succeeded for the current top head'
+  )
+
+  pulls[11].base.ref = 'feature/v3-ai'
+  assert.equal(
+    await authorizeStackReview({
+      github,
+      context: reviewContext,
+      core: {
+        notice: (message) => notices.push(message),
+        setOutput: () => {},
+      },
+    }),
+    false
+  )
+  assert.match(notices.at(-1), /stack root does not target/)
 })
 
 test('preserves current stack evidence across unrelated default-base advancement', async () => {

--- a/.github/scripts/native-stack.js
+++ b/.github/scripts/native-stack.js
@@ -1,4 +1,5 @@
 const crypto = require('node:crypto')
+const { isEligibleBaseBranch } = require('./final-ai-review-shared')
 const MAX_COMPARE_FILES = 300
 const MAX_STACK_HISTORY = 1_000
 const STACK_PAGE_SIZE = 100
@@ -260,10 +261,12 @@ async function resolveNativeStackMembership({
   }
   if (members[0]) {
     if (
-      members[0].pull.base?.ref !== context.payload.repository.default_branch ||
+      !isEligibleBaseBranch({ baseRef: members[0].pull.base?.ref, context }) ||
       members[0].pull.base?.repo?.full_name !== repository
     ) {
-      reasons.push('stack root does not target the default branch')
+      reasons.push(
+        'stack root does not target the default branch or a consolidation branch'
+      )
     }
   }
   for (let index = 1; index < members.length; index += 1) {

--- a/project/2026-09-06-final-review-consolidation-stack-roots-plan.md
+++ b/project/2026-09-06-final-review-consolidation-stack-roots-plan.md
@@ -1,0 +1,60 @@
+# Final review for stacks rooted on consolidation branches - plan
+
+Date: 2026-09-06. Branch: rs/final-review-consolidation-stack-roots from origin/v3 (19f2cac7ea).
+
+## Problem
+
+PR #5674 made individual final reviews accept pull requests that target the
+consolidation branch `v3-ai`, but left native-stack root validation bound to
+the default branch. A native stack whose root targets `v3-ai` therefore still
+fails both review gates: `final-ai-stack-review` reports "Stack review
+unavailable: stack root does not target the default branch" and the member
+status falls back to "Final review requires the default branch, a designated
+consolidation branch, or a verified native stack member". Stack 5686
+(PR #5491 and PR #5492, KEDA foundation) hits exactly this.
+
+The hardcoded allowlist also covers only `v3-ai`, while `v3-course-qa` and
+`v3-polls` are consolidation branches of the same kind.
+
+## Decision
+
+Consolidation branches are the branches named `<default branch>-<suffix>`
+(today `v3-ai`, `v3-course-qa`, `v3-polls`). One shared predicate in
+`final-ai-review-shared.js` replaces the `v3-ai` allowlist and is used by
+individual eligibility, native-stack root validation, and the two stack-review
+base-advance checks. The suffix must be non-empty, start with a letter or
+digit, and contain only letters, digits, `.`, `_`, or `-`; a slash or a bare
+`v3-` never matches, and the default branch itself is not a consolidation
+branch.
+
+Not touched: the workflow-run provenance checks that compare
+`workflow.head_branch` to the default branch (issue-comment runs always
+execute on the default branch, see the #5674 plan), promotion validation, and
+the human-readable rejection messages for individual reviews.
+
+## Do
+
+1. `final-ai-review-shared.js`: add `isConsolidationBaseBranch` and
+   `isEligibleBaseBranch`; export both.
+2. `final-ai-review.js`: drop `CONSOLIDATION_BASE_BRANCHES` and the local
+   predicate; import the shared one.
+3. `native-stack.js`: root check uses the shared predicate; reason text names
+   both accepted base kinds.
+4. `final-ai-stack-review.js`: both root checks in the base-advance paths use
+   the shared predicate.
+5. Tests: predicate contract (accepted and rejected shapes, default-branch
+   derivation), a native stack rooted on `v3-ai` authorizes as
+   `native-stack`, a root on `feature/v3-ai` is denied, and stack membership
+   resolution accepts a consolidation root.
+6. Checks: `node --check`, `node --test` on both policy suites, Biome format,
+   `git diff --check`.
+
+## Boundaries
+
+- Authorized: implement, test, commit, push the branch, open a draft PR to `v3`.
+- Withheld: merge, enable or activate on any branch, post `/final-review` on
+  the KEDA stack before this policy lands on `v3`.
+
+## Progress
+
+- Status: implemented and tested locally (119/119 policy tests, including base-advance preservation for a consolidation root after slice review); draft PR pending.


### PR DESCRIPTION
## Summary

- Accept native stacks whose root pull request targets a consolidation branch, so `/final-review` on a stack member and `/final-review-stack` on the stack top work for stacks rooted on `v3-ai`, `v3-course-qa`, or `v3-polls`.
- Replace the hardcoded `v3-ai` allowlist from PR #5674 with one shared predicate: a consolidation branch is named `<default branch>-<suffix>` where the suffix is non-empty, starts with a letter or digit, and contains only letters, digits, `.`, `_`, or `-`.
- Use that predicate in individual eligibility, native-stack root validation, and both stack-review base-advance root checks.
- Leave workflow-run provenance checks (`workflow.head_branch` equals the default branch), promotion validation, and the individual rejection messages unchanged.
- Motivation: stack 5686 (PR #5491 and PR #5492, KEDA foundation) targets `v3-ai` and currently fails both review gates with "stack root does not target the default branch".

## How It Works

`isConsolidationBaseBranch` and `isEligibleBaseBranch` live in `.github/scripts/final-ai-review-shared.js` and derive the accepted prefix from `context.payload.repository.default_branch`. `final-ai-review.js` imports the shared predicate instead of its local allowlist. `native-stack.js` uses it for the stack root and reports "stack root does not target the default branch or a consolidation branch" when it fails. `final-ai-stack-review.js` uses it in `canUseStackReviewBaseAdvance` and `canPreserveStackReviewAcrossBaseAdvance`, so clean evidence survives an unrelated advance of a consolidation base exactly as it does for the default branch. Bases like `v3-`, `v3-ai/feature`, `feature/v3-ai`, or `v4-ai` fail closed.

## Branch Coverage

- Target: `v3` at `19f2cac7e` (merge base equals the current `origin/v3` head)
- Head: `397e057ee`
- Reviewed: 1 commit; 7 files; 381 insertions and 18 deletions
- Substantive size: 339 changed lines after excluding the 60-line committed project plan
- Covered: shared predicate, three policy call sites, exact behavior tests, and the committed plan
- Packaging: complete standalone CI-policy package; no application runtime, deployment, or data changes

## Review Focus

- Confirm the prefix rule cannot be satisfied by a fork or by a ref a non-collaborator can create: the base ref must exist as a branch in this repository, so only maintainers with push access can create an eligible `v3-<suffix>` branch.
- Confirm the two base-advance call sites in `final-ai-stack-review.js` still require a same-repository root, `behind` or `diverged` root range, and matching previous evidence.
- Confirm deriving the prefix from the default branch is the intended rule for a future default-branch rename.

## Verification

Current head:

- `node --test .github/scripts/final-ai-review.test.js .github/scripts/final-ai-stack-review.test.js` -> 119 passed (115 before this branch)
- New tests: predicate contract for accepted and rejected shapes and a non-`v3` default branch; a native stack rooted on `v3-ai` authorizes as `native-stack` while a root on `feature/v3-ai` is denied with the consolidation reason; stack membership resolution accepts a consolidation root; base-advance preservation keeps stack evidence for a `v3-ai` root and rejects the same stack once the root is renamed
- `node --check` on the four changed scripts -> pass
- Biome format on the six changed scripts and Prettier on the plan -> pass; two pre-existing `useIterableCallbackReturn` lint findings in `final-ai-review.js` are untouched by this branch
- `git diff --check` -> pass; husky pre-commit (`check:all`, 35 tasks) passed on commit
- Slice review (security, correctness, test lenses) -> approve with notes; the one actionable note, missing end-to-end coverage of the base-advance path for a consolidation root, is addressed by the added test

Not run:

- Exact-head GitHub CI and the repository's own final review are pending on this draft.

## Security / Privacy

- This widens a CI authorization rule from one named branch to any branch named `<default branch>-<suffix>` in this repository. It does not change contributor permissions, accept fork bases, or relax the open, ready, same-repository, and exact-SHA checks.
- The change reverses the "stack review and native-stack root validation stay bound to the default branch" scoping recorded in PR #5674's plan; the new plan records the decision.
- No credentials, personal data, production data, or private payloads are included.

## Blocking Before Merge

- Exact-head CI and final review on this PR.

## Follow-Up After Merge

- [ ] Re-run `/final-review` on PR #5491 and PR #5492 once the policy is on `v3` and the OpenRouter weekly key limit has reset.

## Local Session Artifacts

Machine: the maintainer's macOS workstation (repository at `klicker/klicker-uzh`).

- Agent worktree: `trees/rs/final-review-consolidation-stack-roots`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Final review validation now recognizes eligible consolidation branches derived from the repository’s default branch.
  - Native stack roots can target eligible consolidation branches.
  - Stack review status and evidence can be preserved when advancing across eligible consolidation branches.
  - Branch validation is applied consistently across individual reviews and stack reviews.

- **Tests**
  - Added coverage for valid and invalid consolidation branch formats, stack authorization, and review preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->