### PR TITLE
fix(auth): recover participant login after stale LTI cookies

### DIFF
--- a/apps/frontend-pwa/src/pages/login.tsx
+++ b/apps/frontend-pwa/src/pages/login.tsx
@@ -89,14 +89,13 @@ function Login({ redirectPath }: Readonly<LoginProps>) {
           message: t('shared.generic.studentLoginError'),
           options: { duration: 6000 },
         })
-        setSubmitting(false)
         resetForm()
       } else {
         await fetchSelf()
 
         // redirect to the specified redirect path (default: question pool)
         if (redirectPath.startsWith('/')) {
-          void router.push(redirectPath)
+          await router.push(redirectPath)
         } else {
           window.location.assign(redirectPath)
         }
@@ -108,8 +107,9 @@ function Login({ redirectPath }: Readonly<LoginProps>) {
         message: t('shared.generic.systemError'),
         options: { duration: 6000 },
       })
-      setSubmitting(false)
       resetForm()
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -157,7 +157,7 @@ function Login({ redirectPath }: Readonly<LoginProps>) {
           if (magicLinkLogin) {
             sendMagicLinkEmail(values, { setSubmitting })
           } else {
-            loginWithPassword(values, { setSubmitting, resetForm })
+            return loginWithPassword(values, { setSubmitting, resetForm })
           }
         }}
       >

--- a/apps/lti/src/index.ts
+++ b/apps/lti/src/index.ts
@@ -82,6 +82,8 @@ Provider.onConnect(async (token, req, res) => {
   )
 
   res.cookie('lti-token', jwt, {
+    maxAge: 5 * 60 * 1000,
+    path: '/',
     secure: true,
     sameSite: 'none',
     domain: process.env.COOKIE_DOMAIN as string,

--- a/docs/solutions/integration/stale-lti-cookie-login-loop.md
+++ b/docs/solutions/integration/stale-lti-cookie-login-loop.md
@@ -4,7 +4,7 @@ date: 2026-09-07
 problem_type: integration
 severity: medium
 symptoms:
-  - "Course-to-chatbot navigation returns to login despite a participant session"
+  - 'Course-to-chatbot navigation returns to login despite a participant session'
 root_cause: The LTI cookie outlived its JWT and took precedence over the participant session
 tags: [authentication, lti, cookies, pwa]
 ---

--- a/docs/solutions/integration/stale-lti-cookie-login-loop.md
+++ b/docs/solutions/integration/stale-lti-cookie-login-loop.md
@@ -1,0 +1,51 @@
+---
+module: participant-authentication
+date: 2026-09-07
+problem_type: integration
+severity: medium
+symptoms:
+  - "Course-to-chatbot navigation returns to login despite a participant session"
+root_cause: The LTI cookie outlived its JWT and took precedence over the participant session
+tags: [authentication, lti, cookies, pwa]
+---
+
+# Stale LTI cookies can cause a participant login loop
+
+## Problem
+
+A participant can open a course yet return to login when opening its chatbot.
+Direct chatbot access can still work. This combination does not by itself
+indicate missing course access.
+
+## Cause and solution
+
+The PWA checks pending LTI state before accepting an existing participant session
+in [getParticipantToken](../../../apps/frontend-pwa/src/lib/getParticipantToken.ts).
+The LTI JWT expires after five minutes, but its cookie previously lasted for the
+browser session. An expired cookie therefore continued selecting a failed LTI
+authentication path after normal login.
+
+Successful authentication now consumes the cookie in the shared participant
+login helper in [accounts.ts](../../../packages/graphql/src/services/accounts.ts).
+Failed authentication leaves it unchanged. The
+[LTI service](../../../apps/lti/src/index.ts) also gives newly issued cookies a
+five-minute lifetime and an explicit root path. The
+[password form](../../../apps/frontend-pwa/src/pages/login.tsx) awaits navigation
+and settles its submitting state even when navigation fails or is cancelled.
+
+Keep identity selection fail-closed: a valid pending LTI identity takes
+precedence, and invalid LTI state must not silently select another signed-in
+participant. Cookie cleanup belongs after successful authentication.
+
+## Verification lessons
+
+Model the old cookie as a shared-domain session cookie containing an expired
+JWT. A host-only fixture does not reach the PWA host and cannot reproduce the
+failure. Normal login alone is insufficient evidence: check that failed login
+preserves the cookie, successful login deletes the same domain/path scope, and
+the course bridge reaches the chatbot origin afterward.
+
+Focused authentication tests cover cookie effects for successful and rejected
+login paths. Local browser checks covered stale-cookie recovery, same-page
+return, and cancelled or rejected navigation. These checks do not establish
+production deployment or verify a chatbot answer.

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -87,6 +87,7 @@ async function doParticipantLogin(
 
   const jwt = await createParticipantToken(participantId)
   ctx.res.cookie('participant_token', jwt, COOKIE_SETTINGS)
+  ctx.res.cookie('lti-token', '', { ...COOKIE_SETTINGS, maxAge: 0 })
   ctx.res.cookie('NEXT_LOCALE', participantLocale, COOKIE_SETTINGS)
 
   return jwt

--- a/packages/graphql/test/accountLtiLinking.test.ts
+++ b/packages/graphql/test/accountLtiLinking.test.ts
@@ -170,10 +170,16 @@ describe('LTI participant linking and creation', () => {
       email: emailFor('manual-link').toUpperCase(),
     })
 
-    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+    const ctx = createCtx()
+    const result = await loginParticipantWithLti({ signedLtiData }, ctx)
 
     expect(result?.participant?.id).toBe(participant.id)
     expect(result?.participantToken).toBeDefined()
+    expect(ctx.res.cookie).toHaveBeenCalledWith(
+      'lti-token',
+      '',
+      expect.objectContaining({ path: '/', maxAge: 0 })
+    )
 
     const linkedAccount = await prisma.participantAccount.findUnique({
       where: { ssoId: ssoIdFor('manual-link') },
@@ -282,9 +288,11 @@ describe('LTI participant linking and creation', () => {
       email: emailFor('no-match'),
     })
 
-    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+    const ctx = createCtx()
+    const result = await loginParticipantWithLti({ signedLtiData }, ctx)
 
     expect(result).toBeNull()
+    expect(ctx.res.cookie).not.toHaveBeenCalled()
   })
 
   it('creates a new SSO participant from LTI create flow when no match exists', async () => {

--- a/packages/graphql/test/loginParticipant.test.ts
+++ b/packages/graphql/test/loginParticipant.test.ts
@@ -1,5 +1,6 @@
 import { prisma as prismaClient } from '@klicker-uzh/prisma'
-import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { PrismaClient, UserLoginScope } from '@klicker-uzh/prisma/client'
+import { signJWT } from '@klicker-uzh/util'
 import bcrypt from 'bcryptjs'
 import { EventEmitter } from 'events'
 import {
@@ -12,7 +13,11 @@ import {
   vi,
 } from 'vitest'
 import type { Context } from '../src/lib/context.js'
-import { loginParticipant } from '../src/services/accounts.js'
+import {
+  activateParticipantAccount,
+  loginParticipant,
+  loginParticipantMagicLink,
+} from '../src/services/accounts.js'
 
 const TEST_PREFIX = `codex-login-${Date.now()}`
 const emailFor = (label: string) => `${TEST_PREFIX}-${label}@example.com`
@@ -36,6 +41,17 @@ function createCtx(): Context {
     hatchet: {} as any,
     tasks: {} as any,
   } as Context
+}
+
+async function createParticipantLoginToken(
+  participantId: string,
+  scope: UserLoginScope
+) {
+  return signJWT(
+    { sub: participantId, scope },
+    process.env.APP_SECRET as string,
+    { algorithm: 'HS256', expiresIn: '5m' }
+  )
 }
 
 async function cleanupTestData() {
@@ -94,15 +110,21 @@ describe('loginParticipant email/username login', () => {
       },
     })
 
+    const ctx = createCtx()
     const result = await loginParticipant(
       {
         usernameOrEmail: usernameFor('manual-username'),
         password: MANUAL_PASSWORD,
       },
-      createCtx()
+      ctx
     )
 
     expect(result).toBe(participant.id)
+    expect(ctx.res.cookie).toHaveBeenCalledWith(
+      'lti-token',
+      '',
+      expect.objectContaining({ path: '/', maxAge: 0 })
+    )
   })
 
   it('logs in a manual participant by email with a correct password', async () => {
@@ -115,15 +137,106 @@ describe('loginParticipant email/username login', () => {
       },
     })
 
+    const ctx = createCtx()
     const result = await loginParticipant(
       {
         usernameOrEmail: emailFor('manual-email').toUpperCase(),
         password: MANUAL_PASSWORD,
       },
-      createCtx()
+      ctx
     )
 
     expect(result).toBe(participant.id)
+    expect(ctx.res.cookie).toHaveBeenCalledWith(
+      'lti-token',
+      '',
+      expect.objectContaining({ path: '/', maxAge: 0 })
+    )
+  })
+
+  it('clears the LTI token after magic-link participant login', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('magic-link'),
+        username: usernameFor('magic-link'),
+        password: await bcrypt.hash(MANUAL_PASSWORD, 10),
+        isSSOAccount: false,
+      },
+    })
+    const token = await createParticipantLoginToken(
+      participant.id,
+      UserLoginScope.OTP
+    )
+    const ctx = createCtx()
+
+    const result = await loginParticipantMagicLink({ token }, ctx)
+
+    expect(result).toBe(participant.id)
+    expect(ctx.res.cookie).toHaveBeenCalledWith(
+      'lti-token',
+      '',
+      expect.objectContaining({ path: '/', maxAge: 0 })
+    )
+  })
+
+  it('clears the LTI token after participant account activation', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('activation'),
+        username: usernameFor('activation'),
+        password: await bcrypt.hash(MANUAL_PASSWORD, 10),
+        isSSOAccount: false,
+      },
+    })
+    const token = await createParticipantLoginToken(
+      participant.id,
+      UserLoginScope.ACTIVATION
+    )
+    const ctx = createCtx()
+
+    const result = await activateParticipantAccount({ token }, ctx)
+
+    expect(result).toBe(participant.id)
+    expect(ctx.res.cookie).toHaveBeenCalledWith(
+      'lti-token',
+      '',
+      expect.objectContaining({ path: '/', maxAge: 0 })
+    )
+  })
+
+  it('rejects wrong-scope participant tokens without setting cookies', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('wrong-scope'),
+        username: usernameFor('wrong-scope'),
+        password: await bcrypt.hash(MANUAL_PASSWORD, 10),
+        isSSOAccount: false,
+      },
+    })
+    const activationToken = await createParticipantLoginToken(
+      participant.id,
+      UserLoginScope.ACTIVATION
+    )
+    const magicLinkToken = await createParticipantLoginToken(
+      participant.id,
+      UserLoginScope.OTP
+    )
+    const magicLinkCtx = createCtx()
+    const activationCtx = createCtx()
+
+    const magicLinkResult = await loginParticipantMagicLink(
+      { token: activationToken },
+      magicLinkCtx
+    )
+    const activationResult = await activateParticipantAccount(
+      { token: magicLinkToken },
+      activationCtx
+    )
+
+    expect(magicLinkResult).toBeNull()
+    expect(magicLinkCtx.res.cookie).not.toHaveBeenCalled()
+    expect(activationResult).toBeNull()
+    expect(activationCtx.res.cookie).not.toHaveBeenCalled()
   })
 
   it('rejects login when the password does not match', async () => {
@@ -136,27 +249,31 @@ describe('loginParticipant email/username login', () => {
       },
     })
 
+    const ctx = createCtx()
     const result = await loginParticipant(
       {
         usernameOrEmail: usernameFor('wrong-password'),
         password: 'totally-different',
       },
-      createCtx()
+      ctx
     )
 
     expect(result).toBeNull()
+    expect(ctx.res.cookie).not.toHaveBeenCalled()
   })
 
   it('returns null when no participant exists for the supplied identifier', async () => {
+    const ctx = createCtx()
     const result = await loginParticipant(
       {
         usernameOrEmail: emailFor('does-not-exist'),
         password: MANUAL_PASSWORD,
       },
-      createCtx()
+      ctx
     )
 
     expect(result).toBeNull()
+    expect(ctx.res.cookie).not.toHaveBeenCalled()
   })
 
   it('logs in an LTI-created participant by email with the password they chose at signup', async () => {

--- a/project/2026-09-07-pr5807-pwa-lti-cookie-recovery.md
+++ b/project/2026-09-07-pr5807-pwa-lti-cookie-recovery.md
@@ -1,4 +1,4 @@
-# Restore participant login after stale LTI state
+# Restore participant login after stale LTI state — PR #5807
 
 ## Outcome and authority
 
@@ -57,5 +57,9 @@ e6081a2d7f (authentication recovery).
 The separate branch contains only the fix, regression tests, the
 [root-cause lesson](../docs/solutions/integration/stale-lti-cookie-login-loop.md),
 and this publication record. The earlier task runtime is stopped with zero
-routes; no runtime was started for this branch. Draft PR publication is pending.
+routes; no runtime was started for this branch.
+[Draft PR #5807 — stale LTI cookie recovery](https://github.com/uzh-bf/klicker-uzh/pull/5807)
+is published against v3. The user approved deferring the local pre-push full
+build to CI for draft publication only. Current-head checks and navigation
+verification remain blocking before merge.
 Production rollout and both requested test-account checks remain pending.

--- a/project/2026-09-07-pwa-lti-cookie-recovery.md
+++ b/project/2026-09-07-pwa-lti-cookie-recovery.md
@@ -1,0 +1,61 @@
+# Restore participant login after stale LTI state
+
+## Outcome and authority
+
+Restore course-to-chatbot navigation after a stale LTI cookie survives normal
+participant login. Successful authentication consumes pending LTI state, newly
+issued LTI cookies expire after five minutes, and password submission settles
+after successful, cancelled, or failed navigation.
+
+The user approved the reviewed local implementation and then a separate branch
+and draft PR. Publication targets origin/fix/pwa-lti-cookie-recovery with v3 as
+the PR base. Merge and deployment require separate approval. Doc Query settings,
+query-string JWT recovery, permissions, dependencies, and schemas are unchanged.
+
+## Contracts and implementation
+
+The shared successful participant-login helper expires the LTI cookie with the
+configured domain and root path. Rejected authentication leaves it unchanged.
+Valid LTI identity retains precedence; invalid LTI never silently falls back to
+another participant session. Cookie-domain equivalence across deployed services
+must be verified before rollout.
+
+The LTI service sets a five-minute cookie lifetime matching its signed token.
+The password form returns its authentication promise, awaits internal navigation,
+and releases submitting state in finally. External navigation and magic-link
+form behavior remain unchanged.
+
+## Verification and reviews
+
+The source was implemented and reviewed on an earlier task branch. All five
+affected files at that baseline matched v3 before the fix. The source commit
+was cherry-picked without conflicts; the complete changed source matches the
+reviewed version. No prior Doc Query commits are included in this PR.
+
+Earlier verification: 22 tests passed in the GraphQL loginParticipant and
+accountLtiLinking suites. Affected GraphQL, PWA, and LTI type checks passed.
+Four host browser checks passed: stale shared-domain cookie recovery through the
+course bridge, same-page return, cancelled navigation, and rejected navigation.
+Actual cookie serialization and unchanged LTI identity selection were checked.
+
+The full check:all run failed in unchanged analytics lint because pandas required
+a compiler unavailable in the container. The user accepted this limitation for
+local completion. New-base verification is not implied: v3 now pins Next.js
+16.2.11 instead of the previously tested 16.2.10. CI and current-base navigation
+verification remain required before merge. No screenshots or authentication
+traces are published.
+
+The independent simplifier and authentication slice reviewer returned DONE with
+no source findings. Integrated final review returned DONE_WITH_CONCERNS solely
+for stale review-status documentation; that finding was corrected. Their source
+review applies to the unchanged patch. The reviewed source commit is
+fde089e7b119cb457b7eb3e4731b3b1dca539c34; the separate-branch source commit is
+e6081a2d7f (authentication recovery).
+
+## Progress
+
+The separate branch contains only the fix, regression tests, the
+[root-cause lesson](../docs/solutions/integration/stale-lti-cookie-login-loop.md),
+and this publication record. The earlier task runtime is stopped with zero
+routes; no runtime was started for this branch. Draft PR publication is pending.
+Production rollout and both requested test-account checks remain pending.


### PR DESCRIPTION
## Summary

An expired LTI cookie can send a participant back to login when opening a course chatbot, even after a successful password login. Consume pending LTI state after successful participant authentication, expire newly issued LTI cookies after five minutes, and settle the password form after navigation succeeds, fails, or is cancelled.

Failed authentication leaves pending LTI state untouched. Valid LTI identity retains precedence; invalid LTI does not silently fall back to another participant session.

## Branch Coverage

Targets `v3`. Four commits contain the authentication fix, regression tests, a root-cause lesson, and the publication record. No earlier Doc Query work is included.

Substantive size: 203 changed lines excluding project-artifact documentation (152 source/test lines plus 51 solution-documentation lines). Packaging exemption: bounded regression fix.

## LTI Compatibility

The LTI service continues to append the signed token to the launch URL. The PWA consumes that token and already clears the pending LTI cookie after a successful launch. Existing integration coverage includes email linking, repeated launches, new-account creation, ambiguous-match rejection, and course participation. Live LMS verification remains pending.

The bot finding about expiry units is incorrect: Express `res.cookie` accepts milliseconds. The current `300000` value serializes as `Max-Age=300`, as verified with the installed response implementation. Changing the argument to `300` would produce 0.3 seconds. See the [Express response API](https://github.com/expressjs/express/blob/master/_autodocs/api-reference/response.md).

## Review Focus

- Matching cookie domain/path when consuming LTI state across services.
- Shared successful-login behavior across password, magic-link, activation, and LTI flows.
- Password-form settlement and unchanged fail-closed identity selection.

## Verification

Current head:

- Five affected source/test files exactly match the independently reviewed implementation.
- Clean cherry-pick onto `v3`; diff whitespace and source/documentation gitleaks scans pass.

Earlier branch verification:

- 22 focused GraphQL authentication tests passed.
- Affected GraphQL, PWA, and LTI type checks passed.
- Four host browser checks passed: stale shared-domain cookie recovery through the course bridge, same-page return, cancelled navigation, and rejected navigation.
- Actual cookie serialization and unchanged LTI identity-selection contracts were checked.
- Independent simplifier and authentication review found no source issues. Final review requested only a documentation-status correction, which was applied.

Failed/Warning:

- Earlier local `check:all` failed in unchanged analytics lint because pandas needed an unavailable compiler. The first PR codebase check failed only on Markdown quote formatting; that formatting is corrected in the latest commit and CI is rerunning.
- Earlier browser verification used Next.js 16.2.10; the current base uses 16.2.11. It is not current-base browser proof.

Not run:

- Current-base full build and browser rerun; exact-head CI remains pending. The user explicitly approved draft-only publication with the local pre-push build deferred to CI; merge remains blocked on current-head verification.
- Production rollout and both requested test-account checks. No authentication traces or screenshots are published.

## Security / Privacy

Cookie cleanup occurs only after successful authentication. This patch adds no dependency, schema, permission, or Doc Query configuration change. The diff contains synthetic test fixtures and no production credentials or participant records.

## Blocking Before Merge

- Passing current-head checks and navigation verification on the new base.
- Required forge review and explicit merge approval.

## Follow-Up After Merge

- Separately approve rollout, verify deployed cookie-domain equivalence, and check course-to-chatbot navigation with both requested test accounts.

## Local Session Artifacts

Machine: maintainer's macOS workstation; repository `klicker/klicker-uzh`.

- PR worktree: `trees/pwa-lti-cookie-recovery`.
- Earlier verification worktree: `trees/doc-query-canary-activation-proof`.
- Local review reports: `trees/doc-query-canary-activation-proof/project/_local/reviews/2026-09-07-pwa-lti-cookie-{simplifier,slice,final}.md`.
