### PR TITLE
fix(manage): repair feature-access e2e failures on v3-ai

### DIFF
--- a/apps/frontend-manage/src/components/common/Header.tsx
+++ b/apps/frontend-manage/src/components/common/Header.tsx
@@ -368,6 +368,7 @@ function Header({
         },
       ],
       className: {
+        label: 'hidden lg:block',
         content: 'mr-1',
       },
     },

--- a/playwright/tests/B-feature-access.spec.ts
+++ b/playwright/tests/B-feature-access.spec.ts
@@ -204,6 +204,7 @@ test.describe('Tests the availability of standard activity creation formats', ()
     page,
     loginLecturer,
   }) => {
+    await mockGrowthBookFeatureFlags(page, { aiBeta: false })
     await loginLecturer()
 
     // Production builds send hashed queries as GET requests without an
@@ -415,7 +416,11 @@ test.describe('Tests the availability of standard activity creation formats', ()
     await expect(page.getByTestId('homepage')).toBeVisible()
 
     await page.route('**/api/graphql*', async (route) => {
-      if (getGraphqlOperationName(route.request()) === 'UserProfile') {
+      const operationName = getGraphqlOperationName(route.request())
+      if (
+        operationName === 'UserProfile' ||
+        operationName === 'ManageUserProfile'
+      ) {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',


### PR DESCRIPTION
## Summary

- v3-ai's push-route Playwright run (`test-playwright-hosted`, shard 8) has failed on every push since the learning-analytics flag work merged in `cf11c9f714`. `v3` passes; the PR routes of the merged PRs passed because their heads predated that merge.
- Three tests fail. Two are test-side drift; one is a real header layout regression introduced by the AI dropdown.
- One commit, two files, 7 insertions / 1 deletion. Complete package under the packaging floor.
- Review focus: the `Header.tsx` change hides the user-menu shortname label below the `lg` breakpoint (1024px). No Playwright spec asserts that label text; only W4 (749px) and T-chatbot-authoring (800px) exercise manage below 1024px.

## Root Causes And Fixes

| Test | Cause | Fix |
| --- | --- | --- |
| `B-feature-access` "Keep chat account usage hidden when its feature flag is absent" | The auto fixture `growthBookFeatureFlags` now serves `ai-beta: true` by default (via `mockGrowthBookLearningAnalytics`), so `/user/settings` renders `chat-account-usage-boundary` | Mock `ai-beta: false` explicitly before `loginLecturer()` |
| `B-feature-access` "Shows analytics unavailable when the user profile cannot load" | Failure injection matched operation `UserProfile`, but `ManageFeatureFlagProvider` and `Layout` query `ManageUserProfile`, so the injection missed and the dashboard rendered | Match both `UserProfile` and `ManageUserProfile` |
| `W4-activity-wizard-safety` grid layout at 749x820 | The new AI dropdown in the manage header widens the top bar past the viewport; `document.documentElement.scrollWidth > innerWidth` (screenshot shows "Analytics" overlapping the help icon and the shortname clipped) | `className.label: 'hidden lg:block'` on the user dropdown, hiding the shortname label below 1024px |

## Verification

- Current head, local: `pnpm exec turbo run check --filter=@klicker-uzh/frontend-manage` passes; Prettier check on the spec passes; Biome format on `Header.tsx` reports no changes; husky pre-commit `check:all` and pre-push build passed.
- Current head, CI: Playwright `public-pr` run [34093999252](https://github.com/uzh-bf/klicker-uzh/actions/runs/34093999252) succeeded on `fe81bfddc2`; all three tests listed above pass without retry.
- Not run locally: browser verification of the header at 749px. This worktree has no running app stack; the CI W4 test at 749x820 is the acceptance check and passed.
- Earlier evidence: hosted-route failures on v3-ai heads `5c8ee4b6a0` and earlier (shard 8, the three tests above), and passing v3 hosted runs for the same tests.

## Risk

- Lecturers with viewports between 768px and 1023px no longer see their shortname next to the user icon in the header; the dropdown itself and its `data-cy="user-menu"` hook are unchanged.
- If the shard still overflows at 749px after this change, the next lever is hiding the labels of the icon-bearing left navigation items below `lg`.

## Blocking Before Merge

None

## Follow-Up After Merge

- The KEDA foundation stack (#5491, #5492) inherits these failures from its `v3-ai` base; a base refresh there needs its own authorization.

## Local Session Artifacts

Machine: Roland's Mac (`/Volumes/HOME` checkout).

- Worktree: `klicker-uzh/trees/rs/fix-feature-access-e2e` (branch `rs/fix-feature-access-e2e`)
