### PR TITLE
ci(playwright): provision dedicated disposable test databases

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -133,11 +133,21 @@ runs:
       shell: bash
       run: tar -xf playwright-next-builds.tar
 
+    - name: Provision disposable test database
+      shell: bash
+      env:
+        PROVISIONER_ROOT: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        node --test "$PROVISIONER_ROOT/prepare-test-database.test.cjs"
+        sha256sum "$PROVISIONER_ROOT/prepare-test-database.cjs"
+        node "$PROVISIONER_ROOT/prepare-test-database.cjs"
+
     - name: Generate Prisma Client
       shell: bash
       run: pnpm --filter @klicker-uzh/prisma generate
       env:
-        DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
+        DATABASE_URL: postgres://klicker_test:klicker@postgres:5432/klicker_test
 
     - name: Prepare .env files
       shell: bash
@@ -152,13 +162,13 @@ runs:
         cd packages/prisma
         pnpm run prisma:reset:raw -f
       env:
-        DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
+        DATABASE_URL: postgres://klicker_test:klicker@postgres:5432/klicker_test
 
     - name: Seed test participants for Playwright
       shell: bash
       run: pnpm --filter @klicker-uzh/prisma-data seed:test
       env:
-        DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
+        DATABASE_URL: postgres://klicker_test:klicker@postgres:5432/klicker_test
 
     - name: Start services, wait for readiness, and run Playwright tests
       shell: bash
@@ -218,7 +228,7 @@ runs:
         SHARD_INDEX: ${{ inputs.shard-index }}
         SHARD_TOTAL: ${{ inputs.shard-total }}
         APP_SECRET: abcd
-        DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
+        DATABASE_URL: postgres://klicker_test:klicker@postgres:5432/klicker_test
         NODE_ENV: production
         PLAYWRIGHT_BASE_URL: http://127.0.0.1:3001
         URL_AUTH: http://127.0.0.1:3010
@@ -232,8 +242,8 @@ runs:
         CHECK_INTERVAL: '5'
         POSTGRES_CHECK_HOST: postgres
         POSTGRES_CHECK_PORT: 5432
-        POSTGRES_CHECK_USER: klicker-prod
-        POSTGRES_CHECK_DATABASE: klicker-prod
+        POSTGRES_CHECK_USER: klicker_test
+        POSTGRES_CHECK_DATABASE: klicker_test
         REDIS_HOST: redis_exec
         REDIS_PASS: ''
         REDIS_PORT: 6379

--- a/.github/actions/playwright-shard/prepare-test-database.cjs
+++ b/.github/actions/playwright-shard/prepare-test-database.cjs
@@ -1,0 +1,86 @@
+const { createRequire } = require('node:module')
+const path = require('node:path')
+
+function connectionConfig(env) {
+  if (env.GITHUB_ACTIONS !== 'true' || env.CI !== 'true') {
+    throw new Error('Disposable database provisioning requires a CI shard')
+  }
+
+  // This is the shard's private service, never a caller-provided database URL
+  // or a loopback port that might forward to another environment.
+  return {
+    host: 'postgres',
+    port: 5432,
+    user: 'klicker-prod',
+    password: 'klicker',
+    database: 'klicker-prod',
+    ssl: false,
+    options: '',
+    connectionTimeoutMillis: 5000,
+    statement_timeout: 10000,
+    query_timeout: 15000,
+  }
+}
+
+async function provisionDatabase(client) {
+  try {
+    await client.connect()
+    const { rows } = await client.query(`
+      SELECT current_database() AS database,
+             session_user AS login, current_user AS role,
+             EXISTS (SELECT FROM pg_roles WHERE rolname = 'klicker_test') AS role_exists,
+             EXISTS (SELECT FROM pg_database WHERE datname = 'klicker_test') AS database_exists
+    `)
+    const identity = rows[0]
+    if (
+      rows.length !== 1 ||
+      identity.database !== 'klicker-prod' ||
+      identity.login !== 'klicker-prod' ||
+      identity.role !== 'klicker-prod' ||
+      identity.role_exists !== false ||
+      identity.database_exists !== false
+    ) {
+      throw new Error(
+        'Expected a fresh CI service without a test database or role'
+      )
+    }
+
+    await client.query(`CREATE ROLE klicker_test LOGIN PASSWORD 'klicker'
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`)
+    await client.query('CREATE DATABASE klicker_test OWNER klicker_test')
+    // A database comment survives Prisma's schema reset. Never adopt or mark
+    // an existing database, including after a partially failed provisioning.
+    await client.query(
+      "COMMENT ON DATABASE klicker_test IS 'klicker-disposable-test-v1'"
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+async function main() {
+  const config = connectionConfig(process.env)
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions environment contract; this script runs outside Turbo
+  const workspace = process.env.GITHUB_WORKSPACE
+  if (!workspace || !path.isAbsolute(workspace)) {
+    throw new Error('CI workspace is unavailable')
+  }
+  const workspaceRequire = createRequire(
+    path.join(workspace, 'packages/prisma/package.json')
+  )
+  const { Client } = workspaceRequire('pg')
+  await provisionDatabase(new Client(config))
+  console.log('Provisioned dedicated disposable Playwright database')
+}
+
+if (require.main === module) {
+  main().catch(() => {
+    // Driver errors can contain connection data. Keep CI output values-free.
+    console.error(
+      'Disposable database provisioning failed; reset was not started'
+    )
+    process.exitCode = 1
+  })
+}
+
+module.exports = { connectionConfig, provisionDatabase }

--- a/.github/actions/playwright-shard/prepare-test-database.test.cjs
+++ b/.github/actions/playwright-shard/prepare-test-database.test.cjs
@@ -1,0 +1,224 @@
+const assert = require('node:assert/strict')
+const { describe, test } = require('node:test')
+
+const {
+  connectionConfig,
+  provisionDatabase,
+} = require('./prepare-test-database.cjs')
+
+const freshIdentity = {
+  database: 'klicker-prod',
+  login: 'klicker-prod',
+  role: 'klicker-prod',
+  role_exists: false,
+  database_exists: false,
+}
+
+const identityQuery = `
+  SELECT current_database() AS database,
+         session_user AS login, current_user AS role,
+         EXISTS (SELECT FROM pg_roles WHERE rolname = 'klicker_test') AS role_exists,
+         EXISTS (SELECT FROM pg_database WHERE datname = 'klicker_test') AS database_exists
+`
+
+const roleQuery = `CREATE ROLE klicker_test LOGIN PASSWORD 'klicker'
+  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`
+
+const databaseQuery = 'CREATE DATABASE klicker_test OWNER klicker_test'
+const markerQuery =
+  "COMMENT ON DATABASE klicker_test IS 'klicker-disposable-test-v1'"
+
+function normalizeSql(sql) {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function makeClient(options = {}) {
+  const { failAt } = options
+  const rows = Object.hasOwn(options, 'rows') ? options.rows : [freshIdentity]
+  const calls = []
+  let queryNumber = 0
+
+  const client = {
+    async connect() {
+      calls.push({ kind: 'connect' })
+      if (failAt?.kind === 'connect') {
+        throw failAt.error
+      }
+    },
+
+    async query(sql) {
+      queryNumber += 1
+      const kind =
+        queryNumber === 1
+          ? 'identity-query'
+          : queryNumber === 2
+            ? 'create-role'
+            : queryNumber === 3
+              ? 'create-database'
+              : 'comment'
+      calls.push({ kind, sql })
+
+      if (failAt?.kind === kind) {
+        throw failAt.error
+      }
+
+      return queryNumber === 1 ? { rows } : { rows: [] }
+    },
+
+    async end() {
+      calls.push({ kind: 'end' })
+    },
+  }
+
+  return { calls, client }
+}
+
+function callKinds(calls) {
+  return calls.map(({ kind }) => kind)
+}
+
+function querySql(calls) {
+  return calls.filter(({ sql }) => sql).map(({ sql }) => normalizeSql(sql))
+}
+
+describe('prepare-test-database', () => {
+  test('rejects every context that is not an exact CI shard', () => {
+    const rejectedEnvironments = [
+      {},
+      { GITHUB_ACTIONS: 'true' },
+      { CI: 'true' },
+      { GITHUB_ACTIONS: 'false', CI: 'true' },
+      { GITHUB_ACTIONS: 'true', CI: 'false' },
+      { GITHUB_ACTIONS: true, CI: true },
+    ]
+
+    for (const environment of rejectedEnvironments) {
+      assert.throws(() => connectionConfig(environment), Error)
+    }
+  })
+
+  test('uses the fixed disposable target despite hostile connection variables', () => {
+    const config = connectionConfig({
+      GITHUB_ACTIONS: 'true',
+      CI: 'true',
+      DATABASE_URL: 'postgres://hostile.invalid:6543/hostile',
+      PGHOST: 'hostile.invalid',
+      PGPORT: '6543',
+      PGUSER: 'hostile-user',
+      PGPASSWORD: 'hostile-password',
+      PGDATABASE: 'hostile-database',
+    })
+
+    assert.deepEqual(config, {
+      host: 'postgres',
+      port: 5432,
+      user: 'klicker-prod',
+      password: 'klicker',
+      database: 'klicker-prod',
+      ssl: false,
+      options: '',
+      connectionTimeoutMillis: 5000,
+      statement_timeout: 10000,
+      query_timeout: 15000,
+    })
+  })
+
+  test('does not mutate a service with an unexpected identity or inventory', async (t) => {
+    const cases = [
+      ['wrong database', { ...freshIdentity, database: 'other-database' }],
+      ['wrong login', { ...freshIdentity, login: 'other-login' }],
+      ['wrong role', { ...freshIdentity, role: 'other-role' }],
+      ['existing role', { ...freshIdentity, role_exists: true }],
+      ['existing database', { ...freshIdentity, database_exists: true }],
+    ]
+
+    for (const [name, identity] of cases) {
+      await t.test(name, async () => {
+        const { calls, client } = makeClient({ rows: [identity] })
+
+        await assert.rejects(() => provisionDatabase(client), Error)
+        assert.deepEqual(callKinds(calls), ['connect', 'identity-query', 'end'])
+        assert.deepEqual(querySql(calls), [normalizeSql(identityQuery)])
+      })
+    }
+  })
+
+  test('does not mutate when the identity query has unknown rows', async (t) => {
+    const cases = [
+      ['no rows', []],
+      ['multiple rows', [freshIdentity, freshIdentity]],
+      ['missing rows', undefined],
+    ]
+
+    for (const [name, rows] of cases) {
+      await t.test(name, async () => {
+        const { calls, client } = makeClient({ rows })
+
+        await assert.rejects(() => provisionDatabase(client), Error)
+        assert.deepEqual(callKinds(calls), ['connect', 'identity-query', 'end'])
+        assert.deepEqual(querySql(calls), [normalizeSql(identityQuery)])
+      })
+    }
+  })
+
+  test('propagates provisioning failures and always ends the client', async (t) => {
+    const failures = [
+      ['connect', 'connect', []],
+      ['identity query', 'identity-query', [identityQuery]],
+      ['role creation', 'create-role', [identityQuery, roleQuery]],
+      [
+        'database creation',
+        'create-database',
+        [identityQuery, roleQuery, databaseQuery],
+      ],
+      [
+        'marker comment',
+        'comment',
+        [identityQuery, roleQuery, databaseQuery, markerQuery],
+      ],
+    ]
+
+    for (const [name, kind, executedQueries] of failures) {
+      await t.test(name, async () => {
+        const error = new Error(kind)
+        const { calls, client } = makeClient({
+          failAt: { error, kind },
+        })
+
+        await assert.rejects(
+          () => provisionDatabase(client),
+          (actual) => {
+            assert.strictEqual(actual, error)
+            return true
+          }
+        )
+        assert.equal(calls.at(-1).kind, 'end')
+        assert.deepEqual(
+          querySql(calls),
+          executedQueries.map((query) => normalizeSql(query))
+        )
+      })
+    }
+  })
+
+  test('creates the constrained role, database, and marker in order', async () => {
+    const { calls, client } = makeClient()
+
+    await provisionDatabase(client)
+
+    assert.deepEqual(callKinds(calls), [
+      'connect',
+      'identity-query',
+      'create-role',
+      'create-database',
+      'comment',
+      'end',
+    ])
+    assert.deepEqual(querySql(calls), [
+      normalizeSql(identityQuery),
+      normalizeSql(roleQuery),
+      normalizeSql(databaseQuery),
+      normalizeSql(markerQuery),
+    ])
+  })
+})

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -153,6 +153,23 @@ provider-level acceptance check.
 
 ## CI matrix
 
+Playwright's trusted shard action provisions a fresh `klicker_test` database
+and login on each shard's private PostgreSQL service before reset or seed.
+The login owns that database without superuser, role-management, replication
+or row-security-bypass privileges. The database comment
+`klicker-disposable-test-v1` identifies its disposable purpose and survives a
+schema reset. Existing test roles or databases cause provisioning to fail;
+partial failures require a fresh service, never adoption of existing data.
+The provisioner ignores caller database URLs and targets only the fixed CI
+service. It is not a local reset helper and must not be used to mark staging,
+production or a retained development database.
+
+Both runner routes load this action from trusted v3. A candidate PR cannot
+change its own provisioning action. Local PostgreSQL reset/seed proof is
+therefore required before changing the action, followed by a non-skipped
+postmerge shard run. The action logs its provisioner checksum so that run can
+be matched to the reviewed source.
+
 The path-filtered `test-unit` workflow runs the chat, grading, markdown, and util
 suites with one frozen install. It builds Prisma, types, grading, and util once,
 then keeps each suite as a separately visible step. The chat suite runs against

--- a/project/2026-09-07-disposable-test-ci-plan.md
+++ b/project/2026-09-07-disposable-test-ci-plan.md
@@ -1,0 +1,79 @@
+# Disposable Playwright database provisioning
+
+## Approval summary
+
+Give every Playwright shard a dedicated disposable database and login, so the
+following database guard can reject staging and production port forwards.
+The trusted shard action currently uses a production-like database identity.
+Both hosted and public runners load that action from v3, so this prerequisite
+must land before the guard can pass CI.
+
+Provision a new `klicker_test` role and database only on the shard's fixed
+PostgreSQL service. Give the role no cluster administration privileges and
+mark the database with the comment `klicker-disposable-test-v1`. Use that
+identity for reset, seed, application processes and tests. Existing candidates
+remain compatible. No product behavior or production schema changes.
+
+The user approved preparing, reviewing, publishing and merging this separate
+prerequisite on September 7. Publish to origin/rs/disposable-test-ci and merge
+only its passing reviewed head into v3. Do not merge the beta authoring PR,
+integrate upstream without approval, deploy, connect to a cluster, restore
+local data or delete retained data. New verification containers are disposable,
+task-owned and have no host ports or retained volumes.
+
+Completion requires behavioral tests, PostgreSQL reset/seed compatibility,
+independent reviews, current-head CI, prerequisite merge and a non-skipped
+postmerge shard run that identifies the new trusted action. Failed postmerge
+proof blocks beta readiness; it does not authorize rollback or beta merge.
+
+## Execution details
+
+Full-path, one cohesive prerequisite PR, followed by the existing
+[PR #5799 — beta authoring](https://github.com/uzh-bf/klicker-uzh/pull/5799).
+These are sequential packages, not a reorganization of that existing branch.
+No product primitive changes. Source rollback is an ordinary revert, requiring
+separate authorization after merge.
+
+The provisioning script lives with the trusted action. It ignores caller
+connection variables and connects to literal `postgres:5432`, using the
+existing synthetic CI administration account. It loads the existing `pg`
+dependency after the normal dependency install; no new dependency or Docker
+socket is introduced. GitHub context is an intent check, not database proof.
+Check server identity and both role/database existence before creating either.
+Reject existing objects without mutation. Mark only the newly created database.
+Close the client on every exit. Failures block reset and leave partial objects
+untouched; retry requires a fresh disposable service.
+
+| Work | Owner | Acceptance |
+| --- | --- | --- |
+| Provisioning script and trusted action | Main; security-sensitive coupling | Fixed destination, refusal before writes, restricted role, all shard URLs and health identity aligned |
+| Behavioral tests | Executor, test file only | Reject context, conflicting environment cannot retarget, reject existing objects, fail closed on each provisioning error, mark only after creation |
+| Verification and delivery | Main | Local real database smoke, CI contracts, reviews, published CI, authorized prerequisite merge and postmerge shard proof |
+
+Main also updates docs/testing.md and this plan. The action runs its co-located
+tests before provisioning so candidate package scripts need not know the new
+test path. The shared test and provisioning code is reviewed as one slice.
+
+Use PostgreSQL 15, Node 24.16.0 and pnpm 11.5.0 for local verification, plus
+the workflow-pinned Playwright container for environment compatibility. Record
+the exact owned service before writes. Prove test-role login and database
+ownership, prohibited role flags, successful existing Prisma reset and seed,
+and marker survival after reset. Never weaken permissions to pass the smoke.
+Run focused YAML/format checks and check:playwright-ci. No UI or application
+runtime startup is needed solely for the provisioning script.
+
+After verification, commit and run the simplifier and risk reviewer in parallel.
+Complete integrated final review before publication. Premerge CI uses the old
+trusted action, so local smoke is mandatory and postmerge non-skipped proof
+remains distinct. The user has authorized final AI review and prerequisite
+merge, but no branch-protection bypass.
+
+Pause on retained objects, failed restricted-role compatibility, unresolved
+review, missing verification capability or drift requiring integration.
+
+## Progress
+
+Planner round 1 returned REVISE; round 2 APPROVED after the refusal, test
+execution, real smoke and postmerge gates were made explicit. Main accepted
+all findings. Baseline 27f2474547df045cc11302c7d9e195798ec66870 matches v3.
+Implementation is starting. The beta worktree remains untouched.

--- a/project/2026-09-07-disposable-test-ci-plan.md
+++ b/project/2026-09-07-disposable-test-ci-plan.md
@@ -76,4 +76,11 @@ review, missing verification capability or drift requiring integration.
 Planner round 1 returned REVISE; round 2 APPROVED after the refusal, test
 execution, real smoke and postmerge gates were made explicit. Main accepted
 all findings. Baseline 27f2474547df045cc11302c7d9e195798ec66870 matches v3.
-Implementation is starting. The beta worktree remains untouched.
+The provisioner, trusted action wiring, documentation and 19 behavioral tests
+are implemented. The beta worktree remains untouched. Tests pass in the pinned
+Playwright image. In an isolated PostgreSQL 15 tmpfs service with no host ports,
+provisioning created the restricted role and marked database; all five prohibited
+role flags were false. Prisma reset completed 184 migrations and preserved the
+marker. The existing test seed passed under the restricted login using Node
+24.16.0 and pnpm 11.5.0. The 60 Playwright CI contract tests also passed.
+Independent implementation reviews and publication remain pending.

--- a/project/2026-09-07-pr-5812-disposable-test-ci-plan.md
+++ b/project/2026-09-07-pr-5812-disposable-test-ci-plan.md
@@ -1,5 +1,7 @@
 # Disposable Playwright database provisioning
 
+[PR #5812 — disposable CI databases](https://github.com/uzh-bf/klicker-uzh/pull/5812)
+
 ## Approval summary
 
 Give every Playwright shard a dedicated disposable database and login, so the
@@ -83,4 +85,9 @@ provisioning created the restricted role and marked database; all five prohibite
 role flags were false. Prisma reset completed 184 migrations and preserved the
 marker. The existing test seed passed under the restricted login using Node
 24.16.0 and pnpm 11.5.0. The 60 Playwright CI contract tests also passed.
-Independent implementation reviews and publication remain pending.
+Independent simplification, risk and integrated final reviews pass with no
+findings on d1004151f5d0f79323be4eaec5279d535c16236d. Published to the approved
+branch and PR. Both disposable verification containers are stopped; no retained
+database was touched. Current-head CI, final AI review, prerequisite merge and
+postmerge trusted-shard proof remain. Target v3 gained unrelated login changes
+in dd9e0c0bb4; no file overlap, and no upstream integration performed.


### PR DESCRIPTION
## Summary

Give each Playwright shard a dedicated disposable database and restricted login.
This prerequisite lets the following database guard distinguish test targets
from staging or production connections forwarded through localhost.

The trusted action creates `klicker_test` only on its fixed private PostgreSQL
service. It checks the connected identity and refuses an existing role or
database before mutation. It marks only the newly created database, then uses
that login for reset, seed, application processes and tests.

## Important Details

The role owns its database but has no superuser, database-creation,
role-management, replication or row-security-bypass privileges. The database
comment survives schema resets. Partial provisioning failures require a fresh
service; the script never adopts or cleans up existing objects.

Both runner routes load the action from trusted `v3`. Candidate CI therefore
tests the previous action until this prerequisite merges. Local database proof
is recorded below; a non-skipped postmerge shard must prove the new action using
its logged provisioner checksum before the beta guard package is ready.

This PR does not implement the runtime guard, change product behavior or
production schemas, alter runner topology, or add dependencies.

## Branch Coverage

Base: `v3`. Head: `a041475461e166aeec8fa7ad776b0d64b8adb11d`.
Three commits cover the approved plan, provisioner, behavioral tests, trusted
action wiring and testing guidance. Substantive scope excluding project
artifacts: 343 additions and 6 deletions across four files.
The last commit only renames the plan for this PR and records verification.
Target commit `dd9e0c0bb4` changes unrelated login behavior; there is no path
overlap, and no upstream integration has been performed.

## Review Focus

- Fixed-target provisioning and refusal before any mutation.
- Restricted-role compatibility with existing reset and seed commands.
- Distinguishing premerge checks from postmerge trusted-action proof.

## Verification

Current implementation:

- 19 behavioral Node tests pass in Node 24.16.0 and the workflow-pinned
  Playwright image. The latter also connects through `pg` and confirms the
  specific existing-object refusal.
- Isolated PostgreSQL 15 proof: restricted role and marked database created;
  all five prohibited role flags are false. Prisma reset completes 184
  migrations and preserves the comment. Existing `seed:test` succeeds under
  the restricted login with pnpm 11.5.0.
- All 60 `check:playwright-ci` tests pass. Biome, Prettier, diff checks,
  staged secret scanning and Git identity checks pass.

Container-native scoped checks replace host-wide hooks. No app runtime or
browser test was needed for the provisioning script. Both task-owned proof
containers are stopped; no retained database was touched.

## Security / Privacy

Only public source and synthetic CI constants are included. No secret values,
personal records or production data are included. Independent risk and integrated
final review pass with no findings; the simplifier recommends no changes.
Final review covers `27f2474547df045cc11302c7d9e195798ec66870..d1004151f5d0f79323be4eaec5279d535c16236d`.

## Blocking Before Merge

- Current-head required CI and final AI review.
- GitGuardian reports the existing synthetic CI password and its test fixture
  as incidents 1509424 and 37051630. They require false-positive disposition;
  no real credential is included. The findings have not been hidden or bypassed.

## Follow-Up After Merge

- Prove a non-skipped shard uses the newly merged provisioner.
- Finish the guard and database-owned beta preference amendment in
  [PR #5799 — beta authoring](https://github.com/uzh-bf/klicker-uzh/pull/5799).
  That PR is not authorized for merge.

## Local Session Artifacts

On the originating Codex host, repository `klicker-uzh`:

- Worktree: `trees/rs/disposable-test-ci`.
- Review reports: `project/_local/reviews/` within that worktree.
