### PR TITLE
fix(doc-query): preserve source state through cohort activation

### DIFF
--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -18,6 +18,9 @@ const EXPECTED_CHATBOT_COUNT = 22
 const EXPECTED_EXCLUDED_CHATBOT_COUNT = 2
 const EXPECTED_CORPUS_PROOF_COUNT = 15
 const EXPECTED_DIRECT_CALL_COUNT = 37
+const EXPECTED_CANARY_DIRECT_CALL_COUNT = 9
+const FULL_PROOF_MODE = 'full'
+const CANARY_PROOF_MODE = 'canary-only'
 const COLLECTION = 'klicker_course_materials_v1'
 const PRD_ENDPOINT =
   'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker'
@@ -55,6 +58,7 @@ const PLATFORM_ENV_NAMES = new Set(['__CF_USER_TEXT_ENCODING'])
 const WORKER_CONTROL_ENV_NAMES = new Set([
   'DOC_QUERY_PROOF_PARENT_PID',
   'DOC_QUERY_PROOF_MANIFEST_PATH',
+  'DOC_QUERY_PROOF_MODE',
 ])
 const WORKER_INTEGRITY_ENV_NAMES = new Set([
   'DOC_QUERY_PROOF_MANIFEST_FINGERPRINT',
@@ -344,11 +348,41 @@ export function validateManifest(
   }
 }
 
-function emptyReceipt() {
+function resolveProofMode(value) {
+  if (value === undefined || value === FULL_PROOF_MODE) return FULL_PROOF_MODE
+  if (value === CANARY_PROOF_MODE) return CANARY_PROOF_MODE
+  throw new ProofFailure('protocol_failed')
+}
+
+function requireProofMode(value) {
+  if (value === FULL_PROOF_MODE || value === CANARY_PROOF_MODE) return value
+  throw new ProofFailure('protocol_failed')
+}
+
+function proofExpectations(mode) {
+  return mode === CANARY_PROOF_MODE
+    ? {
+        kbPassed: 1,
+        representativeChatbotsPassed: 1,
+        positivePassed: 1,
+        isolationPassed: 1,
+        directCallsAttempted: EXPECTED_CANARY_DIRECT_CALL_COUNT,
+      }
+    : {
+        kbPassed: EXPECTED_KB_COUNT,
+        representativeChatbotsPassed: EXPECTED_CORPUS_PROOF_COUNT,
+        positivePassed: EXPECTED_CORPUS_PROOF_COUNT,
+        isolationPassed: EXPECTED_CORPUS_PROOF_COUNT,
+        directCallsAttempted: EXPECTED_DIRECT_CALL_COUNT,
+      }
+}
+
+function emptyReceipt(mode = FULL_PROOF_MODE) {
   return {
     receiptVersion: RECEIPT_VERSION,
     environment: 'prd',
     collection: COLLECTION,
+    mode,
     phase: 'preflight',
     result: 'failed',
     failureClass: 'none',
@@ -378,9 +412,10 @@ function fixedFailureReceipt(
   failureClass,
   caseId = null,
   rejectionClass = null,
-  diagnosticClass = 'none'
+  diagnosticClass = 'none',
+  mode = FULL_PROOF_MODE
 ) {
-  const receipt = emptyReceipt()
+  const receipt = emptyReceipt(mode)
   receipt.failureClass = FAILURE_CLASSES.has(failureClass)
     ? failureClass
     : 'protocol_failed'
@@ -394,8 +429,11 @@ function fixedFailureReceipt(
   return receipt
 }
 
-function workerProtocolFailureReceipt(failureClass = 'protocol_failed') {
-  return fixedFailureReceipt(failureClass, null, null, 'worker_protocol')
+function workerProtocolFailureReceipt(
+  failureClass = 'protocol_failed',
+  mode = FULL_PROOF_MODE
+) {
+  return fixedFailureReceipt(failureClass, null, null, 'worker_protocol', mode)
 }
 
 function extractDocuments(result) {
@@ -743,11 +781,20 @@ export async function runProofMatrix({
   invoke = invokeMcp,
   createSigner = createScopeSigner,
 }) {
-  const receipt = emptyReceipt()
+  let proofMode = FULL_PROOF_MODE
+  try {
+    proofMode = resolveProofMode(environment.DOC_QUERY_PROOF_MODE)
+  } catch {
+    return fixedFailureReceipt('protocol_failed')
+  }
+  const receipt = emptyReceipt(proofMode)
+  const expectations = proofExpectations(proofMode)
   try {
     const invokeWithCap = async (request) => {
       receipt.counts.directCallsAttempted += 1
-      if (receipt.counts.directCallsAttempted > EXPECTED_DIRECT_CALL_COUNT) {
+      if (
+        receipt.counts.directCallsAttempted > expectations.directCallsAttempted
+      ) {
         throw new ProofFailure('protocol_failed')
       }
       return withDiagnostic(() => invoke(request), 'mcp_invocation')
@@ -759,7 +806,15 @@ export async function runProofMatrix({
     const signer = (request) =>
       withDiagnostic(() => rawSigner(request), 'scope_signing')
     await runCanaryProof(invokeWithCap, signer, environment, manifest, receipt)
-    await runSerialProof(invokeWithCap, signer, environment, manifest, receipt)
+    if (proofMode === FULL_PROOF_MODE) {
+      await runSerialProof(
+        invokeWithCap,
+        signer,
+        environment,
+        manifest,
+        receipt
+      )
+    }
 
     receipt.phase = 'complete'
     receipt.result = 'passed'
@@ -800,6 +855,9 @@ function requiredWorkerEnvironment(source) {
   environment.DOC_QUERY_PROOF_MANIFEST_FINGERPRINT = requireFingerprint(
     source.DOC_QUERY_PROOF_MANIFEST_FINGERPRINT
   )
+  environment.DOC_QUERY_PROOF_MODE = requireProofMode(
+    source.DOC_QUERY_PROOF_MODE
+  )
   return environment
 }
 
@@ -812,8 +870,12 @@ export function validateWorkerEnvironment(source) {
 }
 
 export function minimalChildEnvironment(source, parentPid) {
+  const proofMode = resolveProofMode(source.DOC_QUERY_PROOF_MODE)
   return {
-    ...requiredWorkerEnvironment(source),
+    ...requiredWorkerEnvironment({
+      ...source,
+      DOC_QUERY_PROOF_MODE: proofMode,
+    }),
     DOC_QUERY_PROOF_PARENT_PID: String(parentPid),
   }
 }
@@ -833,13 +895,15 @@ async function readManifest(path, trustedFingerprint) {
   }
 }
 
-function sanitizeReceipt(value) {
+function sanitizeReceipt(value, expectedMode) {
+  const expectations = proofExpectations(expectedMode)
   if (
     !value ||
     typeof value !== 'object' ||
     value.receiptVersion !== RECEIPT_VERSION ||
     value.environment !== 'prd' ||
     value.collection !== COLLECTION ||
+    value.mode !== expectedMode ||
     !['preflight', 'canary', 'rejections', 'matrix', 'complete'].includes(
       value.phase
     ) ||
@@ -847,13 +911,13 @@ function sanitizeReceipt(value) {
     !FAILURE_CLASSES.has(value.failureClass) ||
     !DIAGNOSTIC_CLASSES.has(value.diagnosticClass)
   ) {
-    return workerProtocolFailureReceipt()
+    return workerProtocolFailureReceipt('protocol_failed', expectedMode)
   }
   if (!hasExactZeroPreservation(value.preservation)) {
-    return workerProtocolFailureReceipt()
+    return workerProtocolFailureReceipt('protocol_failed', expectedMode)
   }
   if (value.result === 'failed' && value.failureClass === 'none') {
-    return workerProtocolFailureReceipt()
+    return workerProtocolFailureReceipt('protocol_failed', expectedMode)
   }
   if (
     value.result === 'passed' &&
@@ -863,22 +927,23 @@ function sanitizeReceipt(value) {
       value.failedCaseId !== null ||
       value.failedRejectionClass !== null ||
       value.counts?.kbExpected !== EXPECTED_KB_COUNT ||
-      value.counts?.kbPassed !== EXPECTED_KB_COUNT ||
+      value.counts?.kbPassed !== expectations.kbPassed ||
       value.counts?.chatbotsInScope !== EXPECTED_CHATBOT_COUNT ||
       value.counts?.representativeChatbotsExpected !==
         EXPECTED_CORPUS_PROOF_COUNT ||
       value.counts?.representativeChatbotsPassed !==
-        EXPECTED_CORPUS_PROOF_COUNT ||
+        expectations.representativeChatbotsPassed ||
       value.counts?.excludedExpected !== EXPECTED_EXCLUDED_CHATBOT_COUNT ||
-      value.counts?.positivePassed !== EXPECTED_CORPUS_PROOF_COUNT ||
-      value.counts?.isolationPassed !== EXPECTED_CORPUS_PROOF_COUNT ||
+      value.counts?.positivePassed !== expectations.positivePassed ||
+      value.counts?.isolationPassed !== expectations.isolationPassed ||
       value.counts?.rejectionsPassed !== REJECTION_CLASSES.length ||
-      value.counts?.directCallsAttempted !== EXPECTED_DIRECT_CALL_COUNT ||
+      value.counts?.directCallsAttempted !==
+        expectations.directCallsAttempted ||
       REJECTION_CLASSES.some((name) => value.rejections?.[name] !== 'passed'))
   ) {
-    return workerProtocolFailureReceipt()
+    return workerProtocolFailureReceipt('protocol_failed', expectedMode)
   }
-  const receipt = emptyReceipt()
+  const receipt = emptyReceipt(expectedMode)
   receipt.phase = value.phase
   receipt.result = value.result
   receipt.failureClass = value.failureClass
@@ -980,6 +1045,17 @@ export async function superviseProof({
   spawnForProof = spawn,
 }) {
   const startedAt = Date.now()
+  let proofMode
+  try {
+    proofMode = resolveProofMode(sourceEnvironment.DOC_QUERY_PROOF_MODE)
+  } catch {
+    return {
+      ...fixedFailureReceipt('protocol_failed'),
+      exitCode: null,
+      signal: null,
+      elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
+    }
+  }
   let lock
   try {
     lock = await acquireLockForProof(lockPath)
@@ -987,7 +1063,7 @@ export async function superviseProof({
     const failureClass =
       error instanceof ProofFailure ? error.failureClass : 'child_failed'
     return {
-      ...fixedFailureReceipt(failureClass),
+      ...fixedFailureReceipt(failureClass, null, null, 'none', proofMode),
       exitCode: null,
       signal: null,
       elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
@@ -995,7 +1071,13 @@ export async function superviseProof({
   }
   if (!lock) {
     return {
-      ...fixedFailureReceipt('duplicate_refused'),
+      ...fixedFailureReceipt(
+        'duplicate_refused',
+        null,
+        null,
+        'none',
+        proofMode
+      ),
       exitCode: null,
       signal: null,
       elapsedMs: 0,
@@ -1021,7 +1103,7 @@ export async function superviseProof({
       }
     )
     child.on('message', (candidate) => {
-      if (message === null) message = sanitizeReceipt(candidate)
+      if (message === null) message = sanitizeReceipt(candidate, proofMode)
     })
 
     const terminateChildGroup = () => {
@@ -1063,13 +1145,29 @@ export async function superviseProof({
     })
     clearTimeout(deadlineTimer)
 
-    let receipt = message ?? workerProtocolFailureReceipt()
-    if (timedOut) receipt = fixedFailureReceipt('timeout')
-    else if (interrupted) receipt = fixedFailureReceipt('interrupted')
-    else if (close.signal) receipt = fixedFailureReceipt('child_signaled')
-    else if (close.code === 0) {
+    let receipt =
+      message ?? workerProtocolFailureReceipt('protocol_failed', proofMode)
+    if (timedOut) {
+      receipt = fixedFailureReceipt('timeout', null, null, 'none', proofMode)
+    } else if (interrupted) {
+      receipt = fixedFailureReceipt(
+        'interrupted',
+        null,
+        null,
+        'none',
+        proofMode
+      )
+    } else if (close.signal) {
+      receipt = fixedFailureReceipt(
+        'child_signaled',
+        null,
+        null,
+        'none',
+        proofMode
+      )
+    } else if (close.code === 0) {
       if (message?.result !== 'passed') {
-        receipt = workerProtocolFailureReceipt('child_failed')
+        receipt = workerProtocolFailureReceipt('child_failed', proofMode)
       }
     } else if (
       !Number.isInteger(close.code) ||
@@ -1077,7 +1175,7 @@ export async function superviseProof({
       message === null ||
       message.result === 'passed'
     ) {
-      receipt = workerProtocolFailureReceipt('child_failed')
+      receipt = workerProtocolFailureReceipt('child_failed', proofMode)
     }
 
     return {
@@ -1096,7 +1194,7 @@ export async function superviseProof({
     const failureClass =
       error instanceof ProofFailure ? error.failureClass : 'child_failed'
     return {
-      ...fixedFailureReceipt(failureClass),
+      ...fixedFailureReceipt(failureClass, null, null, 'none', proofMode),
       exitCode: null,
       signal: null,
       elapsedMs: Math.min(Date.now() - startedAt, DEFAULT_DEADLINE_MS + 5_000),
@@ -1131,7 +1229,9 @@ async function workerMain() {
     process.once(signal, () => process.exit(1))
   }
 
+  let proofMode = FULL_PROOF_MODE
   try {
+    proofMode = requireProofMode(process.env.DOC_QUERY_PROOF_MODE)
     validateWorkerEnvironment(process.env)
     const environment = requiredWorkerEnvironment(process.env)
     const manifest = await readManifest(
@@ -1146,9 +1246,11 @@ async function workerMain() {
         ? fixedFailureReceipt(
             error.failureClass,
             error.caseId,
-            error.rejectionClass
+            error.rejectionClass,
+            'none',
+            proofMode
           )
-        : fixedFailureReceipt('protocol_failed')
+        : fixedFailureReceipt('protocol_failed', null, null, 'none', proofMode)
     sendWorkerReceipt(receipt, 1)
   }
 }

--- a/apps/chat/scripts/prd-doc-query-proof.mjs
+++ b/apps/chat/scripts/prd-doc-query-proof.mjs
@@ -781,7 +781,7 @@ export async function runProofMatrix({
   invoke = invokeMcp,
   createSigner = createScopeSigner,
 }) {
-  let proofMode = FULL_PROOF_MODE
+  let proofMode
   try {
     proofMode = resolveProofMode(environment.DOC_QUERY_PROOF_MODE)
   } catch {

--- a/apps/chat/test/doc-query-proof-test-support.ts
+++ b/apps/chat/test/doc-query-proof-test-support.ts
@@ -190,11 +190,13 @@ export function createProofReceiptSources({
   collection,
   passedCounts,
   failedCounts,
+  proofMode,
 }: {
   environment: string
   collection: string
   passedCounts: string
   failedCounts: string
+  proofMode?: string
 }) {
   function passedReceiptSource(
     extra = '',
@@ -207,6 +209,7 @@ export function createProofReceiptSources({
       '  receiptVersion: 1,',
       `  environment: '${environment}',`,
       `  collection: '${collection}',`,
+      ...(proofMode ? [`  mode: '${proofMode}',`] : []),
       "  phase: 'complete',",
       "  result: 'passed',",
       "  failureClass: 'none',",
@@ -230,6 +233,7 @@ export function createProofReceiptSources({
       '  receiptVersion: 1,',
       `  environment: '${environment}',`,
       `  collection: '${collection}',`,
+      ...(proofMode ? [`  mode: '${proofMode}',`] : []),
       "  phase: 'canary',",
       "  result: 'failed',",
       "  failureClass: 'canary_positive_failed',",
@@ -367,6 +371,7 @@ export function defineProofMatrixSuite(
     rejectionWithArguments: () => MockToolResult
     expectedDirectCalls: number
     expectedCounts: Record<string, number>
+    expectedMode?: string
   }
 ) {
   describe(`${label} Doc Query proof matrix`, () => {
@@ -417,6 +422,7 @@ export function defineProofMatrixSuite(
 
       expect(call).toBe(config.expectedDirectCalls)
       expect(receipt.result).toBe('passed')
+      if (config.expectedMode) expect(receipt.mode).toBe(config.expectedMode)
       expect(receipt.counts).toMatchObject(config.expectedCounts)
     })
 
@@ -540,6 +546,7 @@ export function defineProofSupervisorSuite(
     passedReceiptSource: (extra?: string, preservation?: string) => string
     failedReceiptSource: (preservation?: string) => string
     expectProofManifestFingerprint?: boolean
+    expectedProofMode?: string
   }
 ) {
   const suiteRegistry = createTemporaryDirectoryRegistry()
@@ -565,6 +572,12 @@ export function defineProofSupervisorSuite(
       ]
       if (config.expectProofManifestFingerprint) {
         expectedEnvironmentNames.push('DOC_QUERY_PROOF_MANIFEST_FINGERPRINT')
+      }
+      if (config.expectedProofMode) {
+        expectedEnvironmentNames.push('DOC_QUERY_PROOF_MODE')
+        expect(childEnvironment.DOC_QUERY_PROOF_MODE).toBe(
+          config.expectedProofMode
+        )
       }
       expect(Object.keys(childEnvironment).sort(compareStrings)).toEqual(
         expectedEnvironmentNames.sort(compareStrings)
@@ -722,6 +735,9 @@ export function defineProofSupervisorSuite(
       ]
       if (config.expectProofManifestFingerprint) {
         allowedEnvironmentNames.push('DOC_QUERY_PROOF_MANIFEST_FINGERPRINT')
+      }
+      if (config.expectedProofMode) {
+        allowedEnvironmentNames.push('DOC_QUERY_PROOF_MODE')
       }
       const source = [
         "import { fstatSync, readFileSync } from 'node:fs'",

--- a/apps/chat/test/prd-doc-query-proof.test.ts
+++ b/apps/chat/test/prd-doc-query-proof.test.ts
@@ -57,6 +57,16 @@ const receiptSources = createProofReceiptSources({
     '{kbExpected:15,kbPassed:15,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:15,excludedExpected:2,positivePassed:15,isolationPassed:15,rejectionsPassed:7,directCallsAttempted:37}',
   failedCounts:
     '{kbExpected:15,kbPassed:0,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0}',
+  proofMode: 'full',
+})
+const canaryReceiptSources = createProofReceiptSources({
+  environment: 'prd',
+  collection: 'klicker_course_materials_v1',
+  passedCounts:
+    '{kbExpected:15,kbPassed:1,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:1,excludedExpected:2,positivePassed:1,isolationPassed:1,rejectionsPassed:7,directCallsAttempted:9}',
+  failedCounts:
+    '{kbExpected:15,kbPassed:0,chatbotsInScope:22,representativeChatbotsExpected:15,representativeChatbotsPassed:0,excludedExpected:2,positivePassed:0,isolationPassed:0,rejectionsPassed:0,directCallsAttempted:0}',
+  proofMode: 'canary-only',
 })
 const proofRegistry = createTemporaryDirectoryRegistry()
 const writeDummy = createProofChildWriter(proofRegistry)
@@ -156,6 +166,70 @@ describe('PRD Doc Query proof transport', () => {
 })
 
 describe('PRD Doc Query proof matrix', () => {
+  test('runs only the singleton canary in canary-only mode', async () => {
+    const validated = validateTestManifest(manifest())
+    const environment = {
+      ...(await proofDummyEnvironmentWithPin()),
+      DOC_QUERY_PROOF_MODE: 'canary-only',
+    }
+    const questions = new Set<string>()
+    let call = 0
+    const receipt = await runProofMatrix({
+      manifest: validated,
+      environment,
+      invoke: async ({ question, override }) => {
+        call += 1
+        questions.add(question)
+        if ((call >= 3 && call <= 8) || override) {
+          return override ? rejected('invalid arguments') : rejected()
+        }
+        const positive = question.startsWith('positive')
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                mode: 'documents',
+                summary: { sources_returned: 1, chunks_returned: 1 },
+                sources: [
+                  positive
+                    ? {
+                        reference: 'safe-positive-reference',
+                        chunks: [{ content: 'positive-marker-1' }],
+                      }
+                    : { reference: 'safe-foreign-reference', chunks: [] },
+                ],
+              }),
+            },
+          ],
+        }
+      },
+    })
+
+    expect(call).toBe(9)
+    expect([...questions].sort()).toEqual([
+      'foreign fixture 1',
+      'positive fixture 1',
+    ])
+    expect(receipt).toMatchObject({
+      mode: 'canary-only',
+      phase: 'complete',
+      result: 'passed',
+      counts: {
+        kbExpected: 15,
+        kbPassed: 1,
+        chatbotsInScope: 22,
+        representativeChatbotsExpected: 15,
+        representativeChatbotsPassed: 1,
+        excludedExpected: 2,
+        positivePassed: 1,
+        isolationPassed: 1,
+        rejectionsPassed: 7,
+        directCallsAttempted: 9,
+      },
+    })
+  })
+
   test('does not accept an unrelated tool error as an auth rejection', async () => {
     const validated = validateTestManifest(manifest())
     const environment = await proofDummyEnvironmentWithPin()
@@ -247,6 +321,7 @@ defineProofMatrixSuite(
     rejection: rejected,
     rejectionWithArguments: () => rejected('invalid arguments'),
     expectedDirectCalls: 37,
+    expectedMode: 'full',
     expectedCounts: {
       kbPassed: 15,
       chatbotsInScope: 22,
@@ -273,10 +348,99 @@ defineProofSupervisorSuite(
     passedReceiptSource: receiptSources.passedReceiptSource,
     failedReceiptSource: receiptSources.failedReceiptSource,
     expectProofManifestFingerprint: true,
+    expectedProofMode: 'full',
   }
 )
 
 describe('PRD Doc Query proof supervisor', () => {
+  test('rejects an invalid mode before lock acquisition or child spawn', async () => {
+    const dummy = await writeDummy(receiptSources.passedReceiptSource())
+    let acquired = false
+    let spawned = false
+    const receipt = await superviseProof({
+      sourceEnvironment: {
+        ...(await proofProcessEnvironment()),
+        DOC_QUERY_PROOF_MODE: 'canary',
+      },
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      acquireLockForProof: async () => {
+        acquired = true
+        return { close: async () => undefined }
+      },
+      spawnForProof: (() => {
+        spawned = true
+        throw new Error('must not spawn')
+      }) as unknown as typeof import('node:child_process').spawn,
+    })
+
+    expect(receipt).toMatchObject({
+      mode: 'full',
+      result: 'failed',
+      failureClass: 'protocol_failed',
+      exitCode: null,
+    })
+    expect(acquired).toBe(false)
+    expect(spawned).toBe(false)
+  })
+
+  test('accepts a mode-bound canary-only receipt', async () => {
+    const dummy = await writeDummy(canaryReceiptSources.passedReceiptSource())
+    const receipt = await superviseProof({
+      sourceEnvironment: {
+        ...(await proofProcessEnvironment()),
+        DOC_QUERY_PROOF_MODE: 'canary-only',
+      },
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+
+    expect(receipt).toMatchObject({
+      mode: 'canary-only',
+      result: 'passed',
+      failureClass: 'none',
+      counts: { kbPassed: 1, directCallsAttempted: 9 },
+    })
+  })
+
+  test.each([
+    [
+      'a different receipt mode',
+      () => canaryReceiptSources.passedReceiptSource(),
+      'full',
+    ],
+    [
+      'canary counters outside the nine-call contract',
+      () =>
+        canaryReceiptSources
+          .passedReceiptSource()
+          .replace('directCallsAttempted:9', 'directCallsAttempted:10'),
+      'canary-only',
+    ],
+  ])('rejects %s', async (_name, source, selectedMode) => {
+    const dummy = await writeDummy(source())
+    const receipt = await superviseProof({
+      sourceEnvironment: {
+        ...(await proofProcessEnvironment()),
+        DOC_QUERY_PROOF_MODE: selectedMode,
+      },
+      childPath: dummy.path,
+      childArgs: [],
+      lockPath: dummy.lockPath,
+      deadlineMs: 2_000,
+    })
+
+    expect(receipt).toMatchObject({
+      mode: selectedMode,
+      result: 'failed',
+      failureClass: 'child_failed',
+      diagnosticClass: 'worker_protocol',
+    })
+  })
+
   test('does not preserve a failed receipt when the child exit is unknown', async () => {
     const dummy = await writeDummy(receiptSources.failedReceiptSource())
     const child = new EventEmitter() as EventEmitter & { pid: number }
@@ -285,6 +449,7 @@ describe('PRD Doc Query proof supervisor', () => {
       receiptVersion: 1,
       environment: 'prd',
       collection: 'klicker_course_materials_v1',
+      mode: 'full',
       phase: 'canary',
       result: 'failed',
       failureClass: 'canary_positive_failed',

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
@@ -430,19 +430,23 @@ export async function acquireCohortActivationReentrySessionLock(
   predecessorPath: string,
   successorPath: string
 ): Promise<CohortActivationSessionLock> {
-  const paths = [predecessorPath, successorPath].sort()
+  const paths = [predecessorPath, successorPath].sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0
+  )
   const locks: CohortActivationSessionLock[] = []
   try {
     for (const path of paths) {
       locks.push(await acquireCohortActivationSessionLock(path))
     }
   } catch (error) {
-    for (const lock of locks.reverse()) await lock.release()
+    locks.reverse()
+    for (const lock of locks) await lock.release()
     throw error
   }
   return {
     release: async () => {
-      for (const lock of locks.reverse()) await lock.release()
+      locks.reverse()
+      for (const lock of locks) await lock.release()
     },
   }
 }

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
@@ -1,6 +1,15 @@
-import { randomUUID } from 'node:crypto'
-import { mkdir, open, readFile, rename, unlink } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import type { Stats } from 'node:fs'
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  unlink,
+} from 'node:fs/promises'
+import { basename, dirname, join, resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '@klicker-uzh/prisma/client'
@@ -8,6 +17,8 @@ import { encrypt } from '@klicker-uzh/util'
 import { PrismaPg } from '@prisma/adapter-pg'
 import {
   assertCohortActivationNotPrepared,
+  assertCohortActivationReentryPreconditions,
+  assertCohortActivationReentryRoot,
   assertReceiptMatchesManifest,
   assertReceiptTransition,
   CohortActivationError,
@@ -16,9 +27,13 @@ import {
   type CohortActivationReceiptExpectation,
   type CohortActivationReceiptFile,
   type CohortActivationReceiptIntent,
+  type CohortActivationReentryLineage,
+  type CohortActivationStore,
   dryRunCohortActivation,
   makeCohortActivationReceiptIntent,
+  makeCohortActivationReentryReceiptIntent,
   prepareCohortActivation,
+  prepareCohortActivationReentry,
   readCohortActivationState,
   receiptExpectation,
   recoverPreparedCohortActivation,
@@ -40,7 +55,37 @@ type Command =
   | 'clear'
   | 'rollback'
   | 'readback'
+  | 'reenter'
 type ReceiptFile = CohortActivationReceiptFile
+
+type ParsedArgs = {
+  command: Command
+  manifestPath: string
+  receiptPath: string
+  successorPath?: string
+}
+
+export const COHORT_ACTIVATION_REENTRY_CLAIM_VERSION = 1 as const
+
+export type CohortActivationReentryClaim = {
+  claimVersion: typeof COHORT_ACTIVATION_REENTRY_CLAIM_VERSION
+  predecessorPath: string
+  successorPath: string
+  predecessorPayloadDigest: string
+  claimDigest: string
+}
+
+export type CohortActivationReentryPaths = {
+  predecessorPath: string
+  successorPath: string
+  claimPath: string
+}
+
+export type CohortActivationReentryHooks = {
+  afterClaim?: (claim: CohortActivationReentryClaim) => Promise<void>
+  afterIntent?: (intent: CohortActivationReceiptIntent) => Promise<void>
+  afterPrepared?: (receipt: CohortActivationReceipt) => Promise<void>
+}
 
 export type CohortActivationSessionLock = {
   release: () => Promise<void>
@@ -50,11 +95,7 @@ function usage(): never {
   throw new Error('usage')
 }
 
-function parseArgs(argv: string[]): {
-  command: Command
-  manifestPath: string
-  receiptPath: string
-} {
+function parseArgs(argv: string[]): ParsedArgs {
   const command = argv[0]
   if (
     command !== 'dry-run' &&
@@ -62,25 +103,283 @@ function parseArgs(argv: string[]): {
     command !== 'recover' &&
     command !== 'clear' &&
     command !== 'rollback' &&
-    command !== 'readback'
+    command !== 'readback' &&
+    command !== 'reenter'
   ) {
     return usage()
   }
   const manifestIndex = argv.indexOf('--manifest')
   const receiptIndex = argv.indexOf('--receipt')
+  const successorIndex = argv.indexOf('--successor')
   const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined
   const receiptPath = receiptIndex >= 0 ? argv[receiptIndex + 1] : undefined
-  if (!manifestPath || !receiptPath || argv.length !== 5) return usage()
+  const successorPath =
+    successorIndex >= 0 ? argv[successorIndex + 1] : undefined
+  if (
+    !manifestPath ||
+    !receiptPath ||
+    (command === 'reenter'
+      ? !successorPath || argv.length !== 7
+      : successorPath !== undefined || argv.length !== 5)
+  ) {
+    return usage()
+  }
   return {
     command,
     manifestPath: resolve(manifestPath),
     receiptPath: resolve(receiptPath),
+    ...(successorPath ? { successorPath: resolve(successorPath) } : {}),
   }
 }
 
 async function readJsonFile<T>(path: string): Promise<T> {
   const raw = await readFile(path, 'utf8')
   return JSON.parse(raw) as T
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value)
+}
+
+function reentryClaimDigest(
+  claim: Omit<CohortActivationReentryClaim, 'claimDigest'>
+): string {
+  return createHash('sha256').update(JSON.stringify(claim)).digest('hex')
+}
+
+export function cohortActivationReentryClaimPath(
+  predecessorPath: string
+): string {
+  return `${resolve(predecessorPath)}.reentry.claim.json`
+}
+
+function isMissing(error: unknown): boolean {
+  return (
+    error !== null &&
+    error !== undefined &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  )
+}
+
+async function inspectReceiptPath(
+  path: string,
+  role: 'predecessor' | 'successor'
+): Promise<{ path: string; exists: boolean }> {
+  const absolute = resolve(path)
+  const parent = dirname(absolute)
+  let parentStat: Stats
+  try {
+    parentStat = await lstat(parent)
+  } catch (error) {
+    if (isMissing(error)) {
+      throw new CohortActivationError(
+        'REENTRY_PATH_INVALID',
+        `${role} receipt parent is missing`
+      )
+    }
+    throw error
+  }
+  if (parentStat.isSymbolicLink()) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      `${role} receipt parent must not be a symlink`
+    )
+  }
+  const canonicalParent = await realpath(parent)
+  if (canonicalParent !== parent) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      `${role} receipt parent has symlink ambiguity`
+    )
+  }
+
+  let entry: Stats | undefined
+  try {
+    entry = await lstat(absolute)
+  } catch (error) {
+    if (!isMissing(error)) throw error
+  }
+  if (entry?.isSymbolicLink()) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      `${role} receipt must not be a symlink`
+    )
+  }
+  if (entry && !entry.isFile()) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_INVALID',
+      `${role} receipt path is not a regular file`
+    )
+  }
+  const canonicalPath = entry
+    ? await realpath(absolute)
+    : join(canonicalParent, basename(absolute))
+  if (canonicalPath !== absolute) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      `${role} receipt path has symlink ambiguity`
+    )
+  }
+  return { path: canonicalPath, exists: entry !== undefined }
+}
+
+export async function resolveCohortActivationReentryPaths(
+  predecessorPath: string,
+  successorPath: string
+): Promise<CohortActivationReentryPaths> {
+  const predecessor = await inspectReceiptPath(predecessorPath, 'predecessor')
+  const successor = await inspectReceiptPath(successorPath, 'successor')
+  if (!predecessor.exists) {
+    throw new CohortActivationError(
+      'REENTRY_PREDECESSOR_MISSING',
+      're-entry predecessor receipt is missing'
+    )
+  }
+  if (predecessor.path === successor.path) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      're-entry predecessor and successor paths must differ'
+    )
+  }
+  const claimPath = cohortActivationReentryClaimPath(predecessor.path)
+  const claim = await inspectReceiptPath(claimPath, 'predecessor')
+  if (claim.path === successor.path) {
+    throw new CohortActivationError(
+      'REENTRY_PATH_AMBIGUOUS',
+      're-entry successor cannot be the claim sidecar'
+    )
+  }
+  return {
+    predecessorPath: predecessor.path,
+    successorPath: successor.path,
+    claimPath: claim.path,
+  }
+}
+
+export function validateCohortActivationReentryClaim(
+  claim: unknown,
+  expected?: Pick<
+    CohortActivationReentryPaths,
+    'predecessorPath' | 'successorPath'
+  >
+): asserts claim is CohortActivationReentryClaim {
+  if (
+    !claim ||
+    typeof claim !== 'object' ||
+    Array.isArray(claim) ||
+    !('claimVersion' in claim) ||
+    !('predecessorPath' in claim) ||
+    !('successorPath' in claim) ||
+    !('predecessorPayloadDigest' in claim) ||
+    !('claimDigest' in claim) ||
+    Object.keys(claim).length !== 5 ||
+    claim.claimVersion !== COHORT_ACTIVATION_REENTRY_CLAIM_VERSION ||
+    typeof claim.predecessorPath !== 'string' ||
+    typeof claim.successorPath !== 'string' ||
+    !isSha256(claim.predecessorPayloadDigest) ||
+    !isSha256(claim.claimDigest)
+  ) {
+    throw new CohortActivationError(
+      'REENTRY_CLAIM_INVALID',
+      're-entry claim is malformed'
+    )
+  }
+  const { claimDigest, ...withoutDigest } =
+    claim as CohortActivationReentryClaim
+  if (reentryClaimDigest(withoutDigest) !== claimDigest) {
+    throw new CohortActivationError(
+      'REENTRY_CLAIM_INVALID',
+      're-entry claim digest does not match'
+    )
+  }
+  if (
+    expected &&
+    (claim.predecessorPath !== expected.predecessorPath ||
+      claim.successorPath !== expected.successorPath)
+  ) {
+    throw new CohortActivationError(
+      'REENTRY_CLAIM_MISMATCH',
+      're-entry claim is bound to different receipt paths'
+    )
+  }
+}
+
+async function readReentryClaim(
+  claimPath: string,
+  expected: Pick<
+    CohortActivationReentryPaths,
+    'predecessorPath' | 'successorPath'
+  >
+): Promise<CohortActivationReentryClaim | null> {
+  try {
+    const claim = await readJsonFile<unknown>(claimPath)
+    validateCohortActivationReentryClaim(claim, expected)
+    return claim
+  } catch (error) {
+    if (isMissing(error)) return null
+    throw error
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, 'r')
+  try {
+    await directory.sync()
+  } finally {
+    await directory.close()
+  }
+}
+
+async function createReentryClaim(
+  paths: CohortActivationReentryPaths,
+  predecessorPayloadDigest: string
+): Promise<CohortActivationReentryClaim> {
+  const existing = await readReentryClaim(paths.claimPath, paths)
+  if (existing) {
+    throw new CohortActivationError(
+      'REENTRY_CLAIM_EXISTS',
+      're-entry claim already exists'
+    )
+  }
+  const withoutDigest = {
+    claimVersion: COHORT_ACTIVATION_REENTRY_CLAIM_VERSION,
+    predecessorPath: paths.predecessorPath,
+    successorPath: paths.successorPath,
+    predecessorPayloadDigest,
+  }
+  const claim = {
+    ...withoutDigest,
+    claimDigest: reentryClaimDigest(withoutDigest),
+  }
+  let file: Awaited<ReturnType<typeof open>> | undefined
+  let closed = false
+  try {
+    file = await open(paths.claimPath, 'wx', 0o600)
+    await file.writeFile(`${JSON.stringify(claim)}\n`, 'utf8')
+    await file.sync()
+    await file.close()
+    closed = true
+    await syncDirectory(dirname(paths.claimPath))
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'EEXIST'
+    ) {
+      throw new CohortActivationError(
+        'REENTRY_CLAIM_EXISTS',
+        're-entry claim already exists'
+      )
+    }
+    throw error
+  } finally {
+    if (file && !closed) await file.close()
+  }
+  validateCohortActivationReentryClaim(claim, paths)
+  return claim
 }
 
 function isDatabaseLockError(error: unknown): boolean {
@@ -124,6 +423,27 @@ export async function acquireCohortActivationSessionLock(
     }
     if (isDatabaseLockError(error)) throw new Error('SESSION_LOCKED')
     throw error
+  }
+}
+
+export async function acquireCohortActivationReentrySessionLock(
+  predecessorPath: string,
+  successorPath: string
+): Promise<CohortActivationSessionLock> {
+  const paths = [predecessorPath, successorPath].sort()
+  const locks: CohortActivationSessionLock[] = []
+  try {
+    for (const path of paths) {
+      locks.push(await acquireCohortActivationSessionLock(path))
+    }
+  } catch (error) {
+    for (const lock of locks.reverse()) await lock.release()
+    throw error
+  }
+  return {
+    release: async () => {
+      for (const lock of locks.reverse()) await lock.release()
+    },
   }
 }
 
@@ -173,12 +493,22 @@ export async function clearPreparingReceipt(
   expected: NonNullable<CohortActivationReceiptExpectation>
 ): Promise<void> {
   const current = await readReceipt(path)
+  if (current?.reentry) {
+    throw new CohortActivationError(
+      'REENTRY_NOT_ALLOWED',
+      're-entry evidence cannot be cleared'
+    )
+  }
   if (
     !current ||
     current.state !== 'preparing' ||
     current.manifestFingerprint !== expected.manifestFingerprint ||
     current.payloadDigest !== expected.payloadDigest ||
-    current.state !== expected.state
+    current.state !== expected.state ||
+    JSON.stringify(receiptExpectation(current)?.inactiveSource) !==
+      JSON.stringify(expected.inactiveSource) ||
+    JSON.stringify(receiptExpectation(current)?.activeSources) !==
+      JSON.stringify(expected.activeSources)
   ) {
     throw new CohortActivationError(
       'RECEIPT_CONCURRENT_WRITE',
@@ -339,6 +669,95 @@ async function runMigrate(
   })
 }
 
+async function runCohortActivationReentryLocked(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  paths: CohortActivationReentryPaths,
+  hooks: CohortActivationReentryHooks = {}
+): Promise<CohortActivationReceipt> {
+  const predecessor = await readReceipt(paths.predecessorPath)
+  if (!predecessor || isCohortActivationIntent(predecessor)) {
+    throw new CohortActivationError(
+      'REENTRY_PREDECESSOR_INVALID',
+      're-entry predecessor must be a complete receipt'
+    )
+  }
+  const successor = await readReceipt(paths.successorPath)
+  if (successor) {
+    throw new CohortActivationError(
+      'REENTRY_SUCCESSOR_EXISTS',
+      're-entry successor receipt already exists'
+    )
+  }
+  const existingClaim = await readReentryClaim(paths.claimPath, paths)
+  if (existingClaim) {
+    throw new CohortActivationError(
+      'REENTRY_CLAIM_EXISTS',
+      're-entry claim already exists'
+    )
+  }
+
+  assertReceiptMatchesManifest(predecessor, manifest)
+  assertCohortActivationReentryRoot(predecessor)
+  await assertCohortActivationReentryPreconditions(store, manifest, predecessor)
+
+  const claim = await createReentryClaim(paths, predecessor.payloadDigest)
+  await hooks.afterClaim?.(claim)
+  const lineage: CohortActivationReentryLineage = {
+    predecessorPayloadDigest: predecessor.payloadDigest,
+    claimDigest: claim.claimDigest,
+  }
+  const intent = makeCohortActivationReentryReceiptIntent(
+    manifest,
+    predecessor,
+    lineage
+  )
+  let expectedReceipt: CohortActivationReceiptExpectation = null
+  const persistReceipt = async (receipt: ReceiptFile): Promise<void> => {
+    await writeReceipt(paths.successorPath, receipt, expectedReceipt)
+    expectedReceipt = receiptExpectation(receipt)
+  }
+  await persistReceipt(intent)
+  await hooks.afterIntent?.(intent)
+  const prepared = await prepareCohortActivationReentry(
+    store,
+    manifest,
+    predecessor,
+    intent
+  )
+  await persistReceipt(prepared)
+  await hooks.afterPrepared?.(prepared)
+  const switched = await switchCohortActivation(
+    store,
+    prepared,
+    (checkpoint: CohortActivationReceipt) => persistReceipt(checkpoint)
+  )
+  await persistReceipt(switched)
+  return switched
+}
+
+export async function executeCohortActivationReentry(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  predecessorPath: string,
+  successorPath: string,
+  hooks?: CohortActivationReentryHooks
+): Promise<CohortActivationReceipt> {
+  const paths = await resolveCohortActivationReentryPaths(
+    predecessorPath,
+    successorPath
+  )
+  const sessionLock = await acquireCohortActivationReentrySessionLock(
+    paths.predecessorPath,
+    paths.successorPath
+  )
+  try {
+    return await runCohortActivationReentryLocked(store, manifest, paths, hooks)
+  } finally {
+    await sessionLock.release()
+  }
+}
+
 async function runRecover(
   store: ReturnType<typeof createPrismaCohortActivationStore>,
   manifest: CohortActivationManifest,
@@ -352,6 +771,11 @@ async function runRecover(
   }
   if (!isCohortActivationIntent(existingReceipt)) {
     printResult({ status: 'refused', reason: 'receipt_complete' })
+    process.exitCode = 3
+    return
+  }
+  if (existingReceipt.reentry) {
+    printResult({ status: 'refused', reason: 'reentry_not_allowed' })
     process.exitCode = 3
     return
   }
@@ -386,6 +810,11 @@ async function runClear(
   }
   if (!isCohortActivationIntent(existingReceipt)) {
     printResult({ status: 'refused', reason: 'receipt_complete' })
+    process.exitCode = 3
+    return
+  }
+  if (existingReceipt.reentry) {
+    printResult({ status: 'refused', reason: 'reentry_not_allowed' })
     process.exitCode = 3
     return
   }
@@ -455,6 +884,39 @@ async function runSettledCommand(
   })
 }
 
+async function runReentryCommand(args: ParsedArgs): Promise<void> {
+  let prisma: PrismaClient | undefined
+  try {
+    if (!args.successorPath) return usage()
+    prisma = createPrismaClient()
+    const store = createPrismaCohortActivationStore(prisma)
+    const manifest = await readJsonFile<CohortActivationManifest>(
+      args.manifestPath
+    )
+    validatePinnedManifest(manifest)
+    const switched = await executeCohortActivationReentry(
+      store,
+      manifest,
+      args.receiptPath,
+      args.successorPath
+    )
+    const state = await readCohortActivationState(store, switched)
+    printResult({
+      status: 'switched',
+      state: state.state,
+      entryCount: state.entryCount,
+      chatbotCount: state.chatbotCount,
+      sourceDisabled: state.sourceDisabled,
+      targetEnabled: state.targetEnabled,
+    })
+  } catch (error) {
+    printResult({ status: 'failed', category: classifyError(error) })
+    process.exitCode = 1
+  } finally {
+    await prisma?.$disconnect()
+  }
+}
+
 async function main(): Promise<void> {
   let args: ReturnType<typeof parseArgs>
   try {
@@ -462,6 +924,10 @@ async function main(): Promise<void> {
   } catch {
     printResult({ status: 'usage_error' })
     process.exitCode = 2
+    return
+  }
+  if (args.command === 'reenter') {
+    await runReentryCommand(args)
     return
   }
 

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation-run.ts
@@ -91,6 +91,24 @@ export type CohortActivationSessionLock = {
   release: () => Promise<void>
 }
 
+async function releaseCohortActivationSessionLocks(
+  locks: readonly CohortActivationSessionLock[]
+): Promise<void> {
+  let failed = false
+  let firstError: unknown
+  for (const lock of [...locks].reverse()) {
+    try {
+      await lock.release()
+    } catch (error) {
+      if (!failed) {
+        failed = true
+        firstError = error
+      }
+    }
+  }
+  if (failed) throw firstError
+}
+
 function usage(): never {
   throw new Error('usage')
 }
@@ -406,8 +424,11 @@ export async function acquireCohortActivationSessionLock(
   try {
     database = new DatabaseSync(lockPath, { timeout: 0 })
     database.exec('BEGIN EXCLUSIVE')
+    let released = false
     return {
       release: async () => {
+        if (released) return
+        released = true
         try {
           database?.exec('ROLLBACK')
         } finally {
@@ -439,14 +460,18 @@ export async function acquireCohortActivationReentrySessionLock(
       locks.push(await acquireCohortActivationSessionLock(path))
     }
   } catch (error) {
-    locks.reverse()
-    for (const lock of locks) await lock.release()
+    try {
+      await releaseCohortActivationSessionLocks(locks)
+    } catch {
+      // Preserve the lock-acquisition error after attempting every cleanup.
+    }
     throw error
   }
+  let releasePromise: Promise<void> | undefined
   return {
-    release: async () => {
-      locks.reverse()
-      for (const lock of locks) await lock.release()
+    release: () => {
+      releasePromise ??= releaseCohortActivationSessionLocks(locks)
+      return releasePromise
     },
   }
 }
@@ -914,6 +939,11 @@ async function runReentryCommand(args: ParsedArgs): Promise<void> {
       targetEnabled: state.targetEnabled,
     })
   } catch (error) {
+    if (error instanceof Error && error.message === 'SESSION_LOCKED') {
+      printResult({ status: 'refused', reason: 'session_locked' })
+      process.exitCode = 3
+      return
+    }
     printResult({ status: 'failed', category: classifyError(error) })
     process.exitCode = 1
   } finally {

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
@@ -1,7 +1,10 @@
+import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { fileURLToPath } from 'node:url'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 import { describe, expect, it, vi } from 'vitest'
 import {
@@ -9,6 +12,7 @@ import {
   assertCohortActivationReentryRoot,
   assertReceiptMatchesManifest,
   assertReceiptTransition,
+  COHORT_ACTIVATION_MANIFEST_FINGERPRINT_ENV,
   type CohortActivationConfigRecord,
   type CohortActivationConfigUpdate,
   type CohortActivationManifest,
@@ -39,6 +43,7 @@ import {
 } from './doc-query-cohort-activation.js'
 import { createPrismaCohortActivationStore } from './doc-query-cohort-activation-prisma.js'
 import {
+  acquireCohortActivationReentrySessionLock,
   acquireCohortActivationSessionLock,
   clearPreparingReceipt,
   cohortActivationReentryClaimPath,
@@ -1062,6 +1067,100 @@ describe('cohort activation contract', () => {
     }
   })
 
+  it('attempts both re-entry lock releases after one fails and remains idempotent', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-lock-'))
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+    const originalExec = DatabaseSync.prototype.exec
+    let failRollback = true
+    const execSpy = vi
+      .spyOn(DatabaseSync.prototype, 'exec')
+      .mockImplementation(function (this: DatabaseSync, sql: string) {
+        if (sql === 'ROLLBACK' && failRollback) {
+          failRollback = false
+          throw new Error('synthetic release failure')
+        }
+        return originalExec.call(this, sql)
+      })
+
+    try {
+      const lock = await acquireCohortActivationReentrySessionLock(
+        predecessorPath,
+        successorPath
+      )
+      const release = lock.release()
+      expect(lock.release()).toBe(release)
+      await expect(release).rejects.toThrow('synthetic release failure')
+      expect(lock.release()).toBe(release)
+
+      const reacquired = await acquireCohortActivationReentrySessionLock(
+        predecessorPath,
+        successorPath
+      )
+      await reacquired.release()
+    } finally {
+      execSpy.mockRestore()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the refused session-locked result for re-entry CLI contention', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-cli-'))
+    const manifestPath = join(directory, 'manifest.json')
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+    const manifest = makeManifest([sourceConfig, secondModeConfig])
+    await writeFile(manifestPath, JSON.stringify(manifest))
+    await writeFile(predecessorPath, '{}')
+    const lock = await acquireCohortActivationReentrySessionLock(
+      predecessorPath,
+      successorPath
+    )
+
+    try {
+      let failure: { status?: number; stdout?: string | Buffer } | undefined
+      try {
+        execFileSync(
+          process.execPath,
+          [
+            '../../node_modules/tsx/dist/cli.mjs',
+            'doc-query-cohort-activation-run.ts',
+            'reenter',
+            '--manifest',
+            manifestPath,
+            '--receipt',
+            predecessorPath,
+            '--successor',
+            successorPath,
+          ],
+          {
+            cwd: fileURLToPath(new URL('.', import.meta.url)),
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              DATABASE_URL:
+                'postgresql://synthetic:synthetic@127.0.0.1:5432/synthetic',
+              [COHORT_ACTIVATION_MANIFEST_FINGERPRINT_ENV]:
+                manifest.fingerprint,
+            },
+            timeout: 30000,
+          }
+        )
+      } catch (error) {
+        failure = error as { status?: number; stdout?: string | Buffer }
+      }
+
+      expect(failure?.status).toBe(3)
+      expect(JSON.parse(String(failure?.stdout ?? ''))).toEqual({
+        status: 'refused',
+        reason: 'session_locked',
+      })
+    } finally {
+      await lock.release()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('refuses stale and out-of-order receipt replacement', async () => {
     const directory = await mkdtemp(
       join(tmpdir(), 'cohort-activation-receipt-')
@@ -1088,6 +1187,21 @@ describe('cohort activation contract', () => {
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
+  })
+
+  it('reports a concurrent write before comparing source pins when the receipt disappears', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = makeInactiveSourceManifest()
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(prepared), null, prepared)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_CONCURRENT_WRITE' })
+    )
   })
 
   it('clears only the exact preparing receipt expectation', async () => {

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts
@@ -1,14 +1,18 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PrismaClient } from '@klicker-uzh/prisma/client'
 import { describe, expect, it, vi } from 'vitest'
 import {
   assertCohortActivationNotPrepared,
+  assertCohortActivationReentryRoot,
   assertReceiptMatchesManifest,
+  assertReceiptTransition,
   type CohortActivationConfigRecord,
   type CohortActivationConfigUpdate,
   type CohortActivationManifest,
+  type CohortActivationReceipt,
   type CohortActivationServerCreate,
   type CohortActivationServerRecord,
   type CohortActivationStore,
@@ -20,7 +24,10 @@ import {
   DOC_QUERY_TARGET_URL,
   dryRunCohortActivation,
   fingerprintManifest,
+  fingerprintSourceServerSnapshot,
+  type JsonValue,
   makeCohortActivationReceiptIntent,
+  makeCohortActivationReentryReceiptIntent,
   prepareCohortActivation,
   readCohortActivationState,
   receiptExpectation,
@@ -34,6 +41,10 @@ import { createPrismaCohortActivationStore } from './doc-query-cohort-activation
 import {
   acquireCohortActivationSessionLock,
   clearPreparingReceipt,
+  cohortActivationReentryClaimPath,
+  executeCohortActivationReentry,
+  resolveCohortActivationReentryPaths,
+  validateCohortActivationReentryClaim,
   writeReceipt,
 } from './doc-query-cohort-activation-run.js'
 
@@ -49,6 +60,18 @@ const sourceServer: CohortActivationServerRecord = {
   hasAuthSecret: true,
   isActive: true,
   updatedAt: new Date('2026-08-24T10:00:00.000Z'),
+}
+
+const compatibilitySourceServer: CohortActivationServerRecord = {
+  ...sourceServer,
+  name: 'Klicker-compat',
+  description: 'Production compatibility bridge',
+  url: DOC_QUERY_TARGET_URL,
+}
+
+const inactiveSourceServer: CohortActivationServerRecord = {
+  ...sourceServer,
+  isActive: false,
 }
 
 const sourceConfig: CohortActivationConfigRecord = {
@@ -73,6 +96,12 @@ const secondChatbotConfig: CohortActivationConfigRecord = {
   ...sourceConfig,
   id: '00000000-0000-4000-8000-000000000005',
   chatbotId: '00000000-0000-4000-8000-000000000006',
+}
+
+const extraSourceConfig: CohortActivationConfigRecord = {
+  ...sourceConfig,
+  id: '00000000-0000-4000-8000-000000000008',
+  chatMode: 'exam',
 }
 
 const targetServer: CohortActivationServerRecord = {
@@ -103,7 +132,7 @@ function makeManifest(
       configId: config.id,
       chatbotId: config.chatbotId,
       chatMode: config.chatMode,
-      sourceServerId: sourceServer.id,
+      sourceServerId: config.mcpServerId,
       targetTool: 'doc_query' as const,
       kbId:
         config.chatbotId === sourceConfig.chatbotId
@@ -120,6 +149,48 @@ function makeManifest(
     excludedConfigIds: [],
   }
   return { ...unsigned, fingerprint: fingerprintManifest(unsigned) }
+}
+
+function makeInactiveSourceManifest(
+  configs: CohortActivationConfigRecord[] = [sourceConfig, secondModeConfig],
+  options: { heldConfigIds?: string[]; excludedConfigIds?: string[] } = {},
+  server: CohortActivationServerRecord = inactiveSourceServer
+): CohortActivationManifest {
+  const base = makeManifest(configs)
+  const unsigned = {
+    target: base.target,
+    entries: base.entries,
+    heldConfigIds: options.heldConfigIds ?? base.heldConfigIds,
+    inactiveSource: {
+      sourceServerId: server.id,
+      chatbotId: configs[0]!.chatbotId,
+      configIds: configs.map((config) => config.id),
+      snapshotDigest: fingerprintSourceServerSnapshot(server),
+      rollbackMode: 'preserve-inactive' as const,
+    },
+    excludedCorpora: base.excludedCorpora,
+    excludedConfigIds: options.excludedConfigIds ?? base.excludedConfigIds,
+  }
+  return { ...unsigned, fingerprint: fingerprintManifest(unsigned) }
+}
+
+function recomputeReceiptDigest(
+  receipt: Omit<CohortActivationReceipt, 'payloadDigest'>
+): CohortActivationReceipt {
+  return {
+    ...receipt,
+    payloadDigest: createHash('sha256')
+      .update(JSON.stringify(receipt))
+      .digest('hex'),
+  }
+}
+
+function transitionReceipt(
+  receipt: CohortActivationReceipt,
+  changes: Partial<Omit<CohortActivationReceipt, 'payloadDigest'>>
+): CohortActivationReceipt {
+  const { payloadDigest: _ignored, ...withoutDigest } = receipt
+  return recomputeReceiptDigest({ ...withoutDigest, ...changes })
 }
 
 function cloneConfig(
@@ -147,21 +218,25 @@ function fakeStore(
   initialConfigs:
     | CohortActivationConfigRecord[]
     | CohortActivationConfigRecord = [sourceConfig],
-  initialTarget?: CohortActivationServerRecord
+  initialTarget?: CohortActivationServerRecord,
+  initialSources: CohortActivationServerRecord[] = [sourceServer]
 ): {
   store: CohortActivationStore
   currentConfig: (id: string) => CohortActivationConfigRecord | undefined
+  currentSource: () => CohortActivationServerRecord | undefined
+  currentServer: (id: string) => CohortActivationServerRecord | undefined
   currentTarget: () => CohortActivationServerRecord | undefined
   writes: () => number
   transactions: () => number
   targetConfigCount: () => number
   replaceConfig: (config: CohortActivationConfigRecord) => void
   replaceSourceServer: (server: CohortActivationServerRecord) => void
+  replaceTargetServer: (server: CohortActivationServerRecord) => void
   failNextTargetUpdate: () => void
 } {
-  let servers = new Map<string, CohortActivationServerRecord>([
-    [sourceServer.id, cloneServer(sourceServer)],
-  ])
+  let servers = new Map<string, CohortActivationServerRecord>(
+    initialSources.map((server) => [server.id, cloneServer(server)])
+  )
   if (initialTarget) servers.set(initialTarget.id, cloneServer(initialTarget))
   const configsToSeed = Array.isArray(initialConfigs)
     ? initialConfigs
@@ -243,7 +318,11 @@ function fakeStore(
       expectedUpdatedAt,
       data: CohortActivationConfigUpdate
     ) {
-      if (failTargetUpdate && data.mcpServerId !== sourceServer.id) {
+      if (
+        failTargetUpdate &&
+        workingServers.get(data.mcpServerId)?.name ===
+          DOC_QUERY_TARGET_SERVER_NAME
+      ) {
         failTargetUpdate = false
         return null
       }
@@ -290,6 +369,14 @@ function fakeStore(
       const config = configs.get(id)
       return config ? cloneConfig(config) : undefined
     },
+    currentSource: () => {
+      const source = servers.get(sourceServer.id)
+      return source ? cloneServer(source) : undefined
+    },
+    currentServer: (id) => {
+      const server = servers.get(id)
+      return server ? cloneServer(server) : undefined
+    },
     currentTarget: () => {
       const target = [...servers.values()].find(
         (server) => server.name === DOC_QUERY_TARGET_SERVER_NAME
@@ -311,10 +398,454 @@ function fakeStore(
     replaceConfig: (config) => configs.set(config.id, cloneConfig(config)),
     replaceSourceServer: (server) =>
       servers.set(server.id, cloneServer(server)),
+    replaceTargetServer: (server) =>
+      servers.set(server.id, cloneServer(server)),
     failNextTargetUpdate: () => {
       failTargetUpdate = true
     },
   }
+}
+
+function activeAliasesFixture(includeInactive = false) {
+  const aliases: CohortActivationServerRecord[] = [1, 2].map((index) => ({
+    ...sourceServer,
+    id: `00000000-0000-4000-8000-000000000${index}01`,
+    name: `Synthetic active alias ${index}`,
+    parameters: index === 1 ? null : {},
+    description: `Synthetic course alias ${index}`,
+    url: DOC_QUERY_TARGET_URL,
+    passChatbotId: false,
+    chatbotIdHeader: null,
+  }))
+  const activeConfigs = aliases.flatMap((server, index) =>
+    [sourceConfig, secondModeConfig].map((config, mode) => ({
+      ...config,
+      id: `00000000-0000-4000-8000-000000000${index + 1}0${mode + 2}`,
+      chatbotId: `00000000-0000-4000-8000-000000000${index + 1}04`,
+      mcpServerId: server.id,
+    }))
+  )
+  const inactiveConfigs = [sourceConfig, secondModeConfig].map((config) => ({
+    ...config,
+    chatbotId: '00000000-0000-4000-8000-000000000304',
+  }))
+  const protectedServer = {
+    ...sourceServer,
+    id: '00000000-0000-4000-8000-000000000900',
+    name: 'Synthetic excluded source',
+  }
+  const held = {
+    ...sourceConfig,
+    id: '00000000-0000-4000-8000-000000000901',
+    chatbotId: '00000000-0000-4000-8000-000000000904',
+    mcpServerId: targetServer.id,
+    parameters: {
+      required: true,
+      toolAlias: 'doc_query',
+      kb_id: sourceConfig.chatbotId,
+    },
+  }
+  const excluded = {
+    ...secondModeConfig,
+    id: '00000000-0000-4000-8000-000000000902',
+    chatbotId: held.chatbotId,
+    mcpServerId: protectedServer.id,
+    isEnabled: false,
+  }
+  const configs = [
+    ...activeConfigs,
+    ...(includeInactive ? inactiveConfigs : []),
+  ]
+  const servers = [
+    ...aliases,
+    ...(includeInactive ? [inactiveSourceServer] : []),
+    protectedServer,
+  ]
+  const base = makeManifest(configs)
+  const unsigned = {
+    ...base,
+    entries: base.entries.map((entry) => ({
+      ...entry,
+      kbId: entry.chatbotId,
+      corpusIdentity: `synthetic-corpus-${entry.chatbotId}`,
+    })),
+    heldConfigIds: [held.id],
+    excludedConfigIds: [excluded.id],
+    activeSources: aliases.map((server) => {
+      const group = activeConfigs.filter(
+        (config) => config.mcpServerId === server.id
+      )
+      return {
+        sourceServerId: server.id,
+        chatbotId: group[0]!.chatbotId,
+        configIds: group.map((config) => config.id),
+        snapshotDigest: fingerprintSourceServerSnapshot(server),
+        rollbackMode: 'preserve-active' as const,
+      }
+    }),
+    ...(includeInactive
+      ? {
+          inactiveSource:
+            makeInactiveSourceManifest(inactiveConfigs).inactiveSource,
+        }
+      : {}),
+  }
+  const manifest: CohortActivationManifest = {
+    ...unsigned,
+    fingerprint: fingerprintManifest(unsigned),
+  }
+  const fake = fakeStore([...configs, held, excluded], targetServer, servers)
+  return { fake, manifest, aliases, configs, servers, held, excluded }
+}
+
+describe('pinned active source aliases', () => {
+  it('recovers, switches, and restores the combined batch without changing servers or protected rows', async () => {
+    const { fake, manifest, configs, servers, held, excluded } =
+      activeAliasesFixture(true)
+    await expect(
+      dryRunCohortActivation(fake.store, manifest)
+    ).resolves.toMatchObject({ wouldSwitch: 6 })
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      intent,
+    })
+    const recovered = await recoverPreparedCohortActivation(
+      fake.store,
+      manifest,
+      intent
+    )
+    expect(recovered.payloadDigest).toBe(prepared.payloadDigest)
+    expect(intent.activeSources).toEqual(manifest.activeSources)
+    expect(recovered.activeSources).toEqual(manifest.activeSources)
+    const switched = await switchCohortActivation(fake.store, recovered)
+    expect(receiptExpectation(switched)?.activeSources).toEqual(
+      manifest.activeSources
+    )
+    await expect(
+      readCohortActivationState(fake.store, switched)
+    ).resolves.toMatchObject({
+      state: 'switched',
+      sourceDisabled: 6,
+      targetEnabled: 6,
+    })
+    const rolledBack = await rollbackCohortActivation(fake.store, switched)
+    expect(rolledBack.activeSources).toEqual(manifest.activeSources)
+    expect(rolledBack.inactiveSource).toEqual(manifest.inactiveSource)
+    await expect(
+      readCohortActivationState(fake.store, rolledBack)
+    ).resolves.toMatchObject({
+      state: 'rolled_back',
+      sourceEnabled: 6,
+      targetDisabled: 6,
+    })
+    for (const config of configs) {
+      const restored = fake.currentConfig(config.id)!
+      expect(restored).toEqual({ ...config, updatedAt: restored.updatedAt })
+      expect(restored.updatedAt.getTime()).toBeGreaterThan(
+        config.updatedAt.getTime()
+      )
+    }
+    for (const server of [...servers, targetServer]) {
+      expect(fake.currentServer(server.id)).toEqual(server)
+    }
+    expect(fake.currentConfig(held.id)).toEqual(held)
+    expect(fake.currentConfig(excluded.id)).toEqual(excluded)
+  })
+
+  it('rolls back the whole batch after one alias commits and the next transaction fails', async () => {
+    const { fake, manifest, configs, servers, held, excluded } =
+      activeAliasesFixture(true)
+    const prepared = await prepareCohortActivation(fake.store, manifest, {})
+    let checkpoint = prepared
+    let injected = false
+    await expect(
+      switchCohortActivation(fake.store, prepared, async (next) => {
+        checkpoint = next
+        if (!injected && next.switchedChatbotIds.length === 1) {
+          injected = true
+          fake.failNextTargetUpdate()
+        }
+      })
+    ).rejects.toMatchObject({ code: 'CONCURRENT_EDIT' })
+    expect(injected).toBe(true)
+    expect(checkpoint.switchedChatbotIds).toHaveLength(1)
+    expect(
+      configs.filter((config) => !fake.currentConfig(config.id)!.isEnabled)
+    ).toHaveLength(2)
+    const rolledBack = await rollbackCohortActivation(fake.store, checkpoint)
+    await expect(
+      readCohortActivationState(fake.store, rolledBack)
+    ).resolves.toMatchObject({
+      state: 'rolled_back',
+      sourceEnabled: 6,
+      targetDisabled: 6,
+    })
+    for (const config of configs) {
+      const restored = fake.currentConfig(config.id)!
+      expect(restored).toEqual({ ...config, updatedAt: restored.updatedAt })
+    }
+    for (const server of [...servers, targetServer])
+      expect(fake.currentServer(server.id)).toEqual(server)
+    expect(fake.currentConfig(held.id)).toEqual(held)
+    expect(fake.currentConfig(excluded.id)).toEqual(excluded)
+  })
+
+  it('rechecks active-only mode inventory before any switch config writes', async () => {
+    const { fake, manifest, configs } = activeAliasesFixture()
+    expect(manifest.inactiveSource).toBeUndefined()
+    const prepared = await prepareCohortActivation(fake.store, manifest, {})
+    fake.replaceConfig({
+      ...configs[0]!,
+      id: extraSourceConfig.id,
+      chatMode: 'exam',
+    })
+    const writes = fake.writes()
+    await expect(
+      switchCohortActivation(fake.store, prepared)
+    ).rejects.toMatchObject({
+      code: 'ACTIVE_SOURCE_INVENTORY_MISMATCH',
+    })
+    expect(fake.writes()).toBe(writes)
+  })
+
+  it('does not exempt unpinned aliases or disabled source configurations', async () => {
+    const { fake, manifest, configs } = activeAliasesFixture()
+    const unmarked = { ...manifest, activeSources: undefined }
+    unmarked.fingerprint = fingerprintManifest(unmarked)
+    await expect(
+      dryRunCohortActivation(fake.store, unmarked)
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+    fake.replaceConfig({ ...configs[0]!, isEnabled: false })
+    await expect(dryRunCohortActivation(fake.store, manifest)).rejects.toThrow()
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('canonicalizes active pin order and preserves absent-field fingerprints', () => {
+    const { manifest } = activeAliasesFixture()
+    expect(
+      fingerprintManifest({
+        ...manifest,
+        activeSources: [...manifest.activeSources!].reverse().map((pin) => ({
+          ...pin,
+          configIds: [...pin.configIds].reverse(),
+          snapshotDigest: pin.snapshotDigest.toUpperCase(),
+        })),
+      })
+    ).toBe(manifest.fingerprint)
+    const legacy = makeManifest()
+    expect(fingerprintManifest({ ...legacy, activeSources: undefined })).toBe(
+      legacy.fingerprint
+    )
+    expect(
+      fingerprintManifest({ ...manifest, activeSources: undefined })
+    ).not.toBe(manifest.fingerprint)
+  })
+
+  it('rejects malformed, overlapping, and incorrectly scoped pins', async () => {
+    const { fake, manifest } = activeAliasesFixture(true)
+    const pins = manifest.activeSources!
+    const invalid = [
+      { activeSources: [pins[0]!] },
+      { activeSources: [pins[0]!, pins[0]!] },
+      {
+        activeSources: [
+          { ...pins[0]!, configIds: [pins[0]!.configIds[0]!] },
+          pins[1]!,
+        ],
+      },
+      {
+        activeSources: [
+          { ...pins[0]!, chatbotId: pins[1]!.chatbotId },
+          pins[1]!,
+        ],
+      },
+      { activeSources: [{ ...pins[0]!, unexpected: true }, pins[1]!] },
+      { activeSources: [{ ...pins[0]!, snapshotDigest: 'invalid' }, pins[1]!] },
+      {
+        activeSources: [
+          { ...pins[0]!, rollbackMode: 'preserve-inactive' },
+          pins[1]!,
+        ],
+      },
+      { heldConfigIds: [pins[0]!.configIds[0]!] },
+      { excludedConfigIds: [pins[1]!.configIds[0]!] },
+      {
+        activeSources: [
+          { ...manifest.inactiveSource!, rollbackMode: 'preserve-active' },
+          pins[1]!,
+        ],
+      },
+    ]
+    for (const changes of invalid) {
+      await expect(
+        (async () => {
+          const altered = {
+            ...manifest,
+            ...changes,
+          } as CohortActivationManifest
+          altered.fingerprint = fingerprintManifest(altered)
+          await dryRunCohortActivation(fake.store, altered)
+        })()
+      ).rejects.toThrow()
+    }
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('rejects disabled rows on another chatbot even when held or excluded', async () => {
+    for (const kind of ['disabled', 'held', 'excluded']) {
+      const { fake, manifest, configs } = activeAliasesFixture()
+      const extra = {
+        ...configs[0]!,
+        id: extraSourceConfig.id,
+        chatbotId: sourceConfig.chatbotId,
+        isEnabled: false,
+      }
+      fake.replaceConfig(extra)
+      if (kind === 'held') manifest.heldConfigIds.push(extra.id)
+      if (kind === 'excluded') manifest.excludedConfigIds!.push(extra.id)
+      manifest.fingerprint = fingerprintManifest(manifest)
+      await expect(
+        dryRunCohortActivation(fake.store, manifest)
+      ).rejects.toMatchObject({ code: 'ACTIVE_SOURCE_INVENTORY_MISMATCH' })
+      expect(fake.writes()).toBe(0)
+    }
+  })
+
+  it.each([
+    'readback',
+    'restored',
+  ] as const)('checks active alias state and snapshot during %s', async (phase) => {
+    const { fake, manifest, aliases, configs } = activeAliasesFixture()
+    const prepared = await prepareCohortActivation(fake.store, manifest, {})
+    let receipt = await switchCohortActivation(fake.store, prepared)
+    if (phase === 'restored')
+      receipt = transitionReceipt(
+        await rollbackCohortActivation(fake.store, receipt),
+        { state: 'rolling_back' }
+      )
+    const writes = fake.writes()
+    for (const [change, code] of [
+      [{ isActive: false }, 'ACTIVE_SOURCE_INACTIVE'],
+      [
+        { description: 'Changed synthetic metadata' },
+        'ACTIVE_SOURCE_SNAPSHOT_MISMATCH',
+      ],
+    ] as const) {
+      fake.replaceSourceServer({ ...aliases[0]!, ...change })
+      await expect(
+        phase === 'readback'
+          ? readCohortActivationState(fake.store, receipt)
+          : rollbackCohortActivation(fake.store, receipt)
+      ).rejects.toMatchObject({ code })
+    }
+    fake.replaceSourceServer(aliases[0]!)
+    fake.replaceConfig({
+      ...configs[0]!,
+      id: extraSourceConfig.id,
+      chatMode: 'exam',
+      isEnabled: false,
+    })
+    await expect(
+      phase === 'readback'
+        ? readCohortActivationState(fake.store, receipt)
+        : rollbackCohortActivation(fake.store, receipt)
+    ).rejects.toMatchObject({ code: 'ACTIVE_SOURCE_INVENTORY_MISMATCH' })
+    expect(fake.writes()).toBe(writes)
+  })
+
+  it('rejects unsafe alias contracts even when the changed snapshot is pinned', async () => {
+    const changes: Partial<CohortActivationServerRecord>[] = [
+      { url: `${DOC_QUERY_TARGET_URL}/?alias=true` },
+      { name: DOC_QUERY_TARGET_SERVER_NAME },
+      { description: DOC_QUERY_TARGET_DESCRIPTION },
+      { authType: 'none' },
+      { hasAuthSecret: false },
+      { parameters: { alias: true } },
+      { passChatbotId: true },
+    ]
+    for (const change of changes) {
+      const { fake, manifest, aliases } = activeAliasesFixture()
+      const server = { ...aliases[0]!, ...change }
+      fake.replaceSourceServer(server)
+      manifest.activeSources![0]!.snapshotDigest =
+        fingerprintSourceServerSnapshot(server)
+      manifest.fingerprint = fingerprintManifest(manifest)
+      await expect(
+        prepareCohortActivation(fake.store, manifest, {})
+      ).rejects.toMatchObject({ code: 'ACTIVE_SOURCE_CONTRACT_MISMATCH' })
+      expect(fake.writes()).toBe(0)
+    }
+  })
+
+  it.each([
+    'add',
+    'remove',
+    'substitute',
+  ] as const)('rejects recomputed-digest active pin %s in receipts and intents', async (kind) => {
+    const { fake, manifest } = activeAliasesFixture()
+    const marked = kind !== 'add'
+    const originalManifest = marked ? manifest : makeManifest()
+    const store = marked
+      ? fake.store
+      : fakeStore([sourceConfig], targetServer).store
+    const receipt = await prepareCohortActivation(store, originalManifest, {})
+    const changed =
+      kind === 'remove'
+        ? undefined
+        : manifest.activeSources!.map((pin) => ({
+            ...pin,
+            snapshotDigest: 'a'.repeat(64),
+          }))
+    const tampered = transitionReceipt(receipt, { activeSources: changed })
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(receipt), receipt, tampered)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(receipt), tampered, tampered)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    expect(() =>
+      assertReceiptMatchesManifest(tampered, originalManifest)
+    ).toThrow()
+    const intent = makeCohortActivationReceiptIntent(originalManifest)
+    const { payloadDigest: _digest, ...unsigned } = intent
+    const payload = { ...unsigned, activeSources: changed }
+    const alteredIntent = {
+      ...payload,
+      payloadDigest: createHash('sha256')
+        .update(JSON.stringify(payload))
+        .digest('hex'),
+    }
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(intent), intent, alteredIntent)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    await expect(
+      recoverPreparedCohortActivation(store, originalManifest, alteredIntent)
+    ).rejects.toThrow()
+  })
+})
+
+async function rolledBackReentryFixture() {
+  const fake = fakeStore([sourceConfig, secondModeConfig])
+  const manifest = makeManifest([sourceConfig, secondModeConfig])
+  const prepared = await prepareCohortActivation(fake.store, manifest, {
+    encryptedBearer: 'encrypted-synthetic-bearer',
+  })
+  const switched = await switchCohortActivation(fake.store, prepared)
+  const rolledBack = await rollbackCohortActivation(fake.store, switched)
+  return { fake, manifest, rolledBack }
+}
+
+async function writeRolledBackReceipt(
+  path: string,
+  fixture: Awaited<ReturnType<typeof rolledBackReentryFixture>>
+): Promise<void> {
+  await writeFile(path, JSON.stringify(fixture.rolledBack))
 }
 
 describe('cohort activation contract', () => {
@@ -596,15 +1127,38 @@ describe('cohort activation contract', () => {
     expect(fake.currentTarget()).toBeUndefined()
   })
 
+  it('accepts null source parameters without writes', async () => {
+    const sourceWithNullParameters = { ...sourceConfig, parameters: null }
+    const fake = fakeStore(sourceWithNullParameters)
+
+    await expect(
+      dryRunCohortActivation(
+        fake.store,
+        makeManifest([sourceWithNullParameters])
+      )
+    ).resolves.toMatchObject({ status: 'dry-run', wouldSwitch: 1 })
+    expect(fake.writes()).toBe(0)
+  })
+
   it('creates target rows, switches by CAS, and restores exact source content', async () => {
-    const fake = fakeStore()
-    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
-      encryptedBearer: 'encrypted-synthetic-bearer',
-    })
-    expect(prepared.state).toBe('prepared')
-    expect(fake.currentConfig(sourceConfig.id)).toMatchObject({
+    const sourceParameters = { required: true, toolAlias: 'doc_query' }
+    const sourceWithParameters = {
       ...sourceConfig,
-      parameters: {},
+      parameters: sourceParameters,
+    }
+    const fake = fakeStore(sourceWithParameters)
+    const prepared = await prepareCohortActivation(
+      fake.store,
+      makeManifest([sourceWithParameters]),
+      {
+        encryptedBearer: 'encrypted-synthetic-bearer',
+      }
+    )
+    expect(prepared.state).toBe('prepared')
+    expect(prepared.entries[0]!.prior.parameters).toEqual(sourceParameters)
+    expect(fake.currentConfig(sourceConfig.id)).toMatchObject({
+      ...sourceWithParameters,
+      parameters: sourceParameters,
     })
     expect(fake.targetConfigCount()).toBe(1)
     expect(fake.currentConfig(prepared.entries[0]!.target.id)).toMatchObject({
@@ -639,7 +1193,7 @@ describe('cohort activation contract', () => {
       allowedTools: sourceConfig.allowedTools,
       priority: sourceConfig.priority,
       isEnabled: true,
-      parameters: sourceConfig.parameters,
+      parameters: sourceParameters,
     })
     expect(
       fake.currentConfig(sourceConfig.id)?.updatedAt.getTime()
@@ -803,9 +1357,438 @@ describe('cohort activation contract', () => {
     ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
   })
 
-  it('refuses source parameters that could leak into a receipt', async () => {
+  it('switches and rolls back a pinned inactive source while preserving it inactive', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = makeInactiveSourceManifest()
+
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    expect(prepared.inactiveSource).toEqual(manifest.inactiveSource)
+
+    const switched = await switchCohortActivation(fake.store, prepared)
+    await expect(
+      readCohortActivationState(fake.store, switched)
+    ).resolves.toMatchObject({
+      state: 'switched',
+      sourceDisabled: 2,
+      targetEnabled: 2,
+    })
+    expect(fake.currentSource()?.isActive).toBe(false)
+
+    const rolledBack = await rollbackCohortActivation(fake.store, switched)
+    await expect(
+      readCohortActivationState(fake.store, rolledBack)
+    ).resolves.toMatchObject({
+      state: 'rolled_back',
+      sourceEnabled: 2,
+      targetDisabled: 2,
+    })
+    expect(fake.currentSource()?.isActive).toBe(false)
+  })
+
+  it('refuses an inactive source without the pinned exception before writes', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    fake.replaceSourceServer(inactiveSourceServer)
+    await expect(
+      prepareCohortActivation(
+        fake.store,
+        makeManifest([sourceConfig, secondModeConfig]),
+        {}
+      )
+    ).rejects.toMatchObject({ code: 'SOURCE_SERVER_INACTIVE' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('canonicalizes the exception and leaves legacy fingerprints unchanged when absent', () => {
+    const manifest = makeInactiveSourceManifest()
+    expect(
+      fingerprintManifest({
+        ...manifest,
+        inactiveSource: {
+          ...manifest.inactiveSource!,
+          configIds: [...manifest.inactiveSource!.configIds].reverse(),
+          snapshotDigest: manifest.inactiveSource!.snapshotDigest.toUpperCase(),
+        },
+      })
+    ).toBe(manifest.fingerprint)
+    const legacy = makeManifest()
+    expect(fingerprintManifest({ ...legacy, inactiveSource: undefined })).toBe(
+      legacy.fingerprint
+    )
+    expect(
+      fingerprintManifest({ ...manifest, inactiveSource: undefined })
+    ).not.toBe(manifest.fingerprint)
+  })
+
+  it.each([
+    { configIds: [sourceConfig.id, sourceConfig.id] },
+    { configIds: [sourceConfig.id] },
+    { snapshotDigest: 'invalid' },
+    { rollbackMode: 'enable-source' },
+    { extra: true },
+  ])('rejects malformed inactive exceptions %j', (changes) => {
+    const manifest = makeInactiveSourceManifest()
+    expect(() =>
+      fingerprintManifest({
+        ...manifest,
+        inactiveSource: { ...manifest.inactiveSource!, ...changes },
+      } as CohortActivationManifest)
+    ).toThrow()
+  })
+
+  it.each([
+    'heldConfigIds',
+    'excludedConfigIds',
+  ] as const)('refuses exception overlap with %s', (field) => {
+    const manifest = makeInactiveSourceManifest(undefined, {
+      [field]: [sourceConfig.id],
+    })
+    expect(() =>
+      validatePinnedManifest(manifest, manifest.fingerprint)
+    ).toThrow()
+  })
+
+  it.each([
+    'sourceServerId',
+    'chatbotId',
+  ] as const)('rejects a mismatched exception %s', (field) => {
+    const original = makeInactiveSourceManifest()
+    const altered = {
+      ...original,
+      inactiveSource: {
+        ...original.inactiveSource!,
+        [field]: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      },
+    }
+    const manifest = { ...altered, fingerprint: fingerprintManifest(altered) }
+    expect(() =>
+      validatePinnedManifest(manifest, manifest.fingerprint)
+    ).toThrow()
+  })
+
+  it.each([
+    'enabled',
+    'disabled',
+    'held',
+    'excluded',
+  ] as const)('rejects an additional %s source config globally', async (kind) => {
+    const extra = { ...extraSourceConfig, isEnabled: kind === 'enabled' }
+    const fake = fakeStore([sourceConfig, secondModeConfig, extra])
+    fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = makeInactiveSourceManifest(undefined, {
+      heldConfigIds: kind === 'held' ? [extra.id] : [],
+      excludedConfigIds: kind === 'excluded' ? [extra.id] : [],
+    })
+    await expect(
+      prepareCohortActivation(fake.store, manifest, {})
+    ).rejects.toMatchObject({ code: 'INACTIVE_SOURCE_INVENTORY_MISMATCH' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('rechecks global source inventory before switching', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    fake.replaceSourceServer(inactiveSourceServer)
+    const receipt = await prepareCohortActivation(
+      fake.store,
+      makeInactiveSourceManifest(),
+      {}
+    )
+    fake.replaceConfig({ ...extraSourceConfig, isEnabled: false })
+    const writes = fake.writes()
+    await expect(
+      switchCohortActivation(fake.store, receipt)
+    ).rejects.toMatchObject({ code: 'INACTIVE_SOURCE_INVENTORY_MISMATCH' })
+    expect(fake.writes()).toBe(writes)
+  })
+
+  it.each([
+    'prepare',
+    'switch',
+    'readback',
+    'rollback',
+    'restored',
+  ] as const)('rejects source snapshot drift during %s', async (phase) => {
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = makeInactiveSourceManifest()
+    let receipt =
+      phase === 'prepare'
+        ? undefined
+        : await prepareCohortActivation(fake.store, manifest, {})
+    if (phase === 'readback' || phase === 'rollback' || phase === 'restored')
+      receipt = await switchCohortActivation(fake.store, receipt!)
+    if (phase === 'restored')
+      receipt = transitionReceipt(
+        await rollbackCohortActivation(fake.store, receipt!),
+        { state: 'rolling_back' }
+      )
+    fake.replaceSourceServer({
+      ...inactiveSourceServer,
+      description: 'Changed safe metadata',
+    })
+    const writes = fake.writes()
+    const operation =
+      phase === 'prepare'
+        ? prepareCohortActivation(fake.store, manifest, {})
+        : phase === 'switch'
+          ? switchCohortActivation(fake.store, receipt!)
+          : phase === 'readback'
+            ? readCohortActivationState(fake.store, receipt!)
+            : rollbackCohortActivation(fake.store, receipt!)
+    await expect(operation).rejects.toMatchObject({
+      code: 'INACTIVE_SOURCE_SNAPSHOT_MISMATCH',
+    })
+    expect(fake.writes()).toBe(writes)
+  })
+
+  it('refuses activation of the pinned inactive source even with its original metadata', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    fake.replaceSourceServer(inactiveSourceServer)
+    const receipt = await prepareCohortActivation(
+      fake.store,
+      makeInactiveSourceManifest(),
+      {}
+    )
+    fake.replaceSourceServer({ ...inactiveSourceServer, isActive: true })
+    await expect(
+      switchCohortActivation(fake.store, receipt)
+    ).rejects.toMatchObject({ code: 'INACTIVE_SOURCE_ACTIVE' })
+  })
+
+  it.each([
+    { name: DOC_QUERY_TARGET_SERVER_NAME },
+    { description: DOC_QUERY_TARGET_DESCRIPTION },
+    { url: DOC_QUERY_TARGET_URL },
+    { url: `${DOC_QUERY_TARGET_URL}/?ignored=true` },
+    { ...compatibilitySourceServer, isActive: false },
+  ])('refuses managed or shared sources even when their snapshot is pinned %j', async (changes) => {
+    const server = { ...inactiveSourceServer, ...changes }
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    fake.replaceSourceServer(server)
+    await expect(
+      prepareCohortActivation(
+        fake.store,
+        makeInactiveSourceManifest(undefined, {}, server),
+        {}
+      )
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('preserves the inactive exception through intent recovery', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = makeInactiveSourceManifest()
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      intent,
+    })
+    const recovered = await recoverPreparedCohortActivation(
+      fake.store,
+      manifest,
+      intent
+    )
+    expect(intent.inactiveSource).toEqual(manifest.inactiveSource)
+    expect(recovered.inactiveSource).toEqual(manifest.inactiveSource)
+    expect(recovered.payloadDigest).toBe(prepared.payloadDigest)
+  })
+
+  it.each([
+    'remove',
+    'substitute',
+    'add',
+  ] as const)('rejects recomputed-digest exception tampering: %s', async (kind) => {
+    const marked = kind !== 'add'
+    const fake = fakeStore([sourceConfig, secondModeConfig], targetServer)
+    if (marked) fake.replaceSourceServer(inactiveSourceServer)
+    const manifest = marked
+      ? makeInactiveSourceManifest()
+      : makeManifest([sourceConfig, secondModeConfig])
+    const receipt = await prepareCohortActivation(fake.store, manifest, {})
+    const changed =
+      kind === 'remove'
+        ? undefined
+        : {
+            ...makeInactiveSourceManifest().inactiveSource!,
+            snapshotDigest: 'a'.repeat(64),
+          }
+    const tampered = transitionReceipt(receipt, { inactiveSource: changed })
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(receipt), receipt, tampered)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(receipt), tampered, tampered)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    expect(() => assertReceiptMatchesManifest(tampered, manifest)).toThrow()
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    const { payloadDigest: _digest, ...unsigned } = intent
+    const payload = { ...unsigned, inactiveSource: changed }
+    const alteredIntent = {
+      ...payload,
+      payloadDigest: createHash('sha256')
+        .update(JSON.stringify(payload))
+        .digest('hex'),
+    }
+    expect(() =>
+      assertReceiptTransition(receiptExpectation(intent), intent, alteredIntent)
+    ).toThrowError(
+      expect.objectContaining({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+    )
+    await expect(
+      recoverPreparedCohortActivation(fake.store, manifest, alteredIntent)
+    ).rejects.toThrow()
+  })
+
+  it('switches and restores every mode from the pinned compatibility source', async () => {
+    const fake = fakeStore([sourceConfig, secondModeConfig])
+    fake.replaceSourceServer(compatibilitySourceServer)
+    const manifest = makeManifest([sourceConfig, secondModeConfig])
+
+    await expect(
+      dryRunCohortActivation(fake.store, manifest)
+    ).resolves.toMatchObject({ status: 'dry-run', wouldSwitch: 2 })
+    const intent = makeCohortActivationReceiptIntent(manifest)
+    const prepared = await prepareCohortActivation(fake.store, manifest, {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+      intent,
+    })
+    const recovered = await recoverPreparedCohortActivation(
+      fake.store,
+      manifest,
+      intent
+    )
+    expect(recovered.payloadDigest).toBe(prepared.payloadDigest)
+    const switched = await switchCohortActivation(fake.store, recovered)
+    await expect(
+      readCohortActivationState(fake.store, switched)
+    ).resolves.toMatchObject({
+      state: 'switched',
+      sourceDisabled: 2,
+      targetEnabled: 2,
+    })
+
+    const rolledBack = await rollbackCohortActivation(fake.store, switched)
+    await expect(
+      readCohortActivationState(fake.store, rolledBack)
+    ).resolves.toMatchObject({
+      state: 'rolled_back',
+      sourceEnabled: 2,
+      targetDisabled: 2,
+    })
+  })
+
+  it.each<
+    [
+      string,
+      Partial<CohortActivationServerRecord>,
+      'SOURCE_IS_TARGET' | 'SOURCE_SERVER_INACTIVE',
+    ]
+  >([
+    [
+      'different name',
+      { name: 'Other compatibility source' },
+      'SOURCE_IS_TARGET',
+    ],
+    ['missing description', { description: null }, 'SOURCE_IS_TARGET'],
+    [
+      'target ownership marker',
+      { description: DOC_QUERY_TARGET_DESCRIPTION },
+      'SOURCE_IS_TARGET',
+    ],
+    [
+      'alternate route',
+      { url: 'http://compat.example.invalid/mcp/klicker' },
+      'SOURCE_IS_TARGET',
+    ],
+    ['wrong auth type', { authType: 'none' }, 'SOURCE_IS_TARGET'],
+    ['chatbot id disabled', { passChatbotId: false }, 'SOURCE_IS_TARGET'],
+    [
+      'wrong chatbot header',
+      { chatbotIdHeader: 'X-Chatbot-ID' },
+      'SOURCE_IS_TARGET',
+    ],
+    [
+      'nonempty parameters',
+      { parameters: { mode: 'legacy' } },
+      'SOURCE_IS_TARGET',
+    ],
+    ['missing auth secret', { hasAuthSecret: false }, 'SOURCE_IS_TARGET'],
+    ['inactive server', { isActive: false }, 'SOURCE_SERVER_INACTIVE'],
+  ])('refuses a compatibility source with %s', async (_name, change, code) => {
     const fake = fakeStore()
-    const unsafe = { ...sourceConfig, parameters: { source: true } }
+    fake.replaceSourceServer({ ...compatibilitySourceServer, ...change })
+
+    await expect(
+      dryRunCohortActivation(fake.store, makeManifest())
+    ).rejects.toMatchObject({ code })
+    expect(fake.writes()).toBe(0)
+  })
+
+  it('revalidates the compatibility source before switching', async () => {
+    const fake = fakeStore()
+    fake.replaceSourceServer(compatibilitySourceServer)
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    const writesAfterPrepare = fake.writes()
+    fake.replaceSourceServer({
+      ...compatibilitySourceServer,
+      authType: 'none',
+    })
+
+    await expect(
+      readCohortActivationState(fake.store, prepared)
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+    await expect(
+      switchCohortActivation(fake.store, prepared)
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+    expect(fake.writes()).toBe(writesAfterPrepare)
+    expect(fake.currentConfig(sourceConfig.id)?.isEnabled).toBe(true)
+  })
+
+  it('refuses to restore a drifted compatibility source', async () => {
+    const fake = fakeStore()
+    fake.replaceSourceServer(compatibilitySourceServer)
+    const prepared = await prepareCohortActivation(fake.store, makeManifest(), {
+      encryptedBearer: 'encrypted-synthetic-bearer',
+    })
+    const switched = await switchCohortActivation(fake.store, prepared)
+    const writesAfterSwitch = fake.writes()
+    fake.replaceSourceServer({
+      ...compatibilitySourceServer,
+      chatbotIdHeader: 'X-Chatbot-ID',
+    })
+
+    await expect(
+      rollbackCohortActivation(fake.store, switched)
+    ).rejects.toMatchObject({ code: 'SOURCE_IS_TARGET' })
+    expect(fake.writes()).toBe(writesAfterSwitch)
+    expect(fake.currentConfig(sourceConfig.id)?.isEnabled).toBe(false)
+    expect(fake.currentConfig(prepared.entries[0]!.target.id)?.isEnabled).toBe(
+      true
+    )
+
+    fake.replaceSourceServer(compatibilitySourceServer)
+    await expect(
+      rollbackCohortActivation(fake.store, switched)
+    ).resolves.toMatchObject({ state: 'rolled_back' })
+  })
+
+  it.each<JsonValue>([
+    { source: true },
+    { required: false, toolAlias: 'doc_query' },
+    { required: true, toolAlias: 'legacy_doc_query' },
+    { required: true, toolAlias: 'doc_query', extra: true },
+    ['doc_query'],
+  ])('refuses unsafe source parameters before writing: %j', async (parameters) => {
+    const fake = fakeStore()
+    const unsafe = { ...sourceConfig, parameters }
     fake.replaceConfig(unsafe)
     await expect(
       prepareCohortActivation(fake.store, makeManifest(), {
@@ -1098,6 +2081,504 @@ describe('cohort activation contract', () => {
     expect(() => validateReceipt(changed)).toThrow(
       expect.objectContaining({ code: 'RECEIPT_INVALID' })
     )
+  })
+})
+
+describe('cohort activation rollback re-entry', () => {
+  it('refuses a source mode added after preparation before any switch writes', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest, rolledBack } = fixture
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      const predecessorBytes = await readFile(predecessorPath)
+      const writesBefore = fake.writes()
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          successorPath,
+          {
+            afterPrepared: async () => {
+              fake.replaceConfig({
+                ...fake.currentConfig(sourceConfig.id)!,
+                id: '00000000-0000-4000-8000-000000000099',
+                chatMode: 'new-mode',
+              })
+            },
+          }
+        )
+      ).rejects.toMatchObject({ code: 'PARTIAL_MODE_COVERAGE' })
+      expect(fake.writes()).toBe(writesBefore)
+      for (const entry of rolledBack.entries) {
+        expect(fake.currentConfig(entry.prior.id)?.isEnabled).toBe(true)
+        expect(fake.currentConfig(entry.target.id)?.isEnabled).toBe(false)
+      }
+      expect(await readFile(predecessorPath)).toEqual(predecessorBytes)
+      expect(JSON.parse(await readFile(successorPath, 'utf8')).state).toBe(
+        'switching'
+      )
+      expect(
+        await readFile(
+          cohortActivationReentryClaimPath(predecessorPath),
+          'utf8'
+        )
+      ).not.toBe('')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('reuses the rolled-back bindings, preserves lineage, and allows rollback', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest, rolledBack } = fixture
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      const predecessorBytes = await readFile(predecessorPath)
+      const writesBefore = fake.writes()
+      let reentryPrepared: CohortActivationReceipt | undefined
+      const switched = await executeCohortActivationReentry(
+        fake.store,
+        manifest,
+        predecessorPath,
+        successorPath,
+        {
+          afterPrepared: async (receipt) => {
+            reentryPrepared = receipt
+          },
+        }
+      )
+
+      expect(switched.state).toBe('switched')
+      expect(reentryPrepared?.entries[0]?.target.updatedAt).toBe(
+        rolledBack.entries[0]!.target.updatedAt
+      )
+      expect(reentryPrepared?.targetServer.updatedAt).toBe(
+        rolledBack.targetServer.updatedAt
+      )
+      expect(switched.reentry?.predecessorPayloadDigest).toBe(
+        rolledBack.payloadDigest
+      )
+      expect(switched.reentry?.claimDigest).toMatch(/^[0-9a-f]{64}$/)
+      expect(fake.writes()).toBe(writesBefore + 4)
+      expect(fake.targetConfigCount()).toBe(2)
+      expect(fake.currentTarget()?.id).toBe(rolledBack.targetServer.id)
+      expect(switched.entries.map(({ target }) => target.id)).toEqual(
+        rolledBack.entries.map(({ target }) => target.id)
+      )
+      expect(switched.entries[0]!.prior.updatedAt).not.toBe(
+        rolledBack.entries[0]!.prior.updatedAt
+      )
+      expect(await readFile(predecessorPath)).toEqual(predecessorBytes)
+
+      const rolledBackSuccessor = await rollbackCohortActivation(
+        fake.store,
+        switched
+      )
+      await writeReceipt(
+        successorPath,
+        rolledBackSuccessor,
+        receiptExpectation(switched)
+      )
+      expect(rolledBackSuccessor.state).toBe('rolled_back')
+      expect(rolledBackSuccessor.reentry).toEqual(switched.reentry)
+      expect(await readFile(predecessorPath)).toEqual(predecessorBytes)
+      await expect(
+        readCohortActivationState(fake.store, rolledBackSuccessor)
+      ).resolves.toMatchObject({
+        state: 'rolled_back',
+        sourceEnabled: 2,
+        targetDisabled: 2,
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses replay with the same or a different successor path', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest } = fixture
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-activation-replay-'))
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+    const differentSuccessorPath = join(directory, 'different.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      await executeCohortActivationReentry(
+        fake.store,
+        manifest,
+        predecessorPath,
+        successorPath
+      )
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          successorPath
+        )
+      ).rejects.toMatchObject({ code: 'REENTRY_SUCCESSOR_EXISTS' })
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          differentSuccessorPath
+        )
+      ).rejects.toMatchObject({ code: 'REENTRY_CLAIM_MISMATCH' })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects lineage in ordinary prepare, recovery, and clear paths', async () => {
+    const { fake, manifest, rolledBack } = await rolledBackReentryFixture()
+    const intent = makeCohortActivationReentryReceiptIntent(
+      manifest,
+      rolledBack,
+      {
+        predecessorPayloadDigest: rolledBack.payloadDigest,
+        claimDigest: 'a'.repeat(64),
+      }
+    )
+
+    await expect(
+      prepareCohortActivation(fake.store, manifest, { intent })
+    ).rejects.toMatchObject({ code: 'REENTRY_NOT_ALLOWED' })
+    await expect(
+      recoverPreparedCohortActivation(fake.store, manifest, intent)
+    ).rejects.toMatchObject({ code: 'REENTRY_NOT_ALLOWED' })
+    await expect(
+      assertCohortActivationNotPrepared(fake.store, manifest, intent)
+    ).rejects.toMatchObject({ code: 'REENTRY_NOT_ALLOWED' })
+
+    const directory = await mkdtemp(join(tmpdir(), 'cohort-reentry-clear-'))
+    const path = join(directory, 'intent.json')
+    try {
+      await writeReceipt(path, intent, null)
+      const before = await readFile(path)
+      await expect(
+        clearPreparingReceipt(path, receiptExpectation(intent)!)
+      ).rejects.toMatchObject({ code: 'REENTRY_NOT_ALLOWED' })
+      expect(await readFile(path)).toEqual(before)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses a changed manifest, incomplete inventory, and lineage predecessor', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-contract-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      await expect(
+        executeCohortActivationReentry(
+          fixture.fake.store,
+          makeManifest([sourceConfig]),
+          predecessorPath,
+          join(directory, 'changed-manifest.json')
+        )
+      ).rejects.toMatchObject({ code: 'RECEIPT_MANIFEST_MISMATCH' })
+
+      const incompleteFake = fakeStore()
+      const incompleteManifest = makeManifest()
+      const incompletePrepared = await prepareCohortActivation(
+        incompleteFake.store,
+        incompleteManifest,
+        { encryptedBearer: 'encrypted-synthetic-bearer' }
+      )
+      const incompleteSwitched = await switchCohortActivation(
+        incompleteFake.store,
+        incompletePrepared
+      )
+      const incompleteRolledBack = await rollbackCohortActivation(
+        incompleteFake.store,
+        incompleteSwitched
+      )
+      const incompletePath = join(directory, 'incomplete.json')
+      await writeFile(incompletePath, JSON.stringify(incompleteRolledBack))
+      await expect(
+        executeCohortActivationReentry(
+          incompleteFake.store,
+          incompleteManifest,
+          incompletePath,
+          join(directory, 'incomplete-successor.json')
+        )
+      ).rejects.toMatchObject({ code: 'REENTRY_INVENTORY_MISMATCH' })
+
+      const successorPath = join(directory, 'successor.json')
+      await executeCohortActivationReentry(
+        fixture.fake.store,
+        fixture.manifest,
+        predecessorPath,
+        successorPath
+      )
+      const lineageRolledBack = await rollbackCohortActivation(
+        fixture.fake.store,
+        JSON.parse(await readFile(successorPath, 'utf8'))
+      )
+      const lineagePath = join(directory, 'lineage-predecessor.json')
+      await writeFile(lineagePath, JSON.stringify(lineageRolledBack))
+      await expect(
+        executeCohortActivationReentry(
+          fixture.fake.store,
+          fixture.manifest,
+          lineagePath,
+          join(directory, 'lineage-successor.json')
+        )
+      ).rejects.toMatchObject({ code: 'REENTRY_PREDECESSOR_INVALID' })
+      expect(() =>
+        assertCohortActivationReentryRoot(lineageRolledBack)
+      ).toThrow(
+        expect.objectContaining({ code: 'REENTRY_PREDECESSOR_INVALID' })
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it.each<
+    [
+      string,
+      (
+        fake: ReturnType<typeof fakeStore>,
+        rolledBack: Awaited<
+          ReturnType<typeof rolledBackReentryFixture>
+        >['rolledBack']
+      ) => void,
+      string,
+    ]
+  >([
+    [
+      'disabled source',
+      (fake) =>
+        fake.replaceConfig({
+          ...fake.currentConfig(sourceConfig.id)!,
+          isEnabled: false,
+        }),
+      'SOURCE_MISMATCH',
+    ],
+    [
+      'changed source content',
+      (fake) =>
+        fake.replaceConfig({
+          ...fake.currentConfig(sourceConfig.id)!,
+          priority: 9,
+        }),
+      'SOURCE_DRIFT',
+    ],
+    [
+      'enabled target',
+      (fake, rolledBack) =>
+        fake.replaceConfig({
+          ...fake.currentConfig(rolledBack.entries[0]!.target.id)!,
+          isEnabled: true,
+        }),
+      'TARGET_DRIFT',
+    ],
+    [
+      'changed target timestamp',
+      (fake, rolledBack) =>
+        fake.replaceConfig({
+          ...fake.currentConfig(rolledBack.entries[0]!.target.id)!,
+          updatedAt: new Date('2026-08-24T10:00:00.999Z'),
+        }),
+      'TARGET_DRIFT',
+    ],
+    [
+      'changed target server timestamp',
+      (fake) =>
+        fake.replaceTargetServer({
+          ...fake.currentTarget()!,
+          updatedAt: new Date('2026-08-24T10:00:00.999Z'),
+        }),
+      'TARGET_SERVER_DRIFT',
+    ],
+  ])('refuses %s before claiming', async (_name, mutate, code) => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest, rolledBack } = fixture
+    mutate(fake, rolledBack)
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-drift-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      const predecessorBytes = await readFile(predecessorPath)
+      const writesBefore = fake.writes()
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          successorPath
+        )
+      ).rejects.toMatchObject({ code })
+      expect(fake.writes()).toBe(writesBefore)
+      await expect(readFile(successorPath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      await expect(
+        readFile(cohortActivationReentryClaimPath(predecessorPath))
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+      expect(await readFile(predecessorPath)).toEqual(predecessorBytes)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects equal and symlink-ambiguous receipt paths', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest } = fixture
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-path-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const symlinkPath = join(directory, 'symlink.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      await expect(
+        resolveCohortActivationReentryPaths(predecessorPath, predecessorPath)
+      ).rejects.toMatchObject({ code: 'REENTRY_PATH_AMBIGUOUS' })
+      await symlink(predecessorPath, symlinkPath)
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          symlinkPath
+        )
+      ).rejects.toMatchObject({ code: 'REENTRY_PATH_AMBIGUOUS' })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('allows only one competing re-entry session', async () => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest } = fixture
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-concurrency-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const firstSuccessorPath = join(directory, 'first.json')
+    const secondSuccessorPath = join(directory, 'second.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      const results = await Promise.allSettled([
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          firstSuccessorPath
+        ),
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          secondSuccessorPath
+        ),
+      ])
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      expect(
+        results.filter((result) => result.status === 'rejected')
+      ).toHaveLength(1)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    'claim',
+    'intent',
+    'prepared',
+  ] as const)('retains evidence when a crash occurs after the %s boundary', async (boundary) => {
+    const fixture = await rolledBackReentryFixture()
+    const { fake, manifest, rolledBack } = fixture
+    const directory = await mkdtemp(
+      join(tmpdir(), 'cohort-activation-reentry-crash-')
+    )
+    const predecessorPath = join(directory, 'predecessor.json')
+    const successorPath = join(directory, 'successor.json')
+
+    try {
+      await writeRolledBackReceipt(predecessorPath, fixture)
+      const predecessorBytes = await readFile(predecessorPath)
+      const writesBefore = fake.writes()
+      const crash = async () => {
+        throw new Error('simulated crash')
+      }
+      const hooks =
+        boundary === 'claim'
+          ? { afterClaim: crash }
+          : boundary === 'intent'
+            ? { afterIntent: crash }
+            : { afterPrepared: crash }
+      await expect(
+        executeCohortActivationReentry(
+          fake.store,
+          manifest,
+          predecessorPath,
+          successorPath,
+          hooks
+        )
+      ).rejects.toThrow('simulated crash')
+      const claimPath = cohortActivationReentryClaimPath(predecessorPath)
+      const claimBytes = await readFile(claimPath, 'utf8')
+      const claim = JSON.parse(claimBytes)
+      validateCohortActivationReentryClaim(claim, {
+        predecessorPath,
+        successorPath,
+      })
+      expect(claim.predecessorPayloadDigest).toBe(rolledBack.payloadDigest)
+      for (const nextPath of [successorPath, join(directory, 'retry.json')]) {
+        await expect(
+          executeCohortActivationReentry(
+            fake.store,
+            manifest,
+            predecessorPath,
+            nextPath
+          )
+        ).rejects.toThrow()
+      }
+      expect(fake.writes()).toBe(writesBefore)
+      expect(await readFile(claimPath, 'utf8')).toBe(claimBytes)
+      if (boundary === 'claim') {
+        await expect(readFile(successorPath)).rejects.toMatchObject({
+          code: 'ENOENT',
+        })
+      } else {
+        const successor = JSON.parse(await readFile(successorPath, 'utf8'))
+        expect(successor.state).toBe(
+          boundary === 'intent' ? 'preparing' : 'prepared'
+        )
+      }
+      expect(await readFile(predecessorPath)).toEqual(predecessorBytes)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
@@ -2313,6 +2313,12 @@ export function assertReceiptTransition(
   current: CohortActivationReceiptFile | null,
   next: CohortActivationReceiptFile
 ): void {
+  if (expected !== null && current === null) {
+    fail(
+      'RECEIPT_CONCURRENT_WRITE',
+      'receipt disappeared before the expected transition'
+    )
+  }
   if (
     expected &&
     (!inactiveSourceEqual(expected.inactiveSource, current?.inactiveSource) ||
@@ -2340,12 +2346,6 @@ export function assertReceiptTransition(
       )
     }
     return
-  }
-  if (current === null) {
-    fail(
-      'RECEIPT_CONCURRENT_WRITE',
-      'receipt disappeared before the expected transition'
-    )
   }
   validateReceiptFile(current)
   if (

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
@@ -328,6 +328,12 @@ function compareStrings(left: string, right: string): number {
   return left.localeCompare(right)
 }
 
+function trimTrailingSlashes(pathname: string): string {
+  let end = pathname.length
+  while (end > 0 && pathname[end - 1] === '/') end -= 1
+  return pathname.slice(0, end)
+}
+
 function cloneJson(value: JsonValue): JsonValue {
   if (value === null || typeof value !== 'object') return value
   return structuredClone(value)
@@ -422,10 +428,11 @@ function canonicalSourcePin<
   if (value.rollbackMode !== rollbackMode) {
     fail(invalidCode, 'source exception rollback mode is malformed')
   }
+  configIds.sort(compareStrings)
   return {
     sourceServerId,
     chatbotId,
-    configIds: configIds.sort(compareStrings),
+    configIds,
     snapshotDigest: value.snapshotDigest.toLowerCase(),
     rollbackMode: rollbackMode,
   }
@@ -1196,7 +1203,7 @@ function assertInactiveSourceSnapshot(
   if (
     server.name === target.serverName ||
     server.description?.trim() === DOC_QUERY_TARGET_DESCRIPTION ||
-    new URL(server.url).pathname.replace(/\/+$/, '') === target.routePath
+    trimTrailingSlashes(new URL(server.url).pathname) === target.routePath
   ) {
     fail('SOURCE_IS_TARGET', 'inactive source is a managed or shared target')
   }

--- a/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
+++ b/packages/prisma-data/src/scripts/doc-query-cohort-activation.ts
@@ -8,7 +8,10 @@ export const DOC_QUERY_TARGET_DESCRIPTION =
 export const DOC_QUERY_TARGET_URL =
   'http://mcp-doc-query.prd-doc-query.svc.cluster.local:1417/mcp/klicker' as const
 export const DOC_QUERY_TARGET_SCOPE = 'prd-klicker' as const
+const DOC_QUERY_COMPATIBILITY_SERVER_NAME = 'Klicker-compat' as const
 export const COHORT_ACTIVATION_RECEIPT_VERSION = 1 as const
+export const COHORT_ACTIVATION_INACTIVE_SOURCE_ROLLBACK_MODE =
+  'preserve-inactive' as const
 /** Name of the explicit, values-free approval pin supplied to the runner. */
 export const COHORT_ACTIVATION_MANIFEST_FINGERPRINT_ENV =
   'DOC_QUERY_COHORT_ACTIVATION_MANIFEST_FINGERPRINT' as const
@@ -152,6 +155,19 @@ export type CohortActivationTargetContract = {
   url: string
 }
 
+export type CohortActivationInactiveSource = {
+  sourceServerId: string
+  chatbotId: string
+  configIds: string[]
+  snapshotDigest: string
+  rollbackMode: typeof COHORT_ACTIVATION_INACTIVE_SOURCE_ROLLBACK_MODE
+}
+
+export type CohortActivationActiveSource = Omit<
+  CohortActivationInactiveSource,
+  'rollbackMode'
+> & { rollbackMode: 'preserve-active' }
+
 export type CohortActivationManifestEntry = {
   configId: string
   chatbotId: string
@@ -174,6 +190,8 @@ export type CohortActivationManifest = {
   target: CohortActivationTargetContract
   entries: CohortActivationManifestEntry[]
   heldConfigIds: string[]
+  inactiveSource?: CohortActivationInactiveSource
+  activeSources?: CohortActivationActiveSource[]
   /** Canonical exclusion names are required; this alias eases handoff parsing. */
   excludedCorpora?: string[]
   exclusions?: string[]
@@ -211,17 +229,25 @@ export type CohortActivationReceiptState =
   | 'rolling_back'
   | 'rolled_back'
 
+export type CohortActivationReentryLineage = {
+  predecessorPayloadDigest: string
+  claimDigest: string
+}
+
 export type CohortActivationReceipt = {
   receiptVersion: typeof COHORT_ACTIVATION_RECEIPT_VERSION
   manifestFingerprint: string
   target: CohortActivationTargetContract
   targetServer: SafeServerSnapshot
   heldConfigIds: string[]
+  inactiveSource?: CohortActivationInactiveSource
+  activeSources?: CohortActivationActiveSource[]
   excludedCorpora: string[]
   excludedConfigIds: string[]
   entries: CohortActivationReceiptEntry[]
   switchedChatbotIds: string[]
   state: CohortActivationReceiptState
+  reentry?: CohortActivationReentryLineage
   payloadDigest: string
 }
 
@@ -233,9 +259,12 @@ export type CohortActivationReceiptIntent = {
   targetServerId: string | null
   targetConfigIds: Record<string, string>
   heldConfigIds: string[]
+  inactiveSource?: CohortActivationInactiveSource
+  activeSources?: CohortActivationActiveSource[]
   excludedCorpora: string[]
   excludedConfigIds: string[]
   state: 'preparing'
+  reentry?: CohortActivationReentryLineage
   payloadDigest: string
 }
 
@@ -247,6 +276,9 @@ export type CohortActivationReceiptExpectation = {
   manifestFingerprint: string
   payloadDigest: string
   state: CohortActivationReceiptFile['state']
+  inactiveSource?: CohortActivationInactiveSource
+  activeSources?: CohortActivationActiveSource[]
+  reentry?: CohortActivationReentryLineage
 } | null
 
 export type CohortActivationPrepareOptions = {
@@ -339,6 +371,188 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value)
+}
+
+function canonicalSourcePin<
+  Mode extends 'preserve-inactive' | 'preserve-active',
+>(
+  value: unknown,
+  rollbackMode: Mode,
+  field: string,
+  invalidCode: 'INVALID_MANIFEST' | 'RECEIPT_INVALID' = 'INVALID_MANIFEST'
+): Omit<CohortActivationInactiveSource, 'rollbackMode'> & {
+  rollbackMode: Mode
+} {
+  const fields = [
+    'sourceServerId',
+    'chatbotId',
+    'configIds',
+    'snapshotDigest',
+    'rollbackMode',
+  ] as const
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length !== fields.length ||
+    fields.some((field) => !Object.hasOwn(value, field))
+  ) {
+    fail(invalidCode, 'source exception is malformed')
+  }
+  const sourceServerId = normalizeUuid(
+    value.sourceServerId as string,
+    `${field}.sourceServerId`
+  )
+  const chatbotId = normalizeUuid(
+    value.chatbotId as string,
+    `${field}.chatbotId`
+  )
+  if (!Array.isArray(value.configIds) || value.configIds.length !== 2) {
+    fail(invalidCode, 'source exception must contain exactly two config ids')
+  }
+  const configIds = value.configIds.map((configId) =>
+    normalizeUuid(configId as string, `${field}.configIds`)
+  )
+  if (new Set(configIds).size !== configIds.length) {
+    fail(invalidCode, 'source exception config ids must be distinct')
+  }
+  if (!isSha256(value.snapshotDigest)) {
+    fail(invalidCode, 'source exception snapshot digest is malformed')
+  }
+  if (value.rollbackMode !== rollbackMode) {
+    fail(invalidCode, 'source exception rollback mode is malformed')
+  }
+  return {
+    sourceServerId,
+    chatbotId,
+    configIds: configIds.sort(compareStrings),
+    snapshotDigest: value.snapshotDigest.toLowerCase(),
+    rollbackMode: rollbackMode,
+  }
+}
+
+function canonicalInactiveSource(
+  value: unknown,
+  invalidCode: 'INVALID_MANIFEST' | 'RECEIPT_INVALID' = 'INVALID_MANIFEST'
+): CohortActivationInactiveSource | undefined {
+  return value === undefined
+    ? undefined
+    : canonicalSourcePin(
+        value,
+        COHORT_ACTIVATION_INACTIVE_SOURCE_ROLLBACK_MODE,
+        'inactiveSource',
+        invalidCode
+      )
+}
+
+function canonicalActiveSources(
+  value: unknown,
+  invalidCode: 'INVALID_MANIFEST' | 'RECEIPT_INVALID' = 'INVALID_MANIFEST'
+): CohortActivationActiveSource[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || value.length !== 2) {
+    fail(invalidCode, 'active sources must contain exactly two source pins')
+  }
+  const pins = value
+    .map((item) =>
+      canonicalSourcePin(item, 'preserve-active', 'activeSources', invalidCode)
+    )
+    .sort((left, right) =>
+      compareStrings(left.sourceServerId, right.sourceServerId)
+    )
+  assertSourcePinSeparation(undefined, pins)
+  return pins
+}
+
+function assertSourcePinSeparation(
+  inactive: CohortActivationInactiveSource | undefined,
+  active: CohortActivationActiveSource[] | undefined
+): void {
+  const pins = [...(inactive ? [inactive] : []), ...(active ?? [])]
+  const sourceIds = pins.map((pin) => pin.sourceServerId)
+  const configIds = pins.flatMap((pin) => pin.configIds)
+  if (
+    new Set(sourceIds).size !== sourceIds.length ||
+    new Set(configIds).size !== configIds.length
+  ) {
+    fail('INVALID_MANIFEST', 'source exceptions overlap')
+  }
+}
+
+function activeSourcesEqual(
+  left: CohortActivationActiveSource[] | undefined,
+  right: CohortActivationActiveSource[] | undefined
+): boolean {
+  return (
+    JSON.stringify(canonicalActiveSources(left)) ===
+    JSON.stringify(canonicalActiveSources(right))
+  )
+}
+
+function activeSourceFields(value: CohortActivationActiveSource[] | undefined) {
+  const activeSources = canonicalActiveSources(value)
+  return activeSources ? { activeSources } : {}
+}
+
+function inactiveSourceEqual(
+  left: CohortActivationInactiveSource | undefined,
+  right: CohortActivationInactiveSource | undefined
+): boolean {
+  return (
+    JSON.stringify(canonicalInactiveSource(left)) ===
+    JSON.stringify(canonicalInactiveSource(right))
+  )
+}
+
+function inactiveSourceFields(
+  value: CohortActivationInactiveSource | undefined
+) {
+  const inactiveSource = canonicalInactiveSource(value)
+  return inactiveSource ? { inactiveSource } : {}
+}
+
+function canonicalJson(value: JsonValue): string {
+  if (value === null || typeof value !== 'object') {
+    const encoded = JSON.stringify(value)
+    if (encoded === undefined) fail('INVALID_MANIFEST', 'value is not JSON')
+    return encoded
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`
+  }
+  const record = value as { [key: string]: JsonValue }
+  return `{${Object.keys(record)
+    .sort(compareStrings)
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key]!)}`)
+    .join(',')}}`
+}
+
+function validateReentryLineage(
+  lineage: unknown
+): asserts lineage is CohortActivationReentryLineage {
+  if (
+    !isRecord(lineage) ||
+    !isSha256(lineage.predecessorPayloadDigest) ||
+    !isSha256(lineage.claimDigest) ||
+    Object.keys(lineage).length !== 2
+  ) {
+    fail(
+      'REENTRY_LINEAGE_INVALID',
+      'cohortActivation re-entry lineage is malformed'
+    )
+  }
+}
+
+function reentryLineageEqual(
+  left: CohortActivationReentryLineage | undefined,
+  right: CohortActivationReentryLineage | undefined
+): boolean {
+  return (
+    left?.predecessorPayloadDigest === right?.predecessorPayloadDigest &&
+    left?.claimDigest === right?.claimDigest
+  )
+}
+
 function normalizeUuid(value: string, field: string): string {
   assertUuid(value, field)
   return value.toLowerCase()
@@ -366,6 +580,20 @@ function isEmptyJsonObject(value: JsonValue): boolean {
   )
 }
 
+function isSafeSourceParameters(value: JsonValue): boolean {
+  if (value === null || isEmptyJsonObject(value)) return true
+  if (typeof value !== 'object' || Array.isArray(value)) return false
+
+  const keys = Object.keys(value)
+  return (
+    keys.length === 2 &&
+    Object.hasOwn(value, 'required') &&
+    Object.hasOwn(value, 'toolAlias') &&
+    value.required === true &&
+    value.toolAlias === DOC_QUERY_TOOL_ALIAS
+  )
+}
+
 function isSafeSourceAllowedTools(value: JsonValue): boolean {
   if (value === null) return true
   if (!Array.isArray(value)) return false
@@ -381,7 +609,7 @@ function assertSafeSourceReceiptFields(
   allowedTools: JsonValue,
   parameters: JsonValue
 ): void {
-  if (parameters !== null && !isEmptyJsonObject(parameters)) {
+  if (!isSafeSourceParameters(parameters)) {
     fail(
       'SOURCE_SHAPE_UNSUPPORTED',
       'source parameters are not safe to persist in a receipt'
@@ -399,6 +627,46 @@ function assertSafeSourceReceiptShape(
   config: CohortActivationConfigRecord
 ): void {
   assertSafeSourceReceiptFields(config.allowedTools, config.parameters)
+}
+
+function isPinnedCompatibilitySource(
+  server: CohortActivationServerRecord,
+  target: CohortActivationTargetContract
+): boolean {
+  return (
+    server.name === DOC_QUERY_COMPATIBILITY_SERVER_NAME &&
+    typeof server.description === 'string' &&
+    server.description.trim().length > 0 &&
+    server.description.trim() !== DOC_QUERY_TARGET_DESCRIPTION &&
+    server.url === target.url &&
+    server.authType === 'bearer' &&
+    server.passChatbotId === true &&
+    server.chatbotIdHeader === 'Chatbot-ID' &&
+    isEmptyJsonObject(server.parameters) &&
+    server.hasAuthSecret === true &&
+    server.isActive === true
+  )
+}
+
+function assertEligibleSourceServer(
+  server: CohortActivationServerRecord | null,
+  target: CohortActivationTargetContract,
+  inactiveSource?: CohortActivationInactiveSource,
+  activeSources?: CohortActivationActiveSource[]
+): void {
+  if (!server) {
+    fail('SOURCE_SERVER_MISSING', 'source server is missing')
+  }
+  const isPinnedInactiveSource =
+    inactiveSource?.sourceServerId === server.id.toLowerCase()
+  if (!server.isActive && !isPinnedInactiveSource) {
+    fail('SOURCE_SERVER_INACTIVE', 'source server is inactive')
+  }
+  const activePin = activeSources?.find(
+    (pin) => pin.sourceServerId === server.id.toLowerCase()
+  )
+  if (activePin) assertActiveSourceSnapshot(server, target, activePin)
+  else assertSourceServerRoute(server, target)
 }
 
 function snapshotConfig(
@@ -433,6 +701,14 @@ function snapshotServer(
     isActive: server.isActive,
     updatedAt: server.updatedAt.toISOString(),
   }
+}
+
+export function fingerprintSourceServerSnapshot(
+  server: CohortActivationServerRecord
+): string {
+  return createHash('sha256')
+    .update(canonicalJson(snapshotServer(server)))
+    .digest('hex')
 }
 
 function configContentEqual(
@@ -569,6 +845,7 @@ function entryTargetTool(entry: CohortActivationManifestEntry): string {
 function canonicalManifest(
   manifest: Omit<CohortActivationManifest, 'fingerprint'>
 ) {
+  const inactiveSource = canonicalInactiveSource(manifest.inactiveSource)
   return {
     target: manifest.target,
     entries: [...manifest.entries]
@@ -589,6 +866,8 @@ function canonicalManifest(
     heldConfigIds: [...manifest.heldConfigIds].sort(compareStrings),
     excludedCorpora: canonicalExclusionValues(manifest),
     excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    ...(inactiveSource ? { inactiveSource } : {}),
+    ...activeSourceFields(manifest.activeSources),
   }
 }
 
@@ -613,7 +892,7 @@ function canonicalExclusionValues(
 }
 
 function canonicalExcludedConfigIds(
-  manifest: CohortActivationManifest
+  manifest: Pick<CohortActivationManifest, 'excludedConfigIds'>
 ): string[] {
   return excludedConfigValues(manifest)
     .map((value) => normalizeUuid(value, 'excludedConfigIds'))
@@ -682,11 +961,14 @@ function makeReceiptFrom(
     target: receipt.target,
     targetServer: receipt.targetServer,
     heldConfigIds: receipt.heldConfigIds,
+    ...inactiveSourceFields(receipt.inactiveSource),
+    ...activeSourceFields(receipt.activeSources),
     excludedCorpora: receipt.excludedCorpora,
     excludedConfigIds: receipt.excludedConfigIds,
     entries: input.entries,
     switchedChatbotIds: input.switchedChatbotIds,
     state: input.state,
+    ...(receipt.reentry ? { reentry: receipt.reentry } : {}),
   })
 }
 
@@ -831,6 +1113,213 @@ function validateExcludedConfigIds(
   }
 }
 
+function assertPinnedSourceManifest(
+  manifest: CohortActivationManifest,
+  pin: CohortActivationInactiveSource | CohortActivationActiveSource,
+  held: Set<string>
+): void {
+  const excluded = new Set(canonicalExcludedConfigIds(manifest))
+  if (
+    pin.configIds.some(
+      (configId) => held.has(configId) || excluded.has(configId)
+    )
+  ) {
+    fail(
+      pin.rollbackMode === 'preserve-inactive'
+        ? 'INACTIVE_SOURCE_OVERLAP'
+        : 'ACTIVE_SOURCE_OVERLAP',
+      'pinned source configs overlap a held or excluded config'
+    )
+  }
+
+  const sourceEntries = manifest.entries.filter(
+    (entry) =>
+      normalizeUuid(entry.sourceServerId, 'entry.sourceServerId') ===
+      pin.sourceServerId
+  )
+  const matchingEntries = sourceEntries.filter(
+    (entry) =>
+      normalizeUuid(entry.chatbotId, 'entry.chatbotId') === pin.chatbotId
+  )
+  const manifestConfigIds = matchingEntries
+    .map((entry) => normalizeUuid(entry.configId, 'entry.configId'))
+    .sort(compareStrings)
+  if (
+    sourceEntries.length !== pin.configIds.length ||
+    matchingEntries.length !== pin.configIds.length ||
+    manifestConfigIds.some(
+      (configId, index) => configId !== pin.configIds[index]
+    )
+  ) {
+    fail(
+      pin.rollbackMode === 'preserve-inactive'
+        ? 'INACTIVE_SOURCE_INVENTORY_MISMATCH'
+        : 'ACTIVE_SOURCE_INVENTORY_MISMATCH',
+      'pinned source config ids do not exactly match the manifest'
+    )
+  }
+}
+
+function assertSourceServerRoute(
+  server: CohortActivationServerRecord,
+  target: CohortActivationTargetContract
+): void {
+  const requiresCompatibilityContract =
+    server.name === DOC_QUERY_COMPATIBILITY_SERVER_NAME ||
+    server.url === target.url ||
+    server.url.endsWith(DOC_QUERY_ROUTE_PATH)
+  if (
+    requiresCompatibilityContract &&
+    !isPinnedCompatibilitySource(server, target)
+  ) {
+    fail(
+      'SOURCE_IS_TARGET',
+      'source does not match the pinned compatibility server contract'
+    )
+  }
+}
+
+function assertInactiveSourceSnapshot(
+  server: CohortActivationServerRecord,
+  target: CohortActivationTargetContract,
+  inactiveSource: CohortActivationInactiveSource
+): void {
+  if (server.id.toLowerCase() !== inactiveSource.sourceServerId) {
+    fail(
+      'INACTIVE_SOURCE_ID_MISMATCH',
+      'inactive source server does not match the pinned identity'
+    )
+  }
+  if (server.isActive) {
+    fail('INACTIVE_SOURCE_ACTIVE', 'inactive source server is active')
+  }
+  if (
+    server.name === target.serverName ||
+    server.description?.trim() === DOC_QUERY_TARGET_DESCRIPTION ||
+    new URL(server.url).pathname.replace(/\/+$/, '') === target.routePath
+  ) {
+    fail('SOURCE_IS_TARGET', 'inactive source is a managed or shared target')
+  }
+  assertSourceServerRoute(server, target)
+  if (
+    fingerprintSourceServerSnapshot(server) !== inactiveSource.snapshotDigest
+  ) {
+    fail(
+      'INACTIVE_SOURCE_SNAPSHOT_MISMATCH',
+      'inactive source server differs from the pinned safe snapshot'
+    )
+  }
+}
+
+function assertActiveSourceSnapshot(
+  server: CohortActivationServerRecord,
+  target: CohortActivationTargetContract,
+  pin: CohortActivationActiveSource
+): void {
+  if (!server.isActive)
+    fail('ACTIVE_SOURCE_INACTIVE', 'pinned active source is inactive')
+  if (
+    server.id.toLowerCase() !== pin.sourceServerId ||
+    server.url !== target.url ||
+    server.name === target.serverName ||
+    server.description?.trim() === DOC_QUERY_TARGET_DESCRIPTION ||
+    server.name === DOC_QUERY_COMPATIBILITY_SERVER_NAME ||
+    server.authType !== 'bearer' ||
+    !server.hasAuthSecret ||
+    server.passChatbotId !== false ||
+    (server.parameters !== null && !isEmptyJsonObject(server.parameters))
+  ) {
+    fail(
+      'ACTIVE_SOURCE_CONTRACT_MISMATCH',
+      'active source differs from the pinned alias contract'
+    )
+  }
+  if (fingerprintSourceServerSnapshot(server) !== pin.snapshotDigest) {
+    fail(
+      'ACTIVE_SOURCE_SNAPSHOT_MISMATCH',
+      'active source differs from the pinned safe snapshot'
+    )
+  }
+}
+
+type CohortActivationSourceValidationInput = Pick<
+  CohortActivationManifest,
+  | 'target'
+  | 'entries'
+  | 'heldConfigIds'
+  | 'excludedConfigIds'
+  | 'inactiveSource'
+  | 'activeSources'
+>
+
+async function assertSourceExceptionsState(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationSourceValidationInput
+): Promise<void> {
+  const inactive = canonicalInactiveSource(manifest.inactiveSource)
+  if (inactive) {
+    const server = await tx.findServerById(inactive.sourceServerId)
+    if (!server)
+      fail('SOURCE_SERVER_MISSING', 'inactive source server is missing')
+    assertInactiveSourceSnapshot(server, manifest.target, inactive)
+    await assertPinnedSourceInventory(tx, manifest, inactive)
+  }
+  for (const pin of canonicalActiveSources(manifest.activeSources) ?? []) {
+    const server = await tx.findServerById(pin.sourceServerId)
+    if (!server)
+      fail('SOURCE_SERVER_MISSING', 'active source server is missing')
+    assertActiveSourceSnapshot(server, manifest.target, pin)
+    await assertPinnedSourceInventory(tx, manifest, pin)
+  }
+}
+
+async function assertPinnedSourceInventory(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationSourceValidationInput,
+  pin: CohortActivationInactiveSource | CohortActivationActiveSource
+): Promise<void> {
+  const sourceConfigs = await tx.findConfigsByServerId(pin.sourceServerId)
+  const expectedConfigIds = new Set(pin.configIds)
+  const manifestEntries = new Map(
+    manifest.entries.map((entry) => [
+      normalizeUuid(entry.configId, 'entry.configId'),
+      entry,
+    ])
+  )
+  const actualConfigIds = sourceConfigs.map((config) =>
+    normalizeUuid(config.id, 'pin.configIds')
+  )
+  if (
+    actualConfigIds.length !== expectedConfigIds.size ||
+    new Set(actualConfigIds).size !== actualConfigIds.length ||
+    actualConfigIds.some((configId) => !expectedConfigIds.has(configId)) ||
+    sourceConfigs.some((config) => {
+      const configId = normalizeUuid(config.id, 'pin.configIds')
+      const entry = manifestEntries.get(configId)
+      return (
+        !entry ||
+        normalizeUuid(config.chatbotId, 'pin.chatbotId') !== pin.chatbotId ||
+        config.chatMode !== entry.chatMode ||
+        normalizeUuid(config.mcpServerId, 'pin.sourceServerId') !==
+          pin.sourceServerId ||
+        normalizeUuid(entry.sourceServerId, 'entry.sourceServerId') !==
+          pin.sourceServerId ||
+        normalizeUuid(entry.chatbotId, 'entry.chatbotId') !== pin.chatbotId
+      )
+    })
+  ) {
+    fail(
+      pin.rollbackMode === 'preserve-inactive'
+        ? 'INACTIVE_SOURCE_INVENTORY_MISMATCH'
+        : 'ACTIVE_SOURCE_INVENTORY_MISMATCH',
+      'pinned source inventory does not contain exactly the pinned configs'
+    )
+  }
+  for (const config of sourceConfigs) {
+    assertSafeSourceReceiptShape(config)
+  }
+}
+
 export function validateManifest(manifest: CohortActivationManifest): void {
   assertManifestShape(manifest)
   assertNamedExclusions(manifest)
@@ -838,6 +1327,15 @@ export function validateManifest(manifest: CohortActivationManifest): void {
   const held = validateHeldConfigIds(manifest, configIds)
   validateExcludedConfigIds(manifest, configIds, held)
   assertCorpusOwnership(manifest)
+  const inactiveSource = canonicalInactiveSource(manifest.inactiveSource)
+  if (inactiveSource) {
+    assertPinnedSourceManifest(manifest, inactiveSource, held)
+  }
+
+  const activeSources = canonicalActiveSources(manifest.activeSources)
+  assertSourcePinSeparation(inactiveSource, activeSources)
+  for (const pin of activeSources ?? [])
+    assertPinnedSourceManifest(manifest, pin, held)
 
   const expectedFingerprint = fingerprintManifest(manifest)
   if (manifest.fingerprint !== expectedFingerprint) {
@@ -865,6 +1363,15 @@ export function assertReceiptMatchesManifest(
   manifest: CohortActivationManifest
 ): void {
   validateReceipt(receipt)
+  if (
+    !inactiveSourceEqual(receipt.inactiveSource, manifest.inactiveSource) ||
+    !activeSourcesEqual(receipt.activeSources, manifest.activeSources)
+  ) {
+    fail(
+      'RECEIPT_MANIFEST_MISMATCH',
+      'receipt source exceptions differ from manifest'
+    )
+  }
   if (receipt.manifestFingerprint !== manifest.fingerprint) {
     fail('RECEIPT_MANIFEST_MISMATCH', 'receipt does not match the manifest')
   }
@@ -1002,7 +1509,10 @@ async function assertTargetConfigAvailable(
 
 async function assertCompleteModeCoverage(
   tx: CohortActivationTransactionStore,
-  manifest: CohortActivationManifest
+  manifest: Pick<
+    CohortActivationManifest,
+    'entries' | 'heldConfigIds' | 'excludedConfigIds'
+  >
 ): Promise<void> {
   const held = new Set(
     manifest.heldConfigIds.map((id) => normalizeUuid(id, 'heldConfigIds'))
@@ -1050,6 +1560,7 @@ async function readSourceEntries(
 ): Promise<
   Array<{ manifest: CohortActivationManifestEntry; prior: SafeConfigSnapshot }>
 > {
+  await assertSourceExceptionsState(tx, manifest)
   const entries: Array<{
     manifest: CohortActivationManifestEntry
     prior: SafeConfigSnapshot
@@ -1066,24 +1577,92 @@ async function readSourceEntries(
       fail('SOURCE_MISMATCH', 'source config no longer matches manifest')
     }
     const sourceServer = await tx.findServerById(entry.sourceServerId)
-    if (!sourceServer) fail('SOURCE_SERVER_MISSING', 'source server is missing')
-    if (!sourceServer.isActive) {
-      fail('SOURCE_SERVER_INACTIVE', 'source server is inactive')
-    }
+    assertEligibleSourceServer(
+      sourceServer,
+      manifest.target,
+      canonicalInactiveSource(manifest.inactiveSource),
+      canonicalActiveSources(manifest.activeSources)
+    )
     assertSafeSourceReceiptShape(source)
-    if (
-      sourceServer.url === manifest.target.url ||
-      sourceServer.url.endsWith(DOC_QUERY_ROUTE_PATH)
-    ) {
-      fail(
-        'SOURCE_IS_TARGET',
-        'test-route source cannot enter this cohortActivation'
-      )
-    }
     entries.push({ manifest: entry, prior: snapshotConfig(source) })
   }
   await assertCompleteModeCoverage(tx, manifest)
   return entries
+}
+
+type ReentryPreparedState = {
+  targetServer: SafeServerSnapshot
+  entries: CohortActivationReceiptEntry[]
+}
+
+async function readReentryPreparedState(
+  tx: CohortActivationTransactionStore,
+  manifest: CohortActivationManifest,
+  predecessor: CohortActivationReceipt
+): Promise<ReentryPreparedState> {
+  const sourceEntries = await readSourceEntries(tx, manifest)
+  const targetServer = await tx.findServerById(predecessor.targetServer.id)
+  const targetByName = await tx.findServerByName(manifest.target.serverName)
+  if (
+    !targetServer ||
+    !targetByName ||
+    targetByName.id.toLowerCase() !== targetServer.id.toLowerCase() ||
+    !serverSnapshotEqual(targetServer, predecessor.targetServer) ||
+    !serverSnapshotEqual(targetByName, predecessor.targetServer)
+  ) {
+    fail('TARGET_SERVER_DRIFT', 'target server changed before re-entry')
+  }
+  assertTargetServer(targetServer, manifest.target)
+
+  const predecessorEntries = new Map(
+    predecessor.entries.map((item) => [item.manifest.configId, item])
+  )
+  const entries: CohortActivationReceiptEntry[] = []
+  for (const { manifest: entry, prior: source } of sourceEntries) {
+    const predecessorEntry = predecessorEntries.get(entry.configId)
+    if (
+      !predecessorEntry ||
+      !configContentEqual(
+        {
+          ...source,
+          updatedAt: new Date(source.updatedAt),
+        },
+        predecessorEntry.prior
+      )
+    ) {
+      fail('SOURCE_DRIFT', 'source config changed before re-entry')
+    }
+    const target = await tx.findConfigById(predecessorEntry.target.id)
+    if (
+      !target ||
+      !configSnapshotEqual(target, predecessorEntry.target) ||
+      target.isEnabled
+    ) {
+      fail('TARGET_DRIFT', 'target config changed before re-entry')
+    }
+    entries.push({
+      manifest: entry,
+      prior: snapshotConfig({
+        ...source,
+        updatedAt: new Date(source.updatedAt),
+      }),
+      target: snapshotConfig(target),
+    })
+  }
+  return { targetServer: snapshotServer(targetServer), entries }
+}
+
+export async function assertCohortActivationReentryPreconditions(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  predecessor: CohortActivationReceipt
+): Promise<void> {
+  validateManifest(manifest)
+  assertReceiptMatchesManifest(predecessor, manifest)
+  assertCohortActivationReentryRoot(predecessor)
+  await store.transaction(async (tx) => {
+    await readReentryPreparedState(tx, manifest, predecessor)
+  })
 }
 
 function makeReceipt(
@@ -1116,6 +1695,8 @@ export function makeCohortActivationReceiptIntent(
     targetServerId,
     targetConfigIds,
     heldConfigIds: manifest.heldConfigIds,
+    ...inactiveSourceFields(manifest.inactiveSource),
+    ...activeSourceFields(manifest.activeSources),
     excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
     excludedConfigIds: canonicalExcludedConfigIds(manifest),
     state: 'preparing' as const,
@@ -1238,6 +1819,7 @@ export function validateCohortActivationReceiptIntent(
   intent: CohortActivationReceiptIntent
 ): void {
   assertReceiptIntentHeader(intent)
+  if (intent.reentry !== undefined) validateReentryLineage(intent.reentry)
   validateReceiptIntentHeldIds(intent)
   if (intent.targetServerId !== null) {
     assertUuid(intent.targetServerId, 'targetServerId')
@@ -1255,6 +1837,35 @@ export function validateCohortActivationReceiptIntent(
     excludedIds.add(normalized)
   }
   validateReceiptIntentTargetConfigIds(intent)
+  const inactiveSource = canonicalInactiveSource(
+    intent.inactiveSource,
+    'RECEIPT_INVALID'
+  )
+  const activeSources = canonicalActiveSources(
+    intent.activeSources,
+    'RECEIPT_INVALID'
+  )
+  assertSourcePinSeparation(inactiveSource, activeSources)
+  const targetIds = new Set(
+    Object.keys(intent.targetConfigIds).map((id) =>
+      normalizeUuid(id, 'targetConfigIds')
+    )
+  )
+  const excludedOrHeld = new Set(
+    [...intent.heldConfigIds, ...intent.excludedConfigIds].map((id) =>
+      normalizeUuid(id, 'heldOrExcluded')
+    )
+  )
+  for (const pin of [
+    ...(inactiveSource ? [inactiveSource] : []),
+    ...(activeSources ?? []),
+  ]) {
+    if (
+      pin.configIds.some((id) => !targetIds.has(id) || excludedOrHeld.has(id))
+    ) {
+      fail('RECEIPT_INVALID', 'source exception intent inventory differs')
+    }
+  }
   assertReceiptIntentDigest(intent)
 }
 
@@ -1262,6 +1873,15 @@ function assertIntentMatchesManifest(
   manifest: CohortActivationManifest,
   intent: CohortActivationReceiptIntent
 ): void {
+  if (
+    !inactiveSourceEqual(intent.inactiveSource, manifest.inactiveSource) ||
+    !activeSourcesEqual(intent.activeSources, manifest.activeSources)
+  ) {
+    fail(
+      'RECEIPT_MANIFEST_MISMATCH',
+      'intent source exceptions differ from manifest'
+    )
+  }
   if (intent.manifestFingerprint !== manifest.fingerprint) {
     fail(
       'RECEIPT_MANIFEST_MISMATCH',
@@ -1298,6 +1918,132 @@ function assertIntentMatchesManifest(
       'cohortActivation intent does not cover the manifest'
     )
   }
+}
+
+function assertOrdinaryReceiptIntent(
+  intent: CohortActivationReceiptIntent
+): void {
+  if (intent.reentry !== undefined) {
+    fail(
+      'REENTRY_NOT_ALLOWED',
+      'ordinary cohort activation commands cannot use a re-entry intent'
+    )
+  }
+}
+
+export function assertCohortActivationReentryRoot(
+  receipt: CohortActivationReceipt
+): void {
+  validateReceipt(receipt)
+  if (receipt.state !== 'rolled_back') {
+    fail(
+      'REENTRY_PREDECESSOR_INVALID',
+      're-entry requires a rolled-back predecessor receipt'
+    )
+  }
+  if (receipt.reentry !== undefined) {
+    fail(
+      'REENTRY_PREDECESSOR_INVALID',
+      're-entry cannot use a lineage-bearing predecessor receipt'
+    )
+  }
+  if (
+    receipt.entries.length !== 2 ||
+    chatbotIds(receipt.entries.map(({ manifest }) => manifest)).length !== 1
+  ) {
+    fail(
+      'REENTRY_INVENTORY_MISMATCH',
+      're-entry requires exactly two entries for one chatbot'
+    )
+  }
+}
+
+export function makeCohortActivationReentryReceiptIntent(
+  manifest: CohortActivationManifest,
+  predecessor: CohortActivationReceipt,
+  lineage: CohortActivationReentryLineage
+): CohortActivationReceiptIntent {
+  assertReceiptMatchesManifest(predecessor, manifest)
+  assertCohortActivationReentryRoot(predecessor)
+  validateReentryLineage(lineage)
+  if (lineage.predecessorPayloadDigest !== predecessor.payloadDigest) {
+    fail(
+      'REENTRY_LINEAGE_MISMATCH',
+      're-entry lineage does not identify the predecessor receipt'
+    )
+  }
+  const targetConfigIds = Object.fromEntries(
+    predecessor.entries.map(({ manifest: entry, target }) => [
+      entry.configId,
+      target.id,
+    ])
+  )
+  const withoutDigest = {
+    receiptVersion: COHORT_ACTIVATION_RECEIPT_VERSION,
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    targetServerId: predecessor.targetServer.id,
+    targetConfigIds,
+    heldConfigIds: manifest.heldConfigIds,
+    ...inactiveSourceFields(manifest.inactiveSource),
+    ...activeSourceFields(manifest.activeSources),
+    excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    state: 'preparing' as const,
+    reentry: lineage,
+  }
+  const intent = {
+    ...withoutDigest,
+    payloadDigest: createHash('sha256')
+      .update(JSON.stringify(withoutDigest))
+      .digest('hex'),
+  }
+  validateCohortActivationReceiptIntent(intent)
+  assertIntentMatchesManifest(manifest, intent)
+  return intent
+}
+
+function assertReentryIntentMatchesPredecessor(
+  predecessor: CohortActivationReceipt,
+  intent: CohortActivationReceiptIntent
+): CohortActivationReentryLineage {
+  const lineage = intent.reentry
+  if (!lineage) {
+    fail('REENTRY_LINEAGE_INVALID', 're-entry intent lineage is missing')
+  }
+  validateReentryLineage(lineage)
+  if (lineage.predecessorPayloadDigest !== predecessor.payloadDigest) {
+    fail(
+      'REENTRY_LINEAGE_MISMATCH',
+      're-entry intent does not identify the predecessor receipt'
+    )
+  }
+  if (
+    intent.targetServerId?.toLowerCase() !==
+    predecessor.targetServer.id.toLowerCase()
+  ) {
+    fail('REENTRY_INVENTORY_MISMATCH', 're-entry target server id changed')
+  }
+  const expectedTargetIds = new Map(
+    predecessor.entries.map(({ manifest: entry, target }) => [
+      entry.configId,
+      target.id.toLowerCase(),
+    ])
+  )
+  const actualTargetIds = Object.entries(intent.targetConfigIds)
+  if (
+    actualTargetIds.length !== expectedTargetIds.size ||
+    actualTargetIds.some(
+      ([configId, targetId]) =>
+        expectedTargetIds.get(configId) !== targetId.toLowerCase()
+    )
+  ) {
+    fail(
+      'REENTRY_INVENTORY_MISMATCH',
+      're-entry target config ids do not match the predecessor'
+    )
+  }
+  return lineage
 }
 
 function assertReceiptShape(receipt: CohortActivationReceipt): void {
@@ -1430,8 +2176,7 @@ function validateReceiptEntry(
     fail('RECEIPT_INVALID', 'cohortActivation config snapshot is malformed')
   }
   if (
-    (item.prior.parameters !== null &&
-      !isEmptyJsonObject(item.prior.parameters)) ||
+    !isSafeSourceParameters(item.prior.parameters) ||
     !isSafeSourceAllowedTools(item.prior.allowedTools)
   ) {
     fail('RECEIPT_INVALID', 'receipt contains an unsafe source snapshot')
@@ -1495,11 +2240,14 @@ function assertReceiptDigest(receipt: CohortActivationReceipt): void {
 
 export function validateReceipt(receipt: CohortActivationReceipt): void {
   assertReceiptShape(receipt)
+  if (receipt.reentry !== undefined) validateReentryLineage(receipt.reentry)
   validateManifest({
     fingerprint: receipt.manifestFingerprint,
     target: receipt.target,
     entries: receipt.entries.map(({ manifest }) => manifest),
     heldConfigIds: receipt.heldConfigIds,
+    ...inactiveSourceFields(receipt.inactiveSource),
+    ...activeSourceFields(receipt.activeSources),
     excludedCorpora: receipt.excludedCorpora,
     excludedConfigIds: receipt.excludedConfigIds,
   })
@@ -1529,6 +2277,9 @@ export function receiptExpectation(
         manifestFingerprint: receipt.manifestFingerprint,
         payloadDigest: receipt.payloadDigest,
         state: receipt.state,
+        ...inactiveSourceFields(receipt.inactiveSource),
+        ...activeSourceFields(receipt.activeSources),
+        ...(receipt.reentry ? { reentry: receipt.reentry } : {}),
       }
     : null
 }
@@ -1555,6 +2306,18 @@ export function assertReceiptTransition(
   current: CohortActivationReceiptFile | null,
   next: CohortActivationReceiptFile
 ): void {
+  if (
+    expected &&
+    (!inactiveSourceEqual(expected.inactiveSource, current?.inactiveSource) ||
+      !inactiveSourceEqual(current?.inactiveSource, next.inactiveSource) ||
+      !activeSourcesEqual(expected.activeSources, current?.activeSources) ||
+      !activeSourcesEqual(current?.activeSources, next.activeSources))
+  ) {
+    fail(
+      'RECEIPT_MANIFEST_MISMATCH',
+      'receipt transition changed source exceptions'
+    )
+  }
   validateReceiptFile(next)
   if (expected === null) {
     if (current !== null) {
@@ -1588,8 +2351,17 @@ export function assertReceiptTransition(
       'receipt changed before the expected transition'
     )
   }
+  if (!reentryLineageEqual(expected.reentry, current.reentry)) {
+    fail(
+      'REENTRY_LINEAGE_MISMATCH',
+      'receipt lineage changed before the expected transition'
+    )
+  }
   if (current.manifestFingerprint !== next.manifestFingerprint) {
     fail('RECEIPT_MANIFEST_MISMATCH', 'receipt transition changed the manifest')
+  }
+  if (!reentryLineageEqual(current.reentry, next.reentry)) {
+    fail('REENTRY_LINEAGE_MISMATCH', 'receipt transition changed the lineage')
   }
   if (current.payloadDigest === next.payloadDigest) return
   if (!RECEIPT_STATE_TRANSITIONS[current.state].includes(next.state)) {
@@ -1639,6 +2411,7 @@ export async function prepareCohortActivation(
   validateManifest(manifest)
   const intent = options.intent ?? makeCohortActivationReceiptIntent(manifest)
   validateCohortActivationReceiptIntent(intent)
+  assertOrdinaryReceiptIntent(intent)
   assertIntentMatchesManifest(manifest, intent)
   const prepared = await store.transaction(async (tx) => {
     const sourceEntries = await readSourceEntries(tx, manifest)
@@ -1678,11 +2451,44 @@ export async function prepareCohortActivation(
     target: manifest.target,
     targetServer: prepared.targetServer,
     heldConfigIds: manifest.heldConfigIds,
+    ...inactiveSourceFields(manifest.inactiveSource),
+    ...activeSourceFields(manifest.activeSources),
     excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
     excludedConfigIds: canonicalExcludedConfigIds(manifest),
     entries: prepared.entries,
     switchedChatbotIds: [],
     state: 'prepared',
+  })
+}
+
+export async function prepareCohortActivationReentry(
+  store: CohortActivationStore,
+  manifest: CohortActivationManifest,
+  predecessor: CohortActivationReceipt,
+  intent: CohortActivationReceiptIntent
+): Promise<CohortActivationReceipt> {
+  validateManifest(manifest)
+  assertReceiptMatchesManifest(predecessor, manifest)
+  assertCohortActivationReentryRoot(predecessor)
+  validateCohortActivationReceiptIntent(intent)
+  assertIntentMatchesManifest(manifest, intent)
+  const reentry = assertReentryIntentMatchesPredecessor(predecessor, intent)
+  const prepared = await store.transaction((tx) =>
+    readReentryPreparedState(tx, manifest, predecessor)
+  )
+  return makeReceipt({
+    manifestFingerprint: manifest.fingerprint,
+    target: manifest.target,
+    targetServer: prepared.targetServer,
+    heldConfigIds: manifest.heldConfigIds,
+    ...inactiveSourceFields(manifest.inactiveSource),
+    ...activeSourceFields(manifest.activeSources),
+    excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
+    excludedConfigIds: canonicalExcludedConfigIds(manifest),
+    entries: prepared.entries,
+    switchedChatbotIds: [],
+    state: 'prepared',
+    reentry,
   })
 }
 
@@ -1693,6 +2499,7 @@ export async function assertCohortActivationNotPrepared(
 ): Promise<void> {
   validateManifest(manifest)
   validateCohortActivationReceiptIntent(intent)
+  assertOrdinaryReceiptIntent(intent)
   assertIntentMatchesManifest(manifest, intent)
 
   await store.transaction(async (tx) => {
@@ -1754,6 +2561,7 @@ export async function recoverPreparedCohortActivation(
 ): Promise<CohortActivationReceipt> {
   validateManifest(manifest)
   validateCohortActivationReceiptIntent(intent)
+  assertOrdinaryReceiptIntent(intent)
   assertIntentMatchesManifest(manifest, intent)
   const recovered = await store.transaction(async (tx) => {
     const targetServer = await tx.findServerByName(manifest.target.serverName)
@@ -1820,6 +2628,8 @@ export async function recoverPreparedCohortActivation(
     target: manifest.target,
     targetServer: recovered.targetServer,
     heldConfigIds: manifest.heldConfigIds,
+    ...inactiveSourceFields(manifest.inactiveSource),
+    ...activeSourceFields(manifest.activeSources),
     excludedCorpora: [...COHORT_ACTIVATION_EXCLUDED_CORPORA],
     excludedConfigIds: canonicalExcludedConfigIds(manifest),
     entries: recovered.entries,
@@ -1861,6 +2671,17 @@ export async function switchCohortActivation(
     )
     // Keep every mode for one chatbot in the same serializable transaction.
     const switchedEntries = await store.transaction(async (tx) => {
+      await assertSourceExceptionsState(tx, {
+        ...current,
+        entries: current.entries.map((item) => item.manifest),
+      })
+      if (current.reentry || current.inactiveSource || current.activeSources) {
+        await assertCompleteModeCoverage(tx, {
+          entries: group.map((item) => item.manifest),
+          heldConfigIds: current.heldConfigIds,
+          excludedConfigIds: current.excludedConfigIds,
+        })
+      }
       const targetServer = await tx.findServerById(current.targetServer.id)
       if (
         !targetServer ||
@@ -1868,6 +2689,15 @@ export async function switchCohortActivation(
       ) {
         fail('TARGET_SERVER_DRIFT', 'target server changed after prepare')
       }
+      const sourceServer = await tx.findServerById(
+        group[0]!.manifest.sourceServerId
+      )
+      assertEligibleSourceServer(
+        sourceServer,
+        current.target,
+        canonicalInactiveSource(current.inactiveSource),
+        canonicalActiveSources(current.activeSources)
+      )
       const entries: CohortActivationReceiptEntry[] = []
       for (const item of group) {
         const source = await tx.findConfigById(item.manifest.configId)
@@ -1947,6 +2777,10 @@ async function readRollbackStates(
   targetServer: CohortActivationServerRecord
   states: RollbackTransactionState[]
 }> {
+  await assertSourceExceptionsState(tx, {
+    ...receipt,
+    entries: receipt.entries.map((item) => item.manifest),
+  })
   const targetServer = await tx.findServerById(receipt.targetServer.id)
   if (
     !targetServer ||
@@ -1977,6 +2811,17 @@ async function readRollbackStates(
   const hasNew = states.some(({ state }) => state === 'new')
   if (hasOld && hasNew) {
     fail('READBACK_STATE_MISMATCH', 'chatbot group is partially switched')
+  }
+  if (hasNew) {
+    const sourceServer = await tx.findServerById(
+      group[0]!.manifest.sourceServerId
+    )
+    assertEligibleSourceServer(
+      sourceServer,
+      receipt.target,
+      canonicalInactiveSource(receipt.inactiveSource),
+      canonicalActiveSources(receipt.activeSources)
+    )
   }
   return { targetServer, states }
 }
@@ -2172,6 +3017,10 @@ async function readCohortActivationStateInTransaction(
   tx: CohortActivationTransactionStore,
   receipt: CohortActivationReceipt
 ): Promise<CohortActivationReadback> {
+  await assertSourceExceptionsState(tx, {
+    ...receipt,
+    entries: receipt.entries.map((item) => item.manifest),
+  })
   const targetServer = await tx.findServerById(receipt.targetServer.id)
   if (
     !targetServer ||
@@ -2183,6 +3032,17 @@ async function readCohortActivationStateInTransaction(
   const actualChatbotStates = new Map<string, 'prepared' | 'switched'>()
   for (const item of receipt.entries) {
     const { source, target, state } = await readReceiptStateItem(tx, item)
+    if (source.isEnabled) {
+      const sourceServer = await tx.findServerById(
+        normalizeUuid(item.manifest.sourceServerId, 'entry.sourceServerId')
+      )
+      assertEligibleSourceServer(
+        sourceServer,
+        receipt.target,
+        canonicalInactiveSource(receipt.inactiveSource),
+        canonicalActiveSources(receipt.activeSources)
+      )
+    }
     recordReadbackItem(result, actualChatbotStates, item, source, target, state)
   }
   finalizeReadback(result, receipt, actualChatbotStates)

--- a/project/2026-09-04-doc-query-canary-activation-proof-plan.md
+++ b/project/2026-09-04-doc-query-canary-activation-proof-plan.md
@@ -667,3 +667,29 @@ tests passed again with canonical TMPDIR; Biome passed with the same two existin
 warnings. No receipt, activation or production proof was executed. The remaining
 Playwright CI job is unassigned to its public-pr-arm64 runner group; organization
 runner inspection requires permissions not available to this CLI session.
+
+## Review follow-up: recovery limits
+
+The final AI review at 72beea1cf4 raised legacy receipt recovery after source
+deactivation and retained claims after failed re-entry. Legacy fingerprints
+remain compatible, but recovery is not promised after live source eligibility
+changes. Switch, rollback and readback reject an unpinned inactive source.
+Operators must preserve receipts and obtain a separately reviewed recovery
+plan; do not reactivate sources, rewrite receipts or bypass eligibility as an
+automatic unblock. Legacy recovery is a parked compatibility decision.
+
+Retaining a claim after any post-claim failure is the approved one-attempt
+contract, protected by crash-boundary tests. Automatic expiry, deletion or
+retry is intentionally unsupported. The corresponding review suggestion is
+rejected; preserve claim and successor evidence for separately authorized
+recovery. The publication does not execute recovery or production proof.
+
+Ordinary review corrections now attempt every acquired lock release, share the
+cleanup promise across repeated dual-lock releases, and preserve the original
+acquisition error after cleanup. Re-entry lock contention reports the same
+refused/session_locked result and exit3 as other commands. Missing receipt
+transitions report concurrent-write failure before source-pin comparison,
+without changing nonmissing receipt tamper checks. The119activation tests pass,
+including three regression cases; Biome and native script compilation pass.
+The prior42proof tests remain applicable. Host dependency reuse restored every
+temporary source copy; no service or production operation was started.

--- a/project/2026-09-04-doc-query-canary-activation-proof-plan.md
+++ b/project/2026-09-04-doc-query-canary-activation-proof-plan.md
@@ -650,3 +650,12 @@ to GitHub CI; no local application runtime was started for publication.
 
 The separate roadmap reconciliation is published in deployment MR 739.
 No production activation, proof replay, rollback or secret/data change occurred.
+
+
+PR static analysis found one unused initial assignment in `runProofMatrix`.
+Removed only that initializer; the successful resolution always assigns the
+mode and the exception path returns immediately. All 42 synthetic proof tests
+passed again with this correction; the 116 activation tests are unaffected.
+Five executable/test files remain byte-identical to the prior reviewed source;
+the sixth differs only by this behavior-preserving correction. Prior independent
+reviews remain applicable with this explicitly recorded main-session check.

--- a/project/2026-09-04-doc-query-canary-activation-proof-plan.md
+++ b/project/2026-09-04-doc-query-canary-activation-proof-plan.md
@@ -659,3 +659,11 @@ passed again with this correction; the 116 activation tests are unaffected.
 Five executable/test files remain byte-identical to the prior reviewed source;
 the sixth differs only by this behavior-preserving correction. Prior independent
 reviews remain applicable with this explicitly recorded main-session check.
+
+PR quality-gate follow-up preserves UTF-16 lock-path ordering with an explicit
+comparator, separates the existing in-place reverse/sort operations, and replaces
+trailing-slash regex trimming with an equivalent linear scan. All 116 activation
+tests passed again with canonical TMPDIR; Biome passed with the same two existing
+warnings. No receipt, activation or production proof was executed. The remaining
+Playwright CI job is unassigned to its public-pr-arm64 runner group; organization
+runner inspection requires permissions not available to this CLI session.

--- a/project/2026-09-04-doc-query-canary-activation-proof-plan.md
+++ b/project/2026-09-04-doc-query-canary-activation-proof-plan.md
@@ -1,0 +1,622 @@
+# Doc Query production canary activation and proof correction
+
+Date: 2026-09-04
+
+Status: approved and executing
+
+## Goal and non-goals
+
+Correct the fail-closed source defects that prevent the already-approved single
+production canary from running safely. The activation operator must accept the
+current fixed, non-secret Doc Query parameter shape without accepting arbitrary
+configuration. It must also distinguish the manifest-pinned production
+compatibility bridge from the separately managed target server, even though both
+use the shared reader route. The proof supervisor must support a sealed
+canary-only run that cannot be mistaken for the full cohort proof.
+
+This package changes only the existing activation operator, proof supervisor,
+and their focused tests. It does not change the runtime, tool allowlist, target
+configuration, binding cohort, signer design, or deployment configuration.
+
+The source package does not authorize push, pull request creation, merge,
+deployment, cluster changes, secret writes, production database access, live
+proof, cleanup, or deletion. The previously approved production canary remains
+a separate transaction after this source package passes every local gate.
+
+## Current approved continuation: inactive IuW source
+
+On 2026-09-05 the canary re-entry and its nine-call proof passed. The user
+approved activating the remaining 46 bindings across 21 chatbots and running
+one full 37-call proof. The two active canary bindings and four exclusions
+remain preserved. A definite failure rolls back only the new remaining batch;
+ambiguous state stops without lifecycle replay.
+
+Preflight found two IuW configurations on one disabled legacy source server.
+The user approved a narrowly pinned exception so these configurations migrate
+directly to the multi-tenant service. The legacy server stays disabled during
+success and rollback. Rollback restores its prior disabled-service state, not
+a working legacy reader. The correction and local checks, reviews and commits
+are authorized, followed by the approved production continuation. The earlier
+local-only and single-canary boundaries below describe completed phases; this
+section extends them only by the actions explicitly named here.
+
+The main session owns integration and production execution. No push, merge,
+upstream integration, deployment, cluster mutation, source-server activation,
+secret write, cleanup or deletion is authorized. Reuse the existing approved
+loopback forward for proof and stop it afterward. The terminal condition is a
+verified local correction and a recorded result of the remaining activation
+and full proof, with rollback of the new batch on definite failure.
+
+## Approved continuation: two active source aliases
+
+The user approved extending eligibility to the two specifically pinned active
+IuW and RadioSurfVet source servers covering four remaining bindings. They
+already use the shared target URL but do not meet the compatibility-server
+contract. This approval includes local correction, checks, reviews and commits,
+then the same remaining46 activation and full37 proof. Preserve all earlier
+canary, exclusion, disabled legacy source, rollback and ambiguity boundaries.
+No publication, integration, deployment or source-server changes are permitted.
+
+Add optional activeSources containing exactly two distinct source pins. Each
+strict pin records sourceServerId, chatbotId, exactly two distinct configIds,
+safe snapshot SHA256 and rollbackMode preserve-active. Normalize and sort;
+omit absent fields so existing fingerprints remain unchanged. Reject overlap
+between active pins, inactiveSource, held and excluded configurations. Require
+exact manifest and global source inventory, including disabled rows.
+
+Require each active alias to remain active, use the exact target URL, have a
+nonmanaged name/description, bearer auth with secret presence, null or empty-object server
+parameters and passChatbotId false. Pin remaining safe metadata exactly.
+Never modify the source servers. Recheck state, snapshot and inventory across
+all lifecycle paths, even switched readback and already-restored rollback.
+Carry pins through intent, receipts, recovery, lineage, manifest reconstruction,
+CAS and clear checks; reject addition/removal/substitution despite recomputed
+digests. Extend transactional mode coverage to activeSources independently of
+inactiveSource. Keep default source guards unchanged.
+
+The main session owns coupled core/runner integration and private operations.
+The native executor owns only focused tests. Use faithful multi-server fixtures
+for both active aliases and the inactive source, combined successful migration
+and exact rollback, and failure after an earlier chatbot commits. Preserve
+active snapshots, inactive state, held canary and exclusions. Test active-only
+postprepare mode drift and malformed inventory/state/snapshot/tamper contracts.
+Retain all145 baseline tests; run focused native/strict/format/static/data checks.
+Commit then simplify and review data integrity, followed by integrated final.
+
+Rebuild reviewed operator, pin active metadata through the same Prisma adapter
+so UTC timestamps match, and change only the private activeSources and its pin.
+Dry-run and verify canary/exclusions/service/signing state. Reuse the explicitly
+approved loopback forward for the first remaining migration and full proof;
+rollback only the remaining batch on definite failure, stop on ambiguous state,
+and stop the forward at the terminal boundary. No proof replay.
+
+Planner approved this distinct amendment after accepting transactional coverage
+and combined multi-server failure/rollback test requirements. Earlier waived
+second reentry planner is unrelated and was not retried.
+
+## Execution contract
+
+- **Execution owner:** the current main session owns both coupled slices and
+  their integration.
+- **Baseline:** branch `fix/doc-query-canary-activation-proof` starts from exact
+  `origin/v3` commit `468f05b91503b133670dda235be9a4b38bba2155`.
+- **Autonomy:** the approved goal covers this plan, in-scope local edits,
+  focused checks, configured reviews, progress updates, and local commits.
+- **Terminal:** a clean local branch with both corrections, focused checks,
+  slice reviews, and an integrated final review complete.
+- **Pause:** stop for a changed authorization or receipt contract, a broader
+  accepted parameter shape, a different proof matrix, an in-scope test failure,
+  or a blocking reviewer finding that cannot be corrected narrowly.
+- **Rollback:** ordinary source revert. No production state belongs to this
+  source package.
+
+## Decisions
+
+### Exact source-parameter compatibility
+
+Use one shared predicate for both live source validation and receipt validation.
+It accepts only these three shapes:
+
+- `null`;
+- an empty plain object;
+- the exact plain object `{ required: true, toolAlias: 'doc_query' }`.
+
+Reject arrays, objects with extra keys, false `required`, a different alias,
+and every other non-empty object before any write. Keep the existing tool
+allowlist and target configuration checks unchanged. Preserve the exact source
+parameters JSON in the snapshot, receipt, and rollback path; the predicate is a
+compatibility check, not a normalization step.
+
+### Canonical proof mode
+
+Add one non-secret supervisor input named `DOC_QUERY_PROOF_MODE`:
+
+- absent or exact `full` preserves the current full proof;
+- exact `canary-only` selects the bounded canary proof;
+- any other present value fails before a child process or MCP request starts.
+
+The supervisor selects the canonical mode, passes only that mode through the
+fixed child environment, and requires the receipt to contain the same mode.
+It validates exact mode-specific counters and refuses a mismatched receipt.
+
+The canary-only proof still validates the complete frozen manifest and its
+fingerprint. It runs the first knowledge-base case for positive retrieval and
+cross-knowledge-base isolation, uses the second case only as the foreign
+knowledge-base reference, and runs all seven authentication and filter
+rejection checks. It performs exactly nine calls. It does not call cases two
+through fifteen. The full proof retains its current order and exact 37-call cap.
+
+The canary receipt retains manifest-wide expected totals, but records exactly
+one passed knowledge base, representative, positive check, and isolation check;
+seven rejection checks; nine calls; and explicit `canary-only` mode. The full
+receipt adds only explicit `full` mode.
+
+### Pinned compatibility bridge
+
+Keep the ordinary rule that a source cannot already be the target. Permit one
+exception only for the source server ID pinned in each manifest entry when the
+live server matches the complete production compatibility contract: exact name
+`Klicker-compat`, exact target URL, bearer authentication, chatbot ID forwarding
+through `Chatbot-ID`, empty parameters, a present encrypted secret, an active
+server, and a non-empty description that is not the managed target ownership
+marker.
+
+Revalidate that contract during dry-run, prepare and recovery; immediately
+before switch; before rollback would re-enable the compatibility source; and in
+readback whenever that source is expected to be active. The operator does not
+snapshot, restore, or otherwise own the compatibility server.
+
+## Planning review
+
+- The native planner returned `REVISE` in round 1. Accepted findings: bind the
+  supervisor-selected proof mode to the child receipt, share one exact safe
+  parameter predicate, preserve exact rollback JSON, and enforce the nine-call
+  canary boundary.
+- The same planner approved the revised plan in round 2 with no blocking
+  findings.
+- The configured opposing-provider challenge could not authenticate because
+  its OAuth session expired and could not refresh. This pass is fail-open; no
+  opposing-provider finding was available.
+
+## Delegation map
+
+| Workstream | Owner | Dependency | Acceptance |
+| --- | --- | --- | --- |
+| Activation compatibility | main session | current activation operator | focused activation tests and data-integrity review |
+| Canary proof mode | main session | reviewed activation compatibility | focused proof tests and security/runtime-proof review |
+| Integrated result | main session | both committed slices | combined checks and final review |
+
+Both implementation items stay in the main session because they jointly define
+one production canary gate. Splitting ownership would increase the chance that
+the operator and proof supervisor accept different contracts. Reviewers remain
+read-only and independent.
+
+## Test portfolio
+
+| Consequential behavior | Protection |
+| --- | --- |
+| Current fixed source parameters are accepted | add an exact-shape activation regression |
+| Near-miss parameter shapes fail before writes | table-test extra keys, false flag, alternate alias, arrays, and arbitrary objects |
+| Receipt and live validation use one contract | exercise the shared predicate through migration and receipt paths |
+| Rollback restores exact source JSON | retain and extend snapshot/rollback equality assertions |
+| Default full proof stays unchanged | retain current order, counts, and 37-call assertions |
+| Canary-only proof is bounded | assert one positive/isolation case, seven rejections, nine calls, and no remaining corpus calls |
+| Mode cannot be confused or forged | assert invalid input fails before spawn and receipt-mode/counter mismatch fails closed |
+| Full manifest remains sealed | assert canary-only still validates the complete fingerprint and manifest totals |
+| Compatibility bridge remains distinct from the managed target | accept only the complete pinned bridge contract and table-test every near miss |
+| Compatibility drift cannot be activated or restored | mutate the bridge after prepare and after switch; require a write-free refusal before switch or source re-enable |
+
+## Execution slices
+
+### Activation compatibility
+
+- Implement the shared exact predicate in
+  `packages/prisma-data/src/scripts/doc-query-cohort-activation.ts`.
+- Extend
+  `packages/prisma-data/src/scripts/doc-query-cohort-activation.test.ts` with
+  accepted-shape, near-miss, and exact rollback coverage.
+- Run the focused activation suite, package type checking and formatting, then
+  inspect the exact diff and staged data before committing.
+- Run a simplifier and a data-integrity slice review on the immutable commit.
+
+### Canary-only proof
+
+- Implement the canonical mode and mode-bound receipt validation in
+  `apps/chat/scripts/prd-doc-query-proof.mjs`.
+- Extend `apps/chat/test/prd-doc-query-proof.test.ts` and only the existing test
+  support required to observe call selection and receipt validation.
+- Run the focused proof suite, Chat type checking, linting and formatting, then
+  inspect the exact diff and staged data before committing.
+- Run a simplifier and a security/runtime-proof slice review on the immutable
+  commit.
+
+### Finish gate
+
+- Rerun all affected focused checks on the integrated branch.
+- Inspect the complete diff from the recorded baseline and account for every
+  changed hunk.
+- Run an integrated final review over both immutable commits.
+- Record exact commits, checks, review dispositions, and remaining production
+  boundary below.
+
+### Compatibility bridge correction
+
+- Centralize source-server eligibility in the activation operator.
+- Preserve the ordinary target-route refusal while allowing only the complete
+  manifest-pinned `Klicker-compat` bridge contract.
+- Revalidate the bridge at each transition that could disable or re-enable its
+  configurations and whenever readback expects it active.
+- Run the focused activation suite, Prisma data type check, formatting, exact
+  diff inspection, simplification, data-integrity review, and integrated final
+  review before repeating the values-free production dry-run.
+
+## Production continuation boundary
+
+After the source finish gate passes, refresh only the values-free prerequisites
+for the already-approved single production canary. Use `canary-only` mode. The
+transaction may create the separate knowledge-base server/configuration, switch
+only the named canary atomically, run positive retrieval and cross-knowledge-
+base/authentication isolation proof, and restore on a definite failure. Never
+retry an ambiguous transaction. Do not expand the cohort, scale, retire legacy
+readers, clean up, or delete anything under this plan.
+
+## Approved rollback re-entry correction
+
+### Approval summary
+
+A failed canary restored both source bindings and left its two managed target
+bindings disabled. Ordinary preparation refuses these existing targets. Add a
+dedicated one-time `reenter` command that uses those same bindings and a new
+receipt, while preserving the terminal rollback receipt byte-for-byte.
+
+The user approved this local correction and, on 2026-09-05, explicitly directed
+continuation without the rejected second planner review. The first planner's
+four safeguard findings below remain binding. The second-round review is
+waived by the user, not passed or replaced. Source implementation, synthetic
+checks, local commits and independent implementation reviews remain authorized.
+The terminal condition is a clean verified local branch. Production execution,
+publication, upstream integration, merge, secret changes and cleanup are not
+part of this local correction. Earlier production approval remains separate.
+
+### Receipt and state contract
+
+The command accepts the original root `rolled_back` receipt and a distinct
+new receipt path. It refuses lineage-bearing predecessors, preventing repeated
+re-entry chains. An exclusive, durable sidecar claim beside the predecessor
+binds its payload digest to the intended successor. A validated `reentry`
+field binds the new intent and receipt to predecessor and claim digests and
+survives every receipt transition. Ordinary migrate, recover and clear paths
+refuse re-entry intents rather than inheriting their recovery semantics.
+
+Require exactly the predecessor's two entries for one chatbot and the same
+sealed manifest, including canonical held/excluded sets and current complete
+mode coverage. Require enabled source rows with the exact original identifiers
+and content. Capture fresh source timestamps for compare-and-swap because
+rollback updates live `updatedAt` while preserving the original source
+snapshot. Require exact disabled target snapshots, including timestamps, and
+an exact target-server snapshot. Reuse the existing target identifiers; no
+server or binding creation, deletion, schema change or adapter change belongs
+to re-entry.
+
+Resolve both receipt paths canonically, reject equal paths and symlink
+ambiguity, acquire both receipt locks in lexical order, and release in reverse.
+Lock acquisition may create its existing SQLite coordination files; the claim
+is the first durable lifecycle mutation after all read-only validations.
+Create the claim exclusively and fsync it and its containing directory. Then
+persist a lineage-bearing `preparing` intent through receipt compare-and-swap,
+prepare a successor receipt using read-only live snapshots, persist `prepared`,
+and switch using the existing transactional compare-and-swap helper.
+
+Any failure after claim creation stops and retains the claim and all written
+receipt evidence. Do not clear, recover, delete claims, retry lifecycle steps,
+or silently resume after a crash. Existing retries of uncommitted database
+serialization conflicts stay unchanged. A definite switched-state failure
+retains the existing explicit rollback path. No new live attempt is part of
+local verification.
+
+### Delivery and verification
+
+| Workstream                          | Owner           | Acceptance                                                                                     |
+| ----------------------------------- | --------------- | ---------------------------------------------------------------------------------------------- |
+| Re-entry source and synthetic tests | native executor | existing activation tests plus re-entry contract tests, package checks and formatting          |
+| Integration and local delivery      | main            | exact diff and staged-data inspection, data-integrity slice review and integrated final review |
+
+The source scope is the existing activation module, runner and activation test
+file under `packages/prisma-data/src/scripts/`. The Prisma adapter is read-only
+context. Extend tests at the existing fake store and real temporary receipt
+file seams. Cover success and rollback, predecessor byte immutability, replay
+with same or different successors, changed manifest/inventory, invalid enabled
+states, timestamp/content/server drift, competing attempts and crash boundaries.
+Assert no database creation/deletion or identifier replacement. Keep the prior
+56 activation tests and all existing canary/full-proof checks intact. Run
+repository-native package type checks and formatting, inspect the whole diff,
+and retain existing evidence for unchanged earlier source.
+
+The main session owns the plan, local commits, runtime lifecycle and reviews.
+The executor owns only the three source/test files and does not access secrets,
+production data or live services. No new dependencies or runtime applications
+are needed for the synthetic tests; use the existing managed toolchain when
+available. A missing verification environment is a blocker, not test success.
+
+### Review disposition
+
+The recovered first planner review returned `REVISE`; its immutable-predecessor,
+fresh-source-timestamp, durable-claim, ordering and bounded-preparation findings
+were accepted. Its second-round request failed with a safety-system rejection.
+The user waived that specific request with “so proceed without doing that
+which was rejected”. No alternate planner request is authorized or needed.
+Implementation reviews assess the resulting local code and remain required.
+
+## Progress
+
+- [x] Production dry-run stopped before receipt creation or writes with
+  `SOURCE_SHAPE_UNSUPPORTED`.
+- [x] Values-free classification proved the source shape is exactly the fixed
+  `required` plus `doc_query` alias contract.
+- [x] Repository inspection proved the proof tool lacks a canary-only terminal
+  mode and currently always schedules the full 37-call matrix.
+- [x] Native planner approved the revised plan in round 2.
+- [x] Opposing-provider review attempted; authentication was unavailable.
+- [x] Plan committed on the fresh exact-v3 branch as `066cfbc9bd`.
+- [x] Activation compatibility slice implemented and committed as `995d660ded`.
+  Its 43 focused tests, Prisma data type check, Biome check, simplifier, and
+  data-integrity review passed with no blocking finding.
+- [x] Canary-only proof slice implemented and committed as `723459d450`. Its 42
+  focused tests, Chat type check, Biome check, simplifier, and security/runtime
+  review passed with no blocking finding.
+- [x] Integrated `git diff --check`, exact six-path inspection, and final review
+  passed at `723459d4509f1b5327007befa00c8a657563eb41`. The configured reviewer
+  failed before reading the task; the clean-context continuity review returned
+  PASS.
+- [x] The clean local source package is ready for the separately authorized
+  values-free production preflight and single-canary transaction.
+- [x] The first production dry-run remained write-free and created no receipt,
+  but classified the manifest source as `SOURCE_IS_TARGET`.
+- [x] Values-free production readback proved the pinned source is the active
+  `Klicker-compat` bridge on the shared reader route, while the separately
+  managed `KB` target is absent.
+- [x] Planner review approved a narrow compatibility exception with mandatory
+  transition-time revalidation and near-miss regressions.
+- [x] Compatibility bridge correction committed as `3b8351d919`. The 56-test
+  focused activation suite, Prisma data type checks, Biome check, exact diff,
+  simplifier, and data-integrity review passed with no blocking finding.
+- [x] The simplifier's two behavior-preserving suggestions were accepted:
+  missing-source validation now stays inside the shared eligibility check, and
+  readback validates each enabled source directly without a cache set. The same
+  56 tests, type checks, Biome check, and diff check passed afterward.
+- [x] Integrated final review passed at `b85e26f66f` with no P0-P3 findings.
+- [x] The values-free production dry-run passed with the same frozen manifest:
+  two source configurations remain eligible, 46 configurations remain held,
+  the distinct managed target would be created with two configurations, and
+  both canary modes would switch while preserving source rows. No receipt was
+  created and the dry-run made no database writes.
+- [x] The sealed production proof manifest passed independent preflight: 15
+  knowledge bases, 22 in-scope chatbots, two non-overlapping exclusions, a
+  first-position `mat183_v1` canary, exact activation-manifest coverage, and a
+  valid full-cohort fingerprint binding.
+- [x] The loopback-only proof adapter passed its security review after fixing a
+  double-slash URL-authority escape. Exact-origin, Request-preservation, and
+  fixed-child-spawn checks pass, and both local adapter files remain mode 600.
+- [x] The single production canary activation switched exactly two
+  configurations for one chatbot. Immediate readback confirmed both legacy
+  source configurations disabled and both managed target configurations
+  enabled.
+- [x] The bounded proof stopped after its first positive request with
+  `canary_positive_failed`; no isolation or rejection call ran. The mandatory
+  rollback completed, and readback confirms both source configurations enabled
+  and both managed target configurations disabled.
+- [ ] Values-free service-log classification identified ES256 signature
+  verification failure for the recognized key ID. Before another canary can be
+  authorized, the Klicker signing private key and the production Doc Query
+  public-key trust entry must be reconciled through their owning secret and
+  GitOps workflows. The failed canary must not be retried under this receipt.
+- [x] A restricted in-process comparison confirmed that the current Infisical
+  private key and the merged production public key are both valid keys but do
+  not form a pair. The live ConfigMap public-key fingerprint matches the merged
+  GitOps source, so runtime configuration drift is not the cause.
+
+- [x] Takeover verified clean head `4dd2c32016c847909517dc18b887d95f527b6e3f`;
+      fresh `origin/v3` is two commits ahead of the branch base, with eight local
+      commits ahead. No upstream integration occurred.
+- [x] User waived the rejected second planner review on 2026-09-05 and directed
+      local implementation under the recovered first-round safeguards.
+- [x] One-time rollback re-entry implemented as `ce5162117e`; the accepted
+      duplicate-check simplification is `0cccf39f17`.
+- [x] Data-integrity review found a preparation-to-switch coverage race.
+      Transactional coverage revalidation and its regression are committed
+      as `3e9e61c052`; the same reviewer cleared the correction.
+- [x] Verified source `3e9e61c052` passes 113 synthetic tests, repository data
+      and historical-script checks, focused strict TypeScript for four roots,
+      Biome with two existing warnings, and the bounded Opengrep scan with
+      zero findings. Exact diff and staged gitleaks inspections pass.
+- [x] Host Git commits bypassed the unavailable pnpm hook launcher after
+      focused checks in network-disabled ephemeral containers. No full
+      monorepo hook or full-package strict success is claimed; unrelated
+      historical-script strict errors remain outside this source correction.
+- [x] No managed runtime or live service was started. Test containers exited
+      and removed themselves. The task workspace has zero routes; fresh
+      provider-stopped status is unavailable because DevPod CLI is absent.
+- [x] Integrated final review passed with no P0-P3 findings for the complete
+      seven-path source package through `3e9e61c052`. The trusted generic
+      reviewer resumed after a usage-limit interruption; the rejected second
+      planner was never retried. Report:
+      `project/_local/reviews/2026-09-05-doc-query-reentry-final.md`.
+- [x] Local correction complete. Publication, upstream integration and live
+      production execution remain separate from this completed source goal.
+
+## Approved inactive-source correction
+
+### Contract
+
+Add an optional strict `inactiveSource` exception to the existing manifest,
+preparing intent and receipt. Pin one source server, one chatbot, exactly two
+distinct configuration identifiers, a deterministic SHA256 of safe source
+metadata, and the exact rollback mode `preserve-inactive`. Normalize identifiers
+and ordering. Reject unknown fields and invalid digests. Omit the field from
+canonical forms when absent so existing manifest fingerprints stay unchanged.
+
+The two exception entries are a subset of the remaining 46 entries. Require
+exact agreement with the manifest and reject held or excluded overlap. Reject
+any additional configurations on that source globally, including disabled,
+held and excluded rows. Keep enabled-source-configuration and safe legacy
+parameter/tool checks unchanged. Reject managed targets, compatibility bridges
+and shared target routes independently of the inactivity exemption.
+
+Revalidate the exact safe snapshot, inactive server state and complete source
+inventory in dry-run, prepare, recovery, switch, rollback and readback. Check the
+exception independently of source configuration state, including switched
+readback and already-restored rollback. Recheck complete-mode coverage inside
+the affected switch transaction before configuration writes. An earlier durable
+switching receipt checkpoint may remain on failure. Never modify the source
+server or secret values.
+
+Carry the exception through every constructor, manifest reconstruction,
+recovery, re-entry and receipt transition. Bind it to fingerprints, payload
+digests and compare-and-swap expectations. Explicit equality checks reject
+addition, removal or substitution even when payload digests are recomputed.
+Rollback restores exact prior configuration content with fresh timestamp CAS
+while preserving the inactive source server.
+
+### Ownership and acceptance
+
+The trusted native executor owns only the activation core, runner and existing
+activation test file. The Prisma adapter is read-only context. The main session
+owns this plan, integration, local commits, reviews and private operational
+artifacts. No schema, dependency, provider or source-shape expansion is needed.
+The existing product binding and reader contracts are preserved; no new product
+primitive or durable architecture decision is introduced.
+
+Extend synthetic tests for success and exact rollback; unmarked inactivity;
+wrong identity, inventory, snapshot and metadata drift; fingerprint binding;
+recomputed-digest transition downgrade or substitution; and compatibility and
+re-entry regressions. Preserve the passing 113-test baseline. Run focused
+repository checks, strict four-root checks, formatting, bounded static analysis
+and exact staged-data inspection. Run the simplifier and data-integrity slice
+review on the committed correction, then integrated final review. Reuse prior
+passing evidence for unchanged source.
+
+After these gates, rebuild the ignored operational JavaScript from reviewed
+source. Read the identified inactive source snapshot without secret values,
+amend and repin only the private remaining manifest, then dry-run. Verify the
+active canary and exclusions, migrate the remaining batch, run the unchanged
+sealed full proof once, and record terminal readbacks. Preserve the original
+rollback receipt and consumed re-entry claim.
+
+### Planning review and progress
+
+- [x] Native planner `01a07265-9743-71d1-8494-070bdf9cf715` approved the
+  revised contract after all five first-pass findings were accepted: exact
+  global inventory, enabled configuration guards, state-independent checks,
+  canonical propagation and explicit expanded production authority.
+- [x] The earlier waived second re-entry planner remains waived and was not
+  retried. This review covers the distinct inactive-source correction.
+- [x] Fresh remote inspection at `b2a4d3286a` found the clean task branch 14
+  commits ahead and two behind `origin/v3`; no integration occurred.
+- [x] Values-free inspection confirmed both affected configurations already
+  satisfy the approved parameter and legacy-tool shapes.
+- [x] Implement and verify the inactive-source contract. All145 synthetic tests pass (103 activation,42 proof); focused strict TypeScript has zero diagnostics. Repository checks pass with two pre-existing Biome warnings. Bounded Opengrep reports zero findings. No schema or dependencies changed.
+- [x] Complete committed source reviews and rebuild the operator. Native simplifier recommends no change; trusted data-integrity review and native integrated final review pass at8c4839220c. Three operator modules rebuilt from reviewed source.
+- [x] Execute the approved remaining activation and full proof, recording
+  rollback on definite failure and preserving the active canary.
+
+### Resumed execution ownership
+
+The goal resumed after its usage-limited checkpoint. The main session owns
+the coupled core and runner completion; the same native executor owns only
+the focused test file. This reduces the stalled implementation scope without
+replacing the worker or repeating planning. Acceptance and production authority
+remain unchanged. Fresh fetch succeeded; the branch is15 ahead and3 behind
+origin/v3 with no upstream integration.
+
+The executor returned its single success-and-rollback test and released ownership.
+The parent completed the negative regression cases and verified the complete diff.
+Required reviews will use trusted native routes because source contains internal
+service URLs; the external slice-review route is ineligible for this scope.
+
+### Production preflight after inactive-source review
+
+The private remaining manifest is amended only with the approved inactive
+exception and its fingerprint. Initial dry-run stopped write-free on a snapshot
+mismatch. The private SQL helper interpreted a timestamp without timezone in
+local Zurich time, while Prisma interprets it as UTC. A scoped comparison proved
+updatedAt was the only difference, exactly7200000ms; explicit UTC conversion
+matches the adapter snapshot. The helper and private pin were corrected without
+source changes or database writes. Current remaining fingerprint:
+34e3e4d1bf288eab635209310c2323496af95309f0078817c0cb3b680de5a00e.
+Original canary/full/proof fingerprints and rollback receipt bytes are unchanged.
+
+The corrected dry-run stops before writes with SOURCE_IS_TARGET. Two other,
+active source aliases already use the exact shared target URL: one IuW source
+and one RadioSurfVet source. Each has exactly two configurations, all pinned
+in the remaining manifest and enabled, with safe configuration parameters.
+Both use bearer authentication and empty server parameters but do not forward
+the chatbot ID or match the approved compatibility-server name/header contract.
+They are separate from the approved inactive source. Broadening that contract
+requires a new explicit decision; do not enable sources, silently omit bindings,
+weaken the global guard or run migration under the current source contract.
+
+Canary readback remains switched with two target bindings enabled and two source
+bindings disabled. No remaining activation receipt or full-proof result exists.
+No migration, proof, rollback or temporary forward was started in this phase.
+Live service metadata: two ready of two desired, Argo Synced Healthy at
+f4fd59d44c6222dd34caab986be03e7c1cb8a586; verifier signature challenge passes.
+Next decision: authorize a separately pinned active-alias source correction for
+these four bindings, retaining the remaining46 and full37 scope, or revise scope.
+The inactive-source implementation is verified; overall runtime goal unfinished.
+
+### Active-alias implementation verification
+
+Implemented optional canonical activeSources with strict state/snapshot/inventory
+checks and explicit receipt/intent/CAS propagation. Shared pin validation retains
+inactive behavior. Faithful combined multi-server tests protect successful and
+partial-failure rollback, server states and held/excluded rows. Live safe metadata
+confirms both approved aliases represent empty server parameters as null; the
+contract and fixtures explicitly accept null or an empty object, never nonempty
+parameters. All158 tests pass (116activation,42proof), strict4roots zero diagnostics,
+native checks pass, two pre-existing Biome warnings, bounded Opengrep zero findings.
+No schema, dependency, adapter or production mutation is included. Required
+committed reviews and production continuation remain next.
+
+
+## Completed production activation and proof
+
+The approved runtime objective is complete. Reviewed source
+4434e1a5b8135a2301a7a301fdcaefd4ba968ec0 activated all 46 remaining bindings
+across 21 chatbots. The two previously active canary bindings remain active,
+for 48 active managed target bindings in total. The four excluded bindings are
+unchanged. The legacy inactive IuW server remains disabled; both approved
+active source aliases retain their server states.
+
+The active-alias simplifier, data-integrity review and integrated final review
+passed. Their reports are in project/_local/reviews/2026-09-05-doc-query-active-*.md.
+The reviewed source retains passing evidence for 158 synthetic tests, strict
+TypeScript checks, repository checks and the bounded static scan. No source
+behavior changed after these reviews.
+
+The current remaining manifest fingerprint is
+ed04361dca18b7ffc2a96c962b8020ff52d60033a33235d20364f8f2d42797a8.
+Its full dry-run passed before activation. Final preservation reads passed,
+and the live verifier accepted the in-memory signature challenge. A fresh
+fetch found the clean task branch 18 commits ahead and four behind origin/v3.
+The added upstream multi-KB contract preserves singleton kb_id configuration
+and JWT behavior. No upstream integration occurred.
+
+The sealed full proof ran once and passed all 37 calls in 78010 milliseconds:
+15 positive retrieval checks, 15 isolation checks and seven rejection checks.
+All 15 representative knowledge bases passed, covering the manifest's 22
+chatbots. The affected inactive-source IuW chatbot is its proof representative.
+This is direct Doc Query proof; it does not claim a browser-level chat test.
+
+Final readback confirms all 46 remaining target bindings enabled and all 46
+prior source bindings disabled. The two canary targets remain enabled. The
+four exclusions and disabled legacy IuW server are preserved. No rollback or
+proof replay was needed. Production has two ready replicas out of two desired;
+Argo reports Synced and Healthy at ee9a7337a8cec113d06d826e19d8a4b0a48570cb.
+The Doc Query image is unchanged from preflight.
+
+The task-owned loopback forward stopped successfully, and port 1417 has no
+listener. The user's database tunnel was left alone. There are no running
+proof workers or unresolved review children. Private receipts and the sanitized
+proof result remain under /Users/rschlae/Git/ai/_local/klicker-prd-activation/;
+retain them and the original rollback receipt and consumed re-entry claim.
+No publication, merge, infrastructure deployment or cleanup occurred.

--- a/project/2026-09-04-doc-query-canary-activation-proof-plan.md
+++ b/project/2026-09-04-doc-query-canary-activation-proof-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-04
 
-Status: approved and executing
+Status: production activation complete; source publication in PR 5813
 
 ## Goal and non-goals
 
@@ -620,3 +620,33 @@ proof workers or unresolved review children. Private receipts and the sanitized
 proof result remain under /Users/rschlae/Git/ai/_local/klicker-prd-activation/;
 retain them and the original rollback receipt and consumed re-entry claim.
 No publication, merge, infrastructure deployment or cleanup occurred.
+
+
+## Source publication (2026-09-07)
+
+The user authorized source publication and conflict resolution, without merge.
+[PR 5813 — cohort activation source preservation](https://github.com/uzh-bf/klicker-uzh/pull/5813)
+contains the six reviewed executable/test files and this plan on
+`fix/doc-query-activation-publication`, based on `v3` at
+`d8e29ee75168b61e5c6902a5a8d8afa12495e261`. All six files are byte-identical to
+reviewed commit `4434e1a5b8135a2301a7a301fdcaefd4ba968ec0`; prior simplifier,
+data-integrity and final review evidence remains applicable.
+
+The original branch's one target integration resolved the LTI documentation
+conflict by preserving the already-merged PR 5807 version. Mandatory data-hygiene
+checks then rejected unrelated upstream content in the merge commit. No check
+was bypassed: only the seven scoped files were carried to a fresh target-based
+publication branch. The original worktree and prior receipts are preserved.
+
+Fresh focused checks on the resolved target tree: proof 42/42 passed; activation
+116/116 passed with `TMPDIR=/private/tmp`. The default macOS temporary directory
+has a symlinked ancestor, which intentionally fails the re-entry root guard;
+using the canonical temporary directory fixes the test environment without
+weakening the guard or changing source. Host Node was 26.8.1; the prior Node 24
+container checks remain separately recorded. Biome passed with the two known
+warnings, JavaScript syntax passed, and the publication commit's gitleaks scan
+and diff whitespace check passed. Full repository build/check coverage is left
+to GitHub CI; no local application runtime was started for publication.
+
+The separate roadmap reconciliation is published in deployment MR 739.
+No production activation, proof replay, rollback or secret/data change occurred.


### PR DESCRIPTION
## Summary

The production cohort operator rejected valid existing Doc Query source configurations and could not preserve the distinct states of inactive legacy sources and active source aliases. This publishes the reviewed correction used for the completed canary and remaining-cohort activation.

- Accept only the fixed safe parameter shapes and preserve their original snapshots.
- Pin inactive sources and active aliases explicitly; validate complete source inventories and preserve source-server state through activation, rollback, and readback.
- Carry those pins through receipts, recovery, lineage and compare-and-swap checks, rejecting inconsistent or changed lifecycle inputs.
- Distinguish sealed canary-only and full proof modes and retain focused synthetic coverage.

The PR contains six source/test files and the execution plan. It does not change schemas, dependencies, application authentication, deployment manifests, or live configuration. The LTI fix already merged in PR #5807 is excluded.

## Validation

The six executable/test files matched reviewed commit `4434e1a5b8135a2301a7a301fdcaefd4ba968ec0` at initial publication. PR feedback corrections remove an unused proof-mode initializer, preserve deterministic lock ordering with an explicit comparator, separate in-place collection operations, and replace trailing-slash regex trimming with a linear scan. All 42 proof tests and 116 activation tests passed after their respective corrections. Prior simplifier and data-integrity review evidence is reused for unchanged content; the independent final publication review passed at `72beea1cf414fd3a2e31ca1a327b4f5b1d3a2c94`, checking the corrections separately with no actionable findings.

Current head `9f8572788170e2b7e85ce3bbf657a2f0e7d941cf`: all 119 activation tests passed in the Node 24 task container. The full commit hook passed, including 35 check tasks and seven lint tasks. The pre-push build passed all 23 tasks. Git and gitleaks ran on the host; pnpm checks ran in the container without bypassing hooks. The prior 42 proof tests remain applicable to unchanged proof code. Hosted CI and final-review attestation for this head remain pending.

Historical operational evidence: the separately authorized September 5 activation switched 46 remaining bindings across 21 chatbots while preserving two held canary bindings. The sealed full proof passed all 37 calls across 15 knowledge bases. Subsequent browser acceptance passed for IuW and RadioSurfVet. These are historical results, not actions performed by merging this PR.

Substantive size: 3,329 insertions and 84 deletions across source/tests; execution-plan lines excluded. One cohesive operator/proof lifecycle package, independently functional and reviewable against `v3`.

## Blocking Before Merge

The error-handling follow-up is pushed at `9f8572788170e2b7e85ce3bbf657a2f0e7d941cf`. All 119 activation tests pass in the task container; the prior 42 proof tests remain applicable. The mandatory commit hook passed in full, with host Git/gitleaks and pnpm checks forwarded into the container. No hook was bypassed. The native full monorepo check passed 35 tasks and lint passed seven tasks. No repository configuration changed to repair the local check environment.

The follow-up releases all locks despite errors, shares the cleanup promise across repeated dual-lock releases, classifies reentry lock contention consistently, and preserves concurrent-write error reporting when a pinned receipt disappears. Three focused regression cases cover these behaviors.

New-head CI and final-review attestation must settle. The previous head’s browser CI failed in live-quiz/course-group UI timeout checks; those results do not describe the new head. The recovery-policy findings have [explicit dispositions](https://github.com/uzh-bf/klicker-uzh/pull/5813#issuecomment-5568364370); legacy recovery after source deactivation remains a parked compatibility decision. No merge or production replay is authorized.

## Security / Privacy

Only source and synthetic tests are published. No private receipts, production exports, credentials or new secret handling are included. Production receipts and consumed claims remain private and must not be replayed.

## Local Session Artifacts

On the task host: `trees/doc-query-activation-publication` holds this publication branch. Prior reviews remain under `trees/doc-query-canary-activation-proof/project/_local/reviews/2026-09-05-doc-query-active-*.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canary-only and full proof modes for document-query activation checks.
  - Added cohort activation support for pinned active or inactive sources.
  - Added rollback re-entry workflows to resume activation safely from a prior receipt.

- **Bug Fixes**
  - Improved validation for mismatched, invalid, or replayed activation receipts.
  - Added safeguards against ambiguous paths, concurrent operations, and failed recovery claims.

- **Documentation**
  - Updated the activation proof plan with recovery limits, quality checks, and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->