### PR TITLE
fix(devrouter): use explicit host and CI tool installations

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -88,6 +88,10 @@ runs:
       shell: bash
       run: pnpm install
 
+    - name: Install Devrouter profile planner
+      shell: bash
+      run: bash .ci-control/.github/scripts/install-devrouter.sh
+
     - name: Download canonical Playwright execution plan
       uses: actions/download-artifact@v4
       with:
@@ -201,6 +205,7 @@ runs:
         if [ "$profile_file_count" -eq "${#PROFILE_RUNTIME_FILES[@]}" ]; then
           RUNTIME_PLAN="${RUNNER_TEMP}/playwright-runtime-${SHARD_INDEX}.json"
           node util/playwright-profile-runtime.mjs resolve \
+            --devrouter-bin "$KLICKER_DEVROUTER_BIN" \
             --profile "$PROFILE" \
             --output "$RUNTIME_PLAN"
           export PLAYWRIGHT_RUNTIME_PLAN="$RUNTIME_PLAN"

--- a/.github/scripts/install-devrouter.sh
+++ b/.github/scripts/install-devrouter.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI needs profile planning only; this installation never configures a router.
+# Keep the reviewed tool release aligned with .devrouter.yml.
+tool_prefix="${RUNNER_TEMP:?}/klicker-devrouter"
+npm install --global --prefix "$tool_prefix" --ignore-scripts --no-audit --no-fund '@devrouter/cli@0.0.55'
+echo "$tool_prefix/bin" >> "${GITHUB_PATH:?}"
+echo "KLICKER_DEVROUTER_BIN=$tool_prefix/bin/devrouter" >> "${GITHUB_ENV:?}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,8 +61,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Devrouter profile planner
+        run: bash .github/scripts/install-devrouter.sh
+
       - name: Check Playwright CI contracts
         run: pnpm run check:playwright-ci
+
+      - name: Check Playwright host launcher
+        run: pnpm run check:playwright-host
 
       - name: Check file formatting
         shell: bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -225,10 +225,17 @@ trusted planner assigns candidate-only specs to `full`. The runtime adapter
 resolves a union containing `full` through the explicit `playwright` Devrouter
 profile, which includes every CI-supported application but excludes local-only
 MCP, LiteLLM, and MailHog resources.
-The root dependency pins `@devrouter/cli` to exact version `0.0.55`; its reviewed
-minimum-release-age exception is exact as well. The package's optional native
-SSH helpers are explicitly denied build scripts because profile planning has no
-Docker or SSH path.
+CI installs `@devrouter/cli` version `0.0.55` through
+`.github/scripts/install-devrouter.sh` in a job-local tool prefix, with install
+scripts disabled. The shard action uses the trusted control checkout's installer
+and passes its absolute executable path to the runtime adapter, including for
+older caller branches. The codebase-check job uses the same installer for real
+profile-contract tests. No Docker or SSH setup runs through this CLI in CI.
+Local launchers use the host installation, excluding workspace executable bins,
+and check its version against `.devrouter.yml` before runtime access. Set
+`KLICKER_DEVROUTER_BIN` to an absolute host executable when PATH is ambiguous.
+Devrouter is not a repository dependency; update the reviewed CI tool release
+alongside `.devrouter.yml` when raising the required version.
 The repository-owned contract maps app identities to literal Turbo filters and
 loopback readiness endpoints, constrains managed services, and requires the
 exact process marker. `util/playwright-profile-runtime.mjs` remains a thin

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "~2.5.2",
-    "@devrouter/cli": "0.0.55",
     "@types/node": "^24.10.1",
     "cross-env": "~7.0.3",
     "husky": "~9.1.7",

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -23,6 +23,17 @@ Run from a host shell at the repository root. The launcher starts or reconciles
 the exact devrouter workspace, resolves its namespaced routes and database, and
 keeps the Playwright process and browser binaries on the host.
 
+Install Devrouter on the host; it is not a workspace dependency. The launcher
+ignores `node_modules` executable directories, reports the selected absolute
+path and version, and rejects a CLI older than `.devrouter.yml` before runtime
+reconciliation. When multiple global installations exist, set
+`KLICKER_DEVROUTER_BIN` to the intended executable's absolute path. It never
+installs or upgrades the host CLI automatically.
+
+CI installs its reviewed Devrouter release separately for read-only profile
+planning. It continues to run Playwright in the official container without
+starting Devrouter infrastructure.
+
 ```bash
 # run all Chromium tests
 pnpm playwright:host -- --project=chromium

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       '@biomejs/biome':
         specifier: ~2.5.2
         version: 2.5.2
-      '@devrouter/cli':
-        specifier: 0.0.55
-        version: 0.0.55
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.4
@@ -3712,9 +3709,6 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@balena/dockerignore@1.0.2':
-    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
-
   '@bigheads/core@0.3.3':
     resolution: {integrity: sha512-lu+TbgFR3IRPQR539td47935SwujzT4OQJdqReksVPJ9f3Tn80kpemIsdmO4yYm9FWW7eAGV+a5bFKC4/1jpLA==}
     engines: {node: '>=10'}
@@ -4084,11 +4078,6 @@ packages:
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
-
-  '@devrouter/cli@0.0.55':
-    resolution: {integrity: sha512-ZmVCBN1wzjFob0Njz5RhYa/op4/7yuu8w45OWFxpLConrc+R3GOrJaC3OBTPAEWa3BZFxsnzhtdpbVpWacDiKg==}
-    engines: {node: '>=24'}
-    hasBin: true
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -10757,9 +10746,6 @@ packages:
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
   asn1js@3.0.6:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
@@ -10972,9 +10958,6 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
@@ -11091,10 +11074,6 @@ packages:
   buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
-
-  buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -11728,10 +11707,6 @@ packages:
       typescript:
         optional: true
 
-  cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
-
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -12261,14 +12236,6 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
-
-  docker-modem@5.0.7:
-    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
-    engines: {node: '>= 8.0'}
-
-  dockerode@4.0.12:
-    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
-    engines: {node: '>= 8.0'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -15597,9 +15564,6 @@ packages:
     resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
     engines: {node: '>=12.0.0'}
 
-  nan@2.28.0:
-    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -18455,9 +18419,6 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
 
-  split-ca@1.0.1:
-    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
-
   split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
 
@@ -18488,10 +18449,6 @@ packages:
   srcset@4.0.0:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
-
-  ssh2@1.17.0:
-    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
-    engines: {node: '>=10.16.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -19111,9 +19068,6 @@ packages:
 
   tw-animate-css@1.3.7:
     resolution: {integrity: sha512-lvLb3hTIpB5oGsk8JmLoAjeCHV58nKa2zHYn8yWOoG5JJusH3bhJlF2DLAZ/5NmJ+jyH3ssiAx/2KmbhavJy/A==}
-
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -21838,8 +21792,6 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@balena/dockerignore@1.0.2': {}
-
   '@bigheads/core@0.3.3(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -22206,15 +22158,6 @@ snapshots:
       postcss: 8.5.14
 
   '@date-fns/tz@1.2.0': {}
-
-  '@devrouter/cli@0.0.55':
-    dependencies:
-      commander: 12.1.0
-      dockerode: 4.0.12
-      jsonc-parser: 3.3.1
-      yaml: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -30037,10 +29980,6 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
   asn1js@3.0.6:
     dependencies:
       pvtsutils: 1.3.6
@@ -30282,10 +30221,6 @@ snapshots:
 
   batch@0.6.1: {}
 
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
-
   bcryptjs@2.4.3: {}
 
   better-ajv-errors@1.2.0(ajv@8.20.0):
@@ -30456,9 +30391,6 @@ snapshots:
       ieee754: 1.2.1
 
   buffers@0.1.1: {}
-
-  buildcheck@0.0.7:
-    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -31171,12 +31103,6 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  cpu-features@0.0.10:
-    dependencies:
-      buildcheck: 0.0.7
-      nan: 2.28.0
-    optional: true
-
   crc-32@1.2.2: {}
 
   crc32-stream@4.0.3:
@@ -31694,27 +31620,6 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
-
-  docker-modem@5.0.7:
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      readable-stream: 3.6.2
-      split-ca: 1.0.1
-      ssh2: 1.17.0
-    transitivePeerDependencies:
-      - supports-color
-
-  dockerode@4.0.12:
-    dependencies:
-      '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.13.4
-      '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7
-      protobufjs: 7.5.6
-      tar-fs: 2.1.4
-      uuid: 10.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   doctrine@2.1.0:
     dependencies:
@@ -36176,9 +36081,6 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
-  nan@2.28.0:
-    optional: true
-
   nanoid@3.3.11: {}
 
   nanoid@3.3.12: {}
@@ -40041,8 +39943,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  split-ca@1.0.1: {}
-
   split2@3.2.2:
     dependencies:
       readable-stream: 3.6.2
@@ -40068,14 +39968,6 @@ snapshots:
   sqlstring@2.3.3: {}
 
   srcset@4.0.0: {}
-
-  ssh2@1.17.0:
-    dependencies:
-      asn1: 0.2.6
-      bcrypt-pbkdf: 1.0.2
-    optionalDependencies:
-      cpu-features: 0.0.10
-      nan: 2.28.0
 
   stable-hash@0.0.5: {}
 
@@ -40787,8 +40679,6 @@ snapshots:
   tw-animate-css@1.3.4: {}
 
   tw-animate-css@1.3.7: {}
-
-  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,6 @@ minimumReleaseAge: 20160
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:
-  # Exact Devrouter release reviewed with the matching package.json bump: 0.0.55
-  # needs no schema migration or generated-config rewrite for this repository.
-  - '@devrouter/cli@0.0.55'
   # Internal UZH design-system release: the exact 4.1.8 consumer bump is
   # reviewed and verified in this PR.
   - '@uzh-bf/design-system@4.1.8'

--- a/util/devrouter-cli.mjs
+++ b/util/devrouter-cli.mjs
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process'
+import { accessSync, constants, realpathSync, statSync } from 'node:fs'
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path'
+
+function isHostExecutable(path) {
+  if (!isAbsolute(path)) return false
+  try {
+    // pnpm prepends workspace bins, including bins from ancestor checkouts.
+    for (const directory of [dirname(path), realpathSync(dirname(path))]) {
+      if (directory.split(/[\\/]/).includes('node_modules')) return false
+    }
+    accessSync(path, constants.X_OK)
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+export function resolveDevrouter({ repo, env = process.env, executable } = {}) {
+  const override = executable ?? env.KLICKER_DEVROUTER_BIN
+  const candidates = override
+    ? [override]
+    : (env.PATH ?? '')
+        .split(delimiter)
+        .filter(isAbsolute)
+        .map((directory) => join(directory, 'devrouter'))
+  const binary = candidates.find(isHostExecutable)
+  if (!binary) {
+    throw new Error(
+      'No executable host Devrouter found. Install it on the host and set KLICKER_DEVROUTER_BIN to its absolute path if needed; workspace node_modules binaries are excluded.'
+    )
+  }
+
+  const result = spawnSync(binary, ['-V', '--repo', resolve(repo)], {
+    cwd: repo,
+    env,
+    encoding: 'utf8',
+    timeout: 10000,
+  })
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `Devrouter version check failed for ${binary}: ${result.error?.message ?? result.stderr.trim()}`
+    )
+  }
+  const installed = result.stdout.match(
+    /^Installed CLI version: (\d+\.\d+\.\d+)$/m
+  )?.[1]
+  const required = result.stdout.match(
+    /^Local repo version \(.+\): (\d+\.\d+\.\d+)$/m
+  )?.[1]
+  if (!installed || !required) {
+    throw new Error(
+      `Cannot determine installed and required Devrouter versions from ${binary}`
+    )
+  }
+  const current = installed.split('.').map(Number)
+  const minimum = required.split('.').map(Number)
+  const difference =
+    current
+      .map((part, index) => part - minimum[index])
+      .find((part) => part !== 0) ?? 0
+  console.error(
+    `[devrouter] ${binary}: installed ${installed}, required >=${required}`
+  )
+  if (difference < 0) {
+    throw new Error(
+      `Host Devrouter ${binary} is too old. Upgrade that installation to ${required} or newer, or set KLICKER_DEVROUTER_BIN to the intended host executable.`
+    )
+  }
+  return binary
+}

--- a/util/playwright-profile-runtime.mjs
+++ b/util/playwright-profile-runtime.mjs
@@ -4,13 +4,10 @@ import { spawn, spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { resolveDevrouter } from './devrouter-cli.mjs'
 
 const SCHEMA_VERSION = 1
 const REPOSITORY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
-const DEFAULT_DEVROUTER_BIN = resolve(
-  REPOSITORY_ROOT,
-  'node_modules/.bin/devrouter'
-)
 const PROFILE_PLAN_CONTRACT = 'playwright/runtime-contract.yml'
 const PLAYWRIGHT_FULL_PROFILE = 'playwright'
 const TRUSTED_FULL_PROFILE_COMPONENTS = new Set([
@@ -163,7 +160,7 @@ export function resolveRuntimePlan({
   profile,
   output,
   repo = REPOSITORY_ROOT,
-  devrouterBin = DEFAULT_DEVROUTER_BIN,
+  devrouterBin,
   contract = PROFILE_PLAN_CONTRACT,
 }) {
   requireString(profile, 'profile selection')
@@ -180,7 +177,7 @@ export function resolveRuntimePlan({
       : profile
 
   const result = spawnSync(
-    devrouterBin,
+    resolveDevrouter({ repo, executable: devrouterBin }),
     [
       'profile',
       'plan',
@@ -303,7 +300,7 @@ function main(args = process.argv.slice(2)) {
       profile: option(options, '--profile'),
       output: option(options, '--output'),
       repo: option(options, '--repo', REPOSITORY_ROOT),
-      devrouterBin: option(options, '--devrouter-bin', DEFAULT_DEVROUTER_BIN),
+      devrouterBin: option(options, '--devrouter-bin'),
       contract: option(options, '--contract', PROFILE_PLAN_CONTRACT),
     })
     console.log(

--- a/util/run-playwright-host.mjs
+++ b/util/run-playwright-host.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { delimiter, dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { resolveDevrouter } from './devrouter-cli.mjs'
 import {
   assertPlaywrightHostBoundary,
   HOST_RUNNER_ENV,
@@ -236,8 +237,9 @@ export function main(argv = process.argv.slice(2)) {
   const printEnvironment = args[0] === '--print-env'
   if (printEnvironment) args.shift()
 
+  const devrouter = resolveDevrouter({ repo: repoRoot })
   console.log('[playwright:host] Reconciling the devcontainer runtime')
-  run('devrouter', ['ensure', repoRoot])
+  run(devrouter, ['ensure', repoRoot])
 
   const workspace = resolveWorkspace()
   const databasePort = resolveDatabasePort()

--- a/util/run-playwright-host.test.mjs
+++ b/util/run-playwright-host.test.mjs
@@ -1,8 +1,17 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { resolveDevrouter } from './devrouter-cli.mjs'
 import {
   assertPlaywrightHostBoundary,
   HOST_RUNNER_ENV,
@@ -16,6 +25,94 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const simulatedHostCwd = '/Users/test/klicker-uzh'
 
 const noContainerPaths = () => false
+
+function cliFixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'klicker-host-cli-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const calls = join(root, 'calls.jsonl')
+  function binary(directory, version = '0.0.55', status = 0) {
+    const folder = join(root, directory)
+    mkdirSync(folder, { recursive: true })
+    const path = join(folder, 'devrouter')
+    writeFileSync(
+      path,
+      `#!${process.execPath}\nconst fs = require('node:fs')\nfs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(process.argv.slice(2)) + '\\n')\nconsole.log(${JSON.stringify(`Installed CLI version: ${version}\nLocal repo version (${root}/.devrouter.yml): 0.0.55`)})\nprocess.exitCode = ${status}\n`,
+      { mode: 0o755 }
+    )
+    return path
+  }
+  return { root, calls, binary }
+}
+
+test('host CLI selection skips stale worktree bins and symlinked bin directories', (t) => {
+  const { root, calls, binary } = cliFixture(t)
+  const stale = binary('old-worktree/node_modules/.bin', '0.0.51')
+  const host = binary('host/bin')
+  symlinkSync(dirname(stale), join(root, 'alias-bin'))
+  const env = {
+    PATH: [dirname(stale), join(root, 'alias-bin'), dirname(host)].join(
+      delimiter
+    ),
+  }
+  assert.equal(resolveDevrouter({ repo: root, env }), host)
+  assert.deepEqual(
+    readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse),
+    [['-V', '--repo', root]]
+  )
+})
+
+test('a host override resolves multiple global installations without silently selecting another', (t) => {
+  const { root, binary } = cliFixture(t)
+  const old = binary('old-host/bin', '0.0.51')
+  const current = binary('new-host/bin', '0.0.56')
+  const env = { PATH: [dirname(old), dirname(current)].join(delimiter) }
+  assert.throws(() => resolveDevrouter({ repo: root, env }), /too old/)
+  assert.equal(
+    resolveDevrouter({
+      repo: root,
+      env: { ...env, KLICKER_DEVROUTER_BIN: current },
+    }),
+    current
+  )
+})
+
+test('missing, workspace-local, non-executable and broken explicit CLIs fail before runtime access', (t) => {
+  const { root, calls, binary } = cliFixture(t)
+  const stale = binary('node_modules/.bin')
+  const broken = binary('broken/bin', '0.0.55', 1)
+  const nonExecutable = join(root, 'not-executable')
+  writeFileSync(nonExecutable, 'not an executable')
+  for (const executable of [
+    join(root, 'missing'),
+    stale,
+    nonExecutable,
+    './devrouter',
+  ]) {
+    assert.throws(
+      () => resolveDevrouter({ repo: root, executable }),
+      /No executable host Devrouter/
+    )
+  }
+  assert.throws(
+    () => resolveDevrouter({ repo: root, executable: broken }),
+    /version check failed/
+  )
+  assert.deepEqual(
+    readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse),
+    [['-V', '--repo', root]]
+  )
+})
+
+test('unparseable CLI versions cannot pass compatibility checks', (t) => {
+  const { root, binary } = cliFixture(t)
+  for (const version of ['unknown', '0.0.55-rc.1']) {
+    const executable = binary('host/bin', version)
+    assert.throws(
+      () => resolveDevrouter({ repo: root, executable }),
+      /Cannot determine/
+    )
+  }
+})
 
 test('local Playwright rejects direct host execution', () => {
   assert.throws(


### PR DESCRIPTION
## What This Fixes

Local Playwright can select an old repository-installed Devrouter even after the host CLI is upgraded. Remove the workspace dependency and make executable selection explicit before runtime reconciliation.

The local launcher skips workspace `node_modules` bin directories, reports the selected absolute path and installed/required versions, and rejects a CLI older than `.devrouter.yml`. `KLICKER_DEVROUTER_BIN` selects an intended host installation when PATH contains multiple versions. It does not upgrade the host automatically or silently search for a newer CLI after selecting an outdated one.

## How It Works

CI still needs Devrouter for read-only profile planning. A small installer pins `@devrouter/cli@0.0.55` in a job-local tool prefix with install scripts disabled. The shard action uses the trusted control checkout's installer and passes the executable explicitly, including to older caller branches. Codebase checks install the same tool for the real profile-contract tests. Application startup and service-container ownership stay unchanged.

The lockfile removes Devrouter and its unused dependencies. The obsolete release-age exception is removed. Local Playwright and testing documentation explain the installation boundary.

## Branch Coverage

Base: `v3`. The implementation covers the CLI resolver, two callers, CI installation/wiring, regression tests, dependency removal, and documentation. Substantive size excluding the lockfile: 219 additions and 18 deletions across 11 files.

## Review Focus

Host executable selection, version rejection before runtime mutation, and explicit CI executable forwarding to older caller branches. The minimum-version comparison follows Devrouter's numeric version ordering; prerelease or unparseable output is rejected.

## Verification

Local verification applies to the unchanged committed source:

- All 73 relevant tests pass: 60 Playwright CI contracts and 13 host-launcher tests, including real Devrouter profile planning and stale executable regressions.
- Node 24.16.0 disposable containers run launcher/profile checks. Eight Git-based selector tests run separately on host Node 24.16.0 because the slim image has no Git. The combined container invocation failed on that missing executable; its other 52 CI tests passed.
- pnpm 11.5.0 frozen lockfile validation and supply-chain checks pass. Scoped Biome, Prettier, shell syntax, Git identity, diff inspection, and redacted staged Gitleaks pass.

Not run: full application `check:all`/build hooks, browser journeys, or a live managed runtime. Focused checks replace the broad host hooks for this tooling-only change. Main-session review only; subagents are excluded in this side conversation. Six additional workflow and cache-policy tests pass after integrating `v3`; workflow formatting and staged secret checks also pass. Hosted CI and review results remain pending.

## Blocking Before Merge

- Passing exact-head CI and applicable review feedback.
The approved integration of `v3` preserves both the Devrouter installer and the hosted cache-policy check. Merge is authorized once checks and applicable feedback are settled.

## Follow-Up After Merge

Integrate the shared fix from `v3` into `v3-ai`, then update affected PR branches under their owners. This PR does not modify other worktrees or global installations.

## Local Session Artifacts

Originating Codex Mac host, repository `klicker-uzh`: worktree `trees/rs/host-devrouter`. No application runtime is retained.
