### PR TITLE
fix(chat): authenticate local doc query and preserve source links

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -147,17 +147,31 @@ fi
 # read-only MCP fixture; it is opt-in via the mcp capability (or full). When the
 # selection drops it, stop the exact owned process instead of leaving it stale.
 if [ "$PROFILE_WANTS_MCP" = yes ]; then
+  # Rotate the fixture and Chat together. Only the child receives the ephemeral
+  # credentials; the parent owns cleanup if any later readiness check fails.
+  if [ "${LOCAL_MCP_BOOTSTRAPPED:-}" != 1 ]; then
+    exec node apps/chat/scripts/local-mcp-bootstrap.mjs
+  fi
+  : "${LOCAL_MCP_GENERATION:?Missing local MCP credential generation}"
+  export DEVROUTER_PROCESS_FINGERPRINT_ENV="${DEVROUTER_PROCESS_FINGERPRINT_ENV},LOCAL_MCP_GENERATION"
   MCP_FIXTURE_SHA256=$(sha256sum apps/chat/scripts/local-mcp-server.mjs)
   MCP_FIXTURE_SHA256=${MCP_FIXTURE_SHA256%% *}
   "$DEVROUTER_PROCESS_HELPER" ensure \
     --name klicker-local-mcp \
     --match 'apps/chat/scripts/local-mcp-server.mjs' \
     --log /tmp/local-mcp.log \
-    -- node apps/chat/scripts/local-mcp-server.mjs "$MCP_FIXTURE_SHA256"
+    -- node apps/chat/scripts/local-mcp-server.mjs "$MCP_FIXTURE_SHA256" "$LOCAL_MCP_GENERATION"
 
   # Keep startup bounded: this fixture check must not delay managed-app readiness.
   for attempt in $(seq 1 20); do
-    if curl --fail --silent --show-error http://localhost:1417/health >/dev/null; then
+    if curl --fail --silent http://localhost:1417/health | node -e '
+      let body = ""; process.stdin.on("data", chunk => body += chunk)
+      process.stdin.on("end", () => {
+        try {
+          const health = JSON.parse(body)
+          process.exit(health.status === "ok" && health.generation === process.env.LOCAL_MCP_GENERATION ? 0 : 1)
+        } catch { process.exit(1) }
+      })'; then
       break
     fi
     if [ "$attempt" -eq 20 ]; then

--- a/apps/chat/scripts/local-mcp-auth.mjs
+++ b/apps/chat/scripts/local-mcp-auth.mjs
@@ -1,0 +1,119 @@
+import { timingSafeEqual } from 'node:crypto'
+import { importSPKI, jwtVerify } from 'jose'
+
+export const LOCAL_CHATBOT_ID = '8f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
+export const LOCAL_KB_ID = '35a72f62-a714-45f1-8b18-2cf5681b0c75'
+export const LOCAL_SCOPE = {
+  required: true,
+  toolAlias: 'doc_query',
+  kb_id: LOCAL_KB_ID,
+}
+export const LOCAL_FIXTURE_MARKER = { localFixture: 'authenticated-benibot-v1' }
+
+export async function createLocalAuthenticator(env) {
+  for (const name of [
+    'LOCAL_MCP_TRANSPORT_TOKEN',
+    'LOCAL_MCP_PUBLIC_KEY',
+    'LOCAL_MCP_GENERATION',
+    'DOC_QUERY_SCOPE_KID',
+    'DOC_QUERY_SCOPE_ISSUER',
+    'DOC_QUERY_SCOPE_AUDIENCE',
+  ]) {
+    if (!env[name])
+      throw new Error('Local MCP authentication is not configured')
+  }
+  const expected = Buffer.from(`Bearer ${env.LOCAL_MCP_TRANSPORT_TOKEN}`)
+  const publicKey = await importSPKI(env.LOCAL_MCP_PUBLIC_KEY, 'ES256')
+  return async (headers) => {
+    try {
+      if (typeof headers.authorization !== 'string') return false
+      const actual = Buffer.from(headers.authorization)
+      if (
+        actual.length !== expected.length ||
+        !timingSafeEqual(actual, expected)
+      ) {
+        return false
+      }
+      const scoped = headers['x-doc-query-scope-token']
+      if (typeof scoped !== 'string' || !scoped.startsWith('Bearer '))
+        return false
+      const { payload, protectedHeader } = await jwtVerify(
+        scoped.slice(7),
+        publicKey,
+        {
+          algorithms: ['ES256'],
+          typ: 'JWT',
+          issuer: env.DOC_QUERY_SCOPE_ISSUER,
+          audience: env.DOC_QUERY_SCOPE_AUDIENCE,
+          requiredClaims: ['exp', 'iat', 'sub', 'jti', 'chatbot_id', 'kb_id'],
+          maxTokenAge: 300,
+        }
+      )
+      const boundedIdentifier = (value) =>
+        typeof value === 'string' &&
+        value.trim().length > 0 &&
+        value.length <= 256
+      return (
+        protectedHeader.kid === env.DOC_QUERY_SCOPE_KID &&
+        payload.chatbot_id === LOCAL_CHATBOT_ID &&
+        payload.kb_id === LOCAL_KB_ID &&
+        Number.isInteger(payload.iat) &&
+        Number.isInteger(payload.exp) &&
+        payload.exp > payload.iat &&
+        payload.exp - payload.iat <= 300 &&
+        boundedIdentifier(payload.sub) &&
+        boundedIdentifier(payload.jti)
+      )
+    } catch {
+      return false
+    }
+  }
+}
+
+function exactObject(actual, expected) {
+  return (
+    actual !== null &&
+    typeof actual === 'object' &&
+    !Array.isArray(actual) &&
+    Object.keys(actual).length === Object.keys(expected).length &&
+    Object.entries(expected).every(([key, value]) => actual[key] === value)
+  )
+}
+
+export function assertLocalSeedOwnership(server, configs) {
+  const legacy =
+    server?.authType === 'none' &&
+    !server.authSecret &&
+    (server.parameters === null || exactObject(server.parameters, {}))
+  const authenticated =
+    server?.authType === 'bearer' &&
+    typeof server.authSecret === 'string' &&
+    /^[a-f0-9]{32}:[a-f0-9]{32}:[a-f0-9]+$/i.test(server.authSecret) &&
+    exactObject(server.parameters, LOCAL_FIXTURE_MARKER)
+  if (
+    server?.name !== 'KB' ||
+    server.url !== 'http://localhost:1417/mcp' ||
+    !server.isActive ||
+    !server.passChatbotId ||
+    server.chatbotIdHeader !== null ||
+    (!legacy && !authenticated) ||
+    configs.length !== 2 ||
+    new Set(configs.map((config) => config.chatMode)).size !== 2 ||
+    configs.some(
+      (config) =>
+        config.chatbotId !== LOCAL_CHATBOT_ID ||
+        config.ownerId !== '76047345-3801-4628-ae7b-adbebcfe8821' ||
+        config.courseId !== '7c12e44e-d083-4acf-845e-4c34aaff6b49' ||
+        !['tutor', 'explainer'].includes(config.chatMode) ||
+        !config.isEnabled ||
+        config.priority !== 0 ||
+        !Array.isArray(config.allowedTools) ||
+        config.allowedTools.length !== 1 ||
+        config.allowedTools[0] !== 'doc_query' ||
+        !(legacy
+          ? config.parameters === null || exactObject(config.parameters, {})
+          : exactObject(config.parameters, LOCAL_SCOPE))
+    )
+  )
+    throw new Error('Local MCP seed ownership conflict')
+}

--- a/apps/chat/scripts/local-mcp-bootstrap.mjs
+++ b/apps/chat/scripts/local-mcp-bootstrap.mjs
@@ -1,0 +1,112 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { generateKeyPairSync, randomBytes, randomUUID } from 'node:crypto'
+import { realpathSync } from 'node:fs'
+import pg from 'pg'
+import { repairLocalMcpSeed } from './local-mcp-seed.mjs'
+
+const ROOT = '/workspaces/klicker-uzh'
+let child
+let interrupted = false
+let ownsProcesses = false
+let interruptionTimer
+const helper = process.env.DEVROUTER_PROCESS_HELPER
+
+function stopOwnedProcesses() {
+  let failed = false
+  for (const name of ['klicker-dev', 'klicker-local-mcp']) {
+    const result = spawnSync(helper, ['stop', '--name', name], {
+      stdio: 'ignore',
+      timeout: 30000,
+    })
+    if (result.status !== 0) failed = true
+  }
+  if (failed) throw new Error('Local MCP process stop failed')
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    interrupted = true
+    child?.kill(signal)
+    interruptionTimer ??= setTimeout(() => child?.kill('SIGKILL'), 5000)
+    interruptionTimer.unref()
+  })
+}
+
+try {
+  const database = new URL(process.env.DATABASE_URL)
+  if (
+    realpathSync(process.cwd()) !== ROOT ||
+    !['postgres:', 'postgresql:'].includes(database.protocol) ||
+    !['postgres', 'localhost', '127.0.0.1', '[::1]'].includes(
+      database.hostname
+    ) ||
+    database.search !== '' ||
+    !helper ||
+    spawnSync('bash', ['./util/dev-runtime.sh', 'require-bootstrap'], {
+      stdio: 'ignore',
+    }).status !== 0 ||
+    spawnSync(
+      'bash',
+      ['-c', '. ./util/profile-resolver.sh; profile_wants klicker-local-mcp'],
+      {
+        stdio: 'ignore',
+      }
+    ).status !== 0
+  )
+    throw new Error('Local MCP runtime boundary rejected')
+
+  ownsProcesses = true
+  stopOwnedProcesses()
+  if (interrupted) throw new Error('Local MCP startup interrupted')
+  const generation = randomUUID()
+  const token = randomBytes(32).toString('hex')
+  const { privateKey, publicKey } = generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1',
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  })
+  const db = new pg.Client({
+    connectionString: process.env.DATABASE_URL,
+    connectionTimeoutMillis: 10000,
+  })
+  // Avoid emitting driver errors or SQL parameters from this credential writer.
+  db.on('error', () => {})
+  try {
+    await db.connect()
+    await repairLocalMcpSeed(db, token, () => interrupted)
+  } finally {
+    await db.end()
+  }
+  if (interrupted) throw new Error('Local MCP startup interrupted')
+  const status = await new Promise((resolve, reject) => {
+    child = spawn('bash', ['./.devcontainer/post-start.sh'], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        LOCAL_MCP_BOOTSTRAPPED: '1',
+        LOCAL_MCP_GENERATION: generation,
+        LOCAL_MCP_TRANSPORT_TOKEN: token,
+        LOCAL_MCP_PUBLIC_KEY: publicKey,
+        DOC_QUERY_SCOPE_PRIVATE_KEY: privateKey,
+        DOC_QUERY_SCOPE_KID: generation,
+        DOC_QUERY_SCOPE_ISSUER: 'klicker-local-chat',
+        DOC_QUERY_SCOPE_AUDIENCE: 'klicker-local-doc-query',
+      },
+    })
+    child.once('error', reject)
+    child.once('exit', (code) => resolve(code ?? 1))
+  })
+  if (status !== 0 || interrupted) throw new Error('Local MCP startup failed')
+} catch {
+  if (ownsProcesses) {
+    try {
+      stopOwnedProcesses()
+    } catch {
+      console.error('[local-mcp] Owned process cleanup failed')
+    }
+  }
+  console.error(
+    '[local-mcp] Authenticated fixture startup failed; no credentials logged'
+  )
+  process.exitCode = 1
+}

--- a/apps/chat/scripts/local-mcp-seed.mjs
+++ b/apps/chat/scripts/local-mcp-seed.mjs
@@ -1,0 +1,44 @@
+import { encrypt } from '@klicker-uzh/util'
+import {
+  assertLocalSeedOwnership,
+  LOCAL_FIXTURE_MARKER,
+  LOCAL_SCOPE,
+} from './local-mcp-auth.mjs'
+
+// The caller owns the local-runtime boundary and the database connection.
+export async function repairLocalMcpSeed(db, token, isInterrupted) {
+  try {
+    await db.query('BEGIN ISOLATION LEVEL SERIALIZABLE')
+    await db.query("SET LOCAL lock_timeout = '5s'")
+    await db.query("SET LOCAL statement_timeout = '10s'")
+    const { rows: servers } = await db.query(
+      'SELECT * FROM "ChatbotMCPServer" WHERE name = $1 FOR UPDATE',
+      ['KB']
+    )
+    if (servers.length !== 1) throw new Error('Local MCP seed missing')
+    const server = servers[0]
+    const { rows: configs } = await db.query(
+      'SELECT c.*, b."ownerId", b."courseId" FROM "ChatbotMCPConfig" c JOIN "Chatbot" b ON b.id = c."chatbotId" WHERE c."mcpServerId" = $1 FOR UPDATE OF c, b',
+      [server.id]
+    )
+    assertLocalSeedOwnership(server, configs)
+    if (isInterrupted()) throw new Error('Local MCP startup interrupted')
+    await db.query(
+      'UPDATE "ChatbotMCPServer" SET "authType" = $1, "authSecret" = $2, parameters = $3::jsonb, "updatedAt" = NOW() WHERE id = $4',
+      [
+        'bearer',
+        encrypt(token),
+        JSON.stringify(LOCAL_FIXTURE_MARKER),
+        server.id,
+      ]
+    )
+    await db.query(
+      'UPDATE "ChatbotMCPConfig" SET parameters = $1::jsonb, "updatedAt" = NOW() WHERE "mcpServerId" = $2',
+      [JSON.stringify(LOCAL_SCOPE), server.id]
+    )
+    await db.query('COMMIT')
+  } catch {
+    await db.query('ROLLBACK').catch(() => {})
+    throw new Error('Local MCP seed repair rejected')
+  }
+}

--- a/apps/chat/scripts/local-mcp-server.mjs
+++ b/apps/chat/scripts/local-mcp-server.mjs
@@ -2,10 +2,12 @@ import { createServer } from 'node:http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { z } from 'zod'
+import { createLocalAuthenticator } from './local-mcp-auth.mjs'
 
 const HOST = '127.0.0.1'
 const PORT = 1417
 const MAX_BODY_BYTES = 1024 * 1024
+const authenticate = await createLocalAuthenticator(process.env)
 
 const SYNTHETIC_DOCUMENTS = [
   {
@@ -166,7 +168,10 @@ function sendJson(response, status, body) {
 
 const httpServer = createServer(async (request, response) => {
   if (request.url === '/health' && request.method === 'GET') {
-    sendJson(response, 200, { status: 'ok' })
+    sendJson(response, 200, {
+      status: 'ok',
+      generation: process.env.LOCAL_MCP_GENERATION,
+    })
     return
   }
 
@@ -178,6 +183,11 @@ const httpServer = createServer(async (request, response) => {
   if (request.method !== 'POST') {
     response.writeHead(405, { Allow: 'POST' })
     response.end()
+    return
+  }
+
+  if (!(await authenticate(request.headers))) {
+    sendJson(response, 401, { error: 'Unauthorized' })
     return
   }
 
@@ -198,8 +208,8 @@ const httpServer = createServer(async (request, response) => {
     const body = await readJsonBody(request)
     await mcpServer.connect(transport)
     await transport.handleRequest(request, response, body)
-  } catch (error) {
-    console.error('[local-mcp] Request failed:', error)
+  } catch {
+    console.error('[local-mcp] Invalid request')
     if (!response.headersSent) {
       sendJson(response, 400, {
         jsonrpc: '2.0',

--- a/apps/chat/scripts/test-local-mcp-seed.mjs
+++ b/apps/chat/scripts/test-local-mcp-seed.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { realpathSync } from 'node:fs'
+import { isDeepStrictEqual } from 'node:util'
 import { decrypt } from '@klicker-uzh/util'
 import pg from 'pg'
 
@@ -31,28 +32,8 @@ function requireTrue(value, message) {
   assert.equal(value, true, message)
 }
 
-function canonicalJson(value) {
-  if (value instanceof Date) return value.toISOString()
-  if (Array.isArray(value)) return value.map(canonicalJson)
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.keys(value)
-        .sort()
-        .map((key) => [key, canonicalJson(value[key])])
-    )
-  }
-  return value
-}
-
-function jsonEqual(actual, expected) {
-  return (
-    JSON.stringify(canonicalJson(actual)) ===
-    JSON.stringify(canonicalJson(expected))
-  )
-}
-
 function requireJsonEqual(actual, expected, message) {
-  requireTrue(jsonEqual(actual, expected), message)
+  requireTrue(isDeepStrictEqual(actual, expected), message)
 }
 
 function validateRuntimeContext() {

--- a/apps/chat/scripts/test-local-mcp-seed.mjs
+++ b/apps/chat/scripts/test-local-mcp-seed.mjs
@@ -1,0 +1,337 @@
+import assert from 'node:assert/strict'
+import { realpathSync } from 'node:fs'
+import { decrypt } from '@klicker-uzh/util'
+import pg from 'pg'
+
+import {
+  LOCAL_CHATBOT_ID,
+  LOCAL_FIXTURE_MARKER,
+  LOCAL_SCOPE,
+} from './local-mcp-auth.mjs'
+import { repairLocalMcpSeed } from './local-mcp-seed.mjs'
+
+const { Client } = pg
+
+const EXPECTED_CWD = '/workspaces/klicker-uzh'
+const SERVER_ID = 'local-mcp-test-server'
+const TUTOR_CONFIG_ID = 'local-mcp-test-tutor'
+const EXPLAINER_CONFIG_ID = 'local-mcp-test-explainer'
+const EXTRA_CONFIG_ID = 'local-mcp-test-extra'
+const EXTRA_CHATBOT_ID = 'local-mcp-test-extra-chatbot'
+const SYNTHETIC_OWNER_ID = '76047345-3801-4628-ae7b-adbebcfe8821'
+const SYNTHETIC_COURSE_ID = '7c12e44e-d083-4acf-845e-4c34aaff6b49'
+const SYNTHETIC_TOKEN_A = 'local-mcp-transport-token-a'
+const SYNTHETIC_TOKEN_B = 'local-mcp-transport-token-b'
+const SYNTHETIC_TIMESTAMP = '2000-01-01T00:00:00.000Z'
+const AUTH_SECRET_PATTERN = /^[a-f0-9]{32}:[a-f0-9]{32}:[a-f0-9]+$/i
+const STATIC_FAILURE = 'Local MCP seed acceptance failed'
+const STATIC_SUCCESS = 'Local MCP seed acceptance passed'
+
+function requireTrue(value, message) {
+  assert.equal(value, true, message)
+}
+
+function canonicalJson(value) {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map(canonicalJson)
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalJson(value[key])])
+    )
+  }
+  return value
+}
+
+function jsonEqual(actual, expected) {
+  return (
+    JSON.stringify(canonicalJson(actual)) ===
+    JSON.stringify(canonicalJson(expected))
+  )
+}
+
+function requireJsonEqual(actual, expected, message) {
+  requireTrue(jsonEqual(actual, expected), message)
+}
+
+function validateRuntimeContext() {
+  requireTrue(
+    realpathSync(process.cwd()) === EXPECTED_CWD,
+    'invalid working directory'
+  )
+
+  const databaseUrl = process.env.DATABASE_URL
+  requireTrue(
+    typeof databaseUrl === 'string' && databaseUrl.length > 0,
+    'missing database URL'
+  )
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(databaseUrl)
+  } catch {
+    throw new Error('invalid database URL')
+  }
+
+  requireTrue(
+    ['postgres:', 'postgresql:'].includes(parsedUrl.protocol),
+    'invalid database URL protocol'
+  )
+  requireTrue(
+    ['postgres', 'localhost', '127.0.0.1'].includes(parsedUrl.hostname),
+    'invalid database URL host'
+  )
+  requireTrue(parsedUrl.search === '', 'database URL query is not allowed')
+}
+
+async function createTemporarySchema(db) {
+  await db.query(`
+    CREATE TEMP TABLE "ChatbotMCPServer" (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      "authType" text NOT NULL,
+      "authSecret" text,
+      parameters jsonb,
+      url text NOT NULL,
+      "isActive" boolean NOT NULL,
+      "passChatbotId" boolean NOT NULL,
+      "chatbotIdHeader" text,
+      "updatedAt" timestamptz NOT NULL
+    )
+  `)
+  await db.query(`
+    CREATE TEMP TABLE "Chatbot" (
+      id text PRIMARY KEY,
+      "ownerId" text NOT NULL,
+      "courseId" text NOT NULL
+    )
+  `)
+  await db.query(`
+    CREATE TEMP TABLE "ChatbotMCPConfig" (
+      id text PRIMARY KEY,
+      "mcpServerId" text NOT NULL,
+      "chatbotId" text NOT NULL,
+      "chatMode" text NOT NULL,
+      "isEnabled" boolean NOT NULL,
+      priority integer NOT NULL,
+      "allowedTools" text[] NOT NULL,
+      parameters jsonb,
+      "updatedAt" timestamptz NOT NULL
+    )
+  `)
+}
+
+async function resetSyntheticFixture(db) {
+  await db.query('DELETE FROM "ChatbotMCPConfig"')
+  await db.query('DELETE FROM "ChatbotMCPServer"')
+  await db.query('DELETE FROM "Chatbot"')
+
+  await db.query(
+    'INSERT INTO "Chatbot" (id, "ownerId", "courseId") VALUES ($1, $2, $3)',
+    [LOCAL_CHATBOT_ID, SYNTHETIC_OWNER_ID, SYNTHETIC_COURSE_ID]
+  )
+  await db.query(
+    'INSERT INTO "ChatbotMCPServer" (id, name, "authType", "authSecret", parameters, url, "isActive", "passChatbotId", "chatbotIdHeader", "updatedAt") VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10)',
+    [
+      SERVER_ID,
+      'KB',
+      'none',
+      null,
+      null,
+      'http://localhost:1417/mcp',
+      true,
+      true,
+      null,
+      SYNTHETIC_TIMESTAMP,
+    ]
+  )
+
+  for (const [id, chatMode] of [
+    [TUTOR_CONFIG_ID, 'tutor'],
+    [EXPLAINER_CONFIG_ID, 'explainer'],
+  ]) {
+    await db.query(
+      'INSERT INTO "ChatbotMCPConfig" (id, "mcpServerId", "chatbotId", "chatMode", "isEnabled", priority, "allowedTools", parameters, "updatedAt") VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)',
+      [
+        id,
+        SERVER_ID,
+        LOCAL_CHATBOT_ID,
+        chatMode,
+        true,
+        0,
+        ['doc_query'],
+        null,
+        SYNTHETIC_TIMESTAMP,
+      ]
+    )
+  }
+}
+
+async function addExtraConsumer(db) {
+  await db.query(
+    'INSERT INTO "Chatbot" (id, "ownerId", "courseId") VALUES ($1, $2, $3)',
+    [EXTRA_CHATBOT_ID, SYNTHETIC_OWNER_ID, SYNTHETIC_COURSE_ID]
+  )
+  await db.query(
+    'INSERT INTO "ChatbotMCPConfig" (id, "mcpServerId", "chatbotId", "chatMode", "isEnabled", priority, "allowedTools", parameters, "updatedAt") VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)',
+    [
+      EXTRA_CONFIG_ID,
+      SERVER_ID,
+      EXTRA_CHATBOT_ID,
+      'extra',
+      true,
+      0,
+      ['doc_query'],
+      null,
+      SYNTHETIC_TIMESTAMP,
+    ]
+  )
+}
+
+async function snapshot(db) {
+  const { rows: servers } = await db.query(
+    'SELECT id, name, "authType", "authSecret", parameters, url, "isActive", "passChatbotId", "chatbotIdHeader", "updatedAt" FROM "ChatbotMCPServer" ORDER BY id'
+  )
+  const { rows: configs } = await db.query(
+    'SELECT id, "mcpServerId", "chatbotId", "chatMode", "isEnabled", priority, "allowedTools", parameters, "updatedAt" FROM "ChatbotMCPConfig" ORDER BY id'
+  )
+  const { rows: chatbots } = await db.query(
+    'SELECT id, "ownerId", "courseId" FROM "Chatbot" ORDER BY id'
+  )
+  return { chatbots, configs, servers }
+}
+
+function requireAuthenticatedFixture(state, message) {
+  requireTrue(state.servers.length === 1, `${message}: server count`)
+  requireTrue(state.configs.length === 2, `${message}: config count`)
+  const [server] = state.servers
+  requireTrue(server.authType === 'bearer', `${message}: auth type`)
+  requireTrue(
+    typeof server.authSecret === 'string' &&
+      AUTH_SECRET_PATTERN.test(server.authSecret),
+    `${message}: auth secret format`
+  )
+  requireJsonEqual(
+    server.parameters,
+    LOCAL_FIXTURE_MARKER,
+    `${message}: server marker`
+  )
+  for (const config of state.configs) {
+    requireJsonEqual(config.parameters, LOCAL_SCOPE, `${message}: config scope`)
+  }
+}
+
+async function requireRepairRejected(db, token, isInterrupted, message) {
+  let rejected = false
+  try {
+    await repairLocalMcpSeed(db, token, isInterrupted)
+  } catch {
+    rejected = true
+  }
+  requireTrue(rejected, message)
+}
+
+async function runAcceptance(db) {
+  await createTemporarySchema(db)
+
+  await resetSyntheticFixture(db)
+  await repairLocalMcpSeed(db, SYNTHETIC_TOKEN_A, () => false)
+  const firstRotation = await snapshot(db)
+  requireAuthenticatedFixture(firstRotation, 'initial repair')
+
+  const firstAuthSecret = firstRotation.servers[0].authSecret
+  requireTrue(
+    decrypt(firstAuthSecret) === SYNTHETIC_TOKEN_A,
+    'initial repair stored the wrong token'
+  )
+  await repairLocalMcpSeed(db, SYNTHETIC_TOKEN_B, () => false)
+  const secondRotation = await snapshot(db)
+  requireAuthenticatedFixture(secondRotation, 'repeat repair')
+  requireTrue(
+    decrypt(secondRotation.servers[0].authSecret) === SYNTHETIC_TOKEN_B,
+    'repeat repair stored the wrong token'
+  )
+
+  await addExtraConsumer(db)
+  const ownershipBefore = await snapshot(db)
+  await requireRepairRejected(
+    db,
+    SYNTHETIC_TOKEN_A,
+    () => false,
+    'ownership conflict was accepted'
+  )
+  const ownershipAfter = await snapshot(db)
+  requireJsonEqual(
+    ownershipAfter,
+    ownershipBefore,
+    'ownership conflict changed the snapshot'
+  )
+
+  await resetSyntheticFixture(db)
+  const rollbackBefore = await snapshot(db)
+  await db.query(`
+    ALTER TABLE "ChatbotMCPConfig"
+    ADD CONSTRAINT "local_mcp_test_reject_scope"
+    CHECK (parameters IS NULL OR NOT (parameters ? 'required'))
+  `)
+  await requireRepairRejected(
+    db,
+    SYNTHETIC_TOKEN_A,
+    () => false,
+    'second update failure was accepted'
+  )
+  const rollbackAfter = await snapshot(db)
+  requireJsonEqual(
+    rollbackAfter,
+    rollbackBefore,
+    'failed second update changed the snapshot'
+  )
+  await db.query(
+    'ALTER TABLE "ChatbotMCPConfig" DROP CONSTRAINT "local_mcp_test_reject_scope"'
+  )
+
+  await resetSyntheticFixture(db)
+  const interruptionBefore = await snapshot(db)
+  await requireRepairRejected(
+    db,
+    SYNTHETIC_TOKEN_A,
+    () => true,
+    'interruption was accepted'
+  )
+  const interruptionAfter = await snapshot(db)
+  requireJsonEqual(
+    interruptionAfter,
+    interruptionBefore,
+    'interruption before the write changed the snapshot'
+  )
+}
+
+async function main() {
+  requireTrue(
+    process.env.LOCAL_MCP_SEED_TEST === '1',
+    'LOCAL_MCP_SEED_TEST=1 is required'
+  )
+  validateRuntimeContext()
+
+  let client
+  try {
+    client = new Client({
+      connectionString: process.env.DATABASE_URL,
+      connectionTimeoutMillis: 10_000,
+    })
+    client.on('error', () => {})
+    await client.connect()
+    await client.query('SET search_path TO pg_temp')
+    await runAcceptance(client)
+  } finally {
+    if (client) await client.end().catch(() => {})
+  }
+}
+
+main()
+  .then(() => console.log(STATIC_SUCCESS))
+  .catch(() => {
+    console.error(STATIC_FAILURE)
+    process.exitCode = 1
+  })

--- a/apps/chat/scripts/test-local-mcp-startup.mjs
+++ b/apps/chat/scripts/test-local-mcp-startup.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { spawn, spawnSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
+import { setTimeout as delay } from 'node:timers/promises'
+import pg from 'pg'
+
+const helper = '/tmp/devrouter/bin/devrouter-process'
+const root = '/workspaces/klicker-uzh'
+let child
+let db
+let stage = 'runtime boundary'
+let ownsProcesses = false
+
+function stopped() {
+  for (const name of ['klicker-dev', 'klicker-local-mcp']) {
+    const result = spawnSync(helper, ['status', '--name', name], {
+      encoding: 'utf8',
+      timeout: 10000,
+    })
+    assert.equal(result.status, 0)
+    assert.equal(JSON.parse(result.stdout).status, 'stopped')
+  }
+}
+
+function start(env) {
+  let output = ''
+  child = spawn(
+    process.execPath,
+    ['apps/chat/scripts/local-mcp-bootstrap.mjs'],
+    {
+      cwd: root,
+      env: { ...process.env, DEVROUTER_PROFILE: 'mcp', ...env },
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 20000,
+      killSignal: 'SIGKILL',
+    }
+  )
+  child.stdout.on('data', (data) => {
+    output = (output + data.toString()).slice(-8192)
+  })
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', (code, signal) =>
+      resolve({
+        code,
+        signal,
+        fixtureStarted: output.includes('LOCAL_MCP_TEST_FIXTURE_STARTED'),
+      })
+    )
+  })
+}
+
+try {
+  assert.equal(process.env.LOCAL_MCP_STARTUP_TEST, '1')
+  assert.equal(realpathSync(process.cwd()), root)
+  const url = new URL(process.env.DATABASE_URL)
+  assert(['postgres:', 'postgresql:'].includes(url.protocol))
+  assert(['postgres', 'localhost', '127.0.0.1', '[::1]'].includes(url.hostname))
+  assert.equal(url.search, '')
+
+  // Act as the delivered helper only for this subprocess. Start the real fixture
+  // before reporting failure, so cleanup must terminate an actual process.
+  if (['ensure', 'stop'].includes(process.argv[2])) {
+    const result = spawnSync(helper, process.argv.slice(2), {
+      stdio: 'ignore',
+      timeout: 30000,
+    })
+    if (result.status === 0 && process.argv[2] === 'ensure') {
+      console.log('LOCAL_MCP_TEST_FIXTURE_STARTED')
+    }
+    process.exit(
+      result.status === 0 && process.argv[2] === 'ensure'
+        ? 42
+        : (result.status ?? 1)
+    )
+  }
+
+  stage = 'post-start failure'
+  ownsProcesses = true
+  const failed = await start({ DEVROUTER_PROCESS_HELPER: process.argv[1] })
+  assert.deepEqual(failed, { code: 1, signal: null, fixtureStarted: true })
+  stopped()
+  console.log('PASS: post-start failure stops both owned groups')
+
+  stage = 'database lock setup'
+  db = new pg.Client({ connectionString: process.env.DATABASE_URL })
+  db.on('error', () => {})
+  await db.connect()
+  await db.query('BEGIN')
+  await db.query("SET LOCAL statement_timeout = '10s'")
+  await db.query(
+    'SELECT id FROM "ChatbotMCPServer" WHERE name = $1 FOR UPDATE',
+    ['KB']
+  )
+  const application = `local-mcp-interruption-test-${process.pid}`
+  const completed = start({
+    DEVROUTER_PROCESS_HELPER: helper,
+    PGAPPNAME: application,
+  })
+  let waiting = false
+  stage = 'observe bootstrap lock wait'
+  for (let attempt = 0; attempt < 30; attempt++) {
+    await db.query('SELECT pg_stat_clear_snapshot()')
+    const result = await db.query(
+      "SELECT 1 FROM pg_stat_activity WHERE application_name = $1 AND wait_event_type = 'Lock'",
+      [application]
+    )
+    if (result.rowCount === 1) {
+      waiting = true
+      break
+    }
+    await delay(100)
+  }
+  assert(
+    waiting,
+    'Bootstrap must reach the locked transaction before interruption'
+  )
+  stage = 'interruption cleanup'
+  child.kill('SIGTERM')
+  await delay(100)
+  await db.query('ROLLBACK')
+  assert.deepEqual(await completed, {
+    code: 1,
+    signal: null,
+    fixtureStarted: false,
+  })
+  stopped()
+  console.log('PASS: SIGTERM during seed locking exits through owned cleanup')
+} catch {
+  console.error(
+    `FAIL: local MCP startup acceptance at ${stage}; no credentials logged`
+  )
+  process.exitCode = 1
+} finally {
+  if (child?.exitCode === null && child?.signalCode === null)
+    child.kill('SIGKILL')
+  if (db) {
+    await db.query('ROLLBACK').catch(() => {})
+    await db.end()
+  }
+  if (ownsProcesses) {
+    for (const name of ['klicker-dev', 'klicker-local-mcp']) {
+      spawnSync(helper, ['stop', '--name', name], {
+        stdio: 'ignore',
+        timeout: 30000,
+      })
+    }
+  }
+}

--- a/apps/chat/src/lib/sources/normalizeSources.ts
+++ b/apps/chat/src/lib/sources/normalizeSources.ts
@@ -258,6 +258,23 @@ function lastPathSegment(value: string): string | undefined {
   }
 }
 
+// Resource ingestion gateways are machine-to-machine fetch endpoints, never
+// participant source links, even when exposed through a public API hostname.
+function isIngestionReference(value: string | undefined): boolean {
+  if (!value) return false
+  try {
+    const url = new URL(value)
+    const hostname = url.hostname.toLowerCase().replace(/\.$/, '')
+    return (
+      hostname.endsWith('.svc') ||
+      hostname.endsWith('.svc.cluster.local') ||
+      url.pathname.startsWith('/api/ingestion/resources/')
+    )
+  } catch {
+    return false
+  }
+}
+
 function isUrlLike(value: string): boolean {
   return /^https?:\/\//i.test(value)
 }
@@ -330,13 +347,18 @@ function normalizeAnswerModeSources(
     // only one — it also keeps relative paths and other schemes from
     // rendering as links that go nowhere useful from this origin. The raw
     // value still feeds the title and type fallbacks.
-    const url = rawUrl && isUrlLike(rawUrl) ? rawUrl : undefined
+    const ingestionReference = isIngestionReference(rawUrl)
+    const url =
+      rawUrl && isUrlLike(rawUrl) && !ingestionReference ? rawUrl : undefined
     const fileName = cleanString(source.file_name)
     const expert = cleanString(source.expert)
-    // Title fallback chain: file_name -> last URL path segment -> expert
+    // Title fallback chain: display name -> file_name -> URL path -> expert
     // name -> skip (no usable title/url means the entry is useless to show).
     const title =
-      fileName ?? (rawUrl ? lastPathSegment(rawUrl) : undefined) ?? expert
+      cleanString(source.display_name) ??
+      fileName ??
+      (rawUrl && !ingestionReference ? lastPathSegment(rawUrl) : undefined) ??
+      expert
     if (!title) continue
 
     const page = cleanPage(source.page_number)
@@ -349,7 +371,12 @@ function normalizeAnswerModeSources(
       page,
       labeledPage,
       url,
-      dedupeKey: buildDedupeKey({ url, title, page, labeledPage }),
+      dedupeKey: buildDedupeKey({
+        url: ingestionReference ? rawUrl : url,
+        title,
+        page,
+        labeledPage,
+      }),
     })
   }
 
@@ -367,17 +394,23 @@ function normalizeDocumentsModeSources(
     const source = rawSource as Record<string, unknown>
 
     const reference = cleanString(source.reference)
-    const explicitTitle = cleanString(source.title)
+    const explicitTitle =
+      cleanString(source.title) ??
+      cleanString(source.display_name) ??
+      cleanString(source.file_name)
+    const ingestionReference = isIngestionReference(reference)
     const referenceIsUrl = reference ? isUrlLike(reference) : false
-    const url = referenceIsUrl ? reference : undefined
+    const url = referenceIsUrl && !ingestionReference ? reference : undefined
 
     // Title fallback: explicit title -> (if reference is a URL) a short name
     // derived from its last path segment -> the raw reference -> skip.
     const title =
       explicitTitle ??
-      (referenceIsUrl && reference
-        ? (lastPathSegment(reference) ?? reference)
-        : reference)
+      (ingestionReference
+        ? undefined
+        : referenceIsUrl && reference
+          ? (lastPathSegment(reference) ?? reference)
+          : reference)
     if (!title) continue
 
     const rawChunks = Array.isArray(source.chunks) ? source.chunks : []
@@ -409,7 +442,8 @@ function normalizeDocumentsModeSources(
       startSec,
       endSec,
       dedupeKey: buildDedupeKey({
-        url,
+        // Non-link references still identify distinct resources with the same title.
+        url: reference,
         title,
         page,
         labeledPage,

--- a/apps/chat/test/local-mcp-auth.test.ts
+++ b/apps/chat/test/local-mcp-auth.test.ts
@@ -60,14 +60,7 @@ let fixture: SyntheticFixture
 
 async function createSyntheticFixture(
   overrides: Partial<
-    Pick<
-      AuthEnvironment,
-      | 'DOC_QUERY_SCOPE_AUDIENCE'
-      | 'DOC_QUERY_SCOPE_ISSUER'
-      | 'DOC_QUERY_SCOPE_KID'
-      | 'LOCAL_MCP_GENERATION'
-      | 'LOCAL_MCP_TRANSPORT_TOKEN'
-    >
+    Pick<AuthEnvironment, 'LOCAL_MCP_GENERATION' | 'LOCAL_MCP_TRANSPORT_TOKEN'>
   > = {}
 ): Promise<SyntheticFixture> {
   const { privateKey, publicKey } = await generateKeyPair('ES256')
@@ -77,14 +70,9 @@ async function createSyntheticFixture(
     LOCAL_MCP_PUBLIC_KEY: await exportSPKI(publicKey),
     LOCAL_MCP_TRANSPORT_TOKEN:
       overrides.LOCAL_MCP_TRANSPORT_TOKEN ?? SYNTHETIC_TRANSPORT_TOKEN,
-    DOC_QUERY_SCOPE_AUDIENCE:
-      overrides.DOC_QUERY_SCOPE_AUDIENCE ?? SYNTHETIC_AUDIENCE,
-    DOC_QUERY_SCOPE_ISSUER:
-      overrides.DOC_QUERY_SCOPE_ISSUER ?? SYNTHETIC_ISSUER,
-    DOC_QUERY_SCOPE_KID:
-      overrides.DOC_QUERY_SCOPE_KID ??
-      overrides.LOCAL_MCP_GENERATION ??
-      SYNTHETIC_GENERATION,
+    DOC_QUERY_SCOPE_AUDIENCE: SYNTHETIC_AUDIENCE,
+    DOC_QUERY_SCOPE_ISSUER: SYNTHETIC_ISSUER,
+    DOC_QUERY_SCOPE_KID: overrides.LOCAL_MCP_GENERATION ?? SYNTHETIC_GENERATION,
   }
 
   return {
@@ -96,9 +84,7 @@ async function createSyntheticFixture(
 
 async function signScopeToken(
   tokenFixture: SyntheticFixture = fixture,
-  options: ScopeTokenOptions = {},
-  signer: KeyLike = tokenFixture.privateKey,
-  tokenEnvironment: AuthEnvironment = tokenFixture.env
+  options: ScopeTokenOptions = {}
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000)
   const iat = options.iat ?? now - 1
@@ -114,13 +100,13 @@ async function signScopeToken(
     .setProtectedHeader({
       alg: 'ES256',
       typ: 'JWT',
-      kid: options.kid ?? tokenEnvironment.DOC_QUERY_SCOPE_KID,
+      kid: options.kid ?? tokenFixture.env.DOC_QUERY_SCOPE_KID,
     })
     .setIssuedAt(iat)
     .setExpirationTime(exp)
-    .setIssuer(options.issuer ?? tokenEnvironment.DOC_QUERY_SCOPE_ISSUER)
-    .setAudience(options.audience ?? tokenEnvironment.DOC_QUERY_SCOPE_AUDIENCE)
-    .sign(signer)
+    .setIssuer(options.issuer ?? tokenFixture.env.DOC_QUERY_SCOPE_ISSUER)
+    .setAudience(options.audience ?? tokenFixture.env.DOC_QUERY_SCOPE_AUDIENCE)
+    .sign(tokenFixture.privateKey)
 }
 
 function headersFor(

--- a/apps/chat/test/local-mcp-auth.test.ts
+++ b/apps/chat/test/local-mcp-auth.test.ts
@@ -1,0 +1,488 @@
+import {
+  exportSPKI,
+  generateKeyPair,
+  type JWTPayload,
+  type KeyLike,
+  SignJWT,
+} from 'jose'
+import { beforeEach, describe, expect, test } from 'vitest'
+import {
+  assertLocalSeedOwnership,
+  createLocalAuthenticator,
+  LOCAL_CHATBOT_ID,
+  LOCAL_FIXTURE_MARKER,
+  LOCAL_KB_ID,
+  LOCAL_SCOPE,
+} from '../scripts/local-mcp-auth.mjs'
+
+const SYNTHETIC_TRANSPORT_TOKEN = 'synthetic-transport-token'
+const SYNTHETIC_GENERATION = 'synthetic-generation'
+const SYNTHETIC_ISSUER = 'synthetic-local-chat'
+const SYNTHETIC_AUDIENCE = 'synthetic-doc-query'
+const SYNTHETIC_SUBJECT = 'synthetic-session'
+const SYNTHETIC_JTI = 'synthetic-jti'
+const SYNTHETIC_OWNER_ID = '76047345-3801-4628-ae7b-adbebcfe8821'
+const SYNTHETIC_COURSE_ID = '7c12e44e-d083-4acf-845e-4c34aaff6b49'
+const SYNTHETIC_OTHER_CHATBOT_ID = '9f9c2e1d-4b7a-4c3e-9f5d-1a2b3c4d5e6f'
+const SYNTHETIC_AUTH_SECRET = [
+  'a'.repeat(32),
+  'b'.repeat(32),
+  'c'.repeat(16),
+].join(':')
+
+type AuthEnvironment = {
+  LOCAL_MCP_GENERATION: string
+  LOCAL_MCP_PUBLIC_KEY: string
+  LOCAL_MCP_TRANSPORT_TOKEN: string
+  DOC_QUERY_SCOPE_AUDIENCE: string
+  DOC_QUERY_SCOPE_ISSUER: string
+  DOC_QUERY_SCOPE_KID: string
+}
+
+type LocalAuthenticator = (headers: Record<string, string>) => Promise<boolean>
+
+type SyntheticFixture = {
+  authenticate: LocalAuthenticator
+  env: AuthEnvironment
+  privateKey: KeyLike
+}
+
+type ScopeTokenOptions = {
+  audience?: string
+  claims?: Record<string, unknown>
+  exp?: number
+  iat?: number
+  issuer?: string
+  kid?: string
+}
+
+let fixture: SyntheticFixture
+
+async function createSyntheticFixture(
+  overrides: Partial<
+    Pick<
+      AuthEnvironment,
+      | 'DOC_QUERY_SCOPE_AUDIENCE'
+      | 'DOC_QUERY_SCOPE_ISSUER'
+      | 'DOC_QUERY_SCOPE_KID'
+      | 'LOCAL_MCP_GENERATION'
+      | 'LOCAL_MCP_TRANSPORT_TOKEN'
+    >
+  > = {}
+): Promise<SyntheticFixture> {
+  const { privateKey, publicKey } = await generateKeyPair('ES256')
+  const env: AuthEnvironment = {
+    LOCAL_MCP_GENERATION:
+      overrides.LOCAL_MCP_GENERATION ?? SYNTHETIC_GENERATION,
+    LOCAL_MCP_PUBLIC_KEY: await exportSPKI(publicKey),
+    LOCAL_MCP_TRANSPORT_TOKEN:
+      overrides.LOCAL_MCP_TRANSPORT_TOKEN ?? SYNTHETIC_TRANSPORT_TOKEN,
+    DOC_QUERY_SCOPE_AUDIENCE:
+      overrides.DOC_QUERY_SCOPE_AUDIENCE ?? SYNTHETIC_AUDIENCE,
+    DOC_QUERY_SCOPE_ISSUER:
+      overrides.DOC_QUERY_SCOPE_ISSUER ?? SYNTHETIC_ISSUER,
+    DOC_QUERY_SCOPE_KID:
+      overrides.DOC_QUERY_SCOPE_KID ??
+      overrides.LOCAL_MCP_GENERATION ??
+      SYNTHETIC_GENERATION,
+  }
+
+  return {
+    authenticate: await createLocalAuthenticator(env),
+    env,
+    privateKey,
+  }
+}
+
+async function signScopeToken(
+  tokenFixture: SyntheticFixture = fixture,
+  options: ScopeTokenOptions = {},
+  signer: KeyLike = tokenFixture.privateKey,
+  tokenEnvironment: AuthEnvironment = tokenFixture.env
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+  const iat = options.iat ?? now - 1
+  const exp = options.exp ?? now + 299
+
+  return new SignJWT({
+    sub: SYNTHETIC_SUBJECT,
+    jti: SYNTHETIC_JTI,
+    chatbot_id: LOCAL_CHATBOT_ID,
+    kb_id: LOCAL_KB_ID,
+    ...options.claims,
+  } as JWTPayload)
+    .setProtectedHeader({
+      alg: 'ES256',
+      typ: 'JWT',
+      kid: options.kid ?? tokenEnvironment.DOC_QUERY_SCOPE_KID,
+    })
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setIssuer(options.issuer ?? tokenEnvironment.DOC_QUERY_SCOPE_ISSUER)
+    .setAudience(options.audience ?? tokenEnvironment.DOC_QUERY_SCOPE_AUDIENCE)
+    .sign(signer)
+}
+
+function headersFor(
+  scopeToken: string,
+  transportToken = fixture.env.LOCAL_MCP_TRANSPORT_TOKEN
+): Record<string, string> {
+  return {
+    authorization: `Bearer ${transportToken}`,
+    'x-doc-query-scope-token': `Bearer ${scopeToken}`,
+  }
+}
+
+async function expectRejectedScopeToken(
+  label: string,
+  options: ScopeTokenOptions
+) {
+  const token = await signScopeToken(fixture, options)
+  expect(await fixture.authenticate(headersFor(token)), label).toBe(false)
+}
+
+function legacyServer(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'KB',
+    url: 'http://localhost:1417/mcp',
+    isActive: true,
+    passChatbotId: true,
+    chatbotIdHeader: null,
+    authType: 'none',
+    authSecret: null,
+    parameters: null,
+    ...overrides,
+  }
+}
+
+function authenticatedServer(overrides: Record<string, unknown> = {}) {
+  return legacyServer({
+    authType: 'bearer',
+    authSecret: SYNTHETIC_AUTH_SECRET,
+    parameters: { ...LOCAL_FIXTURE_MARKER },
+    ...overrides,
+  })
+}
+
+function seedConfig(chatMode: string, overrides: Record<string, unknown> = {}) {
+  return {
+    chatbotId: LOCAL_CHATBOT_ID,
+    ownerId: SYNTHETIC_OWNER_ID,
+    courseId: SYNTHETIC_COURSE_ID,
+    chatMode,
+    isEnabled: true,
+    priority: 0,
+    allowedTools: ['doc_query'],
+    parameters: null,
+    ...overrides,
+  }
+}
+
+function legacyConfigs() {
+  return [seedConfig('tutor'), seedConfig('explainer')]
+}
+
+function authenticatedConfigs() {
+  return [
+    seedConfig('tutor', { parameters: { ...LOCAL_SCOPE } }),
+    seedConfig('explainer', { parameters: { ...LOCAL_SCOPE } }),
+  ]
+}
+
+function expectOwnershipConflict(
+  server: Record<string, unknown>,
+  configs: Array<Record<string, unknown>>
+) {
+  expect(() => assertLocalSeedOwnership(server, configs)).toThrow(
+    'Local MCP seed ownership conflict'
+  )
+}
+
+describe('createLocalAuthenticator', () => {
+  beforeEach(async () => {
+    fixture = await createSyntheticFixture()
+  })
+
+  test('accepts a valid scope JWT when the same credentials are reused', async () => {
+    const token = await signScopeToken()
+    const headers = headersFor(token)
+
+    await expect(fixture.authenticate(headers)).resolves.toBe(true)
+    await expect(fixture.authenticate(headers)).resolves.toBe(true)
+  })
+
+  test('rejects missing or wrong transport and scope headers', async () => {
+    const token = await signScopeToken()
+    const validScopeHeader = `Bearer ${token}`
+    const validTransportHeader = `Bearer ${fixture.env.LOCAL_MCP_TRANSPORT_TOKEN}`
+    const cases: Array<[string, Record<string, string>]> = [
+      ['missing transport', { 'x-doc-query-scope-token': validScopeHeader }],
+      [
+        'wrong transport',
+        {
+          authorization: 'Bearer synthetic-wrong-transport',
+          'x-doc-query-scope-token': validScopeHeader,
+        },
+      ],
+      ['missing scope', { authorization: validTransportHeader }],
+      [
+        'wrong scope scheme',
+        {
+          authorization: validTransportHeader,
+          'x-doc-query-scope-token': `Basic ${token}`,
+        },
+      ],
+      [
+        'wrong scope token',
+        {
+          authorization: validTransportHeader,
+          'x-doc-query-scope-token': 'Bearer synthetic-invalid-token',
+        },
+      ],
+    ]
+
+    for (const [label, headers] of cases) {
+      expect(await fixture.authenticate(headers), label).toBe(false)
+    }
+  })
+
+  test('rejects an expired scope JWT', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    await expectRejectedScopeToken('expired', {
+      iat: now - 10,
+      exp: now - 1,
+    })
+  })
+
+  test('rejects scope JWTs with invalid identifiers', async () => {
+    const cases: Array<[string, ScopeTokenOptions]> = [
+      ['empty subject', { claims: { sub: '' } }],
+      ['whitespace-only subject', { claims: { sub: '   ' } }],
+      ['long subject', { claims: { sub: 's'.repeat(257) } }],
+      ['non-string subject', { claims: { sub: 42 } }],
+      ['empty jti', { claims: { jti: '' } }],
+      ['long jti', { claims: { jti: 'j'.repeat(257) } }],
+      ['non-string jti', { claims: { jti: { value: 'synthetic' } } }],
+    ]
+
+    for (const [label, options] of cases) {
+      await expectRejectedScopeToken(label, options)
+    }
+  })
+
+  test('rejects scope JWTs with wrong binding claims or signing metadata', async () => {
+    const cases: Array<[string, ScopeTokenOptions]> = [
+      ['wrong knowledge base', { claims: { kb_id: 'synthetic-other-kb' } }],
+      ['wrong chatbot', { claims: { chatbot_id: SYNTHETIC_OTHER_CHATBOT_ID } }],
+      ['wrong key id', { kid: 'synthetic-rotated-key' }],
+      ['wrong issuer', { issuer: 'synthetic-other-issuer' }],
+      ['wrong audience', { audience: 'synthetic-other-audience' }],
+    ]
+
+    for (const [label, options] of cases) {
+      await expectRejectedScopeToken(label, options)
+    }
+  })
+
+  test('rejects scope JWTs outside the five-minute lifetime', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const cases: Array<[string, ScopeTokenOptions]> = [
+      ['lifetime too long', { iat: now - 1, exp: now + 300 }],
+      ['expiration not after issued-at', { iat: now + 30, exp: now + 30 }],
+    ]
+
+    for (const [label, options] of cases) {
+      await expectRejectedScopeToken(label, options)
+    }
+  })
+
+  test('rejects credentials from before transport and signing-key rotation', async () => {
+    const previous = await createSyntheticFixture({
+      LOCAL_MCP_GENERATION: 'synthetic-previous-generation',
+      LOCAL_MCP_TRANSPORT_TOKEN: 'synthetic-previous-transport-token',
+    })
+    const rotated = await createSyntheticFixture({
+      LOCAL_MCP_GENERATION: 'synthetic-rotated-generation',
+      LOCAL_MCP_TRANSPORT_TOKEN: 'synthetic-rotated-transport-token',
+    })
+    const previousToken = await signScopeToken(previous)
+    const rotatedToken = await signScopeToken(rotated)
+
+    await expect(
+      rotated.authenticate(
+        headersFor(rotatedToken, previous.env.LOCAL_MCP_TRANSPORT_TOKEN)
+      )
+    ).resolves.toBe(false)
+    await expect(
+      rotated.authenticate(
+        headersFor(previousToken, rotated.env.LOCAL_MCP_TRANSPORT_TOKEN)
+      )
+    ).resolves.toBe(false)
+    await expect(
+      rotated.authenticate(
+        headersFor(rotatedToken, rotated.env.LOCAL_MCP_TRANSPORT_TOKEN)
+      )
+    ).resolves.toBe(true)
+  })
+})
+
+describe('assertLocalSeedOwnership', () => {
+  test.each([
+    ['null parameters', null],
+    ['empty parameters', {}],
+  ])('accepts the exact legacy seed with %s', (_label, parameters) => {
+    expect(() =>
+      assertLocalSeedOwnership(legacyServer({ parameters }), legacyConfigs())
+    ).not.toThrow()
+  })
+
+  test('accepts the exact marked authenticated seed', () => {
+    expect(() =>
+      assertLocalSeedOwnership(authenticatedServer(), authenticatedConfigs())
+    ).not.toThrow()
+  })
+
+  test.each([
+    ['legacy', legacyServer(), legacyConfigs()],
+    ['authenticated', authenticatedServer(), authenticatedConfigs()],
+  ])('rejects an additional chatbot consumer for the %s seed', (_label, server, configs) => {
+    expectOwnershipConflict(server, [
+      ...configs,
+      seedConfig('tutor', {
+        chatbotId: SYNTHETIC_OTHER_CHATBOT_ID,
+        parameters: server.authType === 'none' ? null : { ...LOCAL_SCOPE },
+      }),
+    ])
+  })
+
+  test('rejects a configuration change for either seed mode', () => {
+    expectOwnershipConflict(legacyServer(), [
+      seedConfig('tutor', { parameters: { ...LOCAL_SCOPE } }),
+      seedConfig('explainer'),
+    ])
+    expectOwnershipConflict(authenticatedServer(), [
+      seedConfig('tutor', {
+        allowedTools: ['doc_query', 'other_tool'],
+        parameters: { ...LOCAL_SCOPE },
+      }),
+      ...authenticatedConfigs().slice(1),
+    ])
+  })
+
+  test('rejects server and configuration changes outside the owned seed', () => {
+    const cases: Array<
+      [string, Record<string, unknown>, Array<Record<string, unknown>>]
+    > = [
+      ['different server name', { name: 'KB-copy' }, authenticatedConfigs()],
+      [
+        'different server URL',
+        { url: 'http://localhost:2417/mcp' },
+        authenticatedConfigs(),
+      ],
+      ['inactive server', { isActive: false }, authenticatedConfigs()],
+      [
+        'chatbot header enabled',
+        { chatbotIdHeader: 'x-chatbot-id' },
+        authenticatedConfigs(),
+      ],
+      [
+        'unmarked bearer server',
+        { parameters: { localFixture: 'other-fixture' } },
+        authenticatedConfigs(),
+      ],
+      [
+        'extra server parameter',
+        { parameters: { ...LOCAL_FIXTURE_MARKER, extra: true } },
+        authenticatedConfigs(),
+      ],
+      [
+        'changed chatbot',
+        {},
+        [
+          seedConfig('tutor', {
+            chatbotId: SYNTHETIC_OTHER_CHATBOT_ID,
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'changed owner',
+        {},
+        [
+          seedConfig('tutor', {
+            ownerId: '86158456-2802-5739-bf8c-bee9dcff9932',
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'changed course',
+        {},
+        [
+          seedConfig('tutor', {
+            courseId: '8d23f55e-f194-5be0-bf5f-5d45bbc06750',
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'disabled configuration',
+        {},
+        [
+          seedConfig('tutor', {
+            isEnabled: false,
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'nonzero priority',
+        {},
+        [
+          seedConfig('tutor', {
+            priority: 1,
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'additional allowed tool',
+        {},
+        [
+          seedConfig('tutor', {
+            allowedTools: ['doc_query', 'other_tool'],
+            parameters: { ...LOCAL_SCOPE },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'extra configuration parameter',
+        {},
+        [
+          seedConfig('tutor', {
+            parameters: { ...LOCAL_SCOPE, extra: true },
+          }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+      [
+        'unsupported chat mode',
+        {},
+        [
+          seedConfig('quizzer', { parameters: { ...LOCAL_SCOPE } }),
+          ...authenticatedConfigs().slice(1),
+        ],
+      ],
+    ]
+
+    for (const [_label, serverOverrides, configs] of cases) {
+      expectOwnershipConflict(authenticatedServer(serverOverrides), configs)
+    }
+  })
+})

--- a/apps/chat/test/normalize-sources.test.ts
+++ b/apps/chat/test/normalize-sources.test.ts
@@ -8,6 +8,109 @@ function toolCallPart(toolName: string, result: unknown, isError = false) {
   return { type: 'tool-call', toolName, result, isError }
 }
 
+describe('resource citation provenance', () => {
+  test('keeps distinct answer-mode uploads while deduplicating repeated sources', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        sources: ['first', 'second', 'first'].map((resource) => ({
+          source_url: `https://api.example.org/api/ingestion/resources/${resource}/versions/1`,
+          file_name: 'Shared title',
+          page_number: 2,
+        })),
+      }),
+    ])
+    expect(sources).toHaveLength(2)
+    expect(new Set(sources.map((source) => source.id)).size).toBe(2)
+    expect(sources.map((source) => source.index)).toEqual([1, 2])
+    expect(sources.every((source) => source.url === undefined)).toBe(true)
+  })
+
+  test('keeps same-title non-link resources distinct', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: ['urn:source:first', 'urn:source:second'].map((reference) => ({
+          reference,
+          title: 'Shared title',
+          chunks: [],
+        })),
+      }),
+    ])
+    expect(sources).toHaveLength(2)
+    expect(new Set(sources.map((source) => source.id)).size).toBe(2)
+    expect(sources.every((source) => source.url === undefined)).toBe(true)
+  })
+
+  test.each([
+    'https://example.org/course?lang=en#overview',
+    'https://example.org/material.pdf?edition=2#page=4',
+  ])('preserves the original linked URL %s', (reference) => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: [{ reference, display_name: 'Course material', chunks: [] }],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]).toMatchObject({
+      title: 'Course material',
+      url: reference,
+    })
+  })
+
+  test.each([
+    'http://backend.stg.svc.cluster.local:3000/api/ingestion/resources/item/versions/3',
+    'http://backend.stg.svc:3000/document',
+    'https://api.example.org/api/ingestion/resources/item/versions/3',
+  ])('renders a named ingestion source without a link: %s', (reference) => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: [{ reference, title: 'Uploaded material', chunks: [] }],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('Uploaded material')
+    expect(sources[0]?.url).toBeUndefined()
+  })
+
+  test('does not turn an unnamed ingestion version into a source title', () => {
+    expect(
+      normalizeSourcesFromParts([
+        toolCallPart('KB_doc_query', {
+          mode: 'documents',
+          sources: [
+            {
+              reference:
+                'https://api.example.org/api/ingestion/resources/item/versions/3',
+              chunks: [],
+            },
+          ],
+        }),
+      ])
+    ).toEqual([])
+  })
+
+  test('also suppresses ingestion links in persisted answer-mode payloads', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        sources: [
+          {
+            source_url:
+              'https://api.example.org/api/ingestion/resources/item/versions/3',
+            file_name: 'Uploaded material.pdf',
+            display_name: 'Accepted source name',
+            source_type: 'pdf',
+          },
+        ],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('Accepted source name')
+    expect(sources[0]?.url).toBeUndefined()
+  })
+})
+
 describe('isDocQueryToolName', () => {
   test('matches the MCP-namespaced tool name', () => {
     expect(isDocQueryToolName('KB_doc_query')).toBe(true)
@@ -171,7 +274,7 @@ describe('normalizeSourcesFromParts', () => {
 
     expect(result).toEqual([
       {
-        id: 'title:Lecture 02|5|5',
+        id: 'url:lecture-02.pdf|5|5',
         index: 1,
         type: 'document',
         title: 'Lecture 02',

--- a/docs/solutions/integration/openrouter-local-chat-runtime.md
+++ b/docs/solutions/integration/openrouter-local-chat-runtime.md
@@ -83,6 +83,26 @@ must use seeded or synthetic content only.
 
 ## Why This Matters
 
+A healthy local MCP endpoint does not prove that Chat can use it. The legacy
+seed had no transport authentication or required knowledge-base scope, while
+Chat's Doc Query client expects bearer authentication and an ES256 scope token.
+Keep that production client unchanged when diagnosing the local fixture.
+
+The managed MCP startup now uses
+[local-mcp-bootstrap.mjs](../../../apps/chat/scripts/local-mcp-bootstrap.mjs)
+to rotate ephemeral credentials and restart both Chat and the fixture together.
+Its seed repair accepts only the exact synthetic owner, course and two mode
+bindings. An ownership conflict stops startup instead of replacing another
+configuration. Plaintext credentials remain in the local process environment;
+the database stores only the encrypted transport token. The local shared
+process environment is not an isolation boundary between apps.
+
+Use the completed tool call, final answer, source card and reload persistence
+as integration evidence. The deterministic fixture has no public origin URL,
+so its source card cannot prove that a linked website or PDF is accessible.
+That requires a separate linked-source canary; source-normalizer tests alone
+prove URL preservation, not reachability or staging retrieval quality.
+
 The LiteLLM configuration resolves every OpenAI-compatible model and embedding
 route through `UPSTREAM_OPENAI_BASE_URL` and `UPSTREAM_OPENAI_API_KEY`
 ([config.yaml](../../../util/litellm/config.yaml)). A route-level 200 or

--- a/project/2026-09-07-local-doc-query-acceptance.md
+++ b/project/2026-09-07-local-doc-query-acceptance.md
@@ -1,0 +1,149 @@
+# Authenticated local Doc Query acceptance
+
+## Approved outcome and authority
+
+Restore the seeded Benibot's local `doc_query` integration through the unchanged
+Chat bearer and ES256 scope-signing path. The user approved local fixture changes,
+guarded repair of the isolated synthetic seed, browser acceptance, local commits,
+and required reviews. This does not authorize staging or production writes,
+deployment, or publication.
+The existing citation-origin changes remain in scope and must be preserved.
+
+No dependencies, production auth changes, or database migrations are planned.
+Local deterministic retrieval proves the Chat integration, not staging indexing
+or retrieval quality. Synthetic content may use the already-approved OpenRouter
+runtime. Keep all plaintext credentials in process memory/environment only.
+
+## Execution contract
+
+The main session owns coupled authentication, local database ownership checks,
+runtime coordination, and browser proof. Test work may be delegated once the
+exported seams settle. Coupling and secret handling keep bootstrap work in the
+main session.
+
+1. Add a local verifier that authenticates transport and scoped JWTs before MCP
+   parsing. Check ES256, type, key ID, issuer, audience, lifetime, session and
+   request identifiers, and the exact synthetic chatbot and knowledge base.
+   A request identifier remains reusable during its token lifetime.
+2. Opt in through the managed MCP profile only. Require the canonical container
+   root, bootstrap marker and local database host. Stop both owned process groups
+   before generating a fresh ephemeral transport token and signing pair.
+3. Lock and validate the global KB server and every consumer in a serializable
+   transaction. Accept only the untouched legacy seed or the exact previously
+   authenticated fixture. Require the seeded chatbot owner/course and exactly
+   Tutor and Explainer consumers. Conflicts produce zero writes. Store only the
+   encrypted bearer and exact singleton scope configuration in the local DB.
+4. Pass ephemeral credentials to a child post-start process, with a nonsecret
+   generation in both process fingerprints and fixture health. On interruption
+   or failed startup, stop both owned groups. Never print raw exceptions.
+5. Verify focused auth and ownership contracts, credential rotation, repeated
+   startup, fixture loss, profile drop/re-add, and cleanup. Run the unchanged Chat
+   signer through a real browser canary, then reload and inspect desktop/mobile.
+   Require the completed tool call, marker, final answer and synthetic source.
+6. Stop the exact runtime with its matching injection and prove Stopped with zero
+   routes. Report any unexecuted checks separately from passing evidence.
+
+## Review and evidence
+
+Native planner Arendt (`01a07ac4-f28f-7fa1-91e8-9ea128e6260f`) approved the
+second plan pass. The revision addresses environment delivery, coordinated
+rotation and cleanup, exclusive seed ownership and atomicity, and strict JWT
+validation with reusable request identifiers. No additional approval gate.
+
+Baseline: `27f2474547df045cc11302c7d9e195798ec66870`, branch
+`rs/citation-acceptance-clean`, no upstream, zero ahead and one behind `origin/v3`
+at resumption. No integration is assumed.
+
+## Progress
+
+- Prior focused citation tests: 45 passed on this worktree.
+- Prior browser canary: HTTP 503 before model execution. Seed scope parameters
+  were empty and the KB server used unauthenticated transport.
+- Runtime was stopped with zero routes after that failed canary.
+- Implemented a guarded local bootstrap and verifier without modifying the
+  production signer, scoped client, or scope resolver. No seed reset or migration.
+- First startup and a repeated startup both report managed runtime ready, with
+  Chat and the authenticated fixture running. The second startup rotates both.
+- Focused citation, MCP policy, signer and scoped-client checks: 82 tests pass.
+  New synthetic verifier/ownership checks: 14 tests pass. Biome check passes after
+  formatting, and shell/Node syntax plus diff whitespace checks pass.
+- Real GPT-4.1 browser canary completes in synthetic conversation
+  `627f439c-8105-4e04-88e9-62c598f9de6a`. Explicit Auto Mode canary also completes
+  in `adbb6666-e3f7-475f-8fdf-d4f4dd055c13`. Both show the completed course-material
+  search, exact marker, nonempty answer, inline citation and synthetic source.
+  Reload preserves the result. Desktop source tooltip and 390px mobile card were
+  inspected. Screenshots are `/tmp/citation-local-reloaded.png`,
+  `/tmp/citation-local-mobile.png`, and `/tmp/citation-auto-reloaded.png`.
+- This fixture has no public origin URL. Preservation of website/PDF origin URLs
+  is covered by the focused normalizer tests, not a live linked-source canary.
+- Full Chat suite: 583 passed, 21 skipped, across 54 passing files and one skipped
+  file. Chat `check` (route type generation and TypeScript) passes.
+- Dropping MCP reports its owned process stopped while Chat remains running.
+  Re-adding MCP reports both processes running and no runtime drift. A fresh Auto
+  Mode tool call for bond pricing succeeds after that cycle, returning the marker
+  and a page-3 synthetic source. Evidence: `/tmp/citation-post-rotation-mobile.png`.
+- At the initial acceptance checkpoint, interruption/fault injection and
+  transactional conflict integration tests had not run. The resumed run below
+  adds that evidence.
+- Bounded source reviewer Franklin (`01a07ad1-4d1b-7cc1-ab4d-cf9fa9f873ee`)
+  completed with no confirmed blockers. Credentials remain visible to local apps
+  in the shared process-group environment; each startup deliberately restarts
+  both owned groups. Publication remains unapproved.
+- Final runtime release is verified: the exact `rs-citation-acceptance-clean`
+  workspace reports `Stopped`, route count is zero, and hosts is empty. The
+  synthetic conversations and worktree are preserved. No staging proof claimed.
+- Resumption on 2026-09-07: refreshed refs show this baseline zero ahead and two
+  behind `origin/v3`, with no upstream. No integration or source edits performed.
+  Fresh shell/Node syntax and `git diff --check` pass. The MCP-only startup and
+  its one permitted retry both failed before execution because the automatic
+  permission approval review exceeded its deadline. Failure-path testing remains
+  blocked on host execution. A fresh provider read reports `Stopped`; fresh
+  route verification failed with `could not determine process identity for host
+  route update lock`, so zero routes is prior evidence, not a refreshed result.
+  Resume startup interruption/cleanup and synthetic transaction conflict/rollback
+  verification when host execution is available. Commits remain withheld.
+- Host execution subsequently resumed. Refreshed refs now show zero ahead and
+  three behind `origin/v3`; no upstream integration. Extracted the unchanged
+  transaction into `apps/chat/scripts/local-mcp-seed.mjs` for direct SQL testing.
+  Executor Kierkegaard supplied `apps/chat/scripts/test-local-mcp-seed.mjs`;
+  main-session inspection and runtime execution verified it. The script sets
+  `search_path` to `pg_temp` and uses only temporary synthetic tables. Successful
+  repair and repeat decrypted-token rotation, extra-consumer rejection with an
+  unchanged snapshot, rollback after the second UPDATE fails, and interruption
+  before writing all pass. No persistent schema or test-data changes.
+- `apps/chat/scripts/test-local-mcp-startup.mjs` passes against the real local
+  bootstrap and managed helper. It confirms the fixture actually starts before
+  an injected post-start failure, then verifies both owned groups stopped. It
+  also sends SIGTERM while bootstrap waits for a deliberately held local KB row
+  lock and verifies normal failure exit plus both groups stopped. Its initial
+  observation loop failed because PostgreSQL cached the activity snapshot inside
+  the observer transaction; clearing that snapshot fixed the test observation.
+  No bootstrap defect was demonstrated by that initial failure.
+- Reproduction commands, inside the exact container with its committed local
+  environment loaded: `LOCAL_MCP_SEED_TEST=1 node apps/chat/scripts/test-local-mcp-seed.mjs`
+  and `LOCAL_MCP_STARTUP_TEST=1 node apps/chat/scripts/test-local-mcp-startup.mjs`.
+  Both exit zero. The startup test intentionally rotates the isolated fixture
+  credential and stops both owned groups; it is not a read-only health probe.
+- Fresh full Chat suite again passes 583 tests with 21 skipped. Chat `check`
+  passes. Repository Biome checked the four extracted/bootstrap/acceptance
+  scripts and formatted three; Node syntax and `git diff --check` pass. Earlier
+  browser evidence is retained, not rerun. No model requests, staging proof, or
+  live website/PDF origin-link proof in this run.
+- At the failure-test checkpoint, delivery was uncommitted and required
+  committed-scope reviews were pending. The earlier bounded source review
+  predates this extraction and these acceptance scripts. The user approved
+  local commits and reviews; the former agent-authored commit gate is removed.
+  Publication and deployment remain withheld.
+- Resumed-run shutdown is verified by exact source path: provider reports
+  `Stopped`, route count is zero, hosts is empty. A plain stop rejected the
+  retained LiteLLM Compose configuration; stopping with the existing approved
+  `klicker-dev` OpenRouter mapping succeeded. No data or worktree was deleted.
+- Local commits and required reviews are authorized. Staging/host-check commands
+  and their permitted retry failed before execution because the automatic
+  permission approval service exceeded its deadline. No commit or review ran;
+  the index remains empty and provider state is freshly confirmed `Stopped`.
+  Resume repository-native pre-commit checks, local commits, and required
+  committed-scope reviews when host execution is restored, without another
+  permission question. The global commit/review guidance was clarified; a
+  concurrent writer subsequently expanded those same global paragraphs, so
+  their broader edits were preserved and not committed by this task.

--- a/project/2026-09-07-local-doc-query-acceptance.md
+++ b/project/2026-09-07-local-doc-query-acceptance.md
@@ -5,8 +5,10 @@
 Restore the seeded Benibot's local `doc_query` integration through the unchanged
 Chat bearer and ES256 scope-signing path. The user approved local fixture changes,
 guarded repair of the isolated synthetic seed, browser acceptance, local commits,
-and required reviews. This does not authorize staging or production writes,
-deployment, or publication.
+and required reviews. Under the current global instructions, routine non-force
+task-branch pushes and draft PR updates are also authorized after the required
+checks and reviews. Staging or production writes, protected-branch pushes,
+marking ready, merges, releases, and deployments remain separate boundaries.
 The existing citation-origin changes remain in scope and must be preserved.
 
 No dependencies, production auth changes, or database migrations are planned.
@@ -147,3 +149,20 @@ at resumption. No integration is assumed.
   permission question. The global commit/review guidance was clarified; a
   concurrent writer subsequently expanded those same global paragraphs, so
   their broader edits were preserved and not committed by this task.
+- Host execution recovered. Plan commit `b2002badec` records this contract;
+  implementation commit `e2974b73b5` contains the verified local fixture and
+  citation changes. Fresh root `pnpm run check:all` passed in the exact container
+  (35 check tasks and seven lint tasks successful); host staged Gitleaks and
+  Git-identity checks passed. Host commits used those equivalent checks instead
+  of invoking the container toolchain through the host hook. The worktree was
+  clean after committing. Current baseline remains five commits behind
+  `origin/v3`, with no integration. Prior blocked/uncommitted notes above are
+  historical, not current gates. Current global authority supersedes the former
+  agent-authored publication restriction for routine task-branch draft delivery.
+- The dedicated simplifier completed; accepted only unused test-option removal
+  and replacement of recursive comparison code with Node's deep comparison.
+  All 14 affected verifier/ownership tests, real temporary-table acceptance,
+  Chat typecheck, and focused formatting pass after those reductions. The full
+  repository pre-push build passes: 23 tasks successful, zero cache hits.
+  Earlier full-suite and root pre-commit results remain applicable to unchanged
+  production code. Report: `_local/reviews/2026-09-07-local-doc-query-simplifier.md`.

--- a/project/2026-09-07-local-doc-query-acceptance.md
+++ b/project/2026-09-07-local-doc-query-acceptance.md
@@ -166,3 +166,14 @@ at resumption. No integration is assumed.
   repository pre-push build passes: 23 tasks successful, zero cache hits.
   Earlier full-suite and root pre-commit results remain applicable to unchanged
   production code. Report: `_local/reviews/2026-09-07-local-doc-query-simplifier.md`.
+- Retry succeeds: remote refresh works and the exact runtime is freshly
+  confirmed Stopped with zero routes and no hosts. Head `e5f3eb2973` has three
+  local commits and remains five behind `origin/v3`, with no upstream or
+  integration. The existing slice reviewer remains active; final review and
+  draft publication follow its terminal result without another permission ask.
+- Captured the authenticated-fixture diagnostic lesson in the existing local
+  Chat solution. Host-side repository Prettier and diff checks pass; no runtime
+  was restarted for documentation. The wiki validator reports 33 pre-existing
+  frontmatter errors in other files. The edited page has no conformance errors;
+  its source links resolve in the repository but trigger the validator's
+  bundle-root warning. No unrelated wiki cleanup is included.

--- a/project/2026-09-07-pr-5817-local-doc-query-acceptance.md
+++ b/project/2026-09-07-pr-5817-local-doc-query-acceptance.md
@@ -1,5 +1,7 @@
 # Authenticated local Doc Query acceptance
 
+Draft delivery: [PR #5817 — authenticated local Doc Query and source links](https://github.com/uzh-bf/klicker-uzh/pull/5817).
+
 ## Approved outcome and authority
 
 Restore the seeded Benibot's local `doc_query` integration through the unchanged
@@ -177,3 +179,10 @@ at resumption. No integration is assumed.
   frontmatter errors in other files. The edited page has no conformance errors;
   its source links resolve in the repository but trigger the validator's
   bundle-root warning. No unrelated wiki cleanup is included.
+- Slice review and integrated final review pass with no reportable findings.
+  The final review covers `27f2474547..5aff22f65a`; subsequent changes are
+  plan metadata only. Reports are retained under `_local/reviews/`.
+  The reviewed branch is pushed and its draft PR is created. Full-range
+  Gitleaks and whitespace checks pass. Hosted checks and forge feedback remain
+  pending; marking ready, integration, merge and deployment are not performed.
+  Staging retrieval and live website/PDF accessibility remain unverified.


### PR DESCRIPTION
## What This Fixes

Restore the seeded local Doc Query fixture through Chat's existing bearer and
ES256 scope-token path. Preserve usable HTTP(S) source references and hide
machine-to-machine ingestion gateway URLs from participant citations.

This is a local integration and citation-normalization package. It does not
deploy a staging fix or prove staging corpus retrieval quality.

## How It Works

Managed MCP startup rotates ephemeral credentials and restarts Chat and the
fixture together. Seed repair accepts only the exact synthetic owner, course,
and two mode bindings, using a serializable transaction. Ownership conflicts
leave the configuration unchanged; startup failures stop both owned groups.

The normalizer prefers supplied display names and preserves distinct non-link
resource references for deduplication. Production signing and scoped-client
code remain unchanged. No dependencies, schema changes, or migrations.

## Branch Coverage

Base: `v3`. Covers authenticated fixture startup, ownership and failure-path
tests, citation normalization and regression tests, the execution plan, and
the local Chat diagnostic guide. Test-only follow-up simplifies fixture helpers.
Substantive scope excluding project artifacts: 1,414 additions and 16 deletions
across 11 files.

Current head: `abe8b0363fd2cd72a8a6638a852a49ed0d2c3719`. The final commit only
records review/delivery evidence and names the
[execution plan](https://github.com/uzh-bf/klicker-uzh/blob/abe8b0363fd2cd72a8a6638a852a49ed0d2c3719/project/2026-09-07-pr-5817-local-doc-query-acceptance.md).

## Review Focus

- Exact synthetic ownership checks and coordinated credential/process rotation.
- Failure cleanup and transactional rollback without raw credential-bearing errors.
- Preserving public source references without presenting ingestion URLs as links.

## Verification

Earlier branch verification, retained for unchanged behavior:

- Full Chat suite: 583 passed, 21 skipped. Chat typecheck passes.
- Root `pnpm run check:all`: 35 check tasks and seven lint tasks pass.
- Full pre-push build: all 23 tasks pass.
- After test simplification: 14 affected tests, real temporary-table acceptance,
  Chat typecheck and focused formatting pass.
- Synthetic database checks cover token rotation, extra-consumer rejection,
  rollback after a failed second update, and interruption before writing.
- Real startup checks cover injected post-start failure and SIGTERM during a
  held database lock, with both owned process groups stopped afterward.
- Browser Auto Mode and GPT-4.1 canaries return the tool marker, nonempty answer,
  citation and synthetic source; reload and desktop/mobile inspection pass.

Current documentation: repository Prettier, diff checks, staged Gitleaks and
Git identity pass. Focused host checks replace broad container hooks for the
documentation-only commit. Whole-wiki validation reports 33 existing
frontmatter errors outside the edited page; no unrelated cleanup is included.

Not run: staging retrieval acceptance and a live linked website/PDF canary.
The synthetic fixture has no public origin URL. URL-preservation tests do not
prove accessibility. Hosted checks are queued or running on the current head;
no hosted CI pass is claimed.

## Security / Privacy

The local process environment carries ephemeral plaintext credentials; the
database stores the encrypted transport token. Apps sharing that environment
are not isolated from those credentials. Tests use synthetic data. No secret
values or private payloads are included. The bounded slice review reports no
reportable findings. Integrated final review passed the complete range
`27f2474547df045cc11302c7d9e195798ec66870..5aff22f65a503b2df1dbb356164597235aa184a9`
with no reportable findings. Full-range Gitleaks and whitespace checks pass.

## Blocking Before Merge

- Passing exact-head CI and applicable forge feedback/final AI review.
- Any required upstream integration and affected verification.
- Explicit approval to mark ready and merge; keep this PR draft.

## Follow-Up After Merge

Separately authorize rollout and staging acceptance. Verify linked website/PDF
origin URLs in a real browser before claiming accessibility.

## Local Session Artifacts

On the originating Codex Mac host, repository `klicker-uzh`:

- Worktree: `trees/rs/citation-acceptance-clean`.
- Review reports: `project/_local/reviews/` within that worktree.
- Browser screenshots: `/tmp/citation-local-reloaded.png`,
  `/tmp/citation-local-mobile.png`, `/tmp/citation-auto-reloaded.png`.
- Runtime `rs-citation-acceptance-clean` is stopped with zero routes.
