### PR TITLE
fix(chat): backport citation source links to staging

### DIFF
--- a/apps/chat/src/lib/sources/normalizeSources.ts
+++ b/apps/chat/src/lib/sources/normalizeSources.ts
@@ -258,6 +258,23 @@ function lastPathSegment(value: string): string | undefined {
   }
 }
 
+// Resource ingestion gateways are machine-to-machine fetch endpoints, never
+// participant source links, even when exposed through a public API hostname.
+function isIngestionReference(value: string | undefined): boolean {
+  if (!value) return false
+  try {
+    const url = new URL(value)
+    const hostname = url.hostname.toLowerCase().replace(/\.$/, '')
+    return (
+      hostname.endsWith('.svc') ||
+      hostname.endsWith('.svc.cluster.local') ||
+      url.pathname.startsWith('/api/ingestion/resources/')
+    )
+  } catch {
+    return false
+  }
+}
+
 function isUrlLike(value: string): boolean {
   return /^https?:\/\//i.test(value)
 }
@@ -330,13 +347,18 @@ function normalizeAnswerModeSources(
     // only one — it also keeps relative paths and other schemes from
     // rendering as links that go nowhere useful from this origin. The raw
     // value still feeds the title and type fallbacks.
-    const url = rawUrl && isUrlLike(rawUrl) ? rawUrl : undefined
+    const ingestionReference = isIngestionReference(rawUrl)
+    const url =
+      rawUrl && isUrlLike(rawUrl) && !ingestionReference ? rawUrl : undefined
     const fileName = cleanString(source.file_name)
     const expert = cleanString(source.expert)
-    // Title fallback chain: file_name -> last URL path segment -> expert
+    // Title fallback chain: display name -> file_name -> URL path -> expert
     // name -> skip (no usable title/url means the entry is useless to show).
     const title =
-      fileName ?? (rawUrl ? lastPathSegment(rawUrl) : undefined) ?? expert
+      cleanString(source.display_name) ??
+      fileName ??
+      (rawUrl && !ingestionReference ? lastPathSegment(rawUrl) : undefined) ??
+      expert
     if (!title) continue
 
     const page = cleanPage(source.page_number)
@@ -349,7 +371,12 @@ function normalizeAnswerModeSources(
       page,
       labeledPage,
       url,
-      dedupeKey: buildDedupeKey({ url, title, page, labeledPage }),
+      dedupeKey: buildDedupeKey({
+        url: ingestionReference ? rawUrl : url,
+        title,
+        page,
+        labeledPage,
+      }),
     })
   }
 
@@ -367,17 +394,23 @@ function normalizeDocumentsModeSources(
     const source = rawSource as Record<string, unknown>
 
     const reference = cleanString(source.reference)
-    const explicitTitle = cleanString(source.title)
+    const explicitTitle =
+      cleanString(source.title) ??
+      cleanString(source.display_name) ??
+      cleanString(source.file_name)
+    const ingestionReference = isIngestionReference(reference)
     const referenceIsUrl = reference ? isUrlLike(reference) : false
-    const url = referenceIsUrl ? reference : undefined
+    const url = referenceIsUrl && !ingestionReference ? reference : undefined
 
     // Title fallback: explicit title -> (if reference is a URL) a short name
     // derived from its last path segment -> the raw reference -> skip.
     const title =
       explicitTitle ??
-      (referenceIsUrl && reference
-        ? (lastPathSegment(reference) ?? reference)
-        : reference)
+      (ingestionReference
+        ? undefined
+        : referenceIsUrl && reference
+          ? (lastPathSegment(reference) ?? reference)
+          : reference)
     if (!title) continue
 
     const rawChunks = Array.isArray(source.chunks) ? source.chunks : []
@@ -409,7 +442,8 @@ function normalizeDocumentsModeSources(
       startSec,
       endSec,
       dedupeKey: buildDedupeKey({
-        url,
+        // Non-link references still identify distinct resources with the same title.
+        url: reference,
         title,
         page,
         labeledPage,

--- a/apps/chat/test/normalize-sources.test.ts
+++ b/apps/chat/test/normalize-sources.test.ts
@@ -8,6 +8,109 @@ function toolCallPart(toolName: string, result: unknown, isError = false) {
   return { type: 'tool-call', toolName, result, isError }
 }
 
+describe('resource citation provenance', () => {
+  test('keeps distinct answer-mode uploads while deduplicating repeated sources', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        sources: ['first', 'second', 'first'].map((resource) => ({
+          source_url: `https://api.example.org/api/ingestion/resources/${resource}/versions/1`,
+          file_name: 'Shared title',
+          page_number: 2,
+        })),
+      }),
+    ])
+    expect(sources).toHaveLength(2)
+    expect(new Set(sources.map((source) => source.id)).size).toBe(2)
+    expect(sources.map((source) => source.index)).toEqual([1, 2])
+    expect(sources.every((source) => source.url === undefined)).toBe(true)
+  })
+
+  test('keeps same-title non-link resources distinct', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: ['urn:source:first', 'urn:source:second'].map((reference) => ({
+          reference,
+          title: 'Shared title',
+          chunks: [],
+        })),
+      }),
+    ])
+    expect(sources).toHaveLength(2)
+    expect(new Set(sources.map((source) => source.id)).size).toBe(2)
+    expect(sources.every((source) => source.url === undefined)).toBe(true)
+  })
+
+  test.each([
+    'https://example.org/course?lang=en#overview',
+    'https://example.org/material.pdf?edition=2#page=4',
+  ])('preserves the original linked URL %s', (reference) => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: [{ reference, display_name: 'Course material', chunks: [] }],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]).toMatchObject({
+      title: 'Course material',
+      url: reference,
+    })
+  })
+
+  test.each([
+    'http://backend.stg.svc.cluster.local:3000/api/ingestion/resources/item/versions/3',
+    'http://backend.stg.svc:3000/document',
+    'https://api.example.org/api/ingestion/resources/item/versions/3',
+  ])('renders a named ingestion source without a link: %s', (reference) => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        mode: 'documents',
+        sources: [{ reference, title: 'Uploaded material', chunks: [] }],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('Uploaded material')
+    expect(sources[0]?.url).toBeUndefined()
+  })
+
+  test('does not turn an unnamed ingestion version into a source title', () => {
+    expect(
+      normalizeSourcesFromParts([
+        toolCallPart('KB_doc_query', {
+          mode: 'documents',
+          sources: [
+            {
+              reference:
+                'https://api.example.org/api/ingestion/resources/item/versions/3',
+              chunks: [],
+            },
+          ],
+        }),
+      ])
+    ).toEqual([])
+  })
+
+  test('also suppresses ingestion links in persisted answer-mode payloads', () => {
+    const sources = normalizeSourcesFromParts([
+      toolCallPart('KB_doc_query', {
+        sources: [
+          {
+            source_url:
+              'https://api.example.org/api/ingestion/resources/item/versions/3',
+            file_name: 'Uploaded material.pdf',
+            display_name: 'Accepted source name',
+            source_type: 'pdf',
+          },
+        ],
+      }),
+    ])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('Accepted source name')
+    expect(sources[0]?.url).toBeUndefined()
+  })
+})
+
 describe('isDocQueryToolName', () => {
   test('matches the MCP-namespaced tool name', () => {
     expect(isDocQueryToolName('KB_doc_query')).toBe(true)
@@ -171,7 +274,7 @@ describe('normalizeSourcesFromParts', () => {
 
     expect(result).toEqual([
       {
-        id: 'title:Lecture 02|5|5',
+        id: 'url:lecture-02.pdf|5|5',
         index: 1,
         type: 'document',
         title: 'Lecture 02',


### PR DESCRIPTION
## What This Fixes

Backport the citation normalizer and regression tests from
[PR #5817 — local Doc Query and source links](https://github.com/uzh-bf/klicker-uzh/pull/5817)
to `v3-ai`, the currently selected staging source. Merging the original into
`v3` did not promote it to staging.

Preserve original HTTP(S) references, including query strings and fragments.
Hide ingestion gateway links, prefer supplied display names, and retain
distinct non-link resources when deduplicating citations. No local MCP fixture,
authentication, seed, deployment, dependency or schema changes are included.

## Branch Coverage

Base: `v3-ai` at `725b4dc2ec174d64becd37f40f66ad0f53b603f3`.
Two files; 148 additions and 11 deletions. This is a mechanical backport of an
already-reviewed patch, not a new implementation package. Its stable patch ID
matches the source change. The normalizer is byte-identical to the reviewed
version; the target's extra response-example regression test is preserved.

## Review Focus

Verify source URL preservation and ingestion-link suppression. The local
fixture changes from the source PR intentionally remain excluded.

## Verification

Current branch: all 46 normalizer tests pass using Node 24.16.0 in a disposable,
network-disabled container with existing dependencies mounted read-only.
Repository Biome, diff checks, staged Gitleaks and Git identity pass.
The initial test attempts failed on dependency resolution and a missing mount
directory; corrected mounts produced the passing run. No dependencies installed.

Earlier review evidence: the source PR's slice and integrated final reviews
passed, including this exact normalizer patch. Reused on patch equality and
the preserved target-only test. Earlier source-branch browser evidence is not
new staging or target-branch acceptance.

Not run: full target-branch build/typecheck, fresh browser acceptance, or live
website/PDF accessibility. Focused checks replace broad host hooks for this
two-file backport; hosted exact-head checks remain required.

## Security / Privacy

No secret values or private data included. Tests use synthetic references.
No provider, authentication or data ownership boundary changes.

## Blocking Before Merge

- Exact-head CI and applicable forge feedback/final AI review.
- Explicit approval to mark ready and merge. This PR remains draft.

## Follow-Up After Merge

Separately authorize promotion and verify the observed deployed revision.
Then run bounded synthetic staging Chat acceptance: actual retrieval, persisted
answer/citations after reload, and accessible original website/PDF links.

## Local Session Artifacts

Originating Codex Mac host, repository `klicker-uzh`:
`trees/rs/citation-links-v3-ai`. No managed application runtime was started;
the disposable test container exited and was removed automatically.
