### PR TITLE
fix(ci): skip submodule fetches during staging promotion

### DIFF
--- a/.github/scripts/stg-release-promoter.js
+++ b/.github/scripts/stg-release-promoter.js
@@ -1183,6 +1183,7 @@ function pushReleaseRefWithLease({
       'fetch',
       '--no-tags',
       '--no-write-fetch-head',
+      '--no-recurse-submodules',
       repositoryUrl,
       candidateSha,
     ],

--- a/.github/scripts/stg-release-promoter.test.js
+++ b/.github/scripts/stg-release-promoter.test.js
@@ -1069,7 +1069,7 @@ test('recovers from a transient post-push ref readback failure', async () => {
   )
 })
 
-test('exercises create, fast-forward, and race rejection against a bare remote', (t) => {
+test('promotes without fetching submodules and rejects a concurrent ref update', (t) => {
   const temporaryDirectory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'stg-release-cas-')
   )
@@ -1079,6 +1079,13 @@ test('exercises create, fast-forward, and race rejection against a bare remote',
   const client = path.join(temporaryDirectory, 'client')
   execFileSync('git', ['init', '--bare', '--quiet', remote])
   execFileSync('git', ['init', '--quiet', client])
+  execFileSync('git', [
+    '-C',
+    client,
+    'config',
+    'fetch.recurseSubmodules',
+    'true',
+  ])
   const fixtureEnvironment = {
     ...process.env,
     GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
@@ -1087,6 +1094,15 @@ test('exercises create, fast-forward, and race rejection against a bare remote',
     GIT_COMMITTER_NAME: 'Fixture',
   }
   const makeCommit = (label, parent = null) => {
+    const modules = execFileSync(
+      'git',
+      ['--git-dir', remote, 'hash-object', '-w', '--stdin'],
+      {
+        encoding: 'utf8',
+        input:
+          '[submodule "unavailable-submodule"]\n\tpath = unavailable-submodule\n\turl = ./missing.git\n',
+      }
+    ).trim()
     const blob = execFileSync(
       'git',
       ['--git-dir', remote, 'hash-object', '-w', '--stdin'],
@@ -1094,7 +1110,7 @@ test('exercises create, fast-forward, and race rejection against a bare remote',
     ).trim()
     const tree = execFileSync('git', ['--git-dir', remote, 'mktree'], {
       encoding: 'utf8',
-      input: `100644 blob ${blob}\tfixture.txt\n`,
+      input: `100644 blob ${modules}\t.gitmodules\n100644 blob ${blob}\tfixture.txt\n160000 commit ${(parent ? '2' : '1').repeat(40)}\tunavailable-submodule\n`,
     }).trim()
     return execFileSync(
       'git',
@@ -1111,6 +1127,22 @@ test('exercises create, fast-forward, and race rejection against a bare remote',
   const baseSha = makeCommit('base')
   const racedSha = makeCommit('raced', baseSha)
   const candidateSha = makeCommit('candidate', racedSha)
+  execFileSync('git', [
+    '-C',
+    client,
+    'fetch',
+    '--quiet',
+    '--no-recurse-submodules',
+    remote,
+    baseSha,
+  ])
+  execFileSync('git', ['-C', client, 'checkout', '--quiet', baseSha])
+  execFileSync('git', ['-C', client, 'submodule', 'init'], { stdio: 'pipe' })
+  execFileSync('git', [
+    'init',
+    '--quiet',
+    path.join(client, 'unavailable-submodule'),
+  ])
   const readRemoteRef = () =>
     execFileSync('git', ['--git-dir', remote, 'rev-parse', PROMOTION_REF], {
       encoding: 'utf8',


### PR DESCRIPTION
## What This Fixes

The staging controller failed before updating the release ref because fetching candidate Git objects also tried to fetch an unavailable submodule. See [failed promotion run](https://github.com/uzh-bf/klicker-uzh/actions/runs/34126304265).

Disable submodule recursion for the candidate fetch. Promotion needs only the parent repository objects. The existing bare-remote regression now includes a changed, unavailable submodule with recursion enabled, while retaining create, fast-forward, and concurrent-update rejection coverage.

## Branch Coverage

Base: `v3`. One commit, `82de39f936`. Two files; 35 additions and 2 deletions. This is a complete focused repair below the packaging floor. No unrelated application changes.

## Verification

Current head:
- Promoter suite: 20/20 pass in an isolated network-disabled container, Node 22.21.0 and Git 2.39.5.
- Regression failed at the real recursive Git fetch before the fix and passed after it.
- Repository Biome 2.5.2 formatting, staged Gitleaks, Git identity, and diff whitespace checks passed.

Not run: full application build/check suite and Node 24 verification. The fresh worktree has no installed dependencies or Husky wrappers. No hook configuration was changed.

## Security / Privacy

Candidate code is not executed. The exact expected-old push lease and prior graph validation are unchanged. Tests use only synthetic local Git repositories. No credentials or private data are included.

## Blocking Before Merge

Human review and required exact-head CI remain pending. This PR does not authorize merging or activation.

## Follow-Up After Merge

Separately approve retrying receipt-backed release-ref creation. This repair does not retry promotion, change repository variables, or alter Argo or production state.

## Local Session Artifacts

Local Codex host: `trees/rs/stg-release-fetch-fix` in repository `klicker-uzh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release promotion now succeeds when candidate commits reference unavailable submodules.
  - Fetching release data no longer attempts to recursively retrieve submodule contents, improving reliability for repositories with inaccessible or unused submodules.

- **Tests**
  - Added coverage for release promotion with unavailable submodule references, including successful creation, fast-forward updates, and rejection of concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->