### PR TITLE
fix(ci): separate staging release write credentials

### DIFF
--- a/.github/scripts/stg-release-promoter.js
+++ b/.github/scripts/stg-release-promoter.js
@@ -1137,6 +1137,7 @@ function gitEnvironment(gitToken, repositoryUrl) {
     GIT_TERMINAL_PROMPT: '0',
   }
   delete environment.GITHUB_TOKEN
+  delete environment.STG_PROMOTE_TOKEN
   if (!gitToken) return environment
 
   const origin = new URL(repositoryUrl).origin
@@ -1161,7 +1162,7 @@ function pushReleaseRefWithLease({
   context,
   expectedSha,
   candidateSha,
-  gitToken = process.env.GITHUB_TOKEN,
+  gitToken,
   repositoryUrl = releaseRepositoryUrl(context),
   gitRunner = runGit,
   workspace = process.cwd(),
@@ -1171,7 +1172,7 @@ function pushReleaseRefWithLease({
     throw new Error('expected release SHA is invalid')
   }
   if (!gitToken && /^https:/i.test(repositoryUrl)) {
-    throw new Error('GITHUB_TOKEN is unavailable for the ref update')
+    throw new Error('STG_PROMOTE_TOKEN is unavailable for the ref update')
   }
 
   const options = {
@@ -1187,7 +1188,7 @@ function pushReleaseRefWithLease({
       repositoryUrl,
       candidateSha,
     ],
-    options
+    { ...options, env: gitEnvironment(process.env.GITHUB_TOKEN, repositoryUrl) }
   )
   gitRunner(
     [

--- a/.github/scripts/stg-release-promoter.test.js
+++ b/.github/scripts/stg-release-promoter.test.js
@@ -946,6 +946,46 @@ test('plans equal, stale, fast-forward, and divergent release refs without force
   )
 })
 
+test('separates Git read and write credentials without an ambient write fallback', (t) => {
+  const readToken = 'synthetic-read-token'
+  const writeToken = 'synthetic-write-token'
+  const previous = {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    STG_PROMOTE_TOKEN: process.env.STG_PROMOTE_TOKEN,
+  }
+  t.after(() => {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  })
+  process.env.GITHUB_TOKEN = readToken
+  process.env.STG_PROMOTE_TOKEN = writeToken
+  const calls = []
+  const options = {
+    context: reviewContext(),
+    candidateSha: CANDIDATE_SHA,
+    expectedSha: null,
+    gitRunner: (args, options) => calls.push({ args, options }),
+  }
+  assert.throws(() => pushReleaseRefWithLease(options), /STG_PROMOTE_TOKEN/)
+  assert.equal(calls.length, 0)
+  pushReleaseRefWithLease({ ...options, gitToken: writeToken })
+  assert.equal(calls.length, 2)
+  for (const [index, token] of [readToken, writeToken].entries()) {
+    const { args, options } = calls[index]
+    assert.equal(args[0], index === 0 ? 'fetch' : 'push')
+    assert.equal(options.env.GITHUB_TOKEN, undefined)
+    assert.equal(options.env.STG_PROMOTE_TOKEN, undefined)
+    assert.equal(
+      options.env.GIT_CONFIG_VALUE_0,
+      `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`
+    )
+    assert.equal(JSON.stringify(args).includes(readToken), false)
+    assert.equal(JSON.stringify(args).includes(writeToken), false)
+  }
+})
+
 test('uses an exact remote lease for create and prevalidated fast-forward updates', async () => {
   const context = reviewContext()
   const create = refGithub()
@@ -1463,6 +1503,10 @@ test('keeps manual defaults dry-run and gates automatic writes', async () => {
     assert.equal(enabled.update_result.result, 'push-succeeded')
     assert.equal(enabled.update_result.verification, 'verified')
     assert.equal(refs.current(), CANDIDATE_SHA)
+    assert.equal(
+      fs.readFileSync(enabled.receiptPath, 'utf8').includes('fixture-token'),
+      false
+    )
   } finally {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true })
   }
@@ -1502,13 +1546,17 @@ test('uses only trusted controller checkout and has no commit or PR commands', (
   assert.doesNotMatch(workflow, /^ {6}confirm:$/m)
   assert.match(workflow, /stg-release/)
   assert.match(workflow, /github\.event\.workflow_run\.head_sha/)
-  assert.doesNotMatch(workflow, /STG_PROMOTE_TOKEN|git commit|git push|gh pr/)
+  assert.doesNotMatch(workflow, /git commit|git push|gh pr/)
   assert.doesNotMatch(workflow, /promote-stg-writer/)
   assert.doesNotMatch(workflow, /ref: \$\{\{[^}]*head_sha/)
   assert.doesNotMatch(workflow, /actions\/cache@|actions\/download-artifact@/)
   assert.match(workflow, /actions\/upload-artifact@/)
   assert.match(workflow, /persist-credentials: false/)
   assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/)
+  assert.match(workflow, /github-token: \$\{\{ github\.token \}\}/)
+  assert.match(workflow, /gitToken: process\.env\.STG_PROMOTE_TOKEN/)
+  assert.match(workflow, /secrets\.STG_PROMOTE_TOKEN/)
+  assert.match(workflow, /^  contents: read$/m)
 
   const workflowRunNames = [
     ...workflow.matchAll(/^      - '([^']+ \(stg\))'$/gm),

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -49,7 +49,7 @@ concurrency:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 jobs:
   promote:
@@ -81,6 +81,7 @@ jobs:
         env:
           CANDIDATE_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.sha }}
           GITHUB_TOKEN: ${{ github.token }}
+          STG_PROMOTE_TOKEN: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' && github.event.inputs.confirm_ref_update == 'stg-release') || (github.event_name == 'workflow_run' && vars.STG_RELEASE_PROMOTION_ENABLED == 'true')) && secrets.STG_PROMOTE_TOKEN || '' }}
           PROMOTION_ENABLED: ${{ vars.STG_RELEASE_PROMOTION_ENABLED || 'false' }}
           SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
           RECEIPT_PATH: ${{ runner.temp }}/stg-release-promotion-receipt.json
@@ -94,6 +95,7 @@ jobs:
               context,
               core,
               github,
+              gitToken: process.env.STG_PROMOTE_TOKEN,
               promotionEnabled: process.env.PROMOTION_ENABLED,
               sourceBranch: process.env.SOURCE_BRANCH,
               receiptPath: process.env.RECEIPT_PATH,

--- a/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
+++ b/docs/adr/0003-promote-stg-via-release-annotation-write-back.md
@@ -24,7 +24,12 @@ closed.
 The controller executes only code checked out at `github.workflow_sha`.
 Candidate Git objects, API metadata, and registry manifests are data; candidate
 actions, scripts, caches, and artifacts are never executed or consumed. It uses
-only `actions: read` and `contents: write`. Automatic writes require
+`actions: read` and `contents: read` on `GITHUB_TOKEN` for API and Git fetch
+reads. The lease-protected push uses the existing `STG_PROMOTE_TOKEN`, which
+must permit repository contents and workflow-file writes. There is no
+job-token fallback for writes. Separate credentials can trigger downstream
+workflows, so release-ref event filters must be checked before activation.
+Automatic writes require
 `STG_RELEASE_PROMOTION_ENABLED=true`; manual runs default to dry-run and require
 the exact input `confirm_ref_update=stg-release` before a write.
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -184,9 +184,19 @@ Operational notes.
   staging ArgoCD Application to track that ref and pass
   `global.imageTag=$ARGOCD_APP_REVISION` as a forced string. Preview, apply,
   runtime health, and acceptance remain separate evidence and approvals.
-- The controller uses the repository `GITHUB_TOKEN`; no promotion PAT,
-  pull-request permission, source-branch bypass actor, auto-merge setting, or
-  squash-title behavior is part of the new path.
+- API and Git fetch reads use `GITHUB_TOKEN` with `actions: read` and
+  `contents: read`. Only the lease-protected Git push uses the existing
+  `STG_PROMOTE_TOKEN`. Its credential must have repository contents write and
+  permission to write workflow files; the job token cannot provide the latter.
+  Confirm the existing credential's scope before activation. Missing write
+  credentials fail before Git runs, without falling back to the job token.
+  Dry-runs, disabled runs, and equal/stale no-ops require no write credential.
+  No pull-request permission, source-branch bypass actor, auto-merge setting,
+  or squash-title behavior is part of the new path.
+- Unlike `GITHUB_TOKEN`, a separate promotion credential can trigger workflows
+  on ref updates. Check the candidate's push/create filters and default-branch
+  downstream controllers before activation; a release-ref write must not
+  rebuild staging images. The publishers accept `v3`/`v3*`, not `stg-release`.
 
 The superseded annotation-write-back rationale remains in
 [ADR-0003](./adr/0003-promote-stg-via-release-annotation-write-back.md).

--- a/project/2026-09-07-pr-5823-stg-release-write-token-plan.md
+++ b/project/2026-09-07-pr-5823-stg-release-write-token-plan.md
@@ -1,4 +1,6 @@
-# Restore staging release-write authentication
+# Restore staging release-write authentication — PR #5823
+
+Draft PR: <https://github.com/uzh-bf/klicker-uzh/pull/5823>.
 
 ## Approval summary
 
@@ -79,5 +81,5 @@ through `9586807d9e` with no findings. Source is ready for draft publication;
 human review and required hosted CI remain before merge. Reports
 are in `project/_local/reviews/2026-09-07-stg-write-token-*.md`.
 Optional AGY challenge unavailable due to catalog/authentication errors.
-No operational state changed. Next: publish the approved draft PR; do not
-retry promotion.
+Draft publication complete. No operational state changed. Next: human review
+and hosted CI before any separately authorized merge; do not retry promotion.

--- a/project/2026-09-07-stg-release-write-token-plan.md
+++ b/project/2026-09-07-stg-release-write-token-plan.md
@@ -73,8 +73,9 @@ diff checks pass. One credential-boundary test was added, existing workflow
 and receipt checks were extended, and no tests were removed. Full application
 build/check and Node 24 proof were not run; no application runtime was started.
 
-Simplifier complete with no recommended reduction. Credential-risk and
-integrated-final reviews remain required before draft publication. Reports
+Simplifier complete with no recommended reduction. Credential-risk review
+complete with no findings. Integrated-final review remains required before
+draft publication. Reports
 are in `project/_local/reviews/2026-09-07-stg-write-token-*.md`.
 Optional AGY challenge unavailable due to catalog/authentication errors.
 No operational state changed. Next: finish required review and publish the

--- a/project/2026-09-07-stg-release-write-token-plan.md
+++ b/project/2026-09-07-stg-release-write-token-plan.md
@@ -74,9 +74,10 @@ and receipt checks were extended, and no tests were removed. Full application
 build/check and Node 24 proof were not run; no application runtime was started.
 
 Simplifier complete with no recommended reduction. Credential-risk review
-complete with no findings. Integrated-final review remains required before
-draft publication. Reports
+complete with no findings. Integrated-final review passed the complete range
+through `9586807d9e` with no findings. Source is ready for draft publication;
+human review and required hosted CI remain before merge. Reports
 are in `project/_local/reviews/2026-09-07-stg-write-token-*.md`.
 Optional AGY challenge unavailable due to catalog/authentication errors.
-No operational state changed. Next: finish required review and publish the
-approved draft PR; do not retry promotion.
+No operational state changed. Next: publish the approved draft PR; do not
+retry promotion.

--- a/project/2026-09-07-stg-release-write-token-plan.md
+++ b/project/2026-09-07-stg-release-write-token-plan.md
@@ -60,8 +60,22 @@ event filters are a publication gate, not an assumed equivalence.
 
 Approved scope; planner approved credential-repair-v2 after accepting explicit
 environment scrubbing, write-only token requirements, and test/audit details.
-Native explore failed before work with provider HTTP 400; the same bounded
-audit uses generic-continuity Luna. Optional AGY challenge unavailable due to
-catalog/authentication errors. No operational state changed.
+Native explore failed before work with provider HTTP 400. Generic-continuity
+Luna did not converge after a narrowing prompt; the main session completed the
+trigger audit. No push/create definition matches stg-release in either tree;
+no downstream build chain or filter edit is needed. Independently configured
+GitHub Apps and future candidates remain outside this source audit.
 
-Next: implement and verify the source slice, review, then publish a draft PR.
+Source slice `df64f832ba` passes all 21 promoter tests on Node 22.21.0 and
+Git 2.39.5 in a network-disabled disposable container. The credential regression
+failed before the repair. Biome, Prettier, staged Gitleaks, Git identity, and
+diff checks pass. One credential-boundary test was added, existing workflow
+and receipt checks were extended, and no tests were removed. Full application
+build/check and Node 24 proof were not run; no application runtime was started.
+
+Simplifier complete with no recommended reduction. Credential-risk and
+integrated-final reviews remain required before draft publication. Reports
+are in `project/_local/reviews/2026-09-07-stg-write-token-*.md`.
+Optional AGY challenge unavailable due to catalog/authentication errors.
+No operational state changed. Next: finish required review and publish the
+approved draft PR; do not retry promotion.

--- a/project/2026-09-07-stg-release-write-token-plan.md
+++ b/project/2026-09-07-stg-release-write-token-plan.md
@@ -1,0 +1,67 @@
+# Restore staging release-write authentication
+
+## Approval summary
+
+The staging controller cannot create its release ref with `GITHUB_TOKEN`
+when the candidate includes workflow changes. Restore the existing
+`STG_PROMOTE_TOKEN` solely for the lease-protected Git push. Keep API and Git
+fetch reads on the job token and lower its contents permission to read.
+
+The user approved the source repair, tests, reviews, and a draft PR into `v3`.
+Secret values and permissions remain unverified. No secret changes, merge,
+workflow dispatch, release-ref update, automatic activation, or cluster action
+are authorized. Production release tags remain unchanged.
+
+Acceptance requires separate read/write credentials, no ambient write-token
+fallback, token-free dry-runs and no-ops, preserved leases, and an audit of
+downstream triggers. Stop before operational activation or broader trigger
+changes. This is a full-path, single regression-repair package because it
+changes credential handling. It is exempt from the size floor as a CI blocker.
+
+## Execution details
+
+Base: `65ae8a3523f6230290b0b99f8a8e263b61e562a6` (`v3`).
+Branch/worktree: `rs/stg-release-write-token`, `trees/rs/stg-release-write-token`.
+Artifacts root: `project/`. Boundary owner: self.
+
+The main session owns the single source slice because credential handling is
+security-sensitive and tightly coupled. A read-only explorer audits workflow
+triggers at the base and candidate
+`26e1934c398e5f614c2bb5a682e94f6929172c3e`. Publication requires its findings
+and the committed slice's simplifier, risk review, and integrated final review.
+
+Remove the implicit write fallback, scrub raw token environment variables from
+Git children, and supply distinct authentication environments for fetch and
+push. Require the dedicated token before Git executes only for actual HTTPS
+create/fast-forward writes. Inject the workflow secret only for enabled
+automatic execution or explicitly confirmed manual apply. Retain trusted
+controller execution, evidence qualification, nonrecursive fetching, and the
+expected-old lease. No product primitive changes.
+
+Extend existing Git-runner and workflow contract tests for credential
+separation, missing-token rejection, permission values, and secret-free
+arguments/receipts. Preserve the real bare-remote lease/submodule regression
+and token-free no-op/dry-run coverage. Run the promoter suite in an isolated
+container with Node and Git, repository formatting, staged secret scan, and
+diff inspection. No application runtime is needed; broad application checks
+are outside this focused proof.
+
+Update `docs/ci-and-deployment.md` and the supersession section of ADR-0003
+to correct their credential claims. This repairs the established design;
+no new ADR is required. If trigger remediation exceeds narrow release-ref
+exclusions, stop for scope resolution.
+
+GitHub documents using a separate credential when job-token permissions are
+insufficient: <https://docs.github.com/en/actions/tutorials/authenticate-with-github_token>.
+Non-job-token writes can trigger workflows, so candidate and default-branch
+event filters are a publication gate, not an assumed equivalence.
+
+## Progress
+
+Approved scope; planner approved credential-repair-v2 after accepting explicit
+environment scrubbing, write-only token requirements, and test/audit details.
+Native explore failed before work with provider HTTP 400; the same bounded
+audit uses generic-continuity Luna. Optional AGY challenge unavailable due to
+catalog/authentication errors. No operational state changed.
+
+Next: implement and verify the source slice, review, then publish a draft PR.


### PR DESCRIPTION
## What This Fixes

[The promotion retry](https://github.com/uzh-bf/klicker-uzh/actions/runs/34127759253) reached the Git push but was rejected because GITHUB_TOKEN cannot write workflow files. Restore the existing STG_PROMOTE_TOKEN for the lease-protected push only. API and Git fetch reads retain the job token, now with contents: read.

## Behavior and Review Focus

- Require an explicit write credential; never fall back to the job token. Dry-runs, disabled runs, and equal/stale no-ops remain credential-independent.
- Gate secret injection to enabled automatic runs or explicitly confirmed manual apply. Remove raw token variables from Git subprocess environments; credentials stay out of arguments and receipts.
- Preserve trusted controller execution, evidence qualification, nonrecursive fetches, and expected-old leases. Correct deployment documentation and ADR-0003.
- Audited committed default 65ae8a3523 and candidate 26e1934c39: no push/create workflow matches stg-release; no resulting build/controller chain. No trigger filters needed changing. External GitHub Apps and future candidates are outside this audit.

## Branch Coverage

Base: v3. Five implementation/documentation files plus the execution plan. Substantive diff: 75 additions and 9 deletions, excluding project artifacts. One cohesive CI regression repair; remaining commits record the approved plan and verification. No unrelated application changes.

## Verification

Current source:
- Promoter suite: 21/21 pass in a network-disabled disposable container, Node 22.21.0 and Git 2.39.5. Credential regression failed before the repair.
- Biome, Prettier, diff checks, Git identity, and Gitleaks passed.
- Planner, simplifier, credential-risk review, and integrated final review completed; no remaining findings. Final review covered 65ae8a3523..9586807d9e; subsequent changes only record review status.

Not run: Node 24 proof and full application build/check suite. This workflow-only repair needs no application runtime. The fresh worktree has no installed Husky wrappers; no hook configuration was changed. Hosted CI remains pending.

## Security / Privacy

No secret values were read or changed. Existing credential permissions remain unverified. No workflow dispatch, promotion retry, ref update, automatic activation, Argo change, or production action occurred. The separate credential can trigger downstream integrations, unlike the job token.

## Blocking Before Merge

Human review and required hosted CI.

## Follow-Up After Merge

Verify the existing credential has repository contents and workflow-file write permissions, then separately approve a promotion retry. Do not treat source tests as runtime or deployment proof.

## Local Session Artifacts

Local Codex host: trees/rs/stg-release-write-token in klicker-uzh. Gitignored review reports: project/_local/reviews/2026-09-07-stg-write-token-*.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staging release promotion security by separating read and write credentials.
  - Prevented unintended write-token fallback and ensured credentials are only available during authorized promotions.
  - Added safeguards to avoid exposing promotion credentials in Git operations or receipts.

- **Documentation**
  - Updated deployment guidance and architecture documentation with the new credential requirements, permissions, activation conditions, and workflow-trigger considerations.
  - Added a documented repair plan and validation criteria for staging release promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->