### PR TITLE
fix(kb): persist retrieval scope when attaching chatbots

### DIFF
--- a/packages/graphql/src/services/knowledge.ts
+++ b/packages/graphql/src/services/knowledge.ts
@@ -1049,11 +1049,13 @@ export async function attachKbToChatbot(
           mcpServerId: mcpServer.id,
           chatMode,
           allowedTools: ['doc_query'],
+          parameters: { required: true, toolAlias: 'doc_query', kb_id: kbId },
           priority: 0,
           isEnabled: true,
         },
         update: {
           allowedTools: ['doc_query'],
+          parameters: { required: true, toolAlias: 'doc_query', kb_id: kbId },
           priority: 0,
           isEnabled: true,
         },

--- a/packages/graphql/test/knowledge.test.ts
+++ b/packages/graphql/test/knowledge.test.ts
@@ -26,6 +26,20 @@ import {
 } from 'graphql'
 import { vi } from 'vitest'
 import type { ContextWithUser } from '../src/lib/context.js'
+
+vi.mock('@/src/lib/config/toolNames', async () =>
+  vi.importActual('../../../apps/chat/src/lib/config/toolNames.ts')
+)
+vi.mock('@/src/lib/server/mcpRuntimePolicy', async () =>
+  vi.importActual('../../../apps/chat/src/lib/server/mcpRuntimePolicy.ts')
+)
+const { resolveMcpScope } = await vi.importActual<{
+  resolveMcpScope: (
+    configurations: readonly unknown[],
+    selectedMode: string,
+    effectiveConfigurations: readonly unknown[]
+  ) => string[] | undefined
+}>('../../../apps/chat/src/services/mcpScope.ts')
 import {
   attachKbToChatbot,
   confirmKbFileReplacement,
@@ -567,6 +581,61 @@ describe('Integration tests for knowledge base CRUD', () => {
       { kbId: firstKb.id, chatbotId: chatbot.id },
       userOneCtx
     )
+
+    const readConfigurations = () =>
+      prisma.chatbotMCPConfig.findMany({
+        where: { chatbotId: chatbot.id, mcpServer: { name: 'KB' } },
+        include: { mcpServer: { select: { id: true, name: true } } },
+        orderBy: { chatMode: 'asc' },
+      })
+    const expectScopedConfigurations = async (kbId: string) => {
+      const configurations = await readConfigurations()
+      expect(configurations).toHaveLength(2)
+      expect(configurations).toEqual([
+        expect.objectContaining({
+          chatMode: 'explainer',
+          allowedTools: ['doc_query'],
+          parameters: {
+            required: true,
+            toolAlias: 'doc_query',
+            kb_id: kbId,
+          },
+          isEnabled: true,
+        }),
+        expect.objectContaining({
+          chatMode: 'tutor',
+          allowedTools: ['doc_query'],
+          parameters: {
+            required: true,
+            toolAlias: 'doc_query',
+            kb_id: kbId,
+          },
+          isEnabled: true,
+        }),
+      ])
+      expect(
+        resolveMcpScope(
+          configurations,
+          'tutor',
+          configurations.filter(
+            (configuration) => configuration.chatMode === 'tutor'
+          )
+        )
+      ).toEqual([kbId])
+      expect(
+        resolveMcpScope(
+          configurations,
+          'explainer',
+          configurations.filter(
+            (configuration) => configuration.chatMode === 'explainer'
+          )
+        )
+      ).toEqual([kbId])
+      return configurations
+    }
+
+    await expectScopedConfigurations(firstKb.id)
+
     await attachKbToChatbot(
       { kbId: secondKb.id, chatbotId: chatbot.id },
       userOneCtx
@@ -581,23 +650,16 @@ describe('Integration tests for knowledge base CRUD', () => {
       expect.objectContaining({ kbId: secondKb.id }),
     ])
 
-    const configurations = await prisma.chatbotMCPConfig.findMany({
-      where: { chatbotId: chatbot.id, mcpServer: { name: 'KB' } },
-      orderBy: { chatMode: 'asc' },
-    })
-    expect(configurations).toHaveLength(2)
-    expect(configurations).toEqual([
-      expect.objectContaining({
-        chatMode: 'explainer',
-        allowedTools: ['doc_query'],
-        isEnabled: true,
-      }),
-      expect.objectContaining({
-        chatMode: 'tutor',
-        allowedTools: ['doc_query'],
-        isEnabled: true,
-      }),
-    ])
+    const configurations = await expectScopedConfigurations(secondKb.id)
+    expect(
+      resolveMcpScope(
+        configurations,
+        'tutor',
+        configurations.filter(
+          (configuration) => configuration.chatMode === 'tutor'
+        )
+      )
+    ).not.toContain(firstKb.id)
   })
 
   it('serializes concurrent replacements to one enabled binding', async () => {
@@ -729,9 +791,22 @@ describe('Integration tests for knowledge base CRUD', () => {
     ).resolves.toBe(0)
     const configurations = await prisma.chatbotMCPConfig.findMany({
       where: { chatbotId: chatbot.id, mcpServer: { name: 'KB' } },
+      include: { mcpServer: { select: { id: true, name: true } } },
     })
     expect(configurations).toHaveLength(2)
     expect(configurations.every(({ isEnabled }) => !isEnabled)).toBe(true)
+    const enabledConfigurations = configurations.filter(
+      ({ isEnabled }) => isEnabled
+    )
+    expect(
+      resolveMcpScope(
+        enabledConfigurations,
+        'tutor',
+        enabledConfigurations.filter(
+          (configuration) => configuration.chatMode === 'tutor'
+        )
+      )
+    ).toBeUndefined()
   })
 
   it('disables chatbot retrieval when its knowledge base is tombstoned', async () => {

--- a/packages/graphql/test/knowledge.test.ts
+++ b/packages/graphql/test/knowledge.test.ts
@@ -631,7 +631,6 @@ describe('Integration tests for knowledge base CRUD', () => {
           )
         )
       ).toEqual([kbId])
-      return configurations
     }
 
     await expectScopedConfigurations(firstKb.id)
@@ -650,16 +649,7 @@ describe('Integration tests for knowledge base CRUD', () => {
       expect.objectContaining({ kbId: secondKb.id }),
     ])
 
-    const configurations = await expectScopedConfigurations(secondKb.id)
-    expect(
-      resolveMcpScope(
-        configurations,
-        'tutor',
-        configurations.filter(
-          (configuration) => configuration.chatMode === 'tutor'
-        )
-      )
-    ).not.toContain(firstKb.id)
+    await expectScopedConfigurations(secondKb.id)
   })
 
   it('serializes concurrent replacements to one enabled binding', async () => {

--- a/project/2026-09-07-kb-attachment-scope-plan.md
+++ b/project/2026-09-07-kb-attachment-scope-plan.md
@@ -1,0 +1,19 @@
+# Keep managed KB attachment and Chat scope consistent
+
+## Approval summary
+
+Normal KB attachment provisions a reserved KB tool binding without its required scope parameters. Fresh Chat retrieval fails closed; replacement leaves any old scope unchanged. Set the single-KB scope in both create and update branches of the existing transaction. Preserve ownership locks, the single-enabled-KB relationship, tool allowlist, modes and detach semantics. No schema, credentials, migrations, live data or gateway configuration changes.
+
+The user approved preparation of this source fix. Deliver a regression-tested and independently reviewed draft PR targeting v3-ai; no merge or deployment. Live UI and migrated-data acceptance remain in the unified KB roadmap. Isolated database/runtime availability gates tests and readiness, never justifies use of a shared database.
+
+## Execution details
+
+Repository: KlickerUZH. Reuse trees/kb-attachment-scope on fix/kb-attachment-scope, based on origin/v3-ai d03d4830622984d43e6712e30f06673a7f2b85cf. The primary checkout is dirty and excluded. Full-path regression package; parent owns contracts and final proof, trusted executor owns packages/graphql/src/services/knowledge.ts and packages/graphql/test/knowledge.test.ts only.
+
+Write parameters {required:true, toolAlias:'doc_query', kb_id:kbId} on create and update. Tests feed the actual persisted configurations into apps/chat/src/services/mcpScope.ts's resolver after fresh attachment, replacement, and detach. Preserve unrelated bindings. Ensure replacement cannot resolve the old KB. Use existing test-owned synthetic fixtures and repository-native tooling; no new dependency or copied scope logic. Resolve test alias imports without changing production architecture. Existing source contains no parameter default.
+
+Run focused GraphQL knowledge tests on an isolated synthetic test database, relevant type/format checks, then simplifier and risk review of the committed slice, followed by integrated final review. Tests must fail without the source fix. No new browser acceptance is claimed by this backend regression package. Pause on a new contract decision, unavailable isolated runtime, or unresolvable required review capability; continue independent source work.
+
+## Progress
+
+2026-09-07: native planner approved this bounded contract. Source head rechecked; missing parameter writes remain. Worktree created, no implementation yet. No live tunnels or data touched.

--- a/project/2026-09-07-kb-attachment-scope-plan.md
+++ b/project/2026-09-07-kb-attachment-scope-plan.md
@@ -16,4 +16,10 @@ Run focused GraphQL knowledge tests on an isolated synthetic test database, rele
 
 ## Progress
 
-2026-09-07: native planner approved this bounded contract. Source head rechecked; missing parameter writes remain. Worktree created, no implementation yet. No live tunnels or data touched.
+2026-09-07: implemented in f5f32a0208. Both create and update persist the required single-KB scope. The isolated synthetic database suite passed all 63 knowledge tests; removing the two source additions made the regression fail, then the original source was restored. GraphQL checks, scoped formatting, diff checks, Gitleaks and focused Opengrep passed.
+
+All hook checks passed with the required environment split: 40 container build/typecheck tasks plus lint and auxiliary checks; 68 host workflow/Devrouter tests. The combined host hook failed on container toolchain outputs; the combined container hook required the host-only Devrouter executable. Equivalent checks ran in their correct environments before committing.
+
+Native slice review found no correctness or scope-isolation issues. Simplifier and final reviewer identified a redundant old-KB exclusion assertion; removed it and the unused helper return, retaining exact equality assertions for both modes. Final review also requested this progress reconciliation. These assertion-only and documentation corrections preserve the tested behavior; prior verification and reviews remain applicable, with final diff inspection of the correction.
+
+Runtime fix-kb-attachment-scope was stopped through devrouter; its recorded container is exited and exact worktree route count is zero. No live data, migration, deployment or browser acceptance was performed. API tunnels are now listening; live reconciliation remains separate. Remaining delivery: ordinary branch push and draft PR targeting v3-ai, followed by human review and required CI. No merge authority.


### PR DESCRIPTION
## What This Fixes

Attaching a managed knowledge base now persists the scope parameters required by Chat retrieval. Fresh attachments select that KB, and replacing an attachment updates the scope instead of retaining the previous selection.

The existing ownership checks, transaction, single enabled KB relationship, Tutor/Explainer modes and tool allowlist remain unchanged. No schema or migration changes and no per-chatbot LiteLLM configuration.

## Branch Coverage

Base: `v3-ai`. Two source/test files plus the execution plan. Substantive diff: 84 additions and 17 deletions. This is one complete regression repair below the packaging floor.

## Review Focus

Both create and update paths must persist the same single-KB scope. Integration tests pass the persisted configurations into Chat's real scope resolver for fresh attachment, replacement and detach.

## Verification

Current implementation:
- 63 knowledge integration tests pass against the isolated synthetic test database.
- The attachment regression fails when the two production additions are removed, then passes after restoration.
- Repository pre-commit checks pass using the required environment split: container build/typechecks (40 tasks) and host workflow/Devrouter tests (68 tests), plus formatting, lint and auxiliary checks.
- Full pre-push production build passes: 26/26 workspace tasks in the isolated container.
- Diff checks, staged Gitleaks and focused Opengrep pass.
- Slice and integrated final review completed. Final-review corrections remove a duplicate test assertion and reconcile the progress note; all findings are addressed. Earlier runtime evidence remains applicable to these assertion-only and documentation changes.

The combined hook cannot run in one environment: host builds lack container tooling, while one container workflow test requires the host Devrouter binary. Equivalent checks ran in their required environments before commit.

## Blocking Before Merge

Human review and required hosted CI. Keep draft.

## Follow-Up After Merge

Roll out the reviewed source through the KB staging release path. Reconcile migrated IuW/RSV resources, then verify migrated and newly created KBs visually in Manage and Chat. This PR does not migrate live records or establish browser acceptance.

## Local Session Artifacts

Local Codex host, repository klicker-uzh: `trees/kb-attachment-scope`. The isolated runtime was stopped and its three routes were removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed chatbot knowledge-base attachments so connected tools consistently use the selected knowledge base when configurations are created or updated.
  - Improved knowledge-base scope handling across supported chatbot modes.
  - Ensured detaching a knowledge base clears its active tool scope correctly.

- **Documentation**
  - Added implementation and validation notes for the knowledge-base attachment scope fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->