### PR TITLE
refactor(graphql): consolidate activity batch policy filters

### DIFF
--- a/packages/graphql/src/services/activities.ts
+++ b/packages/graphql/src/services/activities.ts
@@ -1,11 +1,11 @@
-import { ContextWithUser } from '@/lib/context.js'
 import * as DB from '@klicker-uzh/prisma/client'
 import { ActivityType, SharingType, SortByType } from '@klicker-uzh/types'
 import {
-  PrismaTransactionClient,
+  type PrismaTransactionClient,
   recomputeDerivedPermissions,
 } from '@klicker-uzh/util'
 import generatePassword from 'generate-password'
+import type { ContextWithUser } from '@/lib/context.js'
 import { POINTS_PER_GROUP_ACTIVITY_ELEMENT } from './groups.js'
 import { POINTS_PER_INSTANCE } from './stacks.js'
 
@@ -27,6 +27,67 @@ function isPrismaRecordNotFoundError(error: unknown) {
     'code' in error &&
     error.code === 'P2025'
   )
+}
+
+// at least write permissions are required to update an activity through a
+// batch operation
+const BATCH_UPDATE_PERMISSION_LEVELS: DB.PermissionLevel[] = [
+  DB.PermissionLevel.WRITE,
+  DB.PermissionLevel.ADMIN,
+  DB.PermissionLevel.OWNER,
+]
+
+// shared access clauses for batch activity updates across the four activity
+// models: write-level (or higher) permission and unpublished status
+function activityBatchAccessClauses({
+  activityIds,
+  userId,
+}: {
+  activityIds: string[]
+  userId: string
+}) {
+  return {
+    id: { in: activityIds },
+    permissions: {
+      some: {
+        userId,
+        permissionLevel: { in: BATCH_UPDATE_PERMISSION_LEVELS },
+      },
+    },
+    status: { in: UNPUBLISHED_ACTIVITY_STATUSES },
+  }
+}
+
+// setting a multiplier without a course re-assignment (or updating the grading
+// points of a live quiz) requires the activity to be gamified or
+// assessment-relevant already
+function gamifiedOrAssessmentClause() {
+  return {
+    OR: [{ isGamificationEnabled: true }, { isAssessmentEnabled: true }],
+  }
+}
+
+// assessment-relevant activities can only be assigned to another course (and
+// thereby removed from their current one) by an owner/admin of the assessment
+// course; live quizzes additionally admit activities without a course (the
+// other activity models cannot be assessment-relevant without one)
+function assessmentCourseMoveBranches(userId: string) {
+  return [
+    { isAssessmentEnabled: false },
+    {
+      isAssessmentEnabled: true,
+      course: {
+        permissions: {
+          some: {
+            userId,
+            permissionLevel: {
+              in: [DB.PermissionLevel.OWNER, DB.PermissionLevel.ADMIN],
+            },
+          },
+        },
+      },
+    },
+  ]
 }
 
 export async function deleteWithPublicationStatusGuard<T>(
@@ -524,19 +585,6 @@ export async function applyActivityBatchOperations(
     return 0
   }
 
-  // at least write permissions on the activities are required
-  const requiredPermissionLevels = [
-    DB.PermissionLevel.WRITE,
-    DB.PermissionLevel.ADMIN,
-    DB.PermissionLevel.OWNER,
-  ]
-
-  // only draft and scheduled activities can be updated
-  const allowedActivityStatus = [
-    DB.PublicationStatus.DRAFT,
-    DB.PublicationStatus.SCHEDULED,
-  ]
-
   // check if the live quiz grading logic should be manipulated
   const setLiveQuizPoints =
     typeof basePoints !== 'undefined' &&
@@ -554,44 +602,19 @@ export async function applyActivityBatchOperations(
   // fetch all live quizzes that should be updated
   const liveQuizzes = await ctx.prisma.liveQuiz.findMany({
     where: {
-      id: { in: activityIds },
-      permissions: {
-        some: {
-          userId: ctx.user.sub,
-          permissionLevel: { in: requiredPermissionLevels },
-        },
-      },
-      status: { in: allowedActivityStatus },
+      ...activityBatchAccessClauses({ activityIds, userId: ctx.user.sub }),
       AND: [
         // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
+        // updating the grading points of a live quiz requires the same
         ...((setMultiplier && !newCourse) || setLiveQuizPoints
-          ? [
-              {
-                OR: [
-                  { isGamificationEnabled: true },
-                  { isAssessmentEnabled: true },
-                ],
-              },
-            ]
+          ? [gamifiedOrAssessmentClause()]
           : []),
         // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
+        // live quizzes without a course always qualify for updates
         {
           OR: [
             { courseId: null },
-            { isAssessmentEnabled: false },
-            {
-              isAssessmentEnabled: true,
-              course: {
-                permissions: {
-                  some: {
-                    userId: ctx.user.sub,
-                    permissionLevel: {
-                      in: [DB.PermissionLevel.OWNER, DB.PermissionLevel.ADMIN],
-                    },
-                  },
-                },
-              },
-            },
+            ...assessmentCourseMoveBranches(ctx.user.sub),
           ],
         },
       ],
@@ -603,14 +626,7 @@ export async function applyActivityBatchOperations(
   const practiceQuizzes = !setLiveQuizPoints
     ? await ctx.prisma.practiceQuiz.findMany({
         where: {
-          id: { in: activityIds },
-          permissions: {
-            some: {
-              userId: ctx.user.sub,
-              permissionLevel: { in: requiredPermissionLevels },
-            },
-          },
-          status: { in: allowedActivityStatus },
+          ...activityBatchAccessClauses({ activityIds, userId: ctx.user.sub }),
           AND: [
             // if the practice quiz is assigned to a new course, the scheduled publication date must lie within the course duration (or be null -> draft)
             ...(newCourse
@@ -630,37 +646,10 @@ export async function applyActivityBatchOperations(
               : []),
             // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
             ...(setMultiplier && !newCourse
-              ? [
-                  {
-                    OR: [
-                      { isGamificationEnabled: true },
-                      { isAssessmentEnabled: true },
-                    ],
-                  },
-                ]
+              ? [gamifiedOrAssessmentClause()]
               : []),
             // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
-            {
-              OR: [
-                { isAssessmentEnabled: false },
-                {
-                  isAssessmentEnabled: true,
-                  course: {
-                    permissions: {
-                      some: {
-                        userId: ctx.user.sub,
-                        permissionLevel: {
-                          in: [
-                            DB.PermissionLevel.OWNER,
-                            DB.PermissionLevel.ADMIN,
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
-              ],
-            },
+            { OR: assessmentCourseMoveBranches(ctx.user.sub) },
           ],
         },
         include: { stacks: { include: { elements: true } } },
@@ -671,14 +660,7 @@ export async function applyActivityBatchOperations(
   const microLearnings = !setLiveQuizPoints
     ? await ctx.prisma.microLearning.findMany({
         where: {
-          id: { in: activityIds },
-          permissions: {
-            some: {
-              userId: ctx.user.sub,
-              permissionLevel: { in: requiredPermissionLevels },
-            },
-          },
-          status: { in: allowedActivityStatus },
+          ...activityBatchAccessClauses({ activityIds, userId: ctx.user.sub }),
           // if a new course is assigned, the entire availability interval of the activity should lie inside the course duration
           scheduledStartAt: newCourse
             ? { gte: newCourse.startDate }
@@ -687,37 +669,10 @@ export async function applyActivityBatchOperations(
           AND: [
             // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
             ...(setMultiplier && !newCourse
-              ? [
-                  {
-                    OR: [
-                      { isGamificationEnabled: true },
-                      { isAssessmentEnabled: true },
-                    ],
-                  },
-                ]
+              ? [gamifiedOrAssessmentClause()]
               : []),
             // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
-            {
-              OR: [
-                { isAssessmentEnabled: false },
-                {
-                  isAssessmentEnabled: true,
-                  course: {
-                    permissions: {
-                      some: {
-                        userId: ctx.user.sub,
-                        permissionLevel: {
-                          in: [
-                            DB.PermissionLevel.OWNER,
-                            DB.PermissionLevel.ADMIN,
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
-              ],
-            },
+            { OR: assessmentCourseMoveBranches(ctx.user.sub) },
           ],
         },
         include: { stacks: { include: { elements: true } } },
@@ -729,14 +684,10 @@ export async function applyActivityBatchOperations(
     !setLiveQuizPoints && (!newCourse || newCourse.isGroupCreationEnabled) // if the course is updated, group creation needs to be enabled
       ? await ctx.prisma.groupActivity.findMany({
           where: {
-            id: { in: activityIds },
-            permissions: {
-              some: {
-                userId: ctx.user.sub,
-                permissionLevel: { in: requiredPermissionLevels },
-              },
-            },
-            status: { in: allowedActivityStatus },
+            ...activityBatchAccessClauses({
+              activityIds,
+              userId: ctx.user.sub,
+            }),
             // if a new course is assigned, the group formation deadline should be before the start of the group activity
             // (start date of course does not need to be verified, since group formation deadline is always after start date)
             scheduledStartAt: newCourse
@@ -747,37 +698,10 @@ export async function applyActivityBatchOperations(
             AND: [
               // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
               ...(setMultiplier && !newCourse
-                ? [
-                    {
-                      OR: [
-                        { isGamificationEnabled: true },
-                        { isAssessmentEnabled: true },
-                      ],
-                    },
-                  ]
+                ? [gamifiedOrAssessmentClause()]
                 : []),
               // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
-              {
-                OR: [
-                  { isAssessmentEnabled: false },
-                  {
-                    isAssessmentEnabled: true,
-                    course: {
-                      permissions: {
-                        some: {
-                          userId: ctx.user.sub,
-                          permissionLevel: {
-                            in: [
-                              DB.PermissionLevel.OWNER,
-                              DB.PermissionLevel.ADMIN,
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  },
-                ],
-              },
+              { OR: assessmentCourseMoveBranches(ctx.user.sub) },
             ],
           },
           include: { stacks: { include: { elements: true } } },
@@ -785,10 +709,10 @@ export async function applyActivityBatchOperations(
       : []
 
   // apply activity updates
-  let updatedLiveQuizzes: string[] = []
-  let updatedPracticeQuizzes: string[] = []
-  let updatedMicroLearnings: string[] = []
-  let updatedGroupActivities: string[] = []
+  const updatedLiveQuizzes: string[] = []
+  const updatedPracticeQuizzes: string[] = []
+  const updatedMicroLearnings: string[] = []
+  const updatedGroupActivities: string[] = []
 
   // update live quizzes (including gamification / assessment flags & all instances - depending on the required updates)
   for (const liveQuiz of liveQuizzes) {
@@ -1765,7 +1689,7 @@ export async function setActivityReviewStatus(
         data: { reviewStatus },
       })
 
-      return !!liveQuiz ? reviewStatus : null
+      return liveQuiz ? reviewStatus : null
     } else if (activityType === ActivityType.PRACTICE_QUIZ) {
       const practiceQuiz = await ctx.prisma.practiceQuiz.update({
         where: {
@@ -1782,7 +1706,7 @@ export async function setActivityReviewStatus(
         data: { reviewStatus },
       })
 
-      return !!practiceQuiz ? reviewStatus : null
+      return practiceQuiz ? reviewStatus : null
     } else if (activityType === ActivityType.MICRO_LEARNING) {
       const microLearning = await ctx.prisma.microLearning.update({
         where: {
@@ -1799,7 +1723,7 @@ export async function setActivityReviewStatus(
         data: { reviewStatus },
       })
 
-      return !!microLearning ? reviewStatus : null
+      return microLearning ? reviewStatus : null
     } else if (activityType === ActivityType.GROUP_ACTIVITY) {
       const groupActivity = await ctx.prisma.groupActivity.update({
         where: {
@@ -1816,7 +1740,7 @@ export async function setActivityReviewStatus(
         data: { reviewStatus },
       })
 
-      return !!groupActivity ? reviewStatus : null
+      return groupActivity ? reviewStatus : null
     }
   } catch (error) {
     console.error('Error setting activity review status:', error)

--- a/packages/graphql/test/activityBatchOperations.test.ts
+++ b/packages/graphql/test/activityBatchOperations.test.ts
@@ -5,19 +5,19 @@ import {
   ElementStackType,
   ElementType,
   PermissionLevel,
-  PrismaClient,
+  type PrismaClient,
   PublicationStatus,
   ReviewStatus,
 } from '@klicker-uzh/prisma/client'
-import {
+import type {
   ElementData,
   ElementInstanceResults,
   ElementOptions,
 } from '@klicker-uzh/types'
 import { recomputeDerivedPermissions } from '@klicker-uzh/util'
 import { EventEmitter } from 'events'
-import { vi } from 'vitest'
 import { v4 as uuid } from 'uuid'
+import { vi } from 'vitest'
 import type { ContextWithUser } from '../src/lib/context.js'
 import { applyActivityBatchOperations } from '../src/services/activities.js'
 import { deleteGroupActivity } from '../src/services/groups.js'
@@ -117,7 +117,7 @@ describe('Integration tests for batch operations on activities', () => {
         isGroupCreationEnabled: true,
         groupDeadlineDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // one week in the future
         ownerId: userOneCtx.user.sub,
-        authType: !!args.isAssessmentEnabled
+        authType: args.isAssessmentEnabled
           ? CourseAuthType.SSO
           : CourseAuthType.PIN,
         ...args,
@@ -1070,6 +1070,28 @@ describe('Integration tests for batch operations on activities', () => {
     const gaNonGamifiedInstance =
       unchangedGroupActivityNonGamified?.stacks[0]?.elements[0]
     expect(gaNonGamifiedInstance?.options.pointsMultiplier).toEqual(4)
+  })
+
+  it('Verify that assessment live quizzes without a course remain eligible for multiplier updates', async () => {
+    // only live quizzes can be assessment-relevant without a course assignment
+    // (the other activity models require a course for assessment mode); such
+    // quizzes stay eligible for multiplier-only batch updates
+    const liveQuiz = await seedLiveQuiz(
+      { isAssessmentEnabled: true, isGamificationEnabled: false },
+      prisma
+    )
+
+    const updates = await applyActivityBatchOperations(
+      { activityIds: [liveQuiz.id], multiplier: 2 },
+      userOneCtx
+    )
+    expect(updates).toBe(1)
+
+    const updatedLiveQuiz = await prisma.liveQuiz.findUnique({
+      where: { id: liveQuiz.id },
+    })
+    expect(updatedLiveQuiz?.pointsMultiplier).toEqual(2)
+    expect(updatedLiveQuiz?.courseId).toBeNull()
   })
 
   it('Verify that with live quiz grading components set, the quizzes are updated accordingly (and other activities are skipped', async () => {

--- a/project/2026-09-07-pr5832-production-readiness.md
+++ b/project/2026-09-07-pr5832-production-readiness.md
@@ -1,0 +1,60 @@
+# Production readiness — PR 5832 (activity batch policy filter consolidation)
+
+Reviewed head: 82247bdf4 (branch rs/idle-architecture/ia-2026-09-07/01-activity-batch-policy, base v3 @ 7f81442ad9).
+Wave one: 8 dimension workers (foreground subagents of the session model — no external provider spend;
+no other fan-out was running against this quota). Wave two: not required — zero blockers reported.
+
+## Verdict
+
+**ready-with-conditions.** No dimension reported a blocker or major finding. The change is a
+behavior-preserving, service-internal refactor of Prisma where-clause construction with byte-identical
+query inputs (independently re-verified by a 28-combination deep-equal harness), no schema, migration,
+config, dependency, or API-surface changes, and clean exact-head CI including the full 8-shard
+Playwright suite. Conditions: (1) the repository final AI review must complete on the final head;
+(2) this artifact commit is the only post-CI delta and is documentation-only.
+
+## Prior gates
+
+| gate | artifact | status |
+| --- | --- | --- |
+| exact-head CI: check / test-graphql / test-unit / gitleaks / codeql / sonar / build | GitHub Actions, PR 5832 @ 82247bdf4 | present (28/28 pass, incl. full Playwright 8/8 shards) |
+| repository final-ai-review (/final-review) | workflow check | pending on final head at report time |
+| $code-review / $security-review / $thermo-nuclear artifacts | project/_local/reviews/ | missing (observation; the changed surface is covered by the integration battery, E2E cluster, and this audit's data-safety/UX dimensions) |
+| per-slice reviews | — | not applicable (no slices; single-layer PR) |
+
+## Findings
+
+| severity | dimension | finding | evidence | proposed action | verification |
+| --- | --- | --- | --- | --- | --- |
+| minor | data safety | `UNPUBLISHED_ACTIVITY_STATUSES` is a shared mutable exported array now also used by the batch gate; a future in-place mutation would widen blast radius (today: zero mutation sites repo-wide) | activities.ts:18-21, :57; importers practiceQuizzes.ts:656, microLearning.ts:763, groups.ts:1895 | optional `as const`/readonly hardening in a follow-up | unverified (static) |
+| minor | failure modes | mid-batch failure leaves committed prefix + generic error toast; client catch path does not refetch the activity list | mutation.ts:1342 (bare delegation); ActivityBatchOperationsModal.tsx:591-597 (catch without refetch) | handoff: refetch in catch; optionally return committed count | unverified (static, pre-existing) |
+| minor | failure modes | per-activity transactions use Prisma default 5s timeout while comparable code budgets 60s (pin-code retries + instance updates inside one tx) | activities.ts:719 vs :209 (`{ timeout: 60000 }`) | handoff: explicit timeout on batch loop txs | unverified (static, pre-existing) |
+| minor | observability | zero-update outcome is silent server-side (count 0, no log/metric); UI error toast is the only signal | activities.ts:1042-1047; modal :584-590 | follow-up: warn-log requested>0 && count==0 | unverified (static, pre-existing) |
+| minor | observability | no metrics/APM on GraphQL mutations (Sentry commented out) | apps/backend-docker/src/app.ts:171-185, :199-201 | follow-up: re-enable Sentry or metrics plugin | unverified (static, pre-existing) |
+| minor | observability | `data: undefined` without throw would render as "partial success" toast | ActivityBatchOperationsModal.tsx:561-583 | optional: explicit undefined handling | unverified (static, pre-existing, edge) |
+| minor | UX | count copy lacks ICU plural ("1 activities will be updated") | packages/i18n/messages/en.ts:1678 | handoff to UI/i18n task | confirmed (observed live) |
+| minor | UX | batch toasts not announced to screen readers (no aria-live on toaster) | observed DOM during toast | handoff to design-system owners | confirmed (observed live) |
+| minor | UX | publish confirmation can close silently when the mutation resolves null (schedule branch) | PublishConfirmationModal.tsx:115; microLearning.ts schedule branch | handoff: toast on null result | confirmed (observed live) |
+| minor | UX | eligibility ✓/× marks rely on color + hover/focus tooltip | modal :81-256 | acceptable (count message + disabled apply reinforce); optional text label | unverified (heuristic) |
+| minor | performance | update loops are O(N) sequential transactions with per-instance updates + full permission recompute per activity | activities.ts:712-1040; util/permissions.ts:55-136 | follow-up candidate (out of scope) | unverified (static, pre-existing) |
+| minor | performance | findMany unconditionally includes all instances but reads them only when setMultiplier | activities.ts:622,655,678,707 vs :799-808 | follow-up: conditional include | unverified (static, pre-existing) |
+| pass | UX | client-predicted eligibility === server count on every driven apply (4/4 multiplier, 4/4 course move, 2/3 partial, 2/2 reset), success/partial/zero surfaces correct | observed live, 22 screenshots (/tmp/pr5832-ux-*.png) | none | confirmed (observed) |
+| pass | data safety | all four consolidated where-clauses value-identical to originals branch-for-branch, incl. live-quiz `{courseId: null}` and gamification-on-points nuances; no prisma/SDL diff | activities.ts:34-91,603-708; empty diff under packages/prisma and public/schema.graphql | none | confirmed (static, line-by-line) |
+| pass | performance | where-inputs deep-equal 28/28 combinations (4 models × 7 param combos); index usage unchanged (PK + DerivedPermission unique indexes drive all branches) | harness /tmp/pr5832-where-equiv.mjs; EXPLAIN probe on disposable DB | none | confirmed (harness + probe) |
+| pass | deploy | no migrations, no flags, no env/deps/turbo changes; ships in backend-docker + hatchet-worker-general images from the same release tag; rollback = tag revert (both images atomically) | diff name-only (2 files); backend Dockerfile:33-53; worker index.ts:4 | none | confirmed (static) |
+| pass | config | zero config/secret/env/dependency deltas; test addition synthetic and credential-free | full-diff greps (0 matches) | none | confirmed (static) |
+| pass | docs | no doc/ADR describes the old clause layout; tutorial claims map 1:1 to the new helpers; wiki rule satisfied without a doc edit | docs/graphql-api-layer.md:20; apps/docs activity_batch_operations.mdx:27-29 | none | confirmed (static) |
+
+## Not checked
+
+- Production/staging clusters, registries, and live log pipelines — outside authorization by design; repository-level evidence only.
+- Runtime SQL capture from the engine (substituted by where-input structural equivalence + hand-mirrored EXPLAIN; Prisma compilation is deterministic).
+- Production-scale query plans (disposable DB holds seed-scale data; identical SQL to base makes scale behavior identical to status quo).
+- Fault injection mid-batch (outside read-only charter).
+- The `setLiveQuizPoints` modal card driven live (no second draft live quiz in seed data; covered by the integration battery + E2E cluster instead).
+
+## Handoffs
+
+- Client-side eligibility mirror duplicates server policy (pre-existing; server authoritative; mismatch would surface as preview-vs-count discrepancy) → code-review/maintainability track.
+- Toast aria-live, ICU plural, publish-null silent close, color-only eligibility marks → UI/design-system backlog.
+- Batch-loop tx timeouts + error-path refetch + zero-count warn-log + conditional include + transaction batching → future backend hardening candidates (recorded; none block this PR).


### PR DESCRIPTION
## Problem (evidence)

`applyActivityBatchOperations` (`packages/graphql/src/services/activities.ts`) repeated the same four Prisma policy clauses **verbatim across four `findMany` blocks** (liveQuiz / practiceQuiz / microLearning / groupActivity):

- `permissions.some { userId, WRITE/ADMIN/OWNER }`
- `status in [DRAFT, SCHEDULED]`
- the conditional *gamification-required* OR clause
- the *assessment course-move* OR clause

This is the highest-heat service file (9 commits/12 months; batch archive/delete landed 2026-08-25), so policy changes are expected to keep landing here — and each one currently has to be applied four times inside a single function. A miss produces model-specific behavior drift that no type checker catches (the clauses are structurally independent Prisma objects).

## Change

Extract three module-private helpers and compose the four queries from them:

- `activityBatchAccessClauses({ activityIds, userId })` — id / permission / status core
- `gamifiedOrAssessmentClause()` — the multiplier/points gate
- `assessmentCourseMoveBranches(userId)` — the two assessment-move branches

Net −54 lines. The emitted Prisma `where` objects are **unchanged**:

- live quizzes still admit unassigned (`courseId: null`) activities in the assessment clause and apply the gamification gate when grading points are set (`setLiveQuizPoints`)
- practice-quiz `availableFrom` windows and the microLearning/groupActivity `scheduledStartAt`/`scheduledEndAt` windows stay at their call sites (they are the genuine per-type differences)
- the status filter now reuses the existing exported `UNPUBLISHED_ACTIVITY_STATUSES` instead of a local duplicate

Design note: a single full where-builder was prototyped and rejected — it does not typecheck, because only `LiveQuizWhereInput` admits `courseId: null` and a conditional spread contaminates the inferred return type for the other three models. Three small clause helpers keep each per-type difference visible at its call site with zero casts.

## Tests (consolidation mapping)

Hotspot audit of `packages/graphql/test/activityBatchOperations.test.ts` (16 tests → 10 behavior clusters): **all kept, none merged** — each cluster pins a distinct contract (per-type deletion predicates, status gating, gamification gating, assessment-move authorization, availability windows, derived-permission recomputation, review-status transitions). Compressing the explicit per-type assertions would trade diagnostic clarity for brevity in a characterization battery.

**Added** one characterization test: *assessment live quizzes without a course remain eligible for multiplier updates* — pins the `courseId: null` nuance this refactor must preserve (previously covered only implicitly inside the multiplier test's expected count). A null-course practice-quiz contrast is impossible by schema (`courseId` NOT NULL on the other three models).

## Verification

| Gate | Result |
| --- | --- |
| `pnpm --filter @klicker-uzh/graphql check` (tsc + SDL snapshot) | ✅ pass, schema unchanged |
| Targeted `activityBatchOperations.test.ts` (container, disposable `klicker_test` DB) | ✅ 17/17 (twice) |
| Full `@klicker-uzh/graphql` suite (container) | 868/869 → sole failure (`assessmentRestrictions` reset) reproduced identically on the **parent commit** (stash run): local-workspace Redis topology gap (helpers hardcode `127.0.0.1:6380`, CI publishes it; worktree is port-free). Second full run with a container-local loopback forwarder mirroring CI topology: 867/869 with two `activitySharing` failures — also reproduced identically on the parent commit. Both failure sets are environmental; CI `test-graphql` (isolated services) is the authoritative full-suite gate for this head |
| `pnpm run check:all` (container, CI-style devrouter planner env) | ✅ 35/35 |
| `pnpm run build` (container) | ✅ 23/23 |
| E2E journey: X-review activity-batch cluster (CLEANUP → prepare → modal eligibility → apply multiplier via real mutation → batch delete), 5/5 passed in 47.2s against the task runtime | ✅ |
| Exact-head CI (check / test-unit / test-graphql / Playwright full 8-shard / codeql / gitleaks) | see status below |

## Scope / risks / rollback

- Service-internal refactor: no schema, ops, codegen, or API-surface change (SDL snapshot byte-identical); no other consumers of the query shape exist.
- Authorization semantics preserved by construction (identical clause objects) and pinned by the existing 2,200-line integration battery.
- Rollback: revert the single commit.

## Status

- [x] Implementation + characterization test
- [x] Local gates (check:all, build, targeted + full graphql suite with environmental deltas root-caused on parent)
- [x] Local E2E journey
- [x] Exact-head CI green (45/45 on 5badbad4a: full Playwright 8/8 hosted as draft AND 8/8 public as ready, test-graphql, check, codeql, sonar, gitleaks)
- [x] Final review: /final-review clean (z-ai/glm-5.3-flash, evidence=4e109f44…); OpenCodeReview 0 findings; production-readiness audit report committed (project/2026-09-07-pr5832-production-readiness.md)
