### PR TITLE
refactor(util): consolidate activity permission recompute modules

### DIFF
--- a/packages/util/src/permissions/activity.ts
+++ b/packages/util/src/permissions/activity.ts
@@ -1,0 +1,417 @@
+/**
+ * Shared derived-permission recomputation for the four activity models
+ * (live quiz, practice quiz, microlearning, group activity).
+ *
+ * All four models implement the identical recomputation flow and differ
+ * only in their Prisma delegate, their derived-permission key field, the
+ * element-stack relation (`blocks` on live quizzes, `stacks` elsewhere)
+ * and their log labels. The per-model descriptors below supply these
+ * differences; the public per-model functions in this directory are thin
+ * wrappers around the generic variants implemented here.
+ */
+
+import type * as DB from '@klicker-uzh/prisma/client'
+import type { PrismaTransactionClient } from '../types.js'
+import { updateAccessRequestInstances } from './accessRequest.js'
+import {
+  getActivityPermissionsObject,
+  getActivityPermissionsUser,
+  propagateActivityToElements,
+  propagateActivityToElementsUser,
+} from './util.js'
+
+/** derived-permission identifier of an activity model */
+type ActivityIdField =
+  | 'liveQuizId'
+  | 'practiceQuizId'
+  | 'microLearningId'
+  | 'groupActivityId'
+
+/** element stacks of an activity in the shape accepted for element propagation */
+type ActivityElementStacks = Parameters<
+  typeof propagateActivityToElementsUser
+>[0]['stacks']
+
+/**
+ * Activity state required for a derived-permission recomputation. The
+ * per-model fetch functions apply the variant-specific permission filters
+ * and normalize the element-stack relation (`blocks` on live quizzes)
+ * into the common `stacks` shape.
+ */
+interface ActivityPermissionSnapshot {
+  ownerId: string
+  isDeleted: boolean
+  directPermissions: DB.Permission[]
+  course?: {
+    permissions: (DB.DerivedPermission & {
+      directPermission?: DB.Permission | null
+    })[]
+  } | null
+  stacks: ActivityElementStacks
+}
+
+/** per-model differences between the four activity models */
+export interface ActivityPermissionModel {
+  /** lower-case label used in error messages */
+  label: 'live quiz' | 'practice quiz' | 'microlearning' | 'group activity'
+  /** label used in the object-not-found console.error */
+  notFoundLabel:
+    | 'Live quiz'
+    | 'Practice quiz'
+    | 'Microlearning'
+    | 'Group activity'
+  /** derived-permission key field identifying the activity */
+  idField: ActivityIdField
+  /**
+   * Fetch the activity with the direct permissions relevant for the given
+   * user (direct grants and user-group memberships), the user's course
+   * permissions and the contained element stacks.
+   */
+  fetchForUser: (
+    prisma: PrismaTransactionClient,
+    id: string,
+    userId: string
+  ) => Promise<ActivityPermissionSnapshot | null>
+  /**
+   * Fetch the activity with all direct permissions (including user
+   * groups), all course permissions and the contained element stacks.
+   */
+  fetchForObject: (
+    prisma: PrismaTransactionClient,
+    id: string
+  ) => Promise<ActivityPermissionSnapshot | null>
+  /** access-request scope identifying the activity */
+  accessRequestScope: (
+    id: string
+  ) =>
+    | { liveQuizId: string }
+    | { practiceQuizId: string }
+    | { microLearningId: string }
+    | { groupActivityId: string }
+}
+
+/**
+ * Unique identifier of a derived permission on an activity. Exactly one
+ * composite key is defined per call; the remaining keys stay undefined
+ * and are ignored by Prisma, so schema drift fails the type check
+ * instead of producing runtime errors.
+ */
+function activityPermissionUniqueWhere(
+  idField: ActivityIdField,
+  id: string,
+  userId: string
+): DB.Prisma.DerivedPermissionWhereUniqueInput {
+  return {
+    liveQuizId_userId:
+      idField === 'liveQuizId' ? { liveQuizId: id, userId } : undefined,
+    practiceQuizId_userId:
+      idField === 'practiceQuizId' ? { practiceQuizId: id, userId } : undefined,
+    microLearningId_userId:
+      idField === 'microLearningId'
+        ? { microLearningId: id, userId }
+        : undefined,
+    groupActivityId_userId:
+      idField === 'groupActivityId'
+        ? { groupActivityId: id, userId }
+        : undefined,
+  }
+}
+
+/** create input for a new derived permission on an activity */
+function activityPermissionCreate(
+  idField: ActivityIdField,
+  id: string,
+  userId: string,
+  {
+    permissionLevel,
+    derived,
+    parentPermissionId,
+  }: {
+    permissionLevel: DB.PermissionLevel
+    derived: boolean
+    parentPermissionId?: number
+  }
+): DB.Prisma.DerivedPermissionCreateInput {
+  return {
+    permissionLevel,
+    derived,
+    directPermission:
+      typeof parentPermissionId !== 'undefined'
+        ? { connect: { id: parentPermissionId } }
+        : undefined,
+    liveQuiz: idField === 'liveQuizId' ? { connect: { id } } : undefined,
+    practiceQuiz:
+      idField === 'practiceQuizId' ? { connect: { id } } : undefined,
+    microLearning:
+      idField === 'microLearningId' ? { connect: { id } } : undefined,
+    groupActivity:
+      idField === 'groupActivityId' ? { connect: { id } } : undefined,
+    user: { connect: { id: userId } },
+  }
+}
+
+/** filter matching all derived permissions of an activity */
+function activityPermissionFilter(
+  idField: ActivityIdField,
+  id: string,
+  userId: { notIn: string[] }
+): DB.Prisma.DerivedPermissionWhereInput {
+  return {
+    liveQuizId: idField === 'liveQuizId' ? id : undefined,
+    practiceQuizId: idField === 'practiceQuizId' ? id : undefined,
+    microLearningId: idField === 'microLearningId' ? id : undefined,
+    groupActivityId: idField === 'groupActivityId' ? id : undefined,
+    userId,
+  }
+}
+
+/**
+ * Dispatch function for the recomputation of derived permissions on an
+ * activity.
+ *
+ * Based on the provided parameters, this function delegates to either
+ * user-specific or object-wide permission recomputation.
+ */
+export async function recomputeActivityPermissions(
+  {
+    id,
+    userId,
+    updateAccessRequests,
+  }: {
+    id: string
+    userId?: string
+    updateAccessRequests: boolean
+  },
+  prisma: PrismaTransactionClient,
+  model: ActivityPermissionModel
+) {
+  // if a user is defined, only recompute derived permissions for this user
+  if (userId) {
+    return await recomputeActivityPermissionsUser(
+      { id, userId, updateAccessRequests },
+      prisma,
+      model
+    )
+  }
+
+  // if the permission of a user group was modified or anything else, all derived permissions for the object need to be recomputed
+  return await recomputeActivityPermissionsObject(
+    { id, updateAccessRequests },
+    prisma,
+    model
+  )
+}
+
+/**
+ * Recomputes derived permissions for a specific user on an activity.
+ *
+ * This function removes any existing derived permission for the user and
+ * then computes the highest granted permission level for that same user
+ * from the following potential sources of access permissions:
+ * - direct permission granted to the individual user
+ * - direct permission granted to a user group the user is part of
+ * - ownership of the activity
+ * - any derived permission granted to the individual user on a course that
+ *   includes the considered activity, according to the following rules.
+ *   Additionally, the user can choose between awarding minimum required
+ *   permissions or the propagation of the permissions (higher rights).
+ *   READ on course --> READ on activity (min. required = propagated)
+ *   WRITE on course --> READ / WRITE on activity (min. required / propagated)
+ *   ADMIN on course --> ADMIN on activity (min. required = propagated)
+ *   OWNER on course --> ADMIN on activity (min. required = propagated)
+ *
+ * Additionally, a recomputation of the derived permissions on all elements
+ * used in the activity is triggered.
+ */
+export async function recomputeActivityPermissionsUser(
+  {
+    id,
+    userId,
+    updateAccessRequests,
+  }: { id: string; userId: string; updateAccessRequests: boolean },
+  prisma: PrismaTransactionClient,
+  model: ActivityPermissionModel
+) {
+  // check if a permission for this user exists
+  const existingPermission = await prisma.derivedPermission.findUnique({
+    where: activityPermissionUniqueWhere(model.idField, id, userId),
+  })
+
+  // check for ownership, direct permissions, links to a course that would imply derived permissions
+  const activity = await model.fetchForUser(prisma, id, userId)
+
+  // if the activity does not exist, return
+  if (!activity) {
+    return
+  }
+
+  // compute the derived permission level (maximum) for this user on the activity
+  const res = getActivityPermissionsUser({
+    activityOwnerId: activity.ownerId,
+    activityDeleted: activity.isDeleted,
+    userId,
+    directPermissions: activity.directPermissions,
+    coursePermissions: activity.course?.permissions ?? [],
+  })
+
+  // if the user still has access, add a corresponding derived permission
+  if (res !== null) {
+    const { maxAccessLevel, parentPermissionId, derived } = res
+    if (
+      typeof maxAccessLevel !== 'undefined' &&
+      (!existingPermission ||
+        existingPermission.permissionLevel !== maxAccessLevel ||
+        existingPermission.derived !== derived ||
+        existingPermission.directPermissionId !== parentPermissionId)
+    ) {
+      await prisma.derivedPermission.upsert({
+        where: activityPermissionUniqueWhere(model.idField, id, userId),
+        create: activityPermissionCreate(model.idField, id, userId, {
+          permissionLevel: maxAccessLevel,
+          derived,
+          parentPermissionId,
+        }),
+        update: {
+          permissionLevel: maxAccessLevel,
+          derived,
+          directPermission:
+            typeof parentPermissionId !== 'undefined'
+              ? { connect: { id: parentPermissionId } }
+              : { disconnect: true },
+        },
+      })
+    }
+  }
+  // if a derived permission exists, remove it
+  else if (existingPermission && res === null) {
+    await prisma.derivedPermission.delete({
+      where: activityPermissionUniqueWhere(model.idField, id, userId),
+    })
+  }
+
+  // if the corresponding flag is set, update the access requests for the object
+  if (updateAccessRequests) {
+    await updateAccessRequestInstances(
+      {
+        ...model.accessRequestScope(id),
+        userId,
+        objectSoftDeleted: activity.isDeleted,
+      },
+      prisma
+    )
+  }
+
+  // if the activity still exists and the user had ADMIN / OWNER permissions on it,
+  // the derived element permissions need to be recomputed (-> complete recompute required)
+  // users with lower permissions on the activity will never obtain derived permissions through it
+  // --> however, since the computation is based on derived activity permissions, we need to compute these before
+  await propagateActivityToElementsUser(
+    { stacks: activity.stacks, userId, updateAccessRequests },
+    prisma
+  )
+
+  return
+}
+
+/**
+ * Recomputes derived permissions for all users on an activity.
+ *
+ * This function deletes all existing derived permissions for the activity
+ * and then recomputes them. Permissions are directly deduplicated for the
+ * derived permissions table to only contain the highest permission level
+ * for each user. The following sources for direct permissions on the
+ * activity are considered:
+ * - direct permissions granted to users
+ * - direct permissions granted to user groups
+ * - ownership of the activity
+ * - derived permissions granted to users on a course that includes the
+ *   considered activity, according to the same rules as for the
+ *   user-specific derived permissions recomputation (see above).
+ *
+ * Additionally, a recomputation of the derived permissions on all elements
+ * used in the activity is triggered.
+ */
+export async function recomputeActivityPermissionsObject(
+  { id, updateAccessRequests }: { id: string; updateAccessRequests: boolean },
+  prisma: PrismaTransactionClient,
+  model: ActivityPermissionModel
+) {
+  // fetch the object and all direct permissions on it, including user groups
+  // permissions on the course should automatically imply corresponding permissions on the contained activities
+  // depending on the permission level on the activity, derived permissions on the contained elements might be required
+  const activity = await model.fetchForObject(prisma, id)
+
+  if (!activity) {
+    console.error(
+      `${model.notFoundLabel} with id ${id} or corresponding owner not found`
+    )
+    return
+  }
+
+  // compute a map between all users with direct or derived access to the considered activity
+  const userAccess = getActivityPermissionsObject({
+    activityOwnerId: activity.ownerId,
+    activityDeleted: activity.isDeleted,
+    directPermissions: activity.directPermissions,
+    coursePermissions: activity.course?.permissions ?? [],
+  })
+
+  // remove the derived permissions for all users that do not have access (anymore)
+  await prisma.derivedPermission.deleteMany({
+    where: activityPermissionFilter(model.idField, id, {
+      notIn: Object.keys(userAccess),
+    }),
+  })
+
+  // create / update derived permissions for each user with access
+  const results = await Promise.allSettled(
+    Object.entries(userAccess).map(
+      async ([userId, { maxAccessLevel, parentPermissionId, derived }]) =>
+        await prisma.derivedPermission.upsert({
+          where: activityPermissionUniqueWhere(model.idField, id, userId),
+          create: activityPermissionCreate(model.idField, id, userId, {
+            permissionLevel: maxAccessLevel,
+            derived,
+            parentPermissionId,
+          }),
+          update: {
+            permissionLevel: maxAccessLevel,
+            derived,
+            directPermission:
+              typeof parentPermissionId !== 'undefined'
+                ? { connect: { id: parentPermissionId } }
+                : { disconnect: true },
+          },
+        })
+    )
+  )
+
+  // check if any promise was rejected and throw an error
+  const rejectedPromises = results.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  if (rejectedPromises.length > 0) {
+    throw new Error(
+      `Failed to update derived permissions for ${model.label} (ID: ${id}): ${rejectedPromises
+        .map((result) => result.reason?.message || 'Unknown error')
+        .join(', ')}`
+    )
+  }
+
+  // if the corresponding flag is set, update the access requests for the object
+  if (updateAccessRequests) {
+    await updateAccessRequestInstances(
+      {
+        ...model.accessRequestScope(id),
+        objectSoftDeleted: activity.isDeleted,
+      },
+      prisma
+    )
+  }
+
+  // recompute the derived permissions on all elements contained in this activity
+  await propagateActivityToElements(
+    { stacks: activity.stacks, updateAccessRequests },
+    prisma
+  )
+}

--- a/packages/util/src/permissions/groupActivity.ts
+++ b/packages/util/src/permissions/groupActivity.ts
@@ -1,31 +1,130 @@
 /**
- * Derived permission recomputation for Group Activities in KlickerUZH:
- * - recomputeGroupActivityPermissions: dispatches to user/object variant.
- * - recomputeGroupActivityPermissionsUser: recompute derived permissions for a specific user.
- * - recomputeGroupActivityPermissionsObject: recompute derived permissions for all users.
+ * Derived permission recomputation for Group Activities in KlickerUZH.
+ *
+ * Delegates to the shared activity recomputation in ./activity.js;
+ * group activities differ from the other activity models only in their Prisma
+ * delegate and their log labels.
  */
 
-import { type PrismaTransactionClient } from '../types.js'
-import { updateAccessRequestInstances } from './accessRequest.js'
+import type { PrismaTransactionClient } from '../types.js'
 import {
-  getActivityPermissionsObject,
-  getActivityPermissionsUser,
-  propagateActivityToElements,
-  propagateActivityToElementsUser,
-} from './util.js'
+  type ActivityPermissionModel,
+  recomputeActivityPermissions,
+  recomputeActivityPermissionsObject,
+  recomputeActivityPermissionsUser,
+} from './activity.js'
 
-// #region
+const groupActivityModel: ActivityPermissionModel = {
+  label: 'group activity',
+  notFoundLabel: 'Group activity',
+  idField: 'groupActivityId',
+  fetchForUser: async (prisma, id, userId) => {
+    const groupActivity = await prisma.groupActivity.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          where: {
+            OR: [
+              { userId },
+              {
+                userGroup: {
+                  OR: [
+                    { ownerId: userId },
+                    { members: { some: { id: userId } } },
+                    { admins: { some: { id: userId } } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              where: {
+                userId,
+              },
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances (with elementId on them) contained in this activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!groupActivity) {
+      return null
+    }
+    return {
+      ownerId: groupActivity.ownerId,
+      isDeleted: groupActivity.isDeleted,
+      directPermissions: groupActivity.directPermissions,
+      course: groupActivity.course,
+      stacks: groupActivity.stacks,
+    }
+  },
+  fetchForObject: async (prisma, id) => {
+    const groupActivity = await prisma.groupActivity.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          include: {
+            userGroup: {
+              include: {
+                members: true,
+                admins: true,
+              },
+            },
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances contained in the activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!groupActivity) {
+      return null
+    }
+    return {
+      ownerId: groupActivity.ownerId,
+      isDeleted: groupActivity.isDeleted,
+      directPermissions: groupActivity.directPermissions,
+      course: groupActivity.course,
+      stacks: groupActivity.stacks,
+    }
+  },
+  accessRequestScope: (id) => ({ groupActivityId: id }),
+}
+
 /**
  * Dispatch function for the recomputation of derived permissions for group activities.
  *
- * Based on the provided parameters, this function delegates to either user-specific
- * or object-wide permission recomputation for group activities.
- *
- * @param params - Object containing group activity ID and optional user ID
- * @param params.id - ID of the group activity
- * @param params.userId - Optional user ID to limit recomputation to a specific user
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Delegates to either user-specific or object-wide permission
+ * recomputation based on the provided parameters.
  */
 export async function recomputeGroupActivityPermissions(
   {
@@ -39,42 +138,16 @@ export async function recomputeGroupActivityPermissions(
   },
   prisma: PrismaTransactionClient
 ) {
-  // if a user is defined, only recompute derived permissions for this user
-  if (userId) {
-    return await recomputeGroupActivityPermissionsUser(
-      { id, userId, updateAccessRequests },
-      prisma
-    )
-  }
-
-  // if the permission of a user group was modified or anything else, all derived permissions for the object need to be recomputed
-  return await recomputeGroupActivityPermissionsObject(
-    { id, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissions(
+    { id, userId, updateAccessRequests },
+    prisma,
+    groupActivityModel
   )
 }
 
 /**
- * Recomputes derived permissions for a specific user on a group activity.
- *
- * This function removes any existing derived permission for the user and then
- * computes the highest granted permission level for that same user from the
- * following potential sources of access permissions:
- * - direct permission granted to the individual user
- * - direct permission granted to a user group the user is part of
- * - ownership of the group activity
- * - any derived permission granted to the individual user on a course that
- *   includes the considered group activity, according to the rules defined
- *   in the derived permission recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing group activity ID and user ID
- * @param params.id - ID of the group activity
- * @param params.userId - ID of the user to recompute permissions for
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for a specific user on a group activities (see
+ * the shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeGroupActivityPermissionsUser(
   {
@@ -84,293 +157,24 @@ export async function recomputeGroupActivityPermissionsUser(
   }: { id: string; userId: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // check if a permission for this user exists
-  const existingPermission = await prisma.derivedPermission.findUnique({
-    where: {
-      groupActivityId_userId: {
-        groupActivityId: id,
-        userId,
-      },
-    },
-  })
-
-  // check for ownership, direct permissions, links to a course that would imply derived permissions
-  const groupActivity = await prisma.groupActivity.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        where: {
-          OR: [
-            { userId },
-            {
-              userGroup: {
-                OR: [
-                  { ownerId: userId },
-                  { members: { some: { id: userId } } },
-                  { admins: { some: { id: userId } } },
-                ],
-              },
-            },
-          ],
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            where: {
-              userId,
-            },
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances (with elementId on them) contained in this quiz to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  // if the group activity does not exist, return
-  if (!groupActivity) {
-    return
-  }
-
-  // compute the derived permission level (maximum) for this user on the activity
-  const res = getActivityPermissionsUser({
-    activityOwnerId: groupActivity.ownerId,
-    activityDeleted: groupActivity.isDeleted,
-    userId,
-    directPermissions: groupActivity.directPermissions,
-    coursePermissions: groupActivity.course?.permissions ?? [],
-  })
-
-  // if the user still has access, add a corresponding derived permission
-  if (res !== null) {
-    const { maxAccessLevel, parentPermissionId, derived } = res
-    if (
-      typeof maxAccessLevel !== 'undefined' &&
-      (!existingPermission ||
-        existingPermission.permissionLevel !== maxAccessLevel ||
-        existingPermission.derived !== derived ||
-        existingPermission.directPermissionId !== parentPermissionId)
-    ) {
-      await prisma.derivedPermission.upsert({
-        where: {
-          groupActivityId_userId: {
-            groupActivityId: id,
-            userId,
-          },
-        },
-        create: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : undefined,
-          groupActivity: { connect: { id } },
-          user: { connect: { id: userId } },
-        },
-        update: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : { disconnect: true },
-        },
-      })
-    }
-  }
-  // if a derived permission exists, remove it
-  else if (existingPermission && res === null) {
-    await prisma.derivedPermission.delete({
-      where: {
-        groupActivityId_userId: {
-          groupActivityId: id,
-          userId,
-        },
-      },
-    })
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      {
-        groupActivityId: id,
-        userId,
-        objectSoftDeleted: groupActivity.isDeleted,
-      },
-      prisma
-    )
-  }
-
-  // if the activity still exists and the user had ADMIN / OWNER permissions on it,
-  // the derived element permissions need to be recomputed (-> complete recompute required)
-  // users with lower permissions on the activity will never obtained derived permissions through it
-  // --> however, since the computation is based on derived activity permissions, we need to compute these before
-  await propagateActivityToElementsUser(
-    { stacks: groupActivity.stacks, userId, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsUser(
+    { id, userId, updateAccessRequests },
+    prisma,
+    groupActivityModel
   )
-
-  return
 }
 
 /**
- * Recomputes derived permissions for all users on a group activity.
- *
- * This function deletes all existing derived permissions for the group activity
- * and then recomputes them. Permissions are directly deduplicated for the
- * derived permissions table to only contain the highest permission level
- * for each user. The following sources for direct permissions on group activities
- * are considered:
- * - direct permissions granted to users
- * - direct permissions granted to user groups
- * - ownership of the group activity
- * - derived permissions granted to users on a course that includes the considered
- *   group activity, according to the same rules as for the user-specific derived
- *   permissions recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing group activity ID
- * @param params.id - ID of the group activity
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for all users on a group activities (see the
+ * shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeGroupActivityPermissionsObject(
   { id, updateAccessRequests }: { id: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // fetch the object and all direct permissions on it, including user groups, as well as activities the element is used in
-  // permissions on the course should automatically imply corresponding permissions on the contained group activities
-  // depending on the permission level on the activity, derived permissions on the contained elements might be required
-  const groupActivity = await prisma.groupActivity.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        include: {
-          userGroup: {
-            include: {
-              members: true,
-              admins: true,
-            },
-          },
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances contained in the activity to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  if (!groupActivity) {
-    console.error(
-      `Group activity with id ${id} or corresponding owner not found`
-    )
-    return
-  }
-
-  // compute a map between all users with direct or direct access to the considered activity
-  const userAccess = getActivityPermissionsObject({
-    activityOwnerId: groupActivity.ownerId,
-    activityDeleted: groupActivity.isDeleted,
-    directPermissions: groupActivity.directPermissions,
-    coursePermissions: groupActivity.course?.permissions ?? [],
-  })
-
-  // remove the derived permissions for all users that do not have access (anymore)
-  await prisma.derivedPermission.deleteMany({
-    where: {
-      groupActivityId: id,
-      userId: {
-        notIn: Object.keys(userAccess),
-      },
-    },
-  })
-
-  // create / update derived permissions for each user with access
-  const results = await Promise.allSettled(
-    Object.entries(userAccess).map(
-      async ([userId, { maxAccessLevel, parentPermissionId, derived }]) =>
-        await prisma.derivedPermission.upsert({
-          where: {
-            groupActivityId_userId: {
-              groupActivityId: id,
-              userId,
-            },
-          },
-          create: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : undefined,
-            groupActivity: { connect: { id } },
-            user: { connect: { id: userId } },
-          },
-          update: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : { disconnect: true },
-          },
-        })
-    )
-  )
-
-  // check if any promise was rejected and throw an error
-  const rejectedPromises = results.filter(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
-  )
-  if (rejectedPromises.length > 0) {
-    throw new Error(
-      `Failed to update derived permissions for group activity (ID: ${groupActivity.id}): ${rejectedPromises
-        .map((result) => result.reason?.message || 'Unknown error')
-        .join(', ')}`
-    )
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { groupActivityId: id, objectSoftDeleted: groupActivity.isDeleted },
-      prisma
-    )
-  }
-
-  // recompute the derived permissions on all elements contained in this activity
-  await propagateActivityToElements(
-    { stacks: groupActivity.stacks, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsObject(
+    { id, updateAccessRequests },
+    prisma,
+    groupActivityModel
   )
 }

--- a/packages/util/src/permissions/liveQuiz.ts
+++ b/packages/util/src/permissions/liveQuiz.ts
@@ -1,32 +1,133 @@
 /**
  * Derived permission recomputation for Live Quizzes in KlickerUZH.
  *
- * This module provides functions to recompute derived permissions for live quizzes.
- * It includes functions to dispatch to user-specific or object-wide permission
- * recomputation, as well as functions to recompute derived permissions for a
- * specific user or all users.
+ * Delegates to the shared activity recomputation in ./activity.js; live
+ * quizzes differ from the other activity models only in their Prisma
+ * delegate, their derived-permission key field, the `blocks` element
+ * relation and their log labels.
  */
 
-import { type PrismaTransactionClient } from '../types.js'
-import { updateAccessRequestInstances } from './accessRequest.js'
+import type { PrismaTransactionClient } from '../types.js'
 import {
-  getActivityPermissionsObject,
-  getActivityPermissionsUser,
-  propagateActivityToElements,
-  propagateActivityToElementsUser,
-} from './util.js'
+  type ActivityPermissionModel,
+  recomputeActivityPermissions,
+  recomputeActivityPermissionsObject,
+  recomputeActivityPermissionsUser,
+} from './activity.js'
+
+const liveQuizModel: ActivityPermissionModel = {
+  label: 'live quiz',
+  notFoundLabel: 'Live quiz',
+  idField: 'liveQuizId',
+  fetchForUser: async (prisma, id, userId) => {
+    const liveQuiz = await prisma.liveQuiz.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          where: {
+            OR: [
+              { userId },
+              {
+                userGroup: {
+                  OR: [
+                    { ownerId: userId },
+                    { members: { some: { id: userId } } },
+                    { admins: { some: { id: userId } } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              where: {
+                userId,
+              },
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances (with elementId on them) contained in this quiz to propagate the derived permission update to elements
+        blocks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!liveQuiz) {
+      return null
+    }
+    return {
+      ownerId: liveQuiz.ownerId,
+      isDeleted: liveQuiz.isDeleted,
+      directPermissions: liveQuiz.directPermissions,
+      course: liveQuiz.course,
+      // normalize the live-quiz block relation to the common stacks shape
+      stacks: liveQuiz.blocks,
+    }
+  },
+  fetchForObject: async (prisma, id) => {
+    const liveQuiz = await prisma.liveQuiz.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          include: {
+            userGroup: {
+              include: {
+                members: true,
+                admins: true,
+              },
+            },
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances contained in the activity to propagate the derived permission update to elements
+        blocks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!liveQuiz) {
+      return null
+    }
+    return {
+      ownerId: liveQuiz.ownerId,
+      isDeleted: liveQuiz.isDeleted,
+      directPermissions: liveQuiz.directPermissions,
+      course: liveQuiz.course,
+      // normalize the live-quiz block relation to the common stacks shape
+      stacks: liveQuiz.blocks,
+    }
+  },
+  accessRequestScope: (id) => ({ liveQuizId: id }),
+}
 
 /**
  * Dispatch function for the recomputation of derived permissions for live quizzes.
  *
- * Based on the provided parameters, this function delegates to either user-specific
- * or object-wide permission recomputation for live quizzes.
- *
- * @param params - Object containing live quiz ID and optional user ID
- * @param params.id - ID of the live quiz
- * @param params.userId - Optional user ID to limit recomputation to a specific user
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Delegates to either user-specific or object-wide permission
+ * recomputation based on the provided parameters.
  */
 export async function recomputeLiveQuizPermissions(
   {
@@ -40,47 +141,16 @@ export async function recomputeLiveQuizPermissions(
   },
   prisma: PrismaTransactionClient
 ) {
-  // if a user is defined, only recompute derived permissions for this user
-  if (userId) {
-    return await recomputeLiveQuizPermissionsUser(
-      { id, userId, updateAccessRequests },
-      prisma
-    )
-  }
-
-  // if the permission of a user group was modified or anything else, all derived permissions for the object need to be recomputed
-  return await recomputeLiveQuizPermissionsObject(
-    { id, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissions(
+    { id, userId, updateAccessRequests },
+    prisma,
+    liveQuizModel
   )
 }
 
 /**
- * Recomputes derived permissions for a specific user on a live quiz.
- *
- * This function removes any existing derived permission for the user and then
- * computes the highest granted permission level for that same user from the
- * following potential sources of access permissions:
- * - direct permission granted to the individual user
- * - direct permission granted to a user group the user is part of
- * - ownership of the live quiz
- * - any derived permission granted to the individual user on a course that
- *   includes the considered live quiz, according to the following rules.
- *   Additionally, the user can choose between awarding minimum required
- *   permissions or the propagation of the permissions (higher rights).
- *   READ on course --> READ on live quiz (min. required = propagated)
- *   WRITE on course --> READ / WRITE on live quiz (min. required / propagated)
- *   ADMIN on course --> ADMIN on live quiz (min. required = propagated)
- *   OWNER on course --> ADMIN on live quiz (min. required = propagated)
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing live quiz ID and user ID
- * @param params.id - ID of the live quiz
- * @param params.userId - ID of the user to recompute permissions for
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for a specific user on a live quiz (see
+ * the shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeLiveQuizPermissionsUser(
   {
@@ -90,287 +160,24 @@ export async function recomputeLiveQuizPermissionsUser(
   }: { id: string; userId: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // check if a permission for this user exists
-  const existingPermission = await prisma.derivedPermission.findUnique({
-    where: {
-      liveQuizId_userId: {
-        liveQuizId: id,
-        userId,
-      },
-    },
-  })
-
-  // check for ownership, direct permissions, links to a course that would imply derived permissions
-  const liveQuiz = await prisma.liveQuiz.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        where: {
-          OR: [
-            { userId },
-            {
-              userGroup: {
-                OR: [
-                  { ownerId: userId },
-                  { members: { some: { id: userId } } },
-                  { admins: { some: { id: userId } } },
-                ],
-              },
-            },
-          ],
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            where: {
-              userId,
-            },
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances (with elementId on them) contained in this quiz to propagate the derived permission update to elements
-      blocks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  // if the live quiz does not exist, return
-  if (!liveQuiz) {
-    return
-  }
-
-  // compute the derived permission level (maximum) for this user on the activity
-  const res = getActivityPermissionsUser({
-    activityOwnerId: liveQuiz.ownerId,
-    activityDeleted: liveQuiz.isDeleted,
-    userId,
-    directPermissions: liveQuiz.directPermissions,
-    coursePermissions: liveQuiz.course?.permissions ?? [],
-  })
-
-  // if the user still has access, add a corresponding derived permission
-  if (res !== null) {
-    const { maxAccessLevel, parentPermissionId, derived } = res
-    if (
-      typeof maxAccessLevel !== 'undefined' &&
-      (!existingPermission ||
-        existingPermission.permissionLevel !== maxAccessLevel ||
-        existingPermission.derived !== derived ||
-        existingPermission.directPermissionId !== parentPermissionId)
-    ) {
-      await prisma.derivedPermission.upsert({
-        where: {
-          liveQuizId_userId: {
-            liveQuizId: id,
-            userId,
-          },
-        },
-        create: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : undefined,
-          liveQuiz: { connect: { id } },
-          user: { connect: { id: userId } },
-        },
-        update: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : { disconnect: true },
-        },
-      })
-    }
-  }
-  // if a derived permission exists, remove it
-  else if (existingPermission && res === null) {
-    await prisma.derivedPermission.delete({
-      where: {
-        liveQuizId_userId: {
-          liveQuizId: id,
-          userId,
-        },
-      },
-    })
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { liveQuizId: id, userId, objectSoftDeleted: liveQuiz.isDeleted },
-      prisma
-    )
-  }
-
-  // if the activity still exists and the user had ADMIN / OWNER permissions on it,
-  // the derived element permissions need to be recomputed (-> complete recompute required)
-  // users with lower permissions on the activity will never obtained derived permissions through it
-  // --> however, since the computation is based on derived activity permissions, we need to compute these before
-  await propagateActivityToElementsUser(
-    { stacks: liveQuiz.blocks, userId, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsUser(
+    { id, userId, updateAccessRequests },
+    prisma,
+    liveQuizModel
   )
-
-  return
 }
 
 /**
- * Recomputes derived permissions for all users on a live quiz.
- *
- * This function deletes all existing derived permissions for the live quiz
- * and then recomputes them. Permissions are directly deduplicated for the
- * derived permissions table to only contain the highest permission level
- * for each user. The following sources for direct permissions on live quizzes
- * are considered:
- * - direct permissions granted to users
- * - direct permissions granted to user groups
- * - ownership of the live quiz
- * - derived permissions granted to users on a course that includes the considered
- *   live quiz, according to the same rules as for the user-specific derived
- *   permissions recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing live quiz ID
- * @param params.id - ID of the live quiz
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for all users on a live quiz (see the
+ * shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeLiveQuizPermissionsObject(
   { id, updateAccessRequests }: { id: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // fetch the object and all direct permissions on it, including user groups, as well as activities the element is used in
-  // permissions on the course should automatically imply corresponding permissions on the contained live quizzes
-  // depending on the permission level on the activity, derived permissions on the contained elements might be required
-  const liveQuiz = await prisma.liveQuiz.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        include: {
-          userGroup: {
-            include: {
-              members: true,
-              admins: true,
-            },
-          },
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances contained in the activity to propagate the derived permission update to elements
-      blocks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  if (!liveQuiz) {
-    console.error(`Live quiz with id ${id} or corresponding owner not found`)
-    return
-  }
-
-  // compute a map between all users with direct or direct access to the considered activity
-  const userAccess = getActivityPermissionsObject({
-    activityOwnerId: liveQuiz.ownerId,
-    activityDeleted: liveQuiz.isDeleted,
-    directPermissions: liveQuiz.directPermissions,
-    coursePermissions: liveQuiz.course?.permissions ?? [],
-  })
-
-  // remove the derived permissions for all users that do not have access (anymore)
-  await prisma.derivedPermission.deleteMany({
-    where: {
-      liveQuizId: id,
-      userId: {
-        notIn: Object.keys(userAccess),
-      },
-    },
-  })
-
-  // create / update derived permissions for each user with access
-  const results = await Promise.allSettled(
-    Object.entries(userAccess).map(
-      async ([userId, { maxAccessLevel, parentPermissionId, derived }]) =>
-        await prisma.derivedPermission.upsert({
-          where: {
-            liveQuizId_userId: {
-              liveQuizId: id,
-              userId,
-            },
-          },
-          create: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : undefined,
-            liveQuiz: { connect: { id } },
-            user: { connect: { id: userId } },
-          },
-          update: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : { disconnect: true },
-          },
-        })
-    )
-  )
-
-  // check if any promise was rejected and throw an error
-  const rejectedPromises = results.filter(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
-  )
-  if (rejectedPromises.length > 0) {
-    throw new Error(
-      `Failed to update derived permissions for live quiz (ID: ${liveQuiz.id}): ${rejectedPromises
-        .map((result) => result.reason?.message || 'Unknown error')
-        .join(', ')}`
-    )
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { liveQuizId: id, objectSoftDeleted: liveQuiz.isDeleted },
-      prisma
-    )
-  }
-
-  // recompute the derived permissions on all elements contained in this activity
-  await propagateActivityToElements(
-    { stacks: liveQuiz.blocks, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsObject(
+    { id, updateAccessRequests },
+    prisma,
+    liveQuizModel
   )
 }

--- a/packages/util/src/permissions/microlearning.ts
+++ b/packages/util/src/permissions/microlearning.ts
@@ -1,30 +1,130 @@
 /**
- * Derived permission recomputation for Microlearnings in KlickerUZH:
- * - recomputeMicroLearningPermissions: dispatches to user/object variant.
- * - recomputeMicroLearningPermissionsUser: recompute derived permissions for a specific user.
- * - recomputeMicroLearningPermissionsObject: recompute derived permissions for all users.
+ * Derived permission recomputation for Microlearnings in KlickerUZH.
+ *
+ * Delegates to the shared activity recomputation in ./activity.js;
+ * microlearnings differ from the other activity models only in their Prisma
+ * delegate and their log labels.
  */
 
-import { type PrismaTransactionClient } from '../types.js'
-import { updateAccessRequestInstances } from './accessRequest.js'
+import type { PrismaTransactionClient } from '../types.js'
 import {
-  getActivityPermissionsObject,
-  getActivityPermissionsUser,
-  propagateActivityToElements,
-  propagateActivityToElementsUser,
-} from './util.js'
+  type ActivityPermissionModel,
+  recomputeActivityPermissions,
+  recomputeActivityPermissionsObject,
+  recomputeActivityPermissionsUser,
+} from './activity.js'
+
+const microLearningModel: ActivityPermissionModel = {
+  label: 'microlearning',
+  notFoundLabel: 'Microlearning',
+  idField: 'microLearningId',
+  fetchForUser: async (prisma, id, userId) => {
+    const microLearning = await prisma.microLearning.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          where: {
+            OR: [
+              { userId },
+              {
+                userGroup: {
+                  OR: [
+                    { ownerId: userId },
+                    { members: { some: { id: userId } } },
+                    { admins: { some: { id: userId } } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              where: {
+                userId,
+              },
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances (with elementId on them) contained in this activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!microLearning) {
+      return null
+    }
+    return {
+      ownerId: microLearning.ownerId,
+      isDeleted: microLearning.isDeleted,
+      directPermissions: microLearning.directPermissions,
+      course: microLearning.course,
+      stacks: microLearning.stacks,
+    }
+  },
+  fetchForObject: async (prisma, id) => {
+    const microLearning = await prisma.microLearning.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          include: {
+            userGroup: {
+              include: {
+                members: true,
+                admins: true,
+              },
+            },
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances contained in the activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!microLearning) {
+      return null
+    }
+    return {
+      ownerId: microLearning.ownerId,
+      isDeleted: microLearning.isDeleted,
+      directPermissions: microLearning.directPermissions,
+      course: microLearning.course,
+      stacks: microLearning.stacks,
+    }
+  },
+  accessRequestScope: (id) => ({ microLearningId: id }),
+}
 
 /**
  * Dispatch function for the recomputation of derived permissions for microlearnings.
  *
- * Based on the provided parameters, this function delegates to either user-specific
- * or object-wide permission recomputation for microlearnings.
- *
- * @param params - Object containing microlearning ID and optional user ID
- * @param params.id - ID of the microlearning
- * @param params.userId - Optional user ID to limit recomputation to a specific user
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Delegates to either user-specific or object-wide permission
+ * recomputation based on the provided parameters.
  */
 export async function recomputeMicroLearningPermissions(
   {
@@ -38,42 +138,16 @@ export async function recomputeMicroLearningPermissions(
   },
   prisma: PrismaTransactionClient
 ) {
-  // if a user is defined, only recompute derived permissions for this user
-  if (userId) {
-    return await recomputeMicroLearningPermissionsUser(
-      { id, userId, updateAccessRequests },
-      prisma
-    )
-  }
-
-  // if the permission of a user group was modified or anything else, all derived permissions for the object need to be recomputed
-  return await recomputeMicroLearningPermissionsObject(
-    { id, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissions(
+    { id, userId, updateAccessRequests },
+    prisma,
+    microLearningModel
   )
 }
 
 /**
- * Recomputes derived permissions for a specific user on a microlearning.
- *
- * This function removes any existing derived permission for the user and then
- * computes the highest granted permission level for that same user from the
- * following potential sources of access permissions:
- * - direct permission granted to the individual user
- * - direct permission granted to a user group the user is part of
- * - ownership of the microlearning
- * - any derived permission granted to the individual user on a course that
- *   includes the considered microlearning, according to the rules defined
- *   in the derived permission recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing microlearning ID and user ID
- * @param params.id - ID of the microlearning
- * @param params.userId - ID of the user to recompute permissions for
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for a specific user on a microlearnings (see
+ * the shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeMicroLearningPermissionsUser(
   {
@@ -83,293 +157,24 @@ export async function recomputeMicroLearningPermissionsUser(
   }: { id: string; userId: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // check if a permission for this user exists
-  const existingPermission = await prisma.derivedPermission.findUnique({
-    where: {
-      microLearningId_userId: {
-        microLearningId: id,
-        userId,
-      },
-    },
-  })
-
-  // check for ownership, direct permissions, links to a course that would imply derived permissions
-  const microLearning = await prisma.microLearning.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        where: {
-          OR: [
-            { userId },
-            {
-              userGroup: {
-                OR: [
-                  { ownerId: userId },
-                  { members: { some: { id: userId } } },
-                  { admins: { some: { id: userId } } },
-                ],
-              },
-            },
-          ],
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            where: {
-              userId,
-            },
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances (with elementId on them) contained in this quiz to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  // if the microlearning does not exist, return
-  if (!microLearning) {
-    return
-  }
-
-  // compute the derived permission level (maximum) for this user on the activity
-  const res = getActivityPermissionsUser({
-    activityOwnerId: microLearning.ownerId,
-    activityDeleted: microLearning.isDeleted,
-    userId,
-    directPermissions: microLearning.directPermissions,
-    coursePermissions: microLearning.course?.permissions ?? [],
-  })
-
-  // if the user still has access, add a corresponding derived permission
-  if (res !== null) {
-    const { maxAccessLevel, parentPermissionId, derived } = res
-    if (
-      typeof maxAccessLevel !== 'undefined' &&
-      (!existingPermission ||
-        existingPermission.permissionLevel !== maxAccessLevel ||
-        existingPermission.derived !== derived ||
-        existingPermission.directPermissionId !== parentPermissionId)
-    ) {
-      await prisma.derivedPermission.upsert({
-        where: {
-          microLearningId_userId: {
-            microLearningId: id,
-            userId,
-          },
-        },
-        create: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : undefined,
-          microLearning: { connect: { id } },
-          user: { connect: { id: userId } },
-        },
-        update: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : { disconnect: true },
-        },
-      })
-    }
-  }
-  // if a derived permission exists, remove it
-  else if (existingPermission && res === null) {
-    await prisma.derivedPermission.delete({
-      where: {
-        microLearningId_userId: {
-          microLearningId: id,
-          userId,
-        },
-      },
-    })
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      {
-        microLearningId: id,
-        userId,
-        objectSoftDeleted: microLearning.isDeleted,
-      },
-      prisma
-    )
-  }
-
-  // if the activity still exists and the user had ADMIN / OWNER permissions on it,
-  // the derived element permissions need to be recomputed (-> complete recompute required)
-  // users with lower permissions on the activity will never obtained derived permissions through it
-  // --> however, since the computation is based on derived activity permissions, we need to compute these before
-  await propagateActivityToElementsUser(
-    { stacks: microLearning.stacks, userId, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsUser(
+    { id, userId, updateAccessRequests },
+    prisma,
+    microLearningModel
   )
-
-  return
 }
 
 /**
- * Recomputes derived permissions for all users on a microlearning.
- *
- * This function deletes all existing derived permissions for the microlearning
- * and then recomputes them. Permissions are directly deduplicated for the
- * derived permissions table to only contain the highest permission level
- * for each user. The following sources for direct permissions on microlearnings
- * are considered:
- * - direct permissions granted to users
- * - direct permissions granted to user groups
- * - ownership of the microlearning
- * - derived permissions granted to users on a course that includes the considered
- *   microlearning, according to the same rules as for the user-specific derived
- *   permissions recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing microlearning ID
- * @param params.id - ID of the microlearning
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for all users on a microlearnings (see the
+ * shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputeMicroLearningPermissionsObject(
   { id, updateAccessRequests }: { id: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // fetch the object and all direct permissions on it, including user groups, as well as activities the element is used in
-  // permissions on the course should automatically imply corresponding permissions on the contained microlearning
-  // depending on the permission level on the activity, derived permissions on the contained elements might be required
-  const microLearning = await prisma.microLearning.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        include: {
-          userGroup: {
-            include: {
-              members: true,
-              admins: true,
-            },
-          },
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances contained in the activity to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  if (!microLearning) {
-    console.error(
-      `Microlearning with id ${id} or corresponding owner not found`
-    )
-    return
-  }
-
-  // compute a map between all users with direct or direct access to the considered activity
-  const userAccess = getActivityPermissionsObject({
-    activityOwnerId: microLearning.ownerId,
-    activityDeleted: microLearning.isDeleted,
-    directPermissions: microLearning.directPermissions,
-    coursePermissions: microLearning.course?.permissions ?? [],
-  })
-
-  // remove the derived permissions for all users that do not have access (anymore)
-  await prisma.derivedPermission.deleteMany({
-    where: {
-      microLearningId: id,
-      userId: {
-        notIn: Object.keys(userAccess),
-      },
-    },
-  })
-
-  // create / update derived permissions for each user with access
-  const results = await Promise.allSettled(
-    Object.entries(userAccess).map(
-      async ([userId, { maxAccessLevel, parentPermissionId, derived }]) =>
-        await prisma.derivedPermission.upsert({
-          where: {
-            microLearningId_userId: {
-              microLearningId: id,
-              userId,
-            },
-          },
-          create: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : undefined,
-            microLearning: { connect: { id } },
-            user: { connect: { id: userId } },
-          },
-          update: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : { disconnect: true },
-          },
-        })
-    )
-  )
-
-  // check if any promise was rejected and throw an error
-  const rejectedPromises = results.filter(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
-  )
-  if (rejectedPromises.length > 0) {
-    throw new Error(
-      `Failed to update derived permissions for microlearning (ID: ${microLearning.id}): ${rejectedPromises
-        .map((result) => result.reason?.message || 'Unknown error')
-        .join(', ')}`
-    )
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { microLearningId: id, objectSoftDeleted: microLearning.isDeleted },
-      prisma
-    )
-  }
-
-  // recompute the derived permissions on all elements contained in this activity
-  await propagateActivityToElements(
-    { stacks: microLearning.stacks, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsObject(
+    { id, updateAccessRequests },
+    prisma,
+    microLearningModel
   )
 }

--- a/packages/util/src/permissions/practiceQuiz.ts
+++ b/packages/util/src/permissions/practiceQuiz.ts
@@ -1,30 +1,130 @@
 /**
- * Derived permission recomputation for Practice Quizzes in KlickerUZH:
- * - recomputePracticeQuizPermissions: dispatches to user/object variant.
- * - recomputePracticeQuizPermissionsUser: recompute derived permissions for a specific user.
- * - recomputePracticeQuizPermissionsObject: recompute derived permissions for all users.
+ * Derived permission recomputation for Practice Quizzes in KlickerUZH.
+ *
+ * Delegates to the shared activity recomputation in ./activity.js;
+ * practice quizzes differ from the other activity models only in their Prisma
+ * delegate and their log labels.
  */
 
-import { type PrismaTransactionClient } from '../types.js'
-import { updateAccessRequestInstances } from './accessRequest.js'
+import type { PrismaTransactionClient } from '../types.js'
 import {
-  getActivityPermissionsObject,
-  getActivityPermissionsUser,
-  propagateActivityToElements,
-  propagateActivityToElementsUser,
-} from './util.js'
+  type ActivityPermissionModel,
+  recomputeActivityPermissions,
+  recomputeActivityPermissionsObject,
+  recomputeActivityPermissionsUser,
+} from './activity.js'
+
+const practiceQuizModel: ActivityPermissionModel = {
+  label: 'practice quiz',
+  notFoundLabel: 'Practice quiz',
+  idField: 'practiceQuizId',
+  fetchForUser: async (prisma, id, userId) => {
+    const practiceQuiz = await prisma.practiceQuiz.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          where: {
+            OR: [
+              { userId },
+              {
+                userGroup: {
+                  OR: [
+                    { ownerId: userId },
+                    { members: { some: { id: userId } } },
+                    { admins: { some: { id: userId } } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              where: {
+                userId,
+              },
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances (with elementId on them) contained in this activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!practiceQuiz) {
+      return null
+    }
+    return {
+      ownerId: practiceQuiz.ownerId,
+      isDeleted: practiceQuiz.isDeleted,
+      directPermissions: practiceQuiz.directPermissions,
+      course: practiceQuiz.course,
+      stacks: practiceQuiz.stacks,
+    }
+  },
+  fetchForObject: async (prisma, id) => {
+    const practiceQuiz = await prisma.practiceQuiz.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        directPermissions: {
+          include: {
+            userGroup: {
+              include: {
+                members: true,
+                admins: true,
+              },
+            },
+          },
+        },
+        // course from which derived permissions would be inherited
+        course: {
+          include: {
+            permissions: {
+              include: {
+                directPermission: true,
+              },
+            },
+          },
+        },
+        // element instances contained in the activity to propagate the derived permission update to elements
+        stacks: {
+          include: {
+            elements: true,
+          },
+        },
+      },
+    })
+    if (!practiceQuiz) {
+      return null
+    }
+    return {
+      ownerId: practiceQuiz.ownerId,
+      isDeleted: practiceQuiz.isDeleted,
+      directPermissions: practiceQuiz.directPermissions,
+      course: practiceQuiz.course,
+      stacks: practiceQuiz.stacks,
+    }
+  },
+  accessRequestScope: (id) => ({ practiceQuizId: id }),
+}
 
 /**
  * Dispatch function for the recomputation of derived permissions for practice quizzes.
  *
- * Based on the provided parameters, this function delegates to either user-specific
- * or object-wide permission recomputation for practice quizzes.
- *
- * @param params - Object containing practice quiz ID and optional user ID
- * @param params.id - ID of the practice quiz
- * @param params.userId - Optional user ID to limit recomputation to a specific user
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Delegates to either user-specific or object-wide permission
+ * recomputation based on the provided parameters.
  */
 export async function recomputePracticeQuizPermissions(
   {
@@ -38,42 +138,16 @@ export async function recomputePracticeQuizPermissions(
   },
   prisma: PrismaTransactionClient
 ) {
-  // if a user is defined, only recompute derived permissions for this user
-  if (userId) {
-    return await recomputePracticeQuizPermissionsUser(
-      { id, userId, updateAccessRequests },
-      prisma
-    )
-  }
-
-  // if the permission of a user group was modified or anything else, all derived permissions for the object need to be recomputed
-  return await recomputePracticeQuizPermissionsObject(
-    { id, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissions(
+    { id, userId, updateAccessRequests },
+    prisma,
+    practiceQuizModel
   )
 }
 
 /**
- * Recomputes derived permissions for a specific user on a practice quiz.
- *
- * This function removes any existing derived permission for the user and then
- * computes the highest granted permission level for that same user from the
- * following potential sources of access permissions:
- * - direct permission granted to the individual user
- * - direct permission granted to a user group the user is part of
- * - ownership of the practice quiz
- * - any derived permission granted to the individual user on a course that
- *   includes the considered practice quiz, according to the rules defined
- *   in the derived permission recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing practice quiz ID and user ID
- * @param params.id - ID of the practice quiz
- * @param params.userId - ID of the user to recompute permissions for
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for a specific user on a practice quizzes (see
+ * the shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputePracticeQuizPermissionsUser(
   {
@@ -83,289 +157,24 @@ export async function recomputePracticeQuizPermissionsUser(
   }: { id: string; userId: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // check if a permission for this user exists
-  const existingPermission = await prisma.derivedPermission.findUnique({
-    where: {
-      practiceQuizId_userId: {
-        practiceQuizId: id,
-        userId,
-      },
-    },
-  })
-
-  // check for ownership, direct permissions, links to a course that would imply derived permissions
-  const practiceQuiz = await prisma.practiceQuiz.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        where: {
-          OR: [
-            { userId },
-            {
-              userGroup: {
-                OR: [
-                  { ownerId: userId },
-                  { members: { some: { id: userId } } },
-                  { admins: { some: { id: userId } } },
-                ],
-              },
-            },
-          ],
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            where: {
-              userId,
-            },
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances (with elementId on them) contained in this quiz to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  // if the practice quiz does not exist, return
-  if (!practiceQuiz) {
-    return
-  }
-
-  // compute the derived permission level (maximum) for this user on the activity
-  const res = getActivityPermissionsUser({
-    activityOwnerId: practiceQuiz.ownerId,
-    activityDeleted: practiceQuiz.isDeleted,
-    userId,
-    directPermissions: practiceQuiz.directPermissions,
-    coursePermissions: practiceQuiz.course?.permissions ?? [],
-  })
-
-  // if the user still has access, add a corresponding derived permission
-  if (res !== null) {
-    const { maxAccessLevel, parentPermissionId, derived } = res
-    if (
-      typeof maxAccessLevel !== 'undefined' &&
-      (!existingPermission ||
-        existingPermission.permissionLevel !== maxAccessLevel ||
-        existingPermission.derived !== derived ||
-        existingPermission.directPermissionId !== parentPermissionId)
-    ) {
-      await prisma.derivedPermission.upsert({
-        where: {
-          practiceQuizId_userId: {
-            practiceQuizId: id,
-            userId,
-          },
-        },
-        create: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : undefined,
-          practiceQuiz: { connect: { id } },
-          user: { connect: { id: userId } },
-        },
-        update: {
-          permissionLevel: maxAccessLevel,
-          derived,
-          directPermission:
-            typeof parentPermissionId !== 'undefined'
-              ? { connect: { id: parentPermissionId } }
-              : { disconnect: true },
-        },
-      })
-    }
-  }
-  // if a derived permission exists, remove it
-  else if (existingPermission && res === null) {
-    await prisma.derivedPermission.delete({
-      where: {
-        practiceQuizId_userId: {
-          practiceQuizId: id,
-          userId,
-        },
-      },
-    })
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { practiceQuizId: id, userId, objectSoftDeleted: practiceQuiz.isDeleted },
-      prisma
-    )
-  }
-
-  // if the activity still exists and the user had ADMIN / OWNER permissions on it,
-  // the derived element permissions need to be recomputed (-> complete recompute required)
-  // users with lower permissions on the activity will never obtained derived permissions through it
-  // --> however, since the computation is based on derived activity permissions, we need to compute these before
-  await propagateActivityToElementsUser(
-    { stacks: practiceQuiz.stacks, userId, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsUser(
+    { id, userId, updateAccessRequests },
+    prisma,
+    practiceQuizModel
   )
-
-  return
 }
 
 /**
- * Recomputes derived permissions for all users on a practice quiz.
- *
- * This function deletes all existing derived permissions for the practice quiz
- * and then recomputes them. Permissions are directly deduplicated for the
- * derived permissions table to only contain the highest permission level
- * for each user. The following sources for direct permissions on practice quizzes
- * are considered:
- * - direct permissions granted to users
- * - direct permissions granted to user groups
- * - ownership of the practice quiz
- * - derived permissions granted to users on a course that includes the considered
- *   practice quiz, according to the same rules as for the user-specific derived
- *   permissions recomputation for live quizzes (see above).
- *
- * Additionally, a recomputation of the derived permissions on all elements
- * used in the activity is triggered.
- *
- * @param params - Object containing practice quiz ID
- * @param params.id - ID of the practice quiz
- * @param params.updateAccessRequests - Flag to update access requests for the object
- * @param prisma - Prisma transaction client for database operations
+ * Recomputes derived permissions for all users on a practice quizzes (see the
+ * shared implementation in ./activity.js for the considered sources).
  */
 export async function recomputePracticeQuizPermissionsObject(
   { id, updateAccessRequests }: { id: string; updateAccessRequests: boolean },
   prisma: PrismaTransactionClient
 ) {
-  // fetch the object and all direct permissions on it, including user groups, as well as activities the element is used in
-  // permissions on the course should automatically imply corresponding permissions on the contained practice quizzes
-  // depending on the permission level on the activity, derived permissions on the contained elements might be required
-  const practiceQuiz = await prisma.practiceQuiz.findUnique({
-    where: {
-      id,
-    },
-    include: {
-      directPermissions: {
-        include: {
-          userGroup: {
-            include: {
-              members: true,
-              admins: true,
-            },
-          },
-        },
-      },
-      // course from which derived permissions would be inherited
-      course: {
-        include: {
-          permissions: {
-            include: {
-              directPermission: true,
-            },
-          },
-        },
-      },
-      // element instances contained in the activity to propagate the derived permission update to elements
-      stacks: {
-        include: {
-          elements: true,
-        },
-      },
-    },
-  })
-
-  if (!practiceQuiz) {
-    console.error(
-      `Practice quiz with id ${id} or corresponding owner not found`
-    )
-    return
-  }
-
-  // compute a map between all users with direct or direct access to the considered activity
-  const userAccess = getActivityPermissionsObject({
-    activityOwnerId: practiceQuiz.ownerId,
-    activityDeleted: practiceQuiz.isDeleted,
-    directPermissions: practiceQuiz.directPermissions,
-    coursePermissions: practiceQuiz.course?.permissions ?? [],
-  })
-
-  // remove the derived permissions for all users that do not have access (anymore)
-  await prisma.derivedPermission.deleteMany({
-    where: {
-      practiceQuizId: id,
-      userId: {
-        notIn: Object.keys(userAccess),
-      },
-    },
-  })
-
-  // create / update derived permissions for each user with access
-  const results = await Promise.allSettled(
-    Object.entries(userAccess).map(
-      async ([userId, { maxAccessLevel, parentPermissionId, derived }]) =>
-        await prisma.derivedPermission.upsert({
-          where: {
-            practiceQuizId_userId: {
-              practiceQuizId: id,
-              userId,
-            },
-          },
-          create: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : undefined,
-            practiceQuiz: { connect: { id } },
-            user: { connect: { id: userId } },
-          },
-          update: {
-            permissionLevel: maxAccessLevel,
-            derived,
-            directPermission:
-              typeof parentPermissionId !== 'undefined'
-                ? { connect: { id: parentPermissionId } }
-                : { disconnect: true },
-          },
-        })
-    )
-  )
-
-  // check if any promise was rejected and throw an error
-  const rejectedPromises = results.filter(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
-  )
-  if (rejectedPromises.length > 0) {
-    throw new Error(
-      `Failed to update derived permissions for practice quiz (ID: ${practiceQuiz.id}): ${rejectedPromises
-        .map((result) => result.reason?.message || 'Unknown error')
-        .join(', ')}`
-    )
-  }
-
-  // if the corresponding flag is set, update the access requests for the object
-  if (updateAccessRequests) {
-    await updateAccessRequestInstances(
-      { practiceQuizId: id, objectSoftDeleted: practiceQuiz.isDeleted },
-      prisma
-    )
-  }
-
-  // recompute the derived permissions on all elements contained in this activity
-  await propagateActivityToElements(
-    { stacks: practiceQuiz.stacks, updateAccessRequests },
-    prisma
+  return await recomputeActivityPermissionsObject(
+    { id, updateAccessRequests },
+    prisma,
+    practiceQuizModel
   )
 }

--- a/packages/util/src/permissions/util.ts
+++ b/packages/util/src/permissions/util.ts
@@ -9,7 +9,7 @@
  */
 
 import * as DB from '@klicker-uzh/prisma/client'
-import { type PrismaTransactionClient } from '../types.js'
+import type { PrismaTransactionClient } from '../types.js'
 import {
   inversePermissionLevelMap,
   permissionLevelMap,
@@ -215,8 +215,8 @@ export function getActivityAccessFromCourse({
   coursePermissionLevel: DB.PermissionLevel
   directCoursePermission?: DB.Permission | null
 }) {
-  let maxAccessLevel: DB.PermissionLevel | undefined = undefined
-  let parentPermissionId: number | undefined = undefined
+  let maxAccessLevel: DB.PermissionLevel | undefined
+  let parentPermissionId: number | undefined
   let derived = false
 
   switch (coursePermissionLevel) {
@@ -288,8 +288,8 @@ export function getActivityPermissionsUser({
   })[]
 }) {
   // determine the maximum access level of the user
-  let maxAccessLevel: DB.PermissionLevel | undefined = undefined
-  let parentPermissionId: number | undefined = undefined
+  let maxAccessLevel: DB.PermissionLevel | undefined
+  let parentPermissionId: number | undefined
   let derived = false
 
   // if user is answer collection owner, set the corresponding permission
@@ -370,8 +370,8 @@ export async function propagateActivityToElementsUser(
     updateAccessRequests,
   }: {
     stacks:
-      | (Partial<DB.ElementBlock> & { elements: DB.ElementInstance[] }[])
-      | (Partial<DB.ElementStack> & { elements: DB.ElementInstance[] }[])
+      | (Partial<DB.ElementBlock> & { elements: DB.ElementInstance[] })[]
+      | (Partial<DB.ElementStack> & { elements: DB.ElementInstance[] })[]
     userId: string
     updateAccessRequests: boolean
   },
@@ -487,8 +487,8 @@ export async function propagateActivityToElements(
     updateAccessRequests,
   }: {
     stacks:
-      | (Partial<DB.ElementBlock> & { elements: DB.ElementInstance[] }[])
-      | (Partial<DB.ElementStack> & { elements: DB.ElementInstance[] }[])
+      | (Partial<DB.ElementBlock> & { elements: DB.ElementInstance[] })[]
+      | (Partial<DB.ElementStack> & { elements: DB.ElementInstance[] })[]
     updateAccessRequests: boolean
   },
   prisma: PrismaTransactionClient

--- a/project/2026-09-08-pr5833-production-readiness.md
+++ b/project/2026-09-08-pr5833-production-readiness.md
@@ -1,0 +1,69 @@
+# Production readiness — PR 5833 (activity permission recompute consolidation)
+
+Reviewed head: bf5a96710 (branch rs/idle-architecture/ia-2026-09-07/02-util-permissions-recompute,
+base v3 @ 7f81442ad9). Wave one: 8 dimension workers (foreground subagents of the session model; no
+external provider spend; dispatch ran sequentially after a session-ticket parallelism limit, recorded
+below). Wave two: not required — zero blockers reported.
+
+## Verdict
+
+**ready-with-conditions.** No dimension reported a blocker or major finding. The change consolidates
+four token-identical derived-permission recompute modules into one shared core behind the unchanged
+public API; query shapes are byte-identical (programmatic comparison of all 8 findUnique bodies),
+all four idField→delegate→key mappings audited correct against the schema, and behavior is pinned by
+156/156 permission-battery tests plus a live UX drive of the share-grant and batch-reassignment flows.
+Conditions: (1) repository final AI review on the final head; (2) this artifact commit is the only
+post-CI delta (documentation only); (3) noted environment incident (dev-stack death from a chat
+crash-loop, recovered via scoped profile) is operational, not a PR defect.
+
+## Prior gates
+
+| gate | artifact | status |
+| --- | --- | --- |
+| exact-head CI: check / test-graphql / test-unit / gitleaks / codeql / build / Playwright 8-shard (hosted, draft) | GitHub Actions, PR 5833 @ bf5a96710 | present (28/28 pass) |
+| repository final-ai-review (/final-review) | workflow check | pending on ready head at report time |
+| $code-review / $security-review / $thermo artifacts | project/_local/reviews/ | missing (observation; covered indirectly by permission batteries and this audit) |
+| per-slice reviews | — | not applicable (single-layer PR) |
+
+## Findings
+
+| severity | dimension | finding | evidence | proposed action | verification |
+| --- | --- | --- | --- | --- | --- |
+| minor | failure modes | shared core is now a single failure domain for all four activity models with no in-repo unit tests (coverage not reduced vs v3 — none existed) | diff: 0 test files; packages/util/test has no permission tests | follow-up: commit a parametrized unit battery for the ternary builders + throw/silent semantics | unverified (static) |
+| minor | failure modes | ternary-key dispatch relies on each descriptor's idField matching its delegate; tsc checks each against the union independently, not against each other | activity.ts:99-118; wrappers :19-23 | low-priority hardening: derive delegate/scope from idField in the type | unverified (static; all 4 current mappings audited correct) |
+| minor | data safety | Object-path empty access map → deleteMany removes all rows for the activity; byte-identical pre-existing semantics, unreachable for live objects (owner always seeds the map) | activity.ts:360-364; util.ts:172-178 | none | confirmed (line-by-line vs v3) |
+| minor | observability | user-variant not-found is fully silent (pre-existing, byte-preserved) | activity.ts:244-246 ≡ v3 liveQuiz.ts:147-150 | follow-up: log not-found id in user variant | confirmed (verbatim compare) |
+| minor | failure modes | user-variant not-found leaves an existing derived-permission row unreclaimed (pre-existing) | activity.ts:236-246 ≡ v3 | follow-up: delete orphaned row or log | confirmed |
+| minor | failure modes | transferActivitiesBetweenCourses script calls recompute non-transactionally (pre-existing; all GraphQL mutation paths roll back) | scripts/transferActivitiesBetweenCourses.ts:73,107,138 vs sharing.ts:1569 | follow-up: wrap in transaction | confirmed (call-site audit) |
+| minor | UX | icon-only activity-row overflow buttons lack accessible names; dialogs missing description (pre-existing UI, outside diff) | observed live, a11y tree | handoff to UI track | confirmed (observed) |
+| minor | performance | O(N) sequential per-element propagation and unbounded parallel upserts in object recompute (pre-existing, untouched) | util.ts:388-394,504-510; activity.ts:342-387 | future capacity pass (batching/offload) | confirmed (static) |
+| pass | data safety | all four idField→delegate→compound-key mappings correct; 0 wrong-row writes in live DB (16 rows, 0 multi-model rows); snapshot projection drops nothing | activity.ts:99-166 vs wrappers; DB check | none | confirmed |
+| pass | failure modes | wrapper→core indirection preserves await/error propagation and return values (all `return await`; no new catch/swallow) | wrappers :144,163,178; activity.ts:190,198 | none | confirmed |
+| pass | observability | both historical signals preserved byte-identically for all four models (notFoundLabel/label descriptors) | activity.ts:344-349,393-398 vs v3 | none | confirmed (verbatim) |
+| pass | performance | all 8 findUnique bodies whitespace-identical to v3; literal-key ternaries emit identical SQL (Prisma strips undefined) | programmatic comparison | none | confirmed |
+| pass | deploy | 6 files under packages/util only; migrator lockstep no-op; tag rollback reverts all bundling images (backend-docker, both workers, olat-api) atomically if values.yaml pins move together | diff name-only; v3_backend-docker-prd.yml:19-26 | none | confirmed |
+| pass | config | zero env/config/secret/dependency surface; log strings carry labels + ids only | 2,507-line diff greps | none | confirmed |
+| pass | UX | share grant persists (UI + DB), batch reassignment applies both directions with success toasts, unknown-user error path clean | /tmp/pr5833-*.png (19 screenshots) | none | confirmed (observed live) |
+| pass | docs | no doc/ADR describes the old structure; wiki rule satisfied without edit; log wording preserved for operator triage | docs greps | none | confirmed |
+
+## Not checked
+
+- Production/staging clusters and log pipelines (outside authorization).
+- EXPLAIN probes on the disposable DB (endpoint rejected TLS handshakes at worker time; substituted by byte-identical query shapes vs v3, which makes plan behavior identical to status quo).
+- Live Quiz / MicroLearning models not individually re-driven through the UI (one share + one batch move driven; all four models covered by the 156-test battery and 5/5 E2E cluster).
+
+## Handoffs
+
+- No in-repo unit tests for the recompute core → follow-up test battery (failure-modes/data-safety workers).
+- Silent user-variant not-found + orphaned derived permission row → backend hardening candidate.
+- Script-path (non-transactional) recompute callers → reconciliation/transaction follow-up.
+- UI a11y gaps (icon-button names, dialog descriptions, error-toast next steps) → design-system track.
+
+## Environment incident (operational record)
+
+The task workspace's dev stack had died ~17h before the UX drive (chat dev crash-loop aborted all turbo
+dev tasks; all routes 502). The UX worker recovered with the sanctioned scoped command
+`devrouter ensure <worktree> --profile manage --json` after verifying the worktree was clean at the
+exact PR head; manage/api/auth/redis restored, chat intentionally excluded pending its startup
+investigation. Earlier the same session, a full reset+reseed+repair sequence was applied after E2E
+global-setup wiped the seeded DB (documented recovery ritual). No retained environment was touched.


### PR DESCRIPTION
## Problem (evidence)

The four activity models each carried a **token-identical ~370-line derived-permission recompute module** (`packages/util/src/permissions/{liveQuiz,practiceQuiz,microlearning,groupActivity}.ts`, 1,498 lines total). Verified by normalized diff: excluding comments, the four files differ only in the Prisma delegate, the derived-permission key field, the element-stack relation (`blocks` on live quizzes, `stacks` elsewhere), and log-message wording. This is security-relevant plumbing — any fix to upsert conditions, access-request updates, or error handling had to be replicated four times with no type-level protection against drift.

## Change

Extract the shared User/Object recomputation into a new `permissions/activity.ts` parameterized by a small per-model descriptor (labels, id field, two fetch lambdas, access-request scope). The four modules become thin wrappers keeping their exact public API (`recomputeXPermissions` / `…User` / `…Object`), so the `permissions.ts` barrel and the `recomputeDerivedPermissions` dispatcher are untouched. Net −358 lines.

Design decisions (challenged by a fresh-context review before implementation):

- **Zero casts**: derived-permission `findUnique`/`upsert`/`delete`/`deleteMany` inputs are built with literal-key ternaries (exactly one active key per call, remaining `undefined` — the pattern already used in `accessRequest.ts`), so a future schema rename fails `tsc` instead of producing runtime P2025s.
- The wrappers explicitly project the fetched activity onto a common snapshot, normalizing the live-quiz `blocks` relation to the `stacks` shape (both carry `elements ElementInstance[]`).
- Not-found behavior stays **per-variant** exactly as before: silent return in the User variant, `console.error` with the historical per-model wording in the Object variant.
- The element-stack parameter type of `propagateActivityToElements(User)` is re-parenthesized: it previously parsed as `Partial<Block> & (…[])` — an object∩array intersection that worked by accident. Type-only fix; runtime-identical.

## Behavior preservation

- Same queries (same delegates, same includes, same where-filters per variant), same upsert/create/update/delete sequences, same `Promise.allSettled` error aggregation with the same message formats, same propagation and access-request arguments.
- Pinned by the existing graphql integration batteries that run **both variants for all four models** against a real database: `activityPermissions` (48/48), `coursePermissions`, `elementPermissions`, `catalogPermissions`, `activitySharing` (156/156 combined).

## Tests (consolidation mapping)

Hotspot audit (`rs-test-suite-consolidation`): the behavior seam for this change is the existing DB-backed graphql permission battery — **no test changes**; adding a mock-prisma unit harness would introduce a new pattern without strengthening protection (per review). The util package's own unit tests (65/65) are unaffected.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm --filter @klicker-uzh/util check` (tsc) | ✅ |
| `pnpm --filter @klicker-uzh/util test` | ✅ 65/65 |
| Permission batteries (5 files, container, disposable `klicker_test` DB) | ✅ 156/156 |
| Full `@klicker-uzh/graphql` suite (container) | 866/868 — the 2 `activitySharing` catalog failures reproduce **identically on the parent commit** (stash run in the same workspace): known local-workspace shared-Redis interference, unrelated to the diff; CI `test-graphql` is the authoritative gate |
| `pnpm run check:all` (container, CI-style devrouter planner env) | ✅ 35/35 |
| `pnpm run build` (container; re-run by the pre-push hook) | ✅ 23/23 |
| E2E: X-review activity-batch cluster (CLEANUP → prepare → eligibility → apply multiplier/course through the real mutation → batch delete) | ✅ 5/5 (46.7s) — course reassignment drives `recomputeDerivedPermissions` through the new core for all four activity types; run from a host-side Playwright install against this branch's devrouter runtime (specs unchanged by this diff) |
| Exact-head CI | see status below |

## Scope / risks / rollback

- No schema, migration, ops, codegen, dependency, or API-surface changes; the exported function set of each module is unchanged.
- Rollback: revert the single commit.

## Status

- [x] Implementation + review challenge
- [x] Local gates
- [x] Local E2E journey
- [x] Exact-head CI: 43/44 green on f0b035385 — full 8-shard Playwright suite pass on BOTH routings (hosted draft + public ready; shard 6 flaked once on a timing-sensitive group-creation test amid concurrent Hatchet/Postgres DNS errors, passed on rerun), test-graphql, test-unit, check, codeql, gitleaks, final-ai-review clean (evidence=bf75dd64…). The single failing check, test-olat-api, is a documented infrastructure flake: it errors in pnpm's deps-state gate before any changed code builds, with the identical failure on 3+ unrelated PR heads the same day (see PR comment with reproduction evidence)
- [x] Final review clean + production-readiness audit tracked (project/2026-09-08-pr5833-production-readiness.md, 8 dimensions, 0 blockers/majors)
