### PR TITLE
fix(ci): align Devrouter planner and repository at 0.0.59

### DIFF
--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -21,7 +21,7 @@
 # maps a selection to exact turbo roots, readiness apps, and process markers.
 version: 1
 devrouter:
-  version: 0.0.55
+  version: 0.0.59
 project:
   name: klicker-uzh
 managedRuntime:

--- a/.github/scripts/install-devrouter.sh
+++ b/.github/scripts/install-devrouter.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 # CI needs profile planning only; this installation never configures a router.
 # Keep the reviewed tool release aligned with .devrouter.yml.
 tool_prefix="${RUNNER_TEMP:?}/klicker-devrouter"
-npm install --global --prefix "$tool_prefix" --ignore-scripts --no-audit --no-fund '@devrouter/cli@0.0.55'
+npm install --global --prefix "$tool_prefix" --ignore-scripts --no-audit --no-fund '@devrouter/cli@0.0.59'
 echo "$tool_prefix/bin" >> "${GITHUB_PATH:?}"
 echo "KLICKER_DEVROUTER_BIN=$tool_prefix/bin/devrouter" >> "${GITHUB_ENV:?}"


### PR DESCRIPTION
## What This Fixes

Align the trusted CI Devrouter installer and Klicker's `.devrouter.yml` minimum at 0.0.59. Both were 0.0.55 on `v3`.

Prerequisite for [RAG chunk display and stable citations](https://github.com/uzh-bf/klicker-uzh/pull/5831): its code check and sampled Playwright shards fail before application tests because CI installs 0.0.55 while that branch requires 0.0.57.

The reusable Playwright workflow remains pinned to `v3` and reads its installer from the trusted workflow checkout. This PR does not change that trust boundary. Its own hosted Playwright checks may retain the old installer until the prerequisite lands; a rerun of an existing workflow attempt may retain the old workflow SHA.

## Branch Coverage

Base: `v3`. One commit, two files, two additions and two deletions. Micro CI-unblocking prerequisite; no application version, dependency lockfile, schema, or runtime configuration shape changes.

## Verification

Current head:
- All 62 host CI contract tests pass with installed Devrouter 0.0.59, including planning every shard profile union against the repository minimum.
- Installer Bash syntax, diff whitespace, Git identity and staged Gitleaks checks pass.
- Exact two-line diff inspected.

Earlier consumer evidence: the unchanged RAG worktree starts with published Devrouter 0.0.59 and passes manual in-app Browser inspection of persisted synthetic chunks and citations. That runtime is stopped with zero routes and preserved data.

Not run: full application build/typecheck and Linux installer execution. Broad application hooks were skipped for this configuration-only prerequisite; focused host checks ran directly. No application runtime was started for this branch.

## Blocking Before Merge

Human review and disposition of hosted checks, including the trusted-base installer dependency. Keep draft until explicitly marked ready. No merge is performed by this task.

## Follow-Up After Merge

Refresh the RAG branch's Devrouter minimum to 0.0.59, trigger a new CI run using the updated trusted workflow revision, and continue its PR readiness checks. No deployment is included.

## Local Session Artifacts

Local macOS: KlickerUZH worktree `trees/rs/devrouter-ci-059`. No task runtime.
