### PR TITLE
fix(ci): include audit runtime in Playwright artifacts

### DIFF
--- a/.github/actions/playwright-build/action.yml
+++ b/.github/actions/playwright-build/action.yml
@@ -175,6 +175,7 @@ runs:
           apps/mcp-lecturer/dist
           apps/olat-api/dist
           apps/response-api/dist
+          packages/audit/dist
           packages/export/dist
           packages/feature-flags/dist
           packages/grading/dist

--- a/.github/scripts/validate-public-playwright-workflow.test.cjs
+++ b/.github/scripts/validate-public-playwright-workflow.test.cjs
@@ -40,6 +40,15 @@ test('the current public workflow satisfies the runner trust boundary', () => {
   assert.match(sources[1], /playwright-shard@refs\/heads\/v3/)
   assert.match(sources[2], /repository: \$\{\{ job\.workflow_repository \}\}/)
   assert.match(sources[2], /ref: \$\{\{ job\.workflow_sha \}\}/)
+  const buildAction = YAML.parse(sources[2])
+  const buildUpload = buildAction.runs.steps.find(
+    (step) => step.with?.name === 'playwright-build-artifact'
+  )
+  assert.ok(buildUpload, 'the shared build artifact upload must exist')
+  assert.ok(
+    buildUpload.with.path.split(/\s+/).includes('packages/audit/dist'),
+    'trusted build artifacts must include the audit runtime for candidate workers'
+  )
   assert.match(sources[2], /packages\/feature-flags\/dist/)
   assert.match(sources[2], /packages\/knowledge-graph\/dist/)
   assert.match(sources[3], /repository: \$\{\{ job\.workflow_repository \}\}/)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -255,13 +255,16 @@ public route. The required status gate deliberately has no concurrency group,
 so a stale reporter waiting for GitHub-hosted capacity cannot block current
 filtering, builds, or shards. Public container jobs also trust the exact mounted
 `GITHUB_WORKSPACE` after checkout because its host and container owners differ.
-The public route executes composite build and shard actions from trusted `v3`,
+Both hosted and public routes execute composite build and shard actions from trusted `v3`,
 not from the pull-request checkout. A pull request therefore cannot make a new
 runtime package available to its own shards merely by adding that package to
 the artifact path. Bundle a new runtime dependency into an already transferred
 service artifact, or land the trusted artifact-contract change on `v3` first;
 inspect the downloaded artifact when a built package is missing at shard
 startup.
+The shared build artifact includes `packages/audit/dist` so assessment-audit
+candidate workers can resolve the package in a fresh shard. This entry is
+forward-compatible with `v3` checkouts that do not yet contain the audit package.
 
 Each CI shard also carries an explicit runtime profile from
 `playwright/profiles.json`. Every active spec must appear in that manifest


### PR DESCRIPTION
## What this fixes

The assessment-audit stack's Playwright build succeeds, but all eight shards
fail during startup. The general Hatchet worker cannot resolve
`@klicker-uzh/audit/dist/index.js` because the shared artifact omits it.
[Observed failure](https://github.com/uzh-bf/klicker-uzh/actions/runs/34081354061/job/101618422757).

Both hosted and public routes execute the composite build action from trusted
`v3`. The artifact entry already on #5378 cannot affect that trusted action.
This is a standalone prerequisite for #5311, #5356, #5367, #5369, and #5378.

## Changes and branch coverage

- Base: `v3` (branched from `e3fb9873c`). Head: `4ec0b5c1b`.
- One commit; three files, 14 insertions and one deletion.
- Add `packages/audit/dist` to the shared build artifact upload list.
- Assert the parsed upload action includes that exact runtime path.
- Document the trusted-action boundary for both execution routes.

No application logic, test assertions in browser specs, permissions, or trusted
action refs change. The optional path does not require audit to exist on v3 yet.

## Verification

- Regression reproduced before the action fix: the new assertion failed with
  `trusted build artifacts must include the audit runtime for candidate workers`.
- `node --test .github/scripts/validate-public-playwright-workflow.test.cjs`:
  **5 passed** after the fix, in the isolated development container.
- Broader Playwright CI contract suite: **61 passed, 1 environment failure**.
  The remaining test requires host-installed Devrouter, unavailable inside the
  test container; it is not reported as passing.
- Prettier, targeted Biome, and `git diff --check`: passed.
- No complete browser suite or fresh hosted artifact round trip is claimed.
- Host Git hooks skipped because this isolated worktree has no installed
  dependencies; the container checks above are the local evidence.

## Review and rollout

- Require normal CI and human review before merging this prerequisite.
- After it lands on `v3`, trigger fresh audit-stack workflow runs using the
  updated trusted control; confirm workers start and Playwright executes tests.
- This addresses the missing-package startup blocker, not unrelated GraphQL,
  formatting, or potential later browser failures in the audit stack.

No direct push to `v3`, merge, deployment, or audit activation is included.
