### PR TITLE
fix(manage): keep block actions clear of scrollbars

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -152,6 +152,17 @@ workspace Postgres container's random loopback port for test cleanup and
 seeding. The Playwright process, Node dependencies, and browser binaries stay
 on the host; applications and services stay in this devcontainer.
 
+For Manage-only tests, pass `--profile manage` to select that exact runtime:
+
+```bash
+node util/run-playwright-host.mjs --profile manage W5-block-list-scrollbar --project chromium
+```
+
+To install or repair Chromium without reconciling containers or installing
+workspace dependencies, use `node util/run-playwright-host.mjs --install-browser`
+(add `--force` to reinstall, or `--dry-run` to preview). This requires an
+existing host Playwright CLI and cannot be combined with `--profile`.
+
 The repository sets pnpm's `verifyDepsBeforeRun` policy to `error`, so pnpm
 reports stale dependency links instead of installing before the host launcher
 can control the lifecycle. On a cold host run, when the Playwright CLI is

--- a/apps/frontend-manage/src/components/activities/creation/WizardElementList.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/WizardElementList.tsx
@@ -70,7 +70,7 @@ function WizardElementList({
   return (
     <div
       className={twMerge(
-        'max-h-30 my-2 flex flex-1 flex-col overflow-y-auto',
+        'max-h-30 my-2 flex flex-1 flex-col overflow-y-auto pr-4',
         selectionActive ? 'max-h-22' : ''
       )}
     >

--- a/playwright/profiles.json
+++ b/playwright/profiles.json
@@ -3,7 +3,10 @@
   "groups": [
     {
       "profile": "manage",
-      "specs": ["T-chatbot-authoring.spec.ts"]
+      "specs": [
+        "W5-block-list-scrollbar.spec.ts",
+        "T-chatbot-authoring.spec.ts"
+      ]
     },
     {
       "profile": "manage,pwa",

--- a/playwright/relevance-manifest.json
+++ b/playwright/relevance-manifest.json
@@ -74,6 +74,7 @@
         "U-catalog.spec.ts",
         "V-template.spec.ts",
         "W4-activity-wizard-safety.spec.ts",
+        "W5-block-list-scrollbar.spec.ts",
         "W-activity-log.spec.ts",
         "X-review.spec.ts",
         "Y-chat.spec.ts",

--- a/playwright/tests/W5-block-list-scrollbar.spec.ts
+++ b/playwright/tests/W5-block-list-scrollbar.spec.ts
@@ -1,0 +1,112 @@
+import { expect, type Locator } from '@playwright/test'
+import { cleanupTest } from '../util/cleanup.js'
+import { USER_ID_TEST } from '../util/constants.js'
+import { test } from '../util/fixtures.js'
+import { createQuestionSC } from '../util/fixtures/elements.js'
+
+test('CLEANUP', cleanupTest)
+
+// Overlay scrollbars are platform dependent and may be hidden in headless
+// browsers. Check physical clearance as well as clickability: a successful
+// click alone would also pass on the original, overlapping layout.
+async function expectScrollbarClearance(row: Locator) {
+  await row.scrollIntoViewIfNeeded()
+  await expect
+    .poll(() =>
+      row.evaluate((element) => {
+        const list = element.parentElement!
+        const bounds = list.getBoundingClientRect()
+        return Array.from(element.querySelectorAll('button')).every(
+          (button) => {
+            const rect = button.getBoundingClientRect()
+            const hit = document.elementFromPoint(
+              rect.x + rect.width / 2,
+              rect.y + rect.height / 2
+            )
+            return (
+              rect.width > 0 &&
+              rect.left >= bounds.left &&
+              // Leave room for a typical 15px overlay scrollbar, regardless
+              // of whether this browser currently paints one.
+              bounds.right - rect.right >= 15 &&
+              rect.top >= bounds.top - 1 &&
+              rect.bottom <= bounds.bottom + 1 &&
+              hit !== null &&
+              button.contains(hit)
+            )
+          }
+        )
+      })
+    )
+    .toBe(true)
+}
+
+test('overflowing block keeps reorder and trash buttons clear of the scrollbar', async ({
+  page,
+  loginLecturer,
+}) => {
+  const titles = Array.from(
+    { length: 7 },
+    (_, i) => `Scrollbar ${i + 1} - a long element title that must truncate`
+  )
+  for (const name of titles) {
+    await createQuestionSC({
+      name,
+      content: 'Synthetic scrollbar regression question',
+      choices: [{ value: 'First' }, { value: 'Second' }],
+      userId: USER_ID_TEST,
+    })
+  }
+
+  await loginLecturer()
+  await page.getByTestId('create-live-quiz').click()
+  await page.getByTestId('insert-live-quiz-name').fill('Scrollbar regression')
+  await page.getByTestId('next-or-submit').click()
+  await page
+    .getByTestId('insert-live-display-name')
+    .fill('Scrollbar regression')
+  await page.getByTestId('next-or-submit').click()
+  await page.getByTestId('next-or-submit').click()
+  await expect(page.getByTestId('block-container-header')).toHaveCount(1)
+
+  for (const title of titles.slice(0, 6)) {
+    await page.getByTestId(`element-checkbox-${title}`).check()
+  }
+  await page.getByTestId('add-selection-to-existing-container').click()
+
+  const rows = page.getByTestId(/^element-\d+-block-0$/)
+  await expect(rows).toHaveCount(6)
+  const list = rows.first().locator('..')
+  const spareCheckbox = page.getByTestId(`element-checkbox-${titles[6]}`)
+
+  // Selection reduces the list height; both sizes must remain scrollable
+  // without placing any of the row actions underneath the scrollbar.
+  for (const selectionActive of [false, true]) {
+    await spareCheckbox.setChecked(selectionActive)
+    await expect
+      .poll(() => list.evaluate((el) => el.scrollHeight > el.clientHeight))
+      .toBe(true)
+    for (let index = 0; index < 6; index++) {
+      await expectScrollbarClearance(rows.nth(index))
+    }
+  }
+  await spareCheckbox.uncheck()
+
+  const lastTitle = await rows.nth(5).innerText()
+  const previousTitle = await rows.nth(4).innerText()
+  await page.getByTestId('move-element-5-block-0-up').click()
+  await expect(rows.nth(4)).toHaveText(lastTitle)
+  await expect(rows.nth(5)).toHaveText(previousTitle)
+  await page.getByTestId('move-element-4-block-0-down').click()
+  await expect(rows.nth(5)).toHaveText(lastTitle)
+  await expect(rows.nth(4)).toHaveText(previousTitle)
+
+  await expectScrollbarClearance(rows.nth(5))
+  await expect
+    .poll(() => list.evaluate((el) => el.scrollTop))
+    .toBeGreaterThan(0)
+  await page.getByTestId('remove-element-5-block-0').click()
+  await expect(rows).toHaveCount(5)
+  await expect(rows.filter({ hasText: lastTitle })).toHaveCount(0)
+  await expect(rows.nth(4)).toHaveText(previousTitle)
+})

--- a/util/run-playwright-host.mjs
+++ b/util/run-playwright-host.mjs
@@ -308,7 +308,11 @@ export function main(argv = process.argv.slice(2), dependencies = {}) {
   })
 
   const { profile, args } = parseHostArguments(argv)
-  if (args[0] === '--install-browser') {
+  const installBrowserIndex = args.indexOf('--install-browser')
+  if (installBrowserIndex >= 0) {
+    if (installBrowserIndex !== 0) {
+      fail('--install-browser must be the first argument')
+    }
     if (profile) fail('--profile cannot be combined with --install-browser')
     const installArgs = args.slice(1)
     if (installArgs.some((arg) => !['--force', '--dry-run'].includes(arg))) {

--- a/util/run-playwright-host.mjs
+++ b/util/run-playwright-host.mjs
@@ -273,6 +273,28 @@ function ensureHostDependencies(runtime, playwrightArgs) {
   ])
 }
 
+export function parseHostArguments(argv) {
+  const input = argv[0] === '--' ? argv.slice(1) : argv
+  const args = []
+  let profile
+  for (let index = 0; index < input.length; index += 1) {
+    const arg = input[index]
+    if (arg === '--profile' || arg.startsWith('--profile=')) {
+      if (profile !== undefined) fail('Specify --profile only once')
+      profile = arg === '--profile' ? input[++index] : arg.slice(10)
+      if (
+        !profile ||
+        !/^[a-z0-9][a-z0-9-]*(?:,[a-z0-9][a-z0-9-]*)*$/.test(profile)
+      ) {
+        fail('--profile requires a comma-separated profile selection')
+      }
+    } else {
+      args.push(arg)
+    }
+  }
+  return { profile, args }
+}
+
 export function main(argv = process.argv.slice(2), dependencies = {}) {
   const runtime = createRuntime(dependencies)
   const hostEnvironment = {
@@ -285,7 +307,30 @@ export function main(argv = process.argv.slice(2), dependencies = {}) {
     pathExists: runtime.pathExists,
   })
 
-  const args = argv[0] === '--' ? argv.slice(1) : [...argv]
+  const { profile, args } = parseHostArguments(argv)
+  if (args[0] === '--install-browser') {
+    if (profile) fail('--profile cannot be combined with --install-browser')
+    const installArgs = args.slice(1)
+    if (installArgs.some((arg) => !['--force', '--dry-run'].includes(arg))) {
+      fail('--install-browser accepts only --force and --dry-run')
+    }
+    const cli = join(
+      runtime.repoRoot,
+      'playwright/node_modules/@playwright/test/cli.js'
+    )
+    if (!runtime.pathExists(cli)) {
+      fail(
+        'Playwright CLI is missing; prepare host test dependencies separately. No workspace dependencies were changed.'
+      )
+    }
+    runtime.commandRunner(process.execPath, [
+      cli,
+      'install',
+      'chromium',
+      ...installArgs,
+    ])
+    return
+  }
   const showReport = args[0] === '--show-report'
   if (showReport) args.shift()
 
@@ -311,7 +356,11 @@ export function main(argv = process.argv.slice(2), dependencies = {}) {
   if (!printEnvironment) ensureHostDependencies(runtime, args)
 
   runtime.log('[playwright:host] Reconciling the devcontainer runtime')
-  runtime.commandRunner(runtime.devrouter(), ['ensure', runtime.repoRoot])
+  runtime.commandRunner(runtime.devrouter(), [
+    'ensure',
+    runtime.repoRoot,
+    ...(profile ? ['--profile', profile] : []),
+  ])
 
   const workspace = resolveWorkspace(runtime)
   const databasePort = resolveDatabasePort(runtime)

--- a/util/run-playwright-host.test.mjs
+++ b/util/run-playwright-host.test.mjs
@@ -25,6 +25,7 @@ import {
 } from './playwright-host-policy.mjs'
 import {
   PNPM_VERIFY_DEPS_ENV,
+  parseHostArguments,
   parsePublishedPort,
   resolvePlaywrightEnvironment,
   main as runPlaywrightHost,
@@ -743,4 +744,62 @@ test('Volta-routed pnpm commands retain the lowercase dependency guard', () => {
       ({ options }) => options.env?.[PNPM_VERIFY_DEPS_ENV] === 'error'
     )
   )
+})
+
+test('browser-only install invokes just the existing host CLI', () => {
+  const { calls, dependencies } = createLauncherHarness()
+  runPlaywrightHost(['--install-browser', '--force'], dependencies)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].command, process.execPath)
+  assert.deepEqual(calls[0].args, [
+    '/synthetic/klicker-uzh/playwright/node_modules/@playwright/test/cli.js',
+    'install',
+    'chromium',
+    '--force',
+  ])
+})
+
+test('browser-only install fails without touching dependencies or runtime when CLI is missing', () => {
+  const { calls, dependencies } = createLauncherHarness({
+    playwrightCli: false,
+  })
+  assert.throws(
+    () => runPlaywrightHost(['--install-browser'], dependencies),
+    /CLI is missing/
+  )
+  assert.deepEqual(calls, [])
+})
+
+test('explicit profile reaches Devrouter and is removed from Playwright arguments', () => {
+  const { calls, dependencies } = createLauncherHarness()
+  runPlaywrightHost(['--profile', 'manage', '--list'], dependencies)
+  assert.deepEqual(calls.find(({ args }) => args[0] === 'ensure').args, [
+    'ensure',
+    '/synthetic/klicker-uzh',
+    '--profile',
+    'manage',
+  ])
+  assert.ok(!pnpmCalls(calls).at(-1).args.includes('--profile'))
+  assert.deepEqual(parseHostArguments(['--profile=manage', '--list']), {
+    profile: 'manage',
+    args: ['--list'],
+  })
+  for (const args of [
+    ['--profile'],
+    ['--profile', '--list'],
+    ['--profile=a', '--profile=b'],
+  ]) {
+    assert.throws(() => parseHostArguments(args), /profile/)
+  }
+})
+
+test('browser-only rejects unsupported flags before touching runtime', () => {
+  for (const args of [
+    ['--install-browser', '--profile', 'manage'],
+    ['--install-browser', '--with-deps'],
+  ]) {
+    const { calls, dependencies } = createLauncherHarness()
+    assert.throws(() => runPlaywrightHost(args, dependencies))
+    assert.deepEqual(calls, [])
+  }
 })

--- a/util/run-playwright-host.test.mjs
+++ b/util/run-playwright-host.test.mjs
@@ -803,3 +803,21 @@ test('browser-only rejects unsupported flags before touching runtime', () => {
     assert.deepEqual(calls, [])
   }
 })
+
+for (const playwrightCli of [false, true]) {
+  for (const prefix of [
+    '--force',
+    '--dry-run',
+    '--show-report',
+    '--print-env',
+  ]) {
+    test(`rejects ${prefix} before --install-browser without side effects (CLI present: ${playwrightCli})`, () => {
+      const { calls, dependencies } = createLauncherHarness({ playwrightCli })
+      assert.throws(
+        () => runPlaywrightHost([prefix, '--install-browser'], dependencies),
+        /--install-browser must be the first argument/
+      )
+      assert.deepEqual(calls, [])
+    })
+  }
+}


### PR DESCRIPTION
## Description

Keep the scrollbar in activity creation/editing element lists from covering the trash and reorder buttons. The shared `WizardElementList` now reserves 16px of space on the right while retaining its existing scrolling behavior.

ClickUp Task: [Block list scrollbar overlaps the trash button in Chromium and WebKit](https://app.clickup.com/t/4648007/123zgec18rd)

## Proposed Changes

- Add right padding to the shared block/stack element list.
- Add a Playwright regression covering overflowing lists with and without a pending selection, button clearance and hit testing, reordering, and deletion after scrolling. Register it with CI's Manage-only profile and relevance manifest.
- Allow the host test launcher to select `--profile manage` and install Chromium with `--install-browser` without reconciling containers or reinstalling workspace dependencies. Add launcher coverage and usage notes.

## How to Test & Verification Evidence

```bash
node util/run-playwright-host.mjs --profile manage W5-block-list-scrollbar.spec.ts --project chromium
```

Add `--headed` for visible Chromium or `--ui` for Playwright UI mode.

### Automated Verification

- Chromium headless: 2 passed (cleanup + regression).
- Chromium headed: 2 passed in 7.8 seconds.
- Negative control: removing the padding fails the button-clearance assertion; the fix was restored.
- Host launcher tests: 27 passed.
- CI selector and runtime-profile tests: 19 passed on the host after registering the spec.
- Formatting and diff whitespace checks passed.
- `pnpm run check:all` was attempted in the container but could not finish: the runtime-profile test requires a host devrouter executable. The spec-registration failures discovered in that run were corrected and the affected suite passed on the host.
- Full `pnpm run build`: passed, 23/23 tasks (3m41s).

### Manual/Visual Verification

Checked the activity wizard with delegated synthetic credentials using agent-browser. With ten rows, the list retained a 120px viewport over 289px of content and 16px of right padding. Captured before/after screenshots locally; the before capture removes the added padding only in the browser DOM.

WebKit is not verified locally because of the local Safari login loop. A reported UI-mode timeout was not reproduced in the headed run; its cause remains unresolved. Keeping this PR in draft pending broader verification.
