### PR TITLE
chore(deploy): prepare three-day capacity increase and size staging

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -156,7 +156,7 @@ hatchet:
 auth:
   priorityClassName: production-workload
 
-  replicaCount: 6
+  replicaCount: 3
 
   autoscaling:
     enabled: false
@@ -435,7 +435,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: production-workload
 
-  replicaCount: 4
+  replicaCount: 3
 
   autoscaling:
     enabled: false
@@ -489,7 +489,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://*.df-app.ch'
   priorityClassName: production-workload
 
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -24,7 +24,7 @@ hatchet:
     apiUrl: 'http://app-hatchet-svc-api.prd-hatchet-svc.svc.cluster.local:8080'
   workers:
     general:
-      replicaCount: 2
+      replicaCount: 4
       priorityClassName: production-workload
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
@@ -63,7 +63,7 @@ hatchet:
               app.kubernetes.io/component: hatchet-worker-general
 
     responseProcessor:
-      replicaCount: 4
+      replicaCount: 8
       priorityClassName: production-workload
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
@@ -156,7 +156,7 @@ hatchet:
 auth:
   priorityClassName: production-workload
 
-  replicaCount: 3
+  replicaCount: 6
 
   autoscaling:
     enabled: false
@@ -382,7 +382,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://ius.zone https://*.df-app.ch https://moodle.fernuni.ch https://*.localhost'
   priorityClassName: production-workload
 
-  replicaCount: 4
+  replicaCount: 8
 
   autoscaling:
     enabled: false
@@ -435,7 +435,7 @@ frontendPWA:
 frontendManage:
   priorityClassName: production-workload
 
-  replicaCount: 3
+  replicaCount: 4
 
   autoscaling:
     enabled: false
@@ -542,7 +542,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: production-workload
 
-  replicaCount: 4
+  replicaCount: 8
 
   autoscaling:
     enabled: false
@@ -717,7 +717,7 @@ responseApi:
 
   priorityClassName: production-workload
 
-  replicaCount: 4
+  replicaCount: 8
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -33,7 +33,7 @@ hatchet:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 512Mi
         limits:
           memory: 2Gi
       affinity:
@@ -72,7 +72,7 @@ hatchet:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 192Mi
         limits:
           memory: 512Mi
       affinity:
@@ -111,7 +111,7 @@ hatchet:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 192Mi
         limits:
           memory: 512Mi
       affinity:
@@ -202,7 +202,7 @@ auth:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 192Mi
     limits:
       memory: 512Mi
 
@@ -217,7 +217,7 @@ chat:
   telemetry:
     enabled: false
 
-  replicaCount: 1
+  replicaCount: 2
 
   autoscaling:
     enabled: false
@@ -481,7 +481,7 @@ frontendManage:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 256Mi
     limits:
       memory: 512Mi
 
@@ -489,7 +489,7 @@ frontendControl:
   allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://*.df-app.ch'
   priorityClassName: production-workload
 
-  replicaCount: 1
+  replicaCount: 2
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm
@@ -535,7 +535,7 @@ frontendControl:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 96Mi
     limits:
       memory: 512Mi
 
@@ -604,14 +604,14 @@ backendGraphql:
   resources:
     requests:
       cpu: 100m
-      memory: 200Mi
+      memory: 384Mi
     limits:
       memory: 1Gi
 
 olatApi:
   priorityClassName: production-workload
 
-  replicaCount: 1
+  replicaCount: 2
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/olat-api-arm
@@ -657,7 +657,7 @@ olatApi:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 128Mi
     limits:
       memory: 512Mi
 
@@ -763,7 +763,7 @@ responseApi:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 96Mi
     limits:
       memory: 512Mi
 
@@ -997,7 +997,7 @@ assessment:
     resources:
       requests:
         cpu: 50m
-        memory: 50Mi
+        memory: 96Mi
       limits:
         memory: 512Mi
 

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -450,7 +450,7 @@ frontendManage:
       cpu: 50m
       memory: 192Mi
     limits:
-      memory: 200Mi
+      memory: 256Mi
 
 frontendControl:
   allowedFrameAncestors: 'https://*.df-app.ch https://*.olat.uzh.ch https://lms.uzh.ch'

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -281,7 +281,7 @@ chat:
       cost:
         input: 5.0
         output: 30.0
-  replicaCount: 1
+  replicaCount: 2
 
   autoscaling:
     enabled: false

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -33,6 +33,9 @@ hatchet:
         pullPolicy: Always
         tag: v3-ai
       resources:
+        requests:
+          cpu: 50m
+          memory: 384Mi
         limits:
           memory: 2Gi
       affinity:
@@ -57,6 +60,13 @@ hatchet:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
         tag: v3-ai
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -79,6 +89,13 @@ hatchet:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: Always
         tag: v3-ai
+      resources:
+        requests:
+          cpu: 50m
+          memory: 192Mi
+        limits:
+          memory: 256Mi
+
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -154,7 +171,7 @@ auth:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 192Mi
     limits:
       memory: 200Mi
 
@@ -281,7 +298,7 @@ chat:
       cost:
         input: 5.0
         output: 30.0
-  replicaCount: 2
+  replicaCount: 1
 
   autoscaling:
     enabled: false
@@ -325,7 +342,7 @@ chat:
   resources:
     requests:
       cpu: 50m
-      memory: 250Mi
+      memory: 320Mi
     limits:
       cpu: 200m
       memory: 768Mi
@@ -431,7 +448,7 @@ frontendManage:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 192Mi
     limits:
       memory: 200Mi
 
@@ -484,7 +501,7 @@ frontendControl:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 128Mi
     limits:
       memory: 200Mi
 
@@ -552,7 +569,7 @@ backendGraphql:
   resources:
     requests:
       cpu: 100m
-      memory: 200Mi
+      memory: 384Mi
     limits:
       memory: 600Mi
 
@@ -604,7 +621,7 @@ olatApi:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 128Mi
     limits:
       memory: 200Mi
 
@@ -705,7 +722,7 @@ responseApi:
   resources:
     requests:
       cpu: 50m
-      memory: 50Mi
+      memory: 128Mi
     limits:
       memory: 200Mi
 
@@ -910,7 +927,7 @@ assessment:
     resources:
       requests:
         cpu: 50m
-        memory: 50Mi
+        memory: 128Mi
       limits:
         memory: 200Mi
 

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -7,12 +7,12 @@ Detailed operational evidence is retained locally and is not part of this public
 
 ## Replica plan
 
-| Environment / values key | Before → proposed | Reason |
-| --- | --- | --- |
-| Production `chat` | 1 → 2 | Add serving redundancy; validate multi-pod streaming and persistence in staging first. A failed pod can still interrupt its active streams. |
-| Production `frontendControl` | 1 → 2 | Add a second serving process for lecturer controls. |
-| Production `olatApi` | 1 → 2 | Add a second serving process for LMS integration. |
-| Staging `chat` | 1 → 2 | Establish the multi-pod validation topology for the production change. |
+| Environment / values key     | Before → proposed | Reason                                                                                                                                      |
+| ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Production `chat`            | 1 → 2             | Add serving redundancy; validate multi-pod streaming and persistence in staging first. A failed pod can still interrupt its active streams. |
+| Production `frontendControl` | 1 → 2             | Add a second serving process for lecturer controls.                                                                                         |
+| Production `olatApi`         | 1 → 2             | Add a second serving process for LMS integration.                                                                                           |
+| Staging `chat`               | 1 → 2             | Establish the multi-pod validation topology for the production change.                                                                      |
 
 Existing anti-affinity is preferred, not required. Verify actual placement;
 two replicas do not guarantee node or zone redundancy. Other replica counts
@@ -26,18 +26,18 @@ under representative traffic; they are not claimed to be VPA recommendations.
 Existing CPU requests and all resource limits remain unchanged. Staging memory
 requests also remain unchanged pending environment-specific measurements.
 
-| Values key | Request before → proposed | Purpose |
-| --- | --- | --- |
-| `auth` | 50Mi → 192Mi | Increase the serving-process reservation. |
-| `frontendManage` | 50Mi → 256Mi | Provide a larger reservation for the lecturer frontend. |
-| `frontendControl` | 50Mi → 96Mi | Reserve memory for both proposed serving replicas. |
-| `olatApi` | 50Mi → 128Mi | Reserve memory for both proposed integration replicas. |
-| `backendGraphql` | 200Mi → 384Mi | Increase reservation for the main API. |
-| `hatchet.workers.general` | 64Mi → 512Mi | Give general background tasks a larger baseline; retain the existing 2Gi limit. |
-| `hatchet.workers.responseProcessor` | 64Mi → 192Mi | Increase the response-processing baseline. |
-| `hatchet.workers.responseProcessorAssessment` | 64Mi → 192Mi | Apply the same processing reservation to assessment workers. |
-| `responseApi` | 50Mi → 96Mi | Increase the response-ingestion reservation. |
-| `assessment.responseApi` | 50Mi → 96Mi | Apply the same ingestion reservation to assessment. |
+| Values key                                    | Request before → proposed | Purpose                                                                         |
+| --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
+| `auth`                                        | 50Mi → 192Mi              | Increase the serving-process reservation.                                       |
+| `frontendManage`                              | 50Mi → 256Mi              | Provide a larger reservation for the lecturer frontend.                         |
+| `frontendControl`                             | 50Mi → 96Mi               | Reserve memory for both proposed serving replicas.                              |
+| `olatApi`                                     | 50Mi → 128Mi              | Reserve memory for both proposed integration replicas.                          |
+| `backendGraphql`                              | 200Mi → 384Mi             | Increase reservation for the main API.                                          |
+| `hatchet.workers.general`                     | 64Mi → 512Mi              | Give general background tasks a larger baseline; retain the existing 2Gi limit. |
+| `hatchet.workers.responseProcessor`           | 64Mi → 192Mi              | Increase the response-processing baseline.                                      |
+| `hatchet.workers.responseProcessorAssessment` | 64Mi → 192Mi              | Apply the same processing reservation to assessment workers.                    |
+| `responseApi`                                 | 50Mi → 96Mi               | Increase the response-ingestion reservation.                                    |
+| `assessment.responseApi`                      | 50Mi → 96Mi               | Apply the same ingestion reservation to assessment.                             |
 
 The rendered change adds **production +3 pods, +150m CPU requests and +4620Mi
 memory requests (~4.51Gi)**. Of that memory increase, 650Mi is for assessment

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -1,91 +1,138 @@
-# Staging and production scaling proposal
+# Three-day capacity increase and resource sizing
 
-Status: **draft; not ready to merge or deploy**. This change proposes deployment
-values for review. Resource sizes are provisional engineering estimates and
-must be reconciled with representative Goldilocks recommendations before release.
-Detailed operational evidence is retained locally and is not part of this public PR.
+Status: **draft; capacity and release validation required before deployment**.
+The temporary replica plan targets roughly twice normal demand for a 72-hour
+usage window. Replica counts are a capacity precaution, not a demonstrated
+throughput guarantee. Resource-request corrections are intended to remain after
+the temporary window. Operational measurements are retained locally.
 
-## Replica plan
+## Temporary production replicas
 
-| Environment / values key     | Before → proposed | Reason                                                                                                                                      |
-| ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Production `chat`            | 1 → 2             | Add serving redundancy; validate multi-pod streaming and persistence in staging first. A failed pod can still interrupt its active streams. |
-| Production `frontendControl` | 1 → 2             | Add a second serving process for lecturer controls.                                                                                         |
-| Production `olatApi`         | 1 → 2             | Add a second serving process for LMS integration.                                                                                           |
-| Staging `chat`               | 1 → 2             | Establish the multi-pod validation topology for the production change.                                                                      |
+| Values key                          | Normal → temporary | Restore after window | Reason                                                                                     |
+| ----------------------------------- | ------------------ | -------------------- | ------------------------------------------------------------------------------------------ |
+| `auth`                              | 3 → 6              | 3                    | More concurrent student logins at class starts.                                            |
+| `frontendPWA`                       | 4 → 8              | 4                    | Double the student-facing serving pool.                                                    |
+| `backendGraphql`                    | 4 → 8              | 4                    | Double the main API serving pool.                                                          |
+| `responseApi`                       | 4 → 8              | 4                    | Double response-ingestion processes for synchronized submissions.                          |
+| `hatchet.workers.responseProcessor` | 4 → 8              | 4                    | Increase aggregate response-processing capacity; per-instance serialization still applies. |
+| `hatchet.workers.general`           | 2 → 4              | 2                    | Increase background-task capacity accompanying activity use.                               |
+| `frontendManage`                    | 3 → 4              | 3                    | Modest lecturer-facing headroom; student growth does not imply twice as many lecturers.    |
+| `frontendControl`                   | 1 → 2              | 1                    | Add lecturer-control redundancy.                                                           |
+| `olatApi`                           | 1 → 2              | 1                    | Add LMS-integration concurrency and redundancy.                                            |
+| `chat`                              | 1 → 2              | 1                    | Add chat-serving capacity; upstream limits remain independent.                             |
 
-Existing anti-affinity is preferred, not required. Verify actual placement;
-two replicas do not guarantee node or zone redundancy. Other replica counts
-remain unchanged pending throughput, queue-delay and availability evidence.
+**All staging replica settings remain unchanged, including chat at one. All
+assessment replica settings remain unchanged**, including the assessment
+response worker. LTI replica/autoscaling settings are outside this change.
 
-## Production memory-request plan
+Preferred anti-affinity does not guarantee node or zone separation. Check actual
+placement. More pods do not multiply database, Redis, Hatchet or model-provider
+capacity; verify those dependencies, connection counts and queue behavior.
 
-All values are per container. Raising reservations lets the scheduler account
-for more of the expected workload footprint. These proposed sizes need validation
-under representative traffic; they are not claimed to be VPA recommendations.
-Existing CPU requests and all resource limits remain unchanged. Staging memory
-requests also remain unchanged pending environment-specific measurements.
+## Production memory requests retained after the window
 
-| Values key                                    | Request before → proposed | Purpose                                                                         |
-| --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
-| `auth`                                        | 50Mi → 192Mi              | Increase the serving-process reservation.                                       |
-| `frontendManage`                              | 50Mi → 256Mi              | Provide a larger reservation for the lecturer frontend.                         |
-| `frontendControl`                             | 50Mi → 96Mi               | Reserve memory for both proposed serving replicas.                              |
-| `olatApi`                                     | 50Mi → 128Mi              | Reserve memory for both proposed integration replicas.                          |
-| `backendGraphql`                              | 200Mi → 384Mi             | Increase reservation for the main API.                                          |
-| `hatchet.workers.general`                     | 64Mi → 512Mi              | Give general background tasks a larger baseline; retain the existing 2Gi limit. |
-| `hatchet.workers.responseProcessor`           | 64Mi → 192Mi              | Increase the response-processing baseline.                                      |
-| `hatchet.workers.responseProcessorAssessment` | 64Mi → 192Mi              | Apply the same processing reservation to assessment workers.                    |
-| `responseApi`                                 | 50Mi → 96Mi               | Increase the response-ingestion reservation.                                    |
-| `assessment.responseApi`                      | 50Mi → 96Mi               | Apply the same ingestion reservation to assessment.                             |
+All values are per container. These reservations remain provisional pending
+representative environment-specific sizing validation. CPU requests and resource
+limits are unchanged.
 
-The rendered change adds **production +3 pods, +150m CPU requests and +4620Mi
-memory requests (~4.51Gi)**. Of that memory increase, 650Mi is for assessment
-workloads. Staging adds **+1 pod, +50m CPU and +250Mi memory requests**.
-These are differences calculated from this public chart, not observations of
-cluster capacity, predictions of utilization or monetary estimates.
+| Values key                                    | Request before → proposed |
+| --------------------------------------------- | ------------------------- |
+| `auth`                                        | 50Mi → 192Mi              |
+| `frontendManage`                              | 50Mi → 256Mi              |
+| `frontendControl`                             | 50Mi → 96Mi               |
+| `olatApi`                                     | 50Mi → 128Mi              |
+| `backendGraphql`                              | 200Mi → 384Mi             |
+| `hatchet.workers.general`                     | 64Mi → 512Mi              |
+| `hatchet.workers.responseProcessor`           | 64Mi → 192Mi              |
+| `hatchet.workers.responseProcessorAssessment` | 64Mi → 192Mi              |
+| `responseApi`                                 | 50Mi → 96Mi               |
+| `assessment.responseApi`                      | 50Mi → 96Mi               |
 
-## Evidence and release gates
+## Staging resources
 
-1. Obtain representative Goldilocks recommendations for each environment and
-   reconcile the proposed values. Inspect recommendation age, conditions,
-   bounds and policy caps, alongside peak teaching/assessment traffic, latency,
-   throttling, OOM events and queue delay. Do not downsize based on idle samples.
-2. Verify staging capacity and authorize its release through the normal GitOps
-   process. Check two chat pods, actual placement, login, streaming, tool calls,
-   persisted history across pods, DB connections and controlled-restart behavior.
-   Use synthetic content and explicitly authorized upstream calls.
-3. Confirm production steady-state, rollout-surge and node-failure capacity,
-   admission rules, scheduling constraints and autoscaler ownership. Changing
-   resource requests rolls existing pods too. Three additional simultaneous
-   singleton surges would require another 150m CPU beyond the steady-state
-   delta, plus the surge requests of other affected workloads. Account for all
-   namespaces and reconcile live-versus-Git drift before release.
-4. After approval, coordinate rollout waves in the owning release process and
-   monitor Ready/desired counts, Pending pods, OOMs, restarts, latency, error
-   rate, chat interruptions, DB connections and queue delay. Exercise lecturer
-   controls, OLAT and assessment flows. Halt on regressions or unavailable pods.
-5. Roll back only these values through GitOps if needed, preserving current
-   image tags and release annotations. A rollback also rolls pods and needs
-   scheduling headroom.
+Use rounded memory requests at or above the staging VPA target where the existing
+request is too small. This is a conservative sizing policy, not a literal copy
+of Goldilocks' Burstable view. Retain larger existing requests, existing CPU
+requests, and existing memory limits except for the normal response worker:
+its new request needs additional limit headroom. Assessment resource corrections
+are independent of the excluded assessment replica increases.
 
-Goldilocks supplies container resource recommendations; replica count decisions
-also need availability and throughput requirements. Its Burstable view uses VPA
-`lowerBound` for requests and `upperBound` for limits; Guaranteed uses `target`
+| Values key                                    | Request before → proposed | Limit change                    |
+| --------------------------------------------- | ------------------------- | ------------------------------- |
+| `auth`                                        | 50Mi → 192Mi              | None (200Mi)                    |
+| `frontendManage`                              | 50Mi → 192Mi              | None (200Mi)                    |
+| `frontendControl`                             | 50Mi → 128Mi              | None (200Mi)                    |
+| `olatApi`                                     | 50Mi → 128Mi              | None (200Mi)                    |
+| `backendGraphql`                              | 200Mi → 384Mi             | None (600Mi)                    |
+| `chat`                                        | 250Mi → 320Mi             | None (768Mi); still one replica |
+| `hatchet.workers.general`                     | 64Mi inherited → 384Mi    | None (2Gi)                      |
+| `hatchet.workers.responseProcessor`           | 64Mi inherited → 256Mi    | 256Mi inherited → 512Mi         |
+| `hatchet.workers.responseProcessorAssessment` | 64Mi inherited → 192Mi    | None (256Mi)                    |
+| `responseApi`                                 | 50Mi → 128Mi              | None (200Mi)                    |
+| `assessment.responseApi`                      | 50Mi → 128Mi              | None (200Mi)                    |
+
+Leave both PWA requests, assessment GraphQL and LTI unchanged. Environment-specific
+recommendations should not be transferred blindly between staging and production.
+No MCP service changes are included in this chart revision.
+
+## Reservation deltas and capacity prerequisite
+
+Compared with the base chart, the production proposal adds **25 pods, 1650m CPU
+requests and 9964Mi memory requests (~9.73Gi)**. Of the memory increase, 650Mi
+belongs to assessment resource corrections, with no extra assessment pods.
+Staging adds **1490Mi memory requests**, with **zero additional pods or CPU
+requests**. These are computed manifest deltas, not private cluster observations.
+
+**Provision or verify sufficient eligible application-node capacity before
+release.** Do not assume the existing pool can place the extra pods or that its
+autoscaler is enabled, within bounds, or fast enough. Have the infrastructure
+owner check steady-state placement, rollout surge and a node failure. Account
+for all namespaces, taints, architecture, affinity, overhead and other rollouts.
+Do not use assessment-reserved nodes to meet normal application capacity needs.
+No node-pool changes or direct scaling commands are part of this PR.
+
+Rolling updates need capacity beyond the stated delta. Resource-request changes
+also roll existing workloads. Coordinate release waves and stop on persistent
+Pending pods; do not try to compensate by lowering justified requests.
+
+## Activation and explicit scale-back
+
+1. Record the actual activation timestamp, owner and **activation +72 hours**
+   scale-back timestamp in the private release record. Confirm the window with
+   the event owner; merging this PR does not schedule automatic scale-back.
+2. Validate the staging resource change at its unchanged replica topology.
+   Exercise login, chat and activity flows. Multi-pod production chat needs a
+   separately authorized validation; a one-pod staging test cannot prove it.
+3. Verify dependency limits and eligible production capacity, then authorize
+   the normal GitOps release. Check Ready/desired counts and actual placement
+   before the student peak begins. Image tags and release annotations are
+   preserved by this change; reconcile unrelated live-versus-Git drift first.
+4. Monitor latency, errors, OOMs, restarts, CPU throttling, connection counts,
+   response-processing queue delay and chat interruptions throughout the event.
+   Investigate dependency bottlenecks before increasing replicas further.
+5. At the recorded end, confirm traffic and queues have subsided and restore
+   **only the ten replica settings in the table** to their normal values in a
+   follow-up GitOps change. Keep both environments' resource corrections.
+   Drain workers and allow in-flight requests/streams to finish; monitor the
+   scale-down and pause it if demand remains elevated. No automatic rollback
+   or scheduled cluster mutation is created by this PR.
+6. For an earlier regression, revert the affected settings through GitOps while
+   preserving current release versions. Resource rollback also rolls pods and
+   needs surge capacity.
+
+Goldilocks sizes containers, not replica counts. Its Burstable view maps VPA
+`lowerBound` to requests and `upperBound` to limits; Guaranteed uses `target`
 for both. See the official [FAQ](https://github.com/FairwindsOps/goldilocks/blob/master/docs/faq.md).
 
 ## Verification
 
-- Both environments pass `helm lint` and `helm template`.
-- A structural before/after comparison confirms that only the listed Deployment
-  replica and memory-request fields change. Images and release annotations are
-  preserved.
-- Repository-version Prettier and `git diff --check` pass.
-- Independent review confirmed the rendered scope and arithmetic.
-- `pnpm run check:all` and `pnpm run build` could not start in the fresh worktree
-  without installed dependencies (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`).
-- Application, browser, load and failover checks remain unrun. Review CI
-  separately; deployment-only fallback build checks are not application builds.
+Both values files pass Helm lint and rendering. A structural comparison permits
+only the intended replica and resource changes and asserts that all staging and
+assessment replica fields are unchanged. CPU requests/limits and image versions
+are preserved. Formatting, secret scanning and independent review are checked
+before publishing the revision.
 
-No deployment or cluster mutation was performed. Keep the PR in draft until the
-required evidence and release gates are satisfied.
+Full pnpm checks/build could not start in this fresh worktree without installed
+dependencies (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`). Runtime, load and failover tests
+remain unrun; CI is not a substitute for the capacity/release gates above. No
+cluster mutation or deployment was performed.

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -1,0 +1,91 @@
+# Staging and production scaling proposal
+
+Status: **draft; not ready to merge or deploy**. This change proposes deployment
+values for review. Resource sizes are provisional engineering estimates and
+must be reconciled with representative Goldilocks recommendations before release.
+Detailed operational evidence is retained locally and is not part of this public PR.
+
+## Replica plan
+
+| Environment / values key | Before → proposed | Reason |
+| --- | --- | --- |
+| Production `chat` | 1 → 2 | Add serving redundancy; validate multi-pod streaming and persistence in staging first. A failed pod can still interrupt its active streams. |
+| Production `frontendControl` | 1 → 2 | Add a second serving process for lecturer controls. |
+| Production `olatApi` | 1 → 2 | Add a second serving process for LMS integration. |
+| Staging `chat` | 1 → 2 | Establish the multi-pod validation topology for the production change. |
+
+Existing anti-affinity is preferred, not required. Verify actual placement;
+two replicas do not guarantee node or zone redundancy. Other replica counts
+remain unchanged pending throughput, queue-delay and availability evidence.
+
+## Production memory-request plan
+
+All values are per container. Raising reservations lets the scheduler account
+for more of the expected workload footprint. These proposed sizes need validation
+under representative traffic; they are not claimed to be VPA recommendations.
+Existing CPU requests and all resource limits remain unchanged. Staging memory
+requests also remain unchanged pending environment-specific measurements.
+
+| Values key | Request before → proposed | Purpose |
+| --- | --- | --- |
+| `auth` | 50Mi → 192Mi | Increase the serving-process reservation. |
+| `frontendManage` | 50Mi → 256Mi | Provide a larger reservation for the lecturer frontend. |
+| `frontendControl` | 50Mi → 96Mi | Reserve memory for both proposed serving replicas. |
+| `olatApi` | 50Mi → 128Mi | Reserve memory for both proposed integration replicas. |
+| `backendGraphql` | 200Mi → 384Mi | Increase reservation for the main API. |
+| `hatchet.workers.general` | 64Mi → 512Mi | Give general background tasks a larger baseline; retain the existing 2Gi limit. |
+| `hatchet.workers.responseProcessor` | 64Mi → 192Mi | Increase the response-processing baseline. |
+| `hatchet.workers.responseProcessorAssessment` | 64Mi → 192Mi | Apply the same processing reservation to assessment workers. |
+| `responseApi` | 50Mi → 96Mi | Increase the response-ingestion reservation. |
+| `assessment.responseApi` | 50Mi → 96Mi | Apply the same ingestion reservation to assessment. |
+
+The rendered change adds **production +3 pods, +150m CPU requests and +4620Mi
+memory requests (~4.51Gi)**. Of that memory increase, 650Mi is for assessment
+workloads. Staging adds **+1 pod, +50m CPU and +250Mi memory requests**.
+These are differences calculated from this public chart, not observations of
+cluster capacity, predictions of utilization or monetary estimates.
+
+## Evidence and release gates
+
+1. Obtain representative Goldilocks recommendations for each environment and
+   reconcile the proposed values. Inspect recommendation age, conditions,
+   bounds and policy caps, alongside peak teaching/assessment traffic, latency,
+   throttling, OOM events and queue delay. Do not downsize based on idle samples.
+2. Verify staging capacity and authorize its release through the normal GitOps
+   process. Check two chat pods, actual placement, login, streaming, tool calls,
+   persisted history across pods, DB connections and controlled-restart behavior.
+   Use synthetic content and explicitly authorized upstream calls.
+3. Confirm production steady-state, rollout-surge and node-failure capacity,
+   admission rules, scheduling constraints and autoscaler ownership. Changing
+   resource requests rolls existing pods too. Three additional simultaneous
+   singleton surges would require another 150m CPU beyond the steady-state
+   delta, plus the surge requests of other affected workloads. Account for all
+   namespaces and reconcile live-versus-Git drift before release.
+4. After approval, coordinate rollout waves in the owning release process and
+   monitor Ready/desired counts, Pending pods, OOMs, restarts, latency, error
+   rate, chat interruptions, DB connections and queue delay. Exercise lecturer
+   controls, OLAT and assessment flows. Halt on regressions or unavailable pods.
+5. Roll back only these values through GitOps if needed, preserving current
+   image tags and release annotations. A rollback also rolls pods and needs
+   scheduling headroom.
+
+Goldilocks supplies container resource recommendations; replica count decisions
+also need availability and throughput requirements. Its Burstable view uses VPA
+`lowerBound` for requests and `upperBound` for limits; Guaranteed uses `target`
+for both. See the official [FAQ](https://github.com/FairwindsOps/goldilocks/blob/master/docs/faq.md).
+
+## Verification
+
+- Both environments pass `helm lint` and `helm template`.
+- A structural before/after comparison confirms that only the listed Deployment
+  replica and memory-request fields change. Images and release annotations are
+  preserved.
+- Repository-version Prettier and `git diff --check` pass.
+- Independent review confirmed the rendered scope and arithmetic.
+- `pnpm run check:all` and `pnpm run build` could not start in the fresh worktree
+  without installed dependencies (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`).
+- Application, browser, load and failover checks remain unrun. Review CI
+  separately; deployment-only fallback build checks are not application builds.
+
+No deployment or cluster mutation was performed. Keep the PR in draft until the
+required evidence and release gates are satisfied.

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -53,14 +53,15 @@ limits are unchanged.
 Use rounded memory requests at or above the staging VPA target where the existing
 request is too small. This is a conservative sizing policy, not a literal copy
 of Goldilocks' Burstable view. Retain larger existing requests, existing CPU
-requests, and existing memory limits except for the normal response worker:
-its new request needs additional limit headroom. Assessment resource corrections
+requests, and existing memory limits except for the normal response worker and
+Manage. The response worker needs headroom above its new request; Manage gets
+additional memory headroom. Assessment resource corrections
 are independent of the excluded assessment replica increases.
 
 | Values key                                    | Request before → proposed | Limit change                    |
 | --------------------------------------------- | ------------------------- | ------------------------------- |
 | `auth`                                        | 50Mi → 192Mi              | None (200Mi)                    |
-| `frontendManage`                              | 50Mi → 192Mi              | None (200Mi)                    |
+| `frontendManage`                              | 50Mi → 192Mi              | 200Mi → 256Mi                   |
 | `frontendControl`                             | 50Mi → 128Mi              | None (200Mi)                    |
 | `olatApi`                                     | 50Mi → 128Mi              | None (200Mi)                    |
 | `backendGraphql`                              | 200Mi → 384Mi             | None (600Mi)                    |

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -10,20 +10,18 @@ the temporary window. Operational measurements are retained locally.
 
 | Values key                          | Normal → temporary | Restore after window | Reason                                                                                     |
 | ----------------------------------- | ------------------ | -------------------- | ------------------------------------------------------------------------------------------ |
-| `auth`                              | 3 → 6              | 3                    | More concurrent student logins at class starts.                                            |
 | `frontendPWA`                       | 4 → 8              | 4                    | Double the student-facing serving pool.                                                    |
 | `backendGraphql`                    | 4 → 8              | 4                    | Double the main API serving pool.                                                          |
 | `responseApi`                       | 4 → 8              | 4                    | Double response-ingestion processes for synchronized submissions.                          |
 | `hatchet.workers.responseProcessor` | 4 → 8              | 4                    | Increase aggregate response-processing capacity; per-instance serialization still applies. |
 | `hatchet.workers.general`           | 2 → 4              | 2                    | Increase background-task capacity accompanying activity use.                               |
-| `frontendManage`                    | 3 → 4              | 3                    | Modest lecturer-facing headroom; student growth does not imply twice as many lecturers.    |
-| `frontendControl`                   | 1 → 2              | 1                    | Add lecturer-control redundancy.                                                           |
 | `olatApi`                           | 1 → 2              | 1                    | Add LMS-integration concurrency and redundancy.                                            |
 | `chat`                              | 1 → 2              | 1                    | Add chat-serving capacity; upstream limits remain independent.                             |
 
 **All staging replica settings remain unchanged, including chat at one. All
 assessment replica settings remain unchanged**, including the assessment
-response worker. LTI replica/autoscaling settings are outside this change.
+response worker. Production auth, control and manage stay at 3, 1 and 3 replicas.
+LTI replica/autoscaling settings are outside this change.
 
 Preferred anti-affinity does not guarantee node or zone separation. Check actual
 placement. More pods do not multiply database, Redis, Hatchet or model-provider
@@ -78,8 +76,8 @@ No MCP service changes are included in this chart revision.
 
 ## Reservation deltas and capacity prerequisite
 
-Compared with the base chart, the production proposal adds **25 pods, 1650m CPU
-requests and 9964Mi memory requests (~9.73Gi)**. Of the memory increase, 650Mi
+Compared with the base chart, the production proposal adds **20 pods, 1400m CPU
+requests and 9036Mi memory requests (~8.82Gi)**. Of the memory increase, 650Mi
 belongs to assessment resource corrections, with no extra assessment pods.
 Staging adds **1490Mi memory requests**, with **zero additional pods or CPU
 requests**. These are computed manifest deltas, not private cluster observations.
@@ -112,7 +110,7 @@ Pending pods; do not try to compensate by lowering justified requests.
    response-processing queue delay and chat interruptions throughout the event.
    Investigate dependency bottlenecks before increasing replicas further.
 5. At the recorded end, confirm traffic and queues have subsided and restore
-   **only the ten replica settings in the table** to their normal values in a
+   **only the seven replica settings in the table** to their normal values in a
    follow-up GitOps change. Keep both environments' resource corrections.
    Drain workers and allow in-flight requests/streams to finish; monitor the
    scale-down and pause it if demand remains elevated. No automatic rollback


### PR DESCRIPTION
## Temporary capacity and resource corrections

Prepare roughly 2× normal demand for a 72-hour window. Double production PWA, GraphQL, response API and response workers (4→8), and general workers (2→4). Increase chat and OLAT API 1→2. Production auth, control and manage retain their original replica counts of 3, 1 and 3.

**All assessment replicas remain unchanged. All staging replicas remain unchanged, including chat at one.**

Retain the production memory-request corrections and add staging corrections using rounded staging VPA targets: chat 250→320Mi, GraphQL 200→384Mi, general worker 64→384Mi, response worker 64→256Mi and smaller-service corrections. The staging response-worker limit increases 256→512Mi, and Manage increases 200→256Mi for additional memory headroom. Other limits and CPU settings are preserved. Assessment resource corrections remain included, independently of the excluded replica increases.

The [complete plan](https://github.com/uzh-bf/klicker-uzh/blob/feat/goldilocks-stg-prd-scaling/deploy/scaling-plan-2026-09.md) includes every value change, rationale, release prerequisites and exact replica counts to restore after the window. Keep resource corrections when restoring normal replicas. This PR does not schedule automatic scale-down.

## Capacity and release prerequisites

Chart-derived deltas: production **+20 pods, +1400m CPU requests, +9036Mi memory requests**; staging **+1490Mi memory requests, no extra pods or CPU requests**. These are manifest differences, not operational measurements.

- [ ] Infrastructure owner confirms/provides eligible application-node capacity for steady state, rollout surge and node failure before release; do not use assessment-reserved capacity for the normal workload.
- [ ] Validate resource sizing, staging flows, dependency/DB connection limits and production multi-pod behavior. Single-pod staging cannot prove multi-pod chat behavior.
- [ ] Record activation and activation +72h scale-back timestamps plus an owner in the release record.
- [ ] After the window, restore the seven replica settings from the plan through GitOps after traffic and queues subside, retaining resource corrections.

**Keep in draft pending these gates.** A replica multiplier is not a load-test result. Detailed operational evidence stays local and is excluded from this public PR.

## Verification

Both environments pass Helm lint/rendering. Structural comparison confirms only intended replicas/resources change, with assertions preserving all staging and assessment replica settings, CPU requests/limits and images. Repository-version formatting and diff checks pass. Secret scanning and identity hooks remain enforced at publication. Independent review covers the revised proposal.

Full pnpm check/build previously could not start without installed dependencies; runtime, load and failover checks remain unrun. Review current CI separately. No merge, deployment, node provisioning or cluster mutation was performed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Capacity and Performance**
  - Increased production and staging capacity for key application services and background workers.
  - Added memory resources and raised replica counts to support higher workloads and improved availability.

- **Documentation**
  - Added a deployment capacity plan covering temporary production scaling, prerequisites, monitoring, verification, and rollback procedures.
  - Documented staging and assessment scaling constraints, resource changes, and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->