### PR TITLE
chore(deploy): reduce production replica pools to six

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -63,7 +63,7 @@ hatchet:
               app.kubernetes.io/component: hatchet-worker-general
 
     responseProcessor:
-      replicaCount: 8
+      replicaCount: 6
       priorityClassName: production-workload
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
@@ -382,7 +382,7 @@ frontendPWA:
   allowedFrameAncestors: 'https://*.klicker.uzh.ch https://lms.uzh.ch https://*.olat.uzh.ch https://elearning.klicker.uzh.ch https://ius.zone https://*.df-app.ch https://moodle.fernuni.ch https://*.localhost'
   priorityClassName: production-workload
 
-  replicaCount: 8
+  replicaCount: 6
 
   autoscaling:
     enabled: false
@@ -542,7 +542,7 @@ frontendControl:
 backendGraphql:
   priorityClassName: production-workload
 
-  replicaCount: 8
+  replicaCount: 6
 
   autoscaling:
     enabled: false
@@ -717,7 +717,7 @@ responseApi:
 
   priorityClassName: production-workload
 
-  replicaCount: 8
+  replicaCount: 6
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm

--- a/deploy/scaling-plan-2026-09.md
+++ b/deploy/scaling-plan-2026-09.md
@@ -1,7 +1,7 @@
 # Three-day capacity increase and resource sizing
 
 Status: **draft; capacity and release validation required before deployment**.
-The temporary replica plan targets roughly twice normal demand for a 72-hour
+The temporary replica plan provides additional capacity for a 72-hour
 usage window. Replica counts are a capacity precaution, not a demonstrated
 throughput guarantee. Resource-request corrections are intended to remain after
 the temporary window. Operational measurements are retained locally.
@@ -10,10 +10,10 @@ the temporary window. Operational measurements are retained locally.
 
 | Values key                          | Normal → temporary | Restore after window | Reason                                                                                     |
 | ----------------------------------- | ------------------ | -------------------- | ------------------------------------------------------------------------------------------ |
-| `frontendPWA`                       | 4 → 8              | 4                    | Double the student-facing serving pool.                                                    |
-| `backendGraphql`                    | 4 → 8              | 4                    | Double the main API serving pool.                                                          |
-| `responseApi`                       | 4 → 8              | 4                    | Double response-ingestion processes for synchronized submissions.                          |
-| `hatchet.workers.responseProcessor` | 4 → 8              | 4                    | Increase aggregate response-processing capacity; per-instance serialization still applies. |
+| `frontendPWA`                       | 4 → 6              | 4                    | Increase the student-facing serving pool by 50%.                                           |
+| `backendGraphql`                    | 4 → 6              | 4                    | Increase the main API serving pool by 50%.                                                 |
+| `responseApi`                       | 4 → 6              | 4                    | Increase response-ingestion processes by 50% for synchronized submissions.                 |
+| `hatchet.workers.responseProcessor` | 4 → 6              | 4                    | Increase aggregate response-processing capacity; per-instance serialization still applies. |
 | `hatchet.workers.general`           | 2 → 4              | 2                    | Increase background-task capacity accompanying activity use.                               |
 | `olatApi`                           | 1 → 2              | 1                    | Add LMS-integration concurrency and redundancy.                                            |
 | `chat`                              | 1 → 2              | 1                    | Add chat-serving capacity; upstream limits remain independent.                             |
@@ -76,8 +76,8 @@ No MCP service changes are included in this chart revision.
 
 ## Reservation deltas and capacity prerequisite
 
-Compared with the base chart, the production proposal adds **20 pods, 1400m CPU
-requests and 9036Mi memory requests (~8.82Gi)**. Of the memory increase, 650Mi
+Compared with the pre-scaling base (`e3fb9873c`), production adds **12 pods, 800m CPU
+requests and 7292Mi memory requests (~7.12Gi)**. Of the memory increase, 650Mi
 belongs to assessment resource corrections, with no extra assessment pods.
 Staging adds **1490Mi memory requests**, with **zero additional pods or CPU
 requests**. These are computed manifest deltas, not private cluster observations.


### PR DESCRIPTION
## Change

Reduce production `frontendPWA`, `backendGraphql`, `responseApi`, and `hatchet.workers.responseProcessor` from 8 to 6 replicas after #5840. Update the scaling plan and its totals to match. Base: `v3`.

All other replica counts, staging values, assessment deployments, per-pod resources, and image versions are unchanged. The four pools remain above their original baseline of four replicas; the existing 72-hour scale-back plan still restores them to four.

This reduces the configured total by 8 pods, 600m CPU requests, and 1744Mi memory requests compared with current `v3`. Release capacity and service health still need verification; this is not a deployment or measured throughput claim.

## Verification

- Production Helm lint and template rendering pass.
- Structural before/after comparison confirms exactly four Deployment replica fields change from 8 to 6, with all other rendered fields identical.
- Repository-version Prettier and diff whitespace checks pass.
- Publication retains Gitleaks and Git identity checks.
- Full pnpm check/build cannot start in this fresh worktree without installed dependencies (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`). Runtime/load checks were not run.

No merge or cluster mutation was performed. Keep draft pending release review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Operations**
  - Reduced production capacity for the response processor, frontend, GraphQL backend, and response API from 8 to 6 replicas.
  - Updated the temporary scaling plan to reflect the lower six-replica target and corresponding resource requirements.
  - Revised documented production capacity estimates to 12 additional pods, 800m CPU, and approximately 7.12Gi memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->