### PR TITLE
ci(playwright): qualify selective drafts against retained full runs

### DIFF
--- a/.github/scripts/playwright-shadow-qualification.py
+++ b/.github/scripts/playwright-shadow-qualification.py
@@ -1,0 +1,495 @@
+"""Assess operator-collected CI evidence offline; local JSON is not attestation."""
+
+import argparse
+import json
+import re
+import stat
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from xml.etree import ElementTree
+
+MAX_FILE_BYTES = 16 * 1024 * 1024
+MAX_TOTAL_BYTES = 256 * 1024 * 1024
+CATEGORIES = {
+    "spec-only",
+    "feature",
+    "shared",
+    "docs",
+    "new-spec",
+    "deleted-spec",
+    "unknown",
+}
+SELECTIVE_CATEGORIES = {"spec-only", "feature", "shared"}
+CONTROL_CATEGORIES = CATEGORIES - SELECTIVE_CATEGORIES
+SHA_FIELDS = ("headSha", "baseSha", "mergeBase", "trustedControlSha")
+COUNT_FIELDS = ("tests", "failures", "errors", "skipped")
+
+
+class EvidenceError(ValueError):
+    def __init__(self, reason, status="hard-rejection"):
+        self.reason = reason
+        self.status = status
+
+
+def require(condition, reason, status="hard-rejection"):
+    if not condition:
+        raise EvidenceError(reason, status)
+
+
+def positive(value):
+    return type(value) is int and value > 0
+
+
+def unique_strings(value, reason, allow_empty=False):
+    require(isinstance(value, list) and len(value) <= 512, reason)
+    require(
+        all(isinstance(item, str) and 0 < len(item) <= 512 for item in value), reason
+    )
+    require(len(value) == len(set(value)) and (value or allow_empty), reason)
+    return set(value)
+
+
+def specs(value, allow_empty=False):
+    result = unique_strings(value, "invalid-specs", allow_empty)
+    require(
+        all(
+            re.fullmatch(r"tests/[A-Za-z0-9_./-]+\.spec\.ts", item)
+            and ".." not in PurePosixPath(item).parts
+            for item in result
+        ),
+        "invalid-specs",
+    )
+    return result
+
+
+def profiles(value):
+    require(isinstance(value, str) and len(value) <= 512, "invalid-profile")
+    parts = value.split(",")
+    require(
+        all(re.fullmatch(r"[a-z][a-z0-9-]*", part) for part in parts)
+        and parts == sorted(set(parts)),
+        "invalid-profile",
+    )
+    return set(parts)
+
+
+def parse_json(data):
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, "duplicate-json-key")
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=pairs,
+            parse_constant=lambda _: require(False, "invalid-json"),
+        )
+    except (UnicodeError, json.JSONDecodeError, RecursionError):
+        raise EvidenceError("invalid-json") from None
+
+
+class Files:
+    def __init__(self, root):
+        self.root = root.resolve()
+        self.total = 0
+
+    def read(self, name):
+        require(
+            isinstance(name, str) and 0 < len(name) <= 1024 and "\\" not in name,
+            "unsafe-path",
+        )
+        path = PurePosixPath(name)
+        require(not path.is_absolute() and ".." not in path.parts, "unsafe-path")
+        try:
+            resolved = (self.root / name).resolve(strict=True)
+            require(resolved.is_relative_to(self.root), "unsafe-path")
+            info = resolved.stat()
+            require(stat.S_ISREG(info.st_mode), "unsafe-path")
+            require(info.st_size <= MAX_FILE_BYTES, "input-limit")
+            with resolved.open("rb") as stream:
+                data = stream.read(MAX_FILE_BYTES + 1)
+        except OSError:
+            raise EvidenceError("missing-file", "missing-evidence") from None
+        self.total += len(data)
+        require(
+            len(data) <= MAX_FILE_BYTES and self.total <= MAX_TOTAL_BYTES, "input-limit"
+        )
+        return data
+
+
+def validate_plan(plan, event, candidates=None):
+    require(isinstance(plan, dict) and plan.get("schemaVersion") == 1, "invalid-plan")
+    require(
+        all(plan.get(key) == event[key] for key in SHA_FIELDS[:3]),
+        "plan-identity-mismatch",
+    )
+    actual = specs(plan.get("candidateSpecs"))
+    require(candidates is None or candidates == actual, "candidate-mismatch")
+    selected = specs(plan.get("selectedSpecs"), True)
+    require(selected <= actual, "selected-spec-mismatch")
+    mode = plan.get("mode")
+    require(
+        isinstance(mode, str) and mode in {"selected", "full", "skip"}, "invalid-mode"
+    )
+    require(
+        (mode == "full" and selected == actual)
+        or (mode == "skip" and not selected)
+        or (mode == "selected" and bool(selected) and selected < actual),
+        "invalid-selection",
+    )
+    assignments = plan.get("profileAssignments")
+    require(
+        isinstance(assignments, dict) and set(assignments) == actual, "profile-mismatch"
+    )
+    for profile in assignments.values():
+        profiles(profile)
+    require(
+        unique_strings(plan.get("selectedProfiles"), "profile-mismatch", True)
+        == {assignments[item] for item in selected},
+        "profile-mismatch",
+    )
+    shards = plan.get("shards")
+    require(isinstance(shards, list) and len(shards) <= 8, "invalid-shards")
+    count = len(shards)
+    require(
+        type(plan.get("shardCount")) is int and plan["shardCount"] == count,
+        "invalid-shards",
+    )
+    require(
+        (mode == "full" and count == 8)
+        or (mode == "skip" and count == 0)
+        or (mode == "selected" and 1 <= count <= 4),
+        "incomplete-shards",
+        "missing-evidence",
+    )
+    partition = set()
+    indexed = {}
+    for shard in shards:
+        require(isinstance(shard, dict), "invalid-shard")
+        index = shard.get("shardIndex")
+        require(
+            positive(index)
+            and index <= count
+            and index not in indexed
+            and type(shard.get("shardTotal")) is int
+            and shard["shardTotal"] == count
+            and shard.get("version") == 1,
+            "invalid-shard",
+        )
+        files = specs(shard.get("files"))
+        require(files <= selected and not files & partition, "shard-partition-mismatch")
+        union = set().union(*(profiles(assignments[item]) for item in files))
+        require(profiles(shard.get("profile")) == union, "shard-profile-mismatch")
+        indexed[index] = files
+        partition |= files
+    require(partition == selected, "shard-partition-mismatch")
+    return actual, selected, indexed
+
+
+def read_junit(data, expected):
+    try:
+        text = data.decode("utf-8-sig")
+        require(
+            "\x00" not in text
+            and not re.search(r"<!\s*(DOCTYPE|ENTITY)\b", text, re.IGNORECASE),
+            "unsafe-xml",
+        )
+        declaration = re.match(r"\s*<\?xml[^?]*\?>", text)
+        if declaration:
+            encoding = re.search(
+                r"encoding\s*=\s*['\"]([^'\"]+)", declaration[0], re.IGNORECASE
+            )
+            require(
+                not encoding or encoding[1].lower() in {"utf-8", "utf8"}, "unsafe-xml"
+            )
+        root = ElementTree.fromstring(text)
+    except (UnicodeError, ElementTree.ParseError, RecursionError):
+        raise EvidenceError("invalid-xml") from None
+    require(
+        root.tag == "testsuites" and all(child.tag == "testsuite" for child in root),
+        "invalid-junit",
+    )
+
+    def declared(node):
+        values = []
+        for key in COUNT_FIELDS:
+            raw = node.get(key, "")
+            require(bool(re.fullmatch(r"[0-9]{1,8}", raw)), "invalid-junit-counts")
+            values.append(int(raw))
+        return values
+
+    totals = [0] * 4
+    seen, failed, exercised = set(), set(), set()
+    for suite in root:
+        name = suite.get("name", "")
+        spec = name if name.startswith("tests/") else f"tests/{name}"
+        require(spec in expected and spec not in seen, "junit-spec-mismatch")
+        seen.add(spec)
+        cases = suite.findall("testcase")
+        require(
+            all(
+                child.tag in {"testcase", "system-out", "system-err", "properties"}
+                for child in suite
+            ),
+            "invalid-junit",
+        )
+        observed = [len(cases), 0, 0, 0]
+        for case in cases:
+            require(
+                all(
+                    child.tag
+                    in {
+                        "failure",
+                        "error",
+                        "skipped",
+                        "system-out",
+                        "system-err",
+                        "properties",
+                    }
+                    for child in case
+                ),
+                "invalid-junit",
+            )
+            outcomes = [
+                len(case.findall(tag)) for tag in ("failure", "error", "skipped")
+            ]
+            require(sum(outcomes) <= 1, "invalid-junit-outcome")
+            for index, count in enumerate(outcomes, 1):
+                observed[index] += count
+        require(declared(suite) == observed, "junit-count-mismatch")
+        totals = [a + b for a, b in zip(totals, observed)]
+        if observed[1] or observed[2]:
+            failed.add(spec)
+        if observed[0] > observed[3]:
+            exercised.add(spec)
+    require(seen == expected, "incomplete-junit", "missing-evidence")
+    require(declared(root) == totals, "junit-count-mismatch")
+    return failed, exercised, totals
+
+
+def evaluate_entry(entry, files):
+    require(isinstance(entry, dict), "invalid-entry")
+    event, run = entry.get("event"), entry.get("fullRun")
+    require(
+        isinstance(event, dict) and isinstance(run, dict),
+        "missing-provenance",
+        "missing-evidence",
+    )
+    require(
+        all(
+            isinstance(event.get(key), str)
+            and re.fullmatch(r"[0-9a-f]{40}", event[key])
+            for key in SHA_FIELDS
+        ),
+        "missing-provenance",
+        "missing-evidence",
+    )
+    repository = event.get("repository")
+    require(
+        isinstance(repository, str)
+        and re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository)
+        and event.get("headRepository") == repository
+        and positive(event.get("pullRequestNumber")),
+        "invalid-provenance",
+    )
+    require(
+        event.get("actualDraft") is True
+        and isinstance(event.get("baseRef"), str)
+        and event["baseRef"] in {"v3", "v3-ai"},
+        "ineligible-event",
+        "missing-evidence",
+    )
+    require(
+        run.get("completed") is True
+        and run.get("mode") == "full"
+        and positive(run.get("runId"))
+        and positive(run.get("runAttempt")),
+        "incomplete-run",
+        "missing-evidence",
+    )
+    require(
+        isinstance(entry.get("category"), str) and entry["category"] in CATEGORIES,
+        "missing-category",
+        "missing-evidence",
+    )
+    artifacts = entry.get("artifacts")
+    require(
+        isinstance(artifacts, list) and len(artifacts) == 10,
+        "incomplete-artifacts",
+        "missing-evidence",
+    )
+    ids, paths, reports, plans = set(), set(), {}, {}
+    for artifact in artifacts:
+        require(
+            isinstance(artifact, dict) and positive(artifact.get("artifactId")),
+            "missing-artifact-identity",
+            "missing-evidence",
+        )
+        require(artifact["artifactId"] not in ids, "duplicate-artifact")
+        ids.add(artifact["artifactId"])
+        require(
+            all(
+                type(artifact.get(key)) is int and artifact[key] == run[key]
+                for key in ("runId", "runAttempt")
+            ),
+            "artifact-identity-mismatch",
+        )
+        require(
+            artifact.get("expired") is False, "expired-artifact", "missing-evidence"
+        )
+        path = artifact.get("path")
+        require(isinstance(path, str) and path not in paths, "duplicate-artifact-path")
+        paths.add(path)
+        kind = artifact.get("kind")
+        require(isinstance(kind, str), "invalid-artifact-kind")
+        if kind == "junit":
+            index = artifact.get("shardIndex")
+            require(
+                positive(index) and index <= 8 and index not in reports,
+                "invalid-report-shard",
+            )
+            reports[index] = path
+        else:
+            require(
+                kind in {"canonical-plan", "shadow-plan"} and kind not in plans,
+                "invalid-artifact-kind",
+            )
+            plans[kind] = parse_json(files.read(path))
+    require(
+        len(plans) == 2 and len(reports) == 8,
+        "incomplete-artifacts",
+        "missing-evidence",
+    )
+    canonical, shadow = plans["canonical-plan"], plans["shadow-plan"]
+    candidates, _, shards = validate_plan(canonical, event)
+    require(canonical["mode"] == "full", "canonical-not-full")
+    _, selected, _ = validate_plan(shadow, event, candidates)
+    require(
+        canonical["profileAssignments"] == shadow["profileAssignments"],
+        "profile-mismatch",
+    )
+    failed, exercised, counts = set(), set(), [0] * 4
+    for index, expected in shards.items():
+        failures, ran, totals = read_junit(files.read(reports[index]), expected)
+        failed |= failures
+        exercised |= ran
+        counts = [a + b for a, b in zip(counts, totals)]
+    missed = failed - selected
+    result = {
+        "repository": repository,
+        "baseRef": event["baseRef"],
+        "pullRequestNumber": event["pullRequestNumber"],
+        "headSha": event["headSha"],
+        "runId": run["runId"],
+        "runAttempt": run["runAttempt"],
+        "category": entry["category"],
+        "fullFailureSpecs": sorted(failed),
+        "fullFailureSpecsOutsideSelected": sorted(missed),
+        "counts": dict(zip(COUNT_FIELDS, counts)),
+        "reasons": [],
+    }
+    if missed:
+        result.update(status="hard-rejection", reasons=["missed-failure"])
+    elif exercised != candidates:
+        result.update(status="missing-evidence", reasons=["unexercised-spec"])
+    elif shadow["mode"] == "full":
+        result["status"] = "full-fallback-control"
+    elif shadow["mode"] == "skip":
+        require(entry["category"] == "docs", "unexpected-skip")
+        result["status"] = "skip-control"
+    else:
+        result["status"] = "eligible-selective"
+    return result
+
+
+def evaluate(manifest_path):
+    path = Path(manifest_path)
+    files = Files(path.parent)
+    manifest = parse_json(files.read(path.name))
+    require(
+        isinstance(manifest, dict)
+        and manifest.get("schemaVersion") == 1
+        and isinstance(manifest.get("entries"), list)
+        and len(manifest["entries"]) <= 128,
+        "invalid-manifest",
+    )
+    results, groups = [], {}
+    for entry in manifest["entries"]:
+        event = entry.get("event", {}) if isinstance(entry, dict) else {}
+        population = (
+            (event.get("repository"), event.get("baseRef"))
+            if isinstance(event, dict)
+            else (None, None)
+        )
+        require(
+            all(value is None or isinstance(value, str) for value in population),
+            "invalid-provenance",
+        )
+        try:
+            result = evaluate_entry(entry, files)
+        except EvidenceError as error:
+            result = {"status": error.status, "reasons": [error.reason]}
+        results.append(result)
+        groups.setdefault(population, []).append(result)
+    cohorts = []
+    for (repository, base), entries in groups.items():
+        eligible, controls, seen = [], set(), set()
+        for result in entries:
+            if result["status"] in {"full-fallback-control", "skip-control"}:
+                controls.add(result["category"])
+            if result["status"] != "eligible-selective":
+                continue
+            key = (result["pullRequestNumber"], result["headSha"])
+            if key not in seen:
+                eligible.append(result)
+                seen.add(key)
+        categories = {result["category"] for result in eligible}
+        missing = sorted(
+            (SELECTIVE_CATEGORIES - categories) | (CONTROL_CATEGORIES - controls)
+        )
+        rejected = any(result["status"] == "hard-rejection" for result in entries)
+        cohorts.append(
+            {
+                "repository": repository,
+                "baseRef": base,
+                "eligibleSelectiveHeads": len(eligible),
+                "missingCategories": missing,
+                "statuses": dict(Counter(result["status"] for result in entries)),
+                "qualified": len(eligible) >= 10 and not missing and not rejected,
+            }
+        )
+    return {
+        "schemaVersion": 1,
+        "offlineOnly": True,
+        "entries": results,
+        "cohorts": cohorts,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    args = parser.parse_args()
+    try:
+        report = evaluate(args.manifest)
+    except EvidenceError as error:
+        print(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "offlineOnly": True,
+                    "status": error.status,
+                    "reasons": [error.reason],
+                }
+            )
+        )
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/playwright-shadow-qualification.py
+++ b/.github/scripts/playwright-shadow-qualification.py
@@ -87,7 +87,9 @@ def parse_json(data):
             object_pairs_hook=pairs,
             parse_constant=lambda _: require(False, "invalid-json"),
         )
-    except (UnicodeError, json.JSONDecodeError, RecursionError):
+    except EvidenceError:
+        raise
+    except (UnicodeError, ValueError, RecursionError):
         raise EvidenceError("invalid-json") from None
 
 
@@ -121,7 +123,12 @@ class Files:
 
 
 def validate_plan(plan, event, candidates=None):
-    require(isinstance(plan, dict) and plan.get("schemaVersion") == 1, "invalid-plan")
+    require(
+        isinstance(plan, dict)
+        and type(plan.get("schemaVersion")) is int
+        and plan["schemaVersion"] == 1,
+        "invalid-plan",
+    )
     require(
         all(plan.get(key) == event[key] for key in SHA_FIELDS[:3]),
         "plan-identity-mismatch",
@@ -176,7 +183,8 @@ def validate_plan(plan, event, candidates=None):
             and index not in indexed
             and type(shard.get("shardTotal")) is int
             and shard["shardTotal"] == count
-            and shard.get("version") == 1,
+            and type(shard.get("version")) is int
+            and shard["version"] == 1,
             "invalid-shard",
         )
         files = specs(shard.get("files"))
@@ -411,7 +419,8 @@ def evaluate(manifest_path):
     manifest = parse_json(files.read(path.name))
     require(
         isinstance(manifest, dict)
-        and manifest.get("schemaVersion") == 1
+        and type(manifest.get("schemaVersion")) is int
+        and manifest["schemaVersion"] == 1
         and isinstance(manifest.get("entries"), list)
         and len(manifest["entries"]) <= 128,
         "invalid-manifest",

--- a/.github/scripts/test_playwright_shadow_qualification.py
+++ b/.github/scripts/test_playwright_shadow_qualification.py
@@ -78,11 +78,6 @@ class Fixture:
         *,
         selected=None,
         failure_specs=(),
-        shadow_run_attempt=None,
-        missing_shard=False,
-        expired=False,
-        unsafe_path=False,
-        unsafe_xml=False,
     ):
         selected = list(
             SPECS
@@ -96,35 +91,28 @@ class Fixture:
         artifact_dir.mkdir()
         descriptors = []
 
-        def add_artifact(
-            artifact_id, kind, path, artifact_attempt=None, expired_value=False
-        ):
+        def add_artifact(kind, path):
             descriptors.append(
                 {
                     "artifactId": self.number * 100 + len(descriptors) + 1,
                     "kind": kind,
                     "path": path,
                     "runId": self.run_id,
-                    "runAttempt": artifact_attempt or self.run_attempt,
-                    "expired": expired_value,
+                    "runAttempt": self.run_attempt,
+                    "expired": False,
                 }
             )
 
         canonical_path = artifact_dir / "canonical.json"
         shadow_path = artifact_dir / "shadow.json"
-        report_ids = []
         shards = []
         for index in range(1, 9):
             shard_specs = [SPECS[index - 1]]
-            report_id = f"junit-{index}"
-            report_ids.append(report_id)
             report_name = f"shard-{index}.xml"
             report_path = artifact_dir / report_name
             xml = _xml_report(shard_specs, failure_specs=failure_specs)
-            if unsafe_xml and index == 1:
-                xml = '<!DOCTYPE testsuites [<!ENTITY bad "x">]>' + xml
             report_path.write_text(xml, encoding="utf-8")
-            add_artifact(report_id, "junit", str(report_path.relative_to(self.root)))
+            add_artifact("junit", str(report_path.relative_to(self.root)))
             descriptors[-1]["shardIndex"] = index
             shards.append(
                 {
@@ -183,20 +171,12 @@ class Fixture:
         shadow_path.write_text(json.dumps(shadow), encoding="utf-8")
         add_artifact(
             "canonical-plan",
-            "canonical-plan",
             str(canonical_path.relative_to(self.root)),
         )
         add_artifact(
             "shadow-plan",
-            "shadow-plan",
             str(shadow_path.relative_to(self.root)),
-            artifact_attempt=shadow_run_attempt,
-            expired_value=expired,
         )
-        if unsafe_path:
-            descriptors[-1]["path"] = "../outside.json"
-        if missing_shard:
-            descriptors.pop(0)
         return {
             "event": self.event,
             "fullRun": {
@@ -220,6 +200,44 @@ def _write_manifest(root, entries):
 
 
 class PlaywrightShadowQualificationTests(unittest.TestCase):
+    def test_boolean_versions_cannot_qualify(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory)
+            entry = fixture.entry(selected=[SPECS[0]])
+            path = _write_manifest(directory, [entry])
+            manifest = json.loads(path.read_text())
+            manifest["schemaVersion"] = True
+            path.write_text(json.dumps(manifest))
+            with self.assertRaises(qualification.EvidenceError) as raised:
+                evaluate(path)
+            self.assertEqual(raised.exception.reason, "invalid-manifest")
+            path = _write_manifest(directory, [entry])
+            plan_path = Path(directory) / entry["artifacts"][-1]["path"]
+            original = plan_path.read_text()
+            for field in ("plan", "shard"):
+                with self.subTest(field=field):
+                    plan = json.loads(original)
+                    if field == "plan":
+                        plan["schemaVersion"] = True
+                    else:
+                        plan["shards"][0]["version"] = True
+                    plan_path.write_text(json.dumps(plan))
+                    result = evaluate(path)["entries"][0]
+                    self.assertEqual(result["status"], "hard-rejection")
+
+    def test_json_conversion_failure_preserves_structured_rejection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"
+            for data, reason in (
+                ('{"schemaVersion":' + "1" * 5000 + "}", "invalid-json"),
+                ('{"schemaVersion":1,"schemaVersion":1}', "duplicate-json-key"),
+            ):
+                with self.subTest(reason=reason):
+                    path.write_text(data, encoding="utf-8")
+                    with self.assertRaises(qualification.EvidenceError) as raised:
+                        evaluate(path)
+                    self.assertEqual(raised.exception.reason, reason)
+
     def test_selective_success_preserves_failure_inside_selection(self):
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(directory)
@@ -242,7 +260,8 @@ class PlaywrightShadowQualificationTests(unittest.TestCase):
     def test_identity_attempt_mismatch_is_hard_rejection(self):
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(directory)
-            entry = fixture.entry(shadow_run_attempt=2)
+            entry = fixture.entry()
+            entry["artifacts"][-1]["runAttempt"] = 2
             report = evaluate(_write_manifest(directory, [entry]))
             self.assertEqual(report["entries"][0]["status"], "hard-rejection")
             self.assertIn("artifact-identity-mismatch", report["entries"][0]["reasons"])
@@ -250,13 +269,15 @@ class PlaywrightShadowQualificationTests(unittest.TestCase):
     def test_missing_shards_and_expired_artifact_are_missing_evidence(self):
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(directory, number=1)
-            entry = fixture.entry(missing_shard=True)
+            entry = fixture.entry()
+            entry["artifacts"].pop(0)
             result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
             self.assertEqual(result["status"], "missing-evidence")
             self.assertIn("incomplete-artifacts", result["reasons"])
 
             fixture = Fixture(directory, number=2)
-            entry = fixture.entry(expired=True)
+            entry = fixture.entry()
+            entry["artifacts"][-1]["expired"] = True
             result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
             self.assertEqual(result["status"], "missing-evidence")
             self.assertIn("expired-artifact", result["reasons"])
@@ -314,13 +335,18 @@ class PlaywrightShadowQualificationTests(unittest.TestCase):
     def test_unsafe_path_and_xml_cannot_qualify(self):
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(directory)
-            entry = fixture.entry(unsafe_path=True)
+            entry = fixture.entry()
+            entry["artifacts"][-1]["path"] = "../outside.json"
             result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
             self.assertEqual(result["status"], "hard-rejection")
             self.assertIn("unsafe-path", result["reasons"])
 
             fixture = Fixture(directory, number=2)
-            entry = fixture.entry(unsafe_xml=True)
+            entry = fixture.entry()
+            report_path = Path(directory) / entry["artifacts"][0]["path"]
+            report_path.write_text(
+                '<!DOCTYPE testsuites [<!ENTITY bad "x">]><testsuites/>'
+            )
             result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
             self.assertEqual(result["status"], "hard-rejection")
             self.assertIn("unsafe-xml", result["reasons"])

--- a/.github/scripts/test_playwright_shadow_qualification.py
+++ b/.github/scripts/test_playwright_shadow_qualification.py
@@ -1,0 +1,411 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+module_spec = importlib.util.spec_from_file_location(
+    "qualification", Path(__file__).with_name("playwright-shadow-qualification.py")
+)
+qualification = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(qualification)
+evaluate = qualification.evaluate
+
+
+SPECS = [f"tests/spec-{index}.spec.ts" for index in range(1, 9)]
+SHA_FIELDS = {
+    "headSha": "a" * 40,
+    "baseSha": "b" * 40,
+    "mergeBase": "c" * 40,
+    "trustedControlSha": "d" * 40,
+}
+
+
+def _xml_report(specs, failure_specs=(), skipped_specs=()):
+    failure_specs = set(failure_specs)
+    skipped_specs = set(skipped_specs)
+    suites = []
+    total = failures = errors = skipped = 0
+    for spec in specs:
+        if spec in failure_specs:
+            suites.append(
+                f'<testsuite name="{spec}" tests="1" failures="1" '
+                'errors="0" skipped="0"><testcase name="case">'
+                "<failure>synthetic failure</failure></testcase></testsuite>"
+            )
+            failures += 1
+        elif spec in skipped_specs:
+            suites.append(
+                f'<testsuite name="{spec}" tests="1" failures="0" '
+                'errors="0" skipped="1"><testcase name="case">'
+                "<skipped /></testcase></testsuite>"
+            )
+            skipped += 1
+        else:
+            suites.append(
+                f'<testsuite name="{spec}" tests="1" failures="0" '
+                'errors="0" skipped="0"><testcase name="case" />'
+                "</testsuite>"
+            )
+        total += 1
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<testsuites tests="{total}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}">'
+        f"{''.join(suites)}</testsuites>"
+    )
+
+
+class Fixture:
+    def __init__(self, root, *, number=1, category="feature", mode="selected"):
+        self.root = Path(root)
+        self.number = number
+        self.category = category
+        self.mode = mode
+        self.run_id = number
+        self.run_attempt = 1
+        self.event = {
+            "repository": "example/repo",
+            "headRepository": "example/repo",
+            "pullRequestNumber": number,
+            "actualDraft": True,
+            "baseRef": "v3",
+            **SHA_FIELDS,
+        }
+
+    def entry(
+        self,
+        *,
+        selected=None,
+        failure_specs=(),
+        shadow_run_attempt=None,
+        missing_shard=False,
+        expired=False,
+        unsafe_path=False,
+        unsafe_xml=False,
+    ):
+        selected = list(
+            SPECS
+            if self.mode == "full"
+            else ([] if self.mode == "skip" else selected or [SPECS[0], SPECS[1]])
+        )
+        assignments = {
+            spec: "chat" if index % 2 else "manage" for index, spec in enumerate(SPECS)
+        }
+        artifact_dir = self.root / f"artifacts-{self.number}"
+        artifact_dir.mkdir()
+        descriptors = []
+
+        def add_artifact(
+            artifact_id, kind, path, artifact_attempt=None, expired_value=False
+        ):
+            descriptors.append(
+                {
+                    "artifactId": self.number * 100 + len(descriptors) + 1,
+                    "kind": kind,
+                    "path": path,
+                    "runId": self.run_id,
+                    "runAttempt": artifact_attempt or self.run_attempt,
+                    "expired": expired_value,
+                }
+            )
+
+        canonical_path = artifact_dir / "canonical.json"
+        shadow_path = artifact_dir / "shadow.json"
+        report_ids = []
+        shards = []
+        for index in range(1, 9):
+            shard_specs = [SPECS[index - 1]]
+            report_id = f"junit-{index}"
+            report_ids.append(report_id)
+            report_name = f"shard-{index}.xml"
+            report_path = artifact_dir / report_name
+            xml = _xml_report(shard_specs, failure_specs=failure_specs)
+            if unsafe_xml and index == 1:
+                xml = '<!DOCTYPE testsuites [<!ENTITY bad "x">]>' + xml
+            report_path.write_text(xml, encoding="utf-8")
+            add_artifact(report_id, "junit", str(report_path.relative_to(self.root)))
+            descriptors[-1]["shardIndex"] = index
+            shards.append(
+                {
+                    "shardIndex": index,
+                    "shardTotal": 8,
+                    "version": 1,
+                    "files": shard_specs,
+                    "profile": assignments[shard_specs[0]],
+                }
+            )
+
+        identity = {key: self.event[key] for key in ("headSha", "baseSha", "mergeBase")}
+        canonical = {
+            "schemaVersion": 1,
+            "kind": "canonical",
+            "mode": "full",
+            **identity,
+            "candidateSpecs": SPECS,
+            "selectedSpecs": SPECS,
+            "profileAssignments": assignments,
+            "selectedProfiles": ["chat", "manage"],
+            "shardCount": 8,
+            "shards": shards,
+        }
+        shadow = {
+            "schemaVersion": 1,
+            "kind": "shadow",
+            "mode": self.mode,
+            **identity,
+            "candidateSpecs": SPECS,
+            "selectedSpecs": [] if self.mode == "skip" else selected,
+            "selectedProfiles": sorted({assignments[spec] for spec in selected}),
+            "profileAssignments": assignments,
+            "shardCount": 0
+            if self.mode == "skip"
+            else (8 if self.mode == "full" else 1),
+            "shards": []
+            if self.mode == "skip"
+            else (
+                shards
+                if self.mode == "full"
+                else [
+                    {
+                        "version": 1,
+                        "shardIndex": 1,
+                        "shardTotal": 1,
+                        "files": selected,
+                        "profile": ",".join(
+                            sorted({assignments[spec] for spec in selected})
+                        ),
+                    }
+                ]
+            ),
+        }
+        canonical_path.write_text(json.dumps(canonical), encoding="utf-8")
+        shadow_path.write_text(json.dumps(shadow), encoding="utf-8")
+        add_artifact(
+            "canonical-plan",
+            "canonical-plan",
+            str(canonical_path.relative_to(self.root)),
+        )
+        add_artifact(
+            "shadow-plan",
+            "shadow-plan",
+            str(shadow_path.relative_to(self.root)),
+            artifact_attempt=shadow_run_attempt,
+            expired_value=expired,
+        )
+        if unsafe_path:
+            descriptors[-1]["path"] = "../outside.json"
+        if missing_shard:
+            descriptors.pop(0)
+        return {
+            "event": self.event,
+            "fullRun": {
+                "runId": self.run_id,
+                "runAttempt": self.run_attempt,
+                "mode": "full",
+                "completed": True,
+            },
+            "candidateSpecs": SPECS,
+            "category": self.category,
+            "artifacts": descriptors,
+        }
+
+
+def _write_manifest(root, entries):
+    path = Path(root) / "manifest.json"
+    path.write_text(
+        json.dumps({"schemaVersion": 1, "entries": entries}), encoding="utf-8"
+    )
+    return path
+
+
+class PlaywrightShadowQualificationTests(unittest.TestCase):
+    def test_selective_success_preserves_failure_inside_selection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory)
+            entry = fixture.entry(selected=[SPECS[0]], failure_specs=[SPECS[0]])
+            report = evaluate(_write_manifest(directory, [entry]))
+            result = report["entries"][0]
+            self.assertEqual(result["status"], "eligible-selective")
+            self.assertEqual(result["fullFailureSpecs"], [SPECS[0]])
+            self.assertEqual(result["fullFailureSpecsOutsideSelected"], [])
+
+    def test_missed_failure_outside_subset_is_hard_rejection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory)
+            entry = fixture.entry(selected=[SPECS[0]], failure_specs=[SPECS[1]])
+            report = evaluate(_write_manifest(directory, [entry]))
+            result = report["entries"][0]
+            self.assertEqual(result["status"], "hard-rejection")
+            self.assertIn("missed-failure", result["reasons"])
+
+    def test_identity_attempt_mismatch_is_hard_rejection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory)
+            entry = fixture.entry(shadow_run_attempt=2)
+            report = evaluate(_write_manifest(directory, [entry]))
+            self.assertEqual(report["entries"][0]["status"], "hard-rejection")
+            self.assertIn("artifact-identity-mismatch", report["entries"][0]["reasons"])
+
+    def test_missing_shards_and_expired_artifact_are_missing_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory, number=1)
+            entry = fixture.entry(missing_shard=True)
+            result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
+            self.assertEqual(result["status"], "missing-evidence")
+            self.assertIn("incomplete-artifacts", result["reasons"])
+
+            fixture = Fixture(directory, number=2)
+            entry = fixture.entry(expired=True)
+            result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
+            self.assertEqual(result["status"], "missing-evidence")
+            self.assertIn("expired-artifact", result["reasons"])
+
+    def test_cohort_deduplicates_heads_and_requires_coverage_controls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entries = []
+            for number in range(1, 10):
+                category = "spec-only" if number == 1 else "feature"
+                entries.append(
+                    Fixture(directory, number=number, category=category).entry()
+                )
+            entries.append(entries[0])
+            report = evaluate(_write_manifest(directory, entries))
+            group = report["cohorts"][0]
+            self.assertFalse(group["qualified"])
+            self.assertEqual(group["eligibleSelectiveHeads"], 9)
+            self.assertEqual(
+                set(group["missingCategories"]),
+                {"shared", "docs", "new-spec", "deleted-spec", "unknown"},
+            )
+            for number, category in enumerate(
+                ("docs", "new-spec", "deleted-spec", "unknown"), 11
+            ):
+                entries.append(
+                    Fixture(
+                        directory,
+                        number=number,
+                        category=category,
+                        mode="skip" if category == "docs" else "full",
+                    ).entry()
+                )
+            different = Fixture(directory, number=15, category="shared")
+            different.event["baseRef"] = "v3-ai"
+            entries.append(different.entry())
+            self.assertTrue(
+                all(
+                    not group["qualified"]
+                    for group in evaluate(_write_manifest(directory, entries))[
+                        "cohorts"
+                    ]
+                )
+            )
+            entries.append(Fixture(directory, number=16, category="shared").entry())
+            self.assertTrue(
+                evaluate(_write_manifest(directory, entries))["cohorts"][0]["qualified"]
+            )
+            entries.append(
+                Fixture(directory, number=17).entry(failure_specs=[SPECS[7]])
+            )
+            self.assertFalse(
+                evaluate(_write_manifest(directory, entries))["cohorts"][0]["qualified"]
+            )
+
+    def test_unsafe_path_and_xml_cannot_qualify(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(directory)
+            entry = fixture.entry(unsafe_path=True)
+            result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
+            self.assertEqual(result["status"], "hard-rejection")
+            self.assertIn("unsafe-path", result["reasons"])
+
+            fixture = Fixture(directory, number=2)
+            entry = fixture.entry(unsafe_xml=True)
+            result = evaluate(_write_manifest(directory, [entry]))["entries"][0]
+            self.assertEqual(result["status"], "hard-rejection")
+            self.assertIn("unsafe-xml", result["reasons"])
+
+    def test_full_fallback_and_documentation_skip_are_controls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            full = Fixture(
+                directory, number=1, category="new-spec", mode="full"
+            ).entry()
+            skipped = Fixture(directory, number=2, category="docs", mode="skip").entry()
+            report = evaluate(_write_manifest(directory, [full, skipped]))
+            self.assertEqual(report["entries"][0]["status"], "full-fallback-control")
+            self.assertEqual(report["entries"][1]["status"], "skip-control")
+
+    def test_skipped_specs_and_inconsistent_counts_do_not_prove_execution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entry = Fixture(directory).entry()
+            report_path = Path(directory) / entry["artifacts"][0]["path"]
+            report_path.write_text(_xml_report([SPECS[0]], skipped_specs=[SPECS[0]]))
+            self.assertEqual(
+                evaluate(_write_manifest(directory, [entry]))["entries"][0]["status"],
+                "missing-evidence",
+            )
+            report_path.write_text(
+                _xml_report([SPECS[0]]).replace('tests="1"', 'tests="2"', 1)
+            )
+            self.assertEqual(
+                evaluate(_write_manifest(directory, [entry]))["entries"][0]["reasons"],
+                ["junit-count-mismatch"],
+            )
+
+    def test_event_identity_and_profile_contract_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entries = []
+            for number, (key, value) in enumerate(
+                (("actualDraft", None), ("actualDraft", False), ("headSha", "z" * 40)),
+                1,
+            ):
+                fixture = Fixture(directory, number=number)
+                entry = fixture.entry()
+                entry["event"][key] = value
+                entry["event"]["selectorPrState"] = "draft"
+                entries.append(entry)
+            entry = Fixture(directory, number=4).entry()
+            path = Path(directory) / entry["artifacts"][-1]["path"]
+            plan = json.loads(path.read_text())
+            plan["shards"][0]["profile"] = "other"
+            path.write_text(json.dumps(plan))
+            entries.append(entry)
+            self.assertTrue(
+                all(
+                    item["status"] != "eligible-selective"
+                    for item in evaluate(_write_manifest(directory, entries))["entries"]
+                )
+            )
+
+    def test_encoded_xml_symlink_escape_and_size_limit_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entries = []
+            for number, data in enumerate(
+                (
+                    b'<?xml version="1.0" encoding="UTF-16"?><testsuites/>',
+                    "<!DOCTYPE testsuites><testsuites/>".encode("utf-16"),
+                ),
+                1,
+            ):
+                entry = Fixture(directory, number=number).entry()
+                (Path(directory) / entry["artifacts"][0]["path"]).write_bytes(data)
+                entries.append(entry)
+            entry = Fixture(directory, number=3).entry()
+            link = Path(directory) / "outside"
+            link.symlink_to(Path(directory).parent)
+            entry["artifacts"][0]["path"] = "outside"
+            entries.append(entry)
+            entry = Fixture(directory, number=4).entry()
+            with (Path(directory) / entry["artifacts"][0]["path"]).open("wb") as stream:
+                stream.truncate(qualification.MAX_FILE_BYTES + 1)
+            entries.append(entry)
+            self.assertTrue(
+                all(
+                    item["status"] == "hard-rejection"
+                    for item in evaluate(_write_manifest(directory, entries))["entries"]
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test Playwright timing aggregation
         run: uv run --no-project --python 3.12 python -m unittest discover -s .github/scripts -p test_update_playwright_timings.py
 
+      - name: Test Playwright shadow qualification
+        run: uv run --no-project --python 3.12 python -m unittest discover -s .github/scripts -p test_playwright_shadow_qualification.py
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -53,6 +53,39 @@ neither Node nor pnpm.
 - **Public ARM64 performance evidence**: The first eight-way run after rollout (`33246023106`, 2026-08-29) scheduled all eight shards simultaneously on distinct `public-pr-arm64-01` through `-08` runners. The restore-only build took 3m59s instead of the prior 7m43s cache-writing build. Shard jobs ranged from 14m30s to 21m24s; the remaining floor was spec structure, led by the 846-second serial live-quiz file. Job summaries report the prepare, build, and shard runner names, while the hosted status job records the selected route and dependency results. GitHub's own step timestamps remain the source for phase duration.
 - **Closed PR execution**: Closing or merging a PR starts a checkout-free GitHub-hosted no-op in that PR's existing execution concurrency group. It cancels obsolete Playwright execution without an Actions write token. The close event does not start preparation, builds, shards, status reporting, or telemetry. Push verification uses a branch-ref key and remains independent. Cancellation is asynchronous; verify actual job termination before counting capacity as recovered. Reopening a PR resumes the normal execution path.
 - **Playwright selector shadow**: The hosted-only preparation step observes open pull-request lifecycle transitions, including conversion back to draft. It checks out trusted `v3` policy code separately from the candidate checkout, treats the candidate as data, computes the exact base-to-head merge-base diff, and uploads a values-free plan artifact. Draft plans propose a selected spec set and one to four timing-balanced shards; ready plans always propose the full eight-shard suite. The existing full execution remains authoritative until the selector has at least ten representative draft comparisons with no unexplained misses. Documentation-only paths may skip in draft mode; unknown, global, malformed, or unavailable inputs fail closed to the full suite. This shadow plan never requests the public runner group.
+
+  Qualify selection against retained results from the same completed full run,
+  not a successful aggregate status alone. Preserve the original canonical and
+  shadow JSON plans and all eight JUnit reports before artifact expiration.
+  Record the repository, PR, actual event draft state, head, base, merge-base,
+  trusted-control revision, run attempt and artifact identities separately.
+  The canonical plan's effective ready-state label is not the event's draft
+  state. Operator-collected metadata is evidence provenance, not a cryptographic
+  attestation of arbitrary local files.
+
+  Keep `v3` and `v3-ai` cohorts separate. Reruns of the same PR head count once;
+  full-fallback and skip controls do not count toward ten selective comparisons.
+  Cancelled, partial, expired or mismatched results cannot qualify. A failed test
+  outside the proposed subset is a missed failure, not a report to discard.
+  Specifications with only skipped tests provide no execution proof. Preserve
+  representative feature, specification and shared-change coverage, and report
+  documentation, new/deleted specification and unknown-change controls separately.
+  Qualification never changes a repository variable or enables the canary.
+
+  Run `python .github/scripts/playwright-shadow-qualification.py <manifest.json>`
+  against an operator-acquired manifest. Its `schemaVersion: 1` contains `entries`.
+  Each entry supplies `event` (the identity fields above), `fullRun` (`runId`,
+  `runAttempt`, `mode: full`, `completed: true`), a change `category`, and ten
+  `artifacts`: one `canonical-plan`, one `shadow-plan`, and eight `junit` entries.
+  Artifact descriptors supply positive numeric `artifactId`, `runId` and
+  `runAttempt`, `expired: false`, and a relative `path` beneath the manifest
+  directory; JUnit descriptors also supply `shardIndex`. Use original producer
+  JSON and XML, not rewritten normalized artifacts. The event's exact field names
+  and synthetic examples live in `test_playwright_shadow_qualification.py`.
+  The command returns per-entry dispositions and separate repository/base cohorts.
+  Exit zero means evaluation completed, not that any cohort qualified; inspect
+  each cohort's `qualified` field. Invalid top-level input exits two.
+
 - **Organization ARM64 pool provisioning**: `util/provision-hetzner-arm64-runner.sh` provisions a fresh or explicitly reset ARM64 VM as either `public-pr-arm64-01` through `-08` or `trusted-arm64-01` through `-04`. A VM may host several isolated runner directories and services while sharing Docker and disk cleanup. `util/provision-public-pr-arm64-pool.sh` runs from an administrator host and provisions runners `01` through `04` on one fresh 16-vCPU, 32-GB VM and `05` through `08` on another. It verifies both remote platforms, pins and verifies the remote provisioner, keeps the short-lived GitHub token out of command arguments and files, proves `runner-admin` SSH before root login is disabled, and verifies every service. The matching runner groups must exist before provisioning and must use selected-repository access. The provisioner deliberately does not enforce GitHub's optional workflow allowlist, so the groups and runners can be created before their final reusable workflows exist. The public group may select only public repositories, while the trusted group may select only private repositories. Before enabling public rollout, restrict the public group to `uzh-bf/klicker-uzh` and the exact `uzh-bf/klicker-uzh/.github/workflows/public-pr-playwright-shards.yml@refs/heads/v3` workflow. Configure trusted repository and workflow restrictions after its workflow exists; neither policy change requires runner reprovisioning. Pool assignment is immutable after provisioning because a persistent runner may retain job data. Every apply downloads the pinned runner archive, verifies its checksum, and compares an existing installation against every packaged file before reuse. The short-lived registration token enters `config.sh` through its supported environment input rather than process arguments. `util/reset-hetzner-arm64-runner-host.sh` supports the one-time conversion of the five dedicated, local-disk hosts created by the earlier Klicker-specific provisioner. It removes runner credentials, work data, the runner account, Docker packages, and all local Docker data while preserving `runner-admin`, SSH hardening, SSH keys, UFW, and OS updates. It is not compromise recovery or secure disk erasure: never use it after untrusted execution or suspected compromise, and never prepare a public-PR host if it has received repository, organization, environment, or external secrets, private data, or private source. Those cases require VM replacement. Public PR services are reachable only inside each job's Docker network, and each Playwright shard uses a run-specific Hatchet volume. The provisioner enables UFW with deny-by-default inbound traffic and OpenSSH as the only inbound allowance. Threshold cleanup removes unused Docker volumes as well as old containers, images, and builder data. Use the VM's local NVMe storage initially and add a protected volume only after monitoring shows sustained disk pressure.
 - **Prisma Schema Drift**: A custom `check:prisma-sync` smoke check compares schema structures in the monorepo against mirrored schemas in `apps/analytics` to enforce database integrity.
 - **Markdown Linter**: `check:agents-md` validates links and command script correctness inside the codebase guide.

--- a/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
+++ b/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
@@ -209,11 +209,12 @@ return structured rejection while duplicate-key reasons remain intact. Slice
 review confirmed that defect and found boolean schema versions accepted as one.
 All three version fields now require exact integers. All 23 Python checks pass.
 The same reviewer confirmed both corrections in `11492485a1` and completed.
-Integrated final review is capability-blocked: Claude returned session-limit
-429 (reset reported at 13:00 Europe/Zurich, September 9); the single configured
-AGY fallback terminated without a review. No third route or reset was used.
-Resume final review when capacity returns, then publish the upper stacked draft
-and verify Actions. All five upper paths remain in scope; no gate is waived.
+Claude final review returned session-limit 429. The user requested AGY fallback.
+AGY's schema flag failed, then headless command permission blocked inspection.
+The same AGY session received the complete immutable source directly, with no
+tool use or permission changes. It returned a source-only pass for all five paths
+at `0f606b3a2f`; main validated its JSON against the shared review schema.
+Publish the upper stacked draft and verify Actions. No gate or rollout is waived.
 The configured Husky
 entrypoint is absent in this worktree; full monorepo build/check hooks are not
 claimed. No hook configuration was changed or bypass flag used.

--- a/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
+++ b/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
@@ -191,13 +191,31 @@ Scoped formatting, diff inspection and secret scanning pass. Slice review is
 done with no findings; simplification removes three redundant test fields and
 assertions. Integrated final review completed; producing-run evidence resolves
 the banner concern, and the cumulative stderr field is explicitly labelled.
-The lower layer is published at88fc9b3258; its exact-head CI is in progress.
-The upper offline qualifier is being implemented separately. The configured Husky
+The lower layer is published at `99e3883238`; executable behavior is unchanged
+from `88fc9b3258`. Its static checks pass. Its exact-head hosted Playwright run
+34333572968 passed seven shards and failed one unchanged Chat streaming-scroll
+assertion on both attempts (533/532 pixels from the expected bottom). The final
+status correctly failed. No blind retry or application change is made here.
+The upper offline qualifier is implemented and wired into the existing Python
+CI checks. Main took over its artifact/provenance integration after the worker's
+initial fixture used a different shape from the real producer; no replacement
+worker was started. Ten qualifier tests and eleven existing timing tests pass.
+The evaluator independently reconciles retained run34321312168: 1050 tests,
+two failures, zero errors, twelve skipped, no missed failure, full-fallback
+control on v3-ai. It does not qualify selective execution. Review is pending.
+The configured Husky
 entrypoint is absent in this worktree; full monorepo build/check hooks are not
 claimed. No hook configuration was changed or bypass flag used.
-No merge, rollout or runner change is performed.
+No merge, rollout or runner change is performed. The separate Devrouter owner
+reports [draft recovery PR67](https://github.com/rschlaefli/devrouter/pull/67)
+at `75b082d`, with 1300 unit tests, clean packed synthetic qualification and
+Linux CI passing.
+This is source evidence only: no release, install or consumer runtime change
+has occurred. Missing stop-baseline repair remains separate; retain runtime data.
 The existing `collect-smart-draft-qualification-evidence` hourly automation is
-active; its completed one-time post-merge observation has been removed. Its evidence and
+paused. The sole PR watcher completed and its handle is gone, but the automation
+approval check rejected reactivation on an overlapping-watcher concern. Do not
+bypass it or create a duplicate monitor. Its evidence and
 cursor live in the old scheduling worktree's ignored
 `project/_local/evidence/2026-09-08-goal-audit/`; do not replace or duplicate it.
 

--- a/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
+++ b/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
@@ -202,7 +202,14 @@ initial fixture used a different shape from the real producer; no replacement
 worker was started. Ten qualifier tests and eleven existing timing tests pass.
 The evaluator independently reconciles retained run34321312168: 1050 tests,
 two failures, zero errors, twelve skipped, no missed failure, full-fallback
-control on v3-ai. It does not qualify selective execution. Review is pending.
+control on v3-ai. It does not qualify selective execution. The simplifier's
+fixture-only reduction preserves the original checks. Main reproduced and
+corrected an unhandled oversized JSON integer conversion: parser failures now
+return structured rejection while duplicate-key reasons remain intact. Slice
+review confirmed that defect and found boolean schema versions accepted as one.
+All three version fields now require exact integers. All 23 Python checks pass.
+The same reviewer `01a08590-f486-7bc2-82e7-30c68657b32a` will check the bounded
+correction, followed by integrated final review and upper stacked draft delivery.
 The configured Husky
 entrypoint is absent in this worktree; full monorepo build/check hooks are not
 claimed. No hook configuration was changed or bypass flag used.
@@ -213,9 +220,9 @@ Linux CI passing.
 This is source evidence only: no release, install or consumer runtime change
 has occurred. Missing stop-baseline repair remains separate; retain runtime data.
 The existing `collect-smart-draft-qualification-evidence` hourly automation is
-paused. The sole PR watcher completed and its handle is gone, but the automation
-approval check rejected reactivation on an overlapping-watcher concern. Do not
-bypass it or create a duplicate monitor. Its evidence and
+active again after an elevated read-only host process check proved that no
+GitHub run/check watcher remained. The automation API confirmed reactivation
+of the same hourly collector; no duplicate monitor was created. Its evidence and
 cursor live in the old scheduling worktree's ignored
 `project/_local/evidence/2026-09-08-goal-audit/`; do not replace or duplicate it.
 

--- a/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
+++ b/project/2026-09-09-pr-5850-ci-reliability-followup-plan.md
@@ -208,8 +208,12 @@ corrected an unhandled oversized JSON integer conversion: parser failures now
 return structured rejection while duplicate-key reasons remain intact. Slice
 review confirmed that defect and found boolean schema versions accepted as one.
 All three version fields now require exact integers. All 23 Python checks pass.
-The same reviewer `01a08590-f486-7bc2-82e7-30c68657b32a` will check the bounded
-correction, followed by integrated final review and upper stacked draft delivery.
+The same reviewer confirmed both corrections in `11492485a1` and completed.
+Integrated final review is capability-blocked: Claude returned session-limit
+429 (reset reported at 13:00 Europe/Zurich, September 9); the single configured
+AGY fallback terminated without a review. No third route or reset was used.
+Resume final review when capacity returns, then publish the upper stacked draft
+and verify Actions. All five upper paths remain in scope; no gate is waived.
 The configured Husky
 entrypoint is absent in this worktree; full monorepo build/check hooks are not
 claimed. No hook configuration was changed or bypass flag used.


### PR DESCRIPTION
## What This Adds

An offline evaluator for deciding whether selective draft Playwright plans have
enough trustworthy comparison evidence. It reads the original canonical plan,
shadow plan and eight JUnit reports, with operator-collected GitHub provenance.
It does not change test selection or activate a canary.

## How It Works

- Reconciles complete full-run results against the proposed selected specs,
  including failures outside selection and specs that never executed.
- Checks matching event, head, base, merge-base, run attempt, artifact identity,
  shard partition and profiles. Keeps v3 and v3-ai cohorts separate.
- Requires ten unique eligible selective heads and representative categories.
  Full fallbacks, expired reports and incomplete evidence cannot count toward ten.
- Bounds local inputs and rejects unsafe paths, XML entities, malformed metadata
  and inconsistent report counts. Uses Python's standard library only.

An operator manifest is a collection receipt, not cryptographic attestation.
The evaluator has no network access or settings-write path. Its successful exit
means evaluation finished; callers must inspect each cohort's `qualified` field.

## Branch Coverage

- Base: `rs/ci-review-execution`, the [review-execution draft](https://github.com/uzh-bf/klicker-uzh/pull/5850).
- Head: `8e53340fe4` (qualifier code unchanged since `11492485a1`).
- The layer covers the evaluator, tests, CI test wiring, documentation and shared
  roadmap progress. Substantive size: 977 added lines, excluding project artifacts.
- This exceeds the initial size estimate because validation covers original
  producer files rather than a normalized test-only format. It remains one
  independently useful evaluator with its behavior tests, not separate layers
  for parsing and verification.

## Review Focus

Failure completeness, identity and cohort boundaries are the important contracts.
No passing unit test or full-fallback observation establishes canary readiness.
Review the distinction between trustworthy collection and offline consistency.

## Verification

Reused qualifier evidence, with unchanged evaluator inputs and code:

- Python 3.12, no-network container: all 23 Playwright Python tests pass.
- Scoped Ruff checks, `git diff --check` and staged Gitleaks pass.
- [Exact-head codebase check](https://github.com/uzh-bf/klicker-uzh/actions/runs/34340957260)
  passed in 4m03s. Producing logs confirm all twelve qualifier tests and eleven
  timing tests executed. Secret scanning, CodeQL and GraphQL status also passed.
- Original retained [full run](https://github.com/uzh-bf/klicker-uzh/actions/runs/34321312168)
  reconciles 1,050 tests, two failures, zero errors and twelve skips. It is a
  v3-ai full-fallback control: zero eligible selective heads, `qualified: false`.

Failed/Warning:

- [Automatic OCR](https://github.com/uzh-bf/klicker-uzh/actions/runs/34340957143)
  reports partial completion: zero findings, one of three selected items timed
  out. Its green job is not complete review evidence; the separate AGY final
  source review remains the local delivery review. No review threads are open.
- Final stack status reports unavailable because both members remain drafts.
  Manual final review was not triggered.

- The lower draft's [hosted Playwright run](https://github.com/uzh-bf/klicker-uzh/actions/runs/34333572968)
  failed an unchanged Chat streaming-scroll assertion on both attempts. This
  remains an explicit CI blocker, not a claimed harmless failure.

Not run:

- New-head Actions results are pending. Local commit hooks now pass: 62 CI
  contracts and 31 launcher tests on pinned Node 24.16.0; 35 build/typecheck
  tasks, seven lint tasks, staged formatting, syncpack, identity and policy
  guards, and Prisma synchronization inside one container execution. No hooks
  were disabled.
- Playwright has no run in the initial upper-layer check set. The upper PR targets
  the lower task branch, not v3; this is not additional Playwright or runner proof.

The lower Chat follow-up is integrated by ordinary merge, without rebasing.
It synchronizes feedback persistence and adds bounded scroll diagnostics while
preserving the original scroll assertion. The earlier local 95-case Chat pass
is not a substitute for new hosted CI evidence.

## Security / Privacy

No dependency, secret, runner restriction, repository setting or test-selection
change. Public artifact contents are not committed. Parser bounds and rejection
behavior have focused tests. Slice-review findings about numeric conversion and
boolean schema versions are corrected and confirmed by the same reviewer.
AGY Gemini 3.8 Flash High reviewed all five changed paths and producer context,
returning no findings; main validated its response against the review schema.
This is source-only review using supplied immutable source after headless tool
permission denied inspection, not reviewer-run verification. No permissions
were changed or bypassed.

## Blocking Before Merge

- Obtain the required manual final review after a human readiness decision;
  automated draft checks pass, but this does not make the stack merge-ready.
- Resolve the failing Chat CI check without weakening coverage or blind retries.
- Human readiness and merge decision; this PR remains draft.

## Follow-Up After Merge

Continue collecting natural comparisons. Keep activation disabled until the
qualification gate is met and a specific canary is separately authorized.


