### PR TITLE
chore(release): prepare 3.4.0-alpha.75

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,16 @@
 - This is a KlickerUZH repository capability, not a GitHub-wide assumption. Verify native stack support before using the workflow in another repository.
 - Final AI review is standing-authorized for all KlickerUZH PRs. Once exact-head CI and ordinary feedback are settled, agents may post `/final-review` for an unstacked PR or ordinary stack layer, and `/final-review-stack` only on the top PR of a verified native stack, without asking again. This approval covers sending the public PR diff to the workflow's configured OpenRouter model and the resulting usage cost; it does not authorize merging, approving, force-pushing, or exposing uncommitted or private data.
 
+## Release preparation
+
+Use the release scripts in the root `package.json` to generate versions and
+`CHANGELOG.md`; never hand-edit package versions or assemble release notes as a
+substitute. For an alpha release, run `pnpm run release:alpha` (preview with
+`pnpm run release:alpha:dry`). The script uses `.versionrc.js` as the authoritative
+version-target list. During PR preparation, pass `--skip.tag` and create the tag
+only at the approved merged release commit. Tag publication and production
+activation remain separately authorized actions.
+
 ## Commands
 
 ### Root-level (from repo root)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,26 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [3.4.0-alpha.75](https://github.com/uzh-bf/klicker-uzh/compare/v3.4.0-alpha.74...v3.4.0-alpha.75) (2026-09-09)
 
+
 ### Bug Fixes
 
-- Restore the shared translation context in production account forms and other frontend consumers ([#5854](https://github.com/uzh-bf/klicker-uzh/pull/5854)).
-- Show retrieved Chat chunks with stable citations and distinguish sources cited in an answer from retrieved material ([#5831](https://github.com/uzh-bf/klicker-uzh/pull/5831), [#5842](https://github.com/uzh-bf/klicker-uzh/pull/5842)).
-- Make focused activity tests repeatable, isolate host and container dependencies, and restore deterministic CI fixtures ([#5835](https://github.com/uzh-bf/klicker-uzh/pull/5835), [#5821](https://github.com/uzh-bf/klicker-uzh/pull/5821), [#5829](https://github.com/uzh-bf/klicker-uzh/pull/5829)).
-- Align the CI planner with Devrouter 0.0.59 ([#5834](https://github.com/uzh-bf/klicker-uzh/pull/5834)).
+* **chat:** distinguish cited sources from retrieved material ([#5842](https://github.com/uzh-bf/klicker-uzh/issues/5842)) ([a0472c6](https://github.com/uzh-bf/klicker-uzh/commit/a0472c6732430ddc35b3372b9292069d3e504acf))
+* **chat:** show retrieved chunks with stable source citations ([#5831](https://github.com/uzh-bf/klicker-uzh/issues/5831)) ([7936b6e](https://github.com/uzh-bf/klicker-uzh/commit/7936b6e51a1158d4b6218aa384f39b5c43462edc))
+* **ci:** align Devrouter planner and repository at 0.0.59 ([#5834](https://github.com/uzh-bf/klicker-uzh/issues/5834)) ([1a270f3](https://github.com/uzh-bf/klicker-uzh/commit/1a270f33053e12d56df6e4536133753edcaae636))
+* **ci:** restore release manifest order and deterministic OLAT fixtures ([#5829](https://github.com/uzh-bf/klicker-uzh/issues/5829)) ([7592bc8](https://github.com/uzh-bf/klicker-uzh/commit/7592bc8e2b246c1a6f5e6883d24968ad022cb3f1))
+* **i18n:** restore shared translation context in production ([#5854](https://github.com/uzh-bf/klicker-uzh/issues/5854)) ([236ecd4](https://github.com/uzh-bf/klicker-uzh/commit/236ecd4fef9c9fddb6f4e6dd252e7e2f2226ddc4))
+* **playwright:** make focused activity runs repeatable ([#5835](https://github.com/uzh-bf/klicker-uzh/issues/5835)) ([cbcede7](https://github.com/uzh-bf/klicker-uzh/commit/cbcede79718e8e60ff04d3f8376ab6a3f4bb64ed))
+* **tooling:** isolate host and container dependencies ([#5821](https://github.com/uzh-bf/klicker-uzh/issues/5821)) ([e3fb987](https://github.com/uzh-bf/klicker-uzh/commit/e3fb9873c98a664987cc48f0ec9bbf51c9337e8a))
 
-### Enhancements
-
-- Improve Chat tracing and use repository-owned prompt templates. Production telemetry remains disabled ([#5761](https://github.com/uzh-bf/klicker-uzh/pull/5761)).
 
 ### Deployment
 
-- Adjust resource requests and replica pools. These configuration changes are already applied in production with the previous application images ([#5840](https://github.com/uzh-bf/klicker-uzh/pull/5840), [#5841](https://github.com/uzh-bf/klicker-uzh/pull/5841)).
+* **prd:** roll out v3.4.0-alpha.74 ([#5830](https://github.com/uzh-bf/klicker-uzh/issues/5830)) ([7f81442](https://github.com/uzh-bf/klicker-uzh/commit/7f81442ad98138f99a88277d59ba06eada2abe9a))
+
+
+### Enhancements
+
+* **chat:** improve Langfuse tracing ([#5761](https://github.com/uzh-bf/klicker-uzh/issues/5761)) ([825a5a5](https://github.com/uzh-bf/klicker-uzh/commit/825a5a55d4b783f480ebfdea832ac5af36a47653))
 
 ## [3.4.0-alpha.74](https://github.com/uzh-bf/klicker-uzh/compare/v3.4.0-alpha.73...v3.4.0-alpha.74) (2026-09-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.4.0-alpha.75](https://github.com/uzh-bf/klicker-uzh/compare/v3.4.0-alpha.74...v3.4.0-alpha.75) (2026-09-09)
+
+### Bug Fixes
+
+- Restore the shared translation context in production account forms and other frontend consumers ([#5854](https://github.com/uzh-bf/klicker-uzh/pull/5854)).
+- Show retrieved Chat chunks with stable citations and distinguish sources cited in an answer from retrieved material ([#5831](https://github.com/uzh-bf/klicker-uzh/pull/5831), [#5842](https://github.com/uzh-bf/klicker-uzh/pull/5842)).
+- Make focused activity tests repeatable, isolate host and container dependencies, and restore deterministic CI fixtures ([#5835](https://github.com/uzh-bf/klicker-uzh/pull/5835), [#5821](https://github.com/uzh-bf/klicker-uzh/pull/5821), [#5829](https://github.com/uzh-bf/klicker-uzh/pull/5829)).
+- Align the CI planner with Devrouter 0.0.59 ([#5834](https://github.com/uzh-bf/klicker-uzh/pull/5834)).
+
+### Enhancements
+
+- Improve Chat tracing and use repository-owned prompt templates. Production telemetry remains disabled ([#5761](https://github.com/uzh-bf/klicker-uzh/pull/5761)).
+
+### Deployment
+
+- Adjust resource requests and replica pools. These configuration changes are already applied in production with the previous application images ([#5840](https://github.com/uzh-bf/klicker-uzh/pull/5840), [#5841](https://github.com/uzh-bf/klicker-uzh/pull/5841)).
+
 ## [3.4.0-alpha.74](https://github.com/uzh-bf/klicker-uzh/compare/v3.4.0-alpha.73...v3.4.0-alpha.74) (2026-09-07)
 
 

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/auth",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "dependencies": {
     "@auth/prisma-adapter": "2.11.2",

--- a/apps/backend-docker/package.json
+++ b/apps/backend-docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/backend-docker",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@klicker-uzh/docs",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "devDependencies": {
     "@docusaurus/core": "~3.8.1",

--- a/apps/frontend-control/package.json
+++ b/apps/frontend-control/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@klicker-uzh/frontend-control",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/client": "3.13.8",

--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@klicker-uzh/frontend-manage",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/client": "3.13.8",

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@klicker-uzh/frontend-pwa",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/client": "3.13.8",

--- a/apps/hatchet-worker-general/package.json
+++ b/apps/hatchet-worker-general/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/hatchet-worker-general",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/hatchet-worker-response-processor/package.json
+++ b/apps/hatchet-worker-response-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/hatchet-worker-response-processor",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/lti/package.json
+++ b/apps/lti/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/lti-service",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/office-addin/package.json
+++ b/apps/office-addin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/office-addin",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "devDependencies": {
     "@rollup/plugin-terser": "~0.4.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@klicker-uzh/monorepo",
   "description": "KlickerUZH instant-class-response system.",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "repository": "uzh-bf/klicker-uzh.git",
   "homepage": "https://www.klicker.uzh.ch/",
   "bugs": "https://github.com/uzh-bf/klicker-uzh/issues",

--- a/packages/grading/package.json
+++ b/packages/grading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/grading",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/graphql",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hatchet/package.json
+++ b/packages/hatchet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/hatchet",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/i18n",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "files": [
     "index.ts",
     "routing.ts",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/markdown",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/next-config",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "files": [
     "index.js"
   ],

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/prisma",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@klicker-uzh/shared-components",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "devDependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/util",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/word-cloud/package.json
+++ b/packages/word-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klicker-uzh/word-cloud",
-  "version": "3.4.0-alpha.74",
+  "version": "3.4.0-alpha.75",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/project/2026-09-09-alpha75-release-preparation.md
+++ b/project/2026-09-09-alpha75-release-preparation.md
@@ -4,7 +4,8 @@
 
 Prepare version `3.4.0-alpha.75` from verified application source
 `236ecd4fef9c9fddb6f4e6dd252e7e2f2226ddc4` on `v3`. This package updates the
-21 version targets declared in `.versionrc.js`, records release notes, and
+21 version targets declared in `.versionrc.js` through `pnpm run release:alpha`,
+generates the changelog, documents the command requirement in `AGENTS.md`, and
 provides the publication and activation checklist. It changes no executable
 application logic, dependencies, database schema, or deployment values.
 
@@ -63,7 +64,8 @@ explicit authority, either in the rollout approval or separately when needed.
 ## Verification of this preparation
 
 No new tests are needed for version metadata and release documentation.
-Validate every configured version target, preserve every other manifest field,
+Run `pnpm run release:alpha --skip.tag --commit-all` for PR preparation; defer
+the tag until the approved merged release commit. Validate every configured version target, preserve every other manifest field,
 check the changelog and document formatting, inspect the exact diff, and scan
 staged content for secrets. Existing exact-candidate CI covers unchanged
 application source. PRD image builds and candidate runtime acceptance remain

--- a/project/2026-09-09-alpha75-release-preparation.md
+++ b/project/2026-09-09-alpha75-release-preparation.md
@@ -1,0 +1,70 @@
+# Alpha 75 release preparation
+
+## Outcome and authority
+
+Prepare version `3.4.0-alpha.75` from verified application source
+`236ecd4fef9c9fddb6f4e6dd252e7e2f2226ddc4` on `v3`. This package updates the
+21 version targets declared in `.versionrc.js`, records release notes, and
+provides the publication and activation checklist. It changes no executable
+application logic, dependencies, database schema, or deployment values.
+
+The user authorized release preparation on September 9. Main owns version
+metadata, verification, and draft PR delivery. A read-only explorer owns
+release-check discovery; an independent reviewer checks the final package.
+This is a light preparation package with a release correctness review.
+Terminal: a reviewed draft PR targeting `v3`. Publishing a release tag,
+merging, and activating production require separate authorization.
+
+## Candidate evidence
+
+- [Exact-candidate Playwright](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349948438): shared build and all eight hosted shards passed.
+- [Codebase checks](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947688), [unit suites](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947858), [GraphQL](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947927), and [OLAT](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947565) passed.
+- [Production translation smoke](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349933376) passed on the translation PR head for PWA and Manage.
+- STG runs the `v3-ai` descendant `7a4648aa931dab207146dd06a54131581ab0a63c`. English/German account forms render and disclosure controls work; anonymous entry checks cover PWA, Assessment, Manage, Control, Auth, and Chat. The user confirms STG works. This is not exact-v3 authenticated Chat or LMS acceptance.
+- Source diff from `v3.4.0-alpha.74` contains no Prisma changes. No migration is introduced by this package.
+
+Production observation on September 9: Argo tracks `v3`, is Synced/Healthy at
+the candidate, and all 15 listed deployments meet desired replica counts.
+Application images remain `v3.4.0-alpha.74`. Current resource configuration is
+therefore already running with the rollback image version. Chat telemetry is
+disabled and must remain disabled through this release.
+
+## Publication and activation sequence
+
+1. Merge this preparation PR only after its checks and review pass. Confirm
+   the resulting commit contains only the reviewed version and documentation
+   delta above the qualified source; requalify any intervening application changes.
+2. With explicit publication approval, create and push `v3.4.0-alpha.75` at
+   that merged release commit. The existing tag-triggered PRD workflows build
+   and publish images. Record each required image digest and producing run;
+   do not change deployment image tags before every required image exists.
+3. Before activation, verify the built production PWA/Manage forms in EN/DE,
+   exercise Chat citation rendering with synthetic content, and verify prompt
+   assets are present with telemetry disabled. Check browser reload/cache
+   behavior. Reuse equivalent existing proof only when the image/configuration
+   and tested contract match. Any missing runtime proof stays an explicit gate.
+4. Prepare a separate deployment PR changing only the 15 production image tags
+   in `deploy/env-uzh-prd/values.yaml` from `v3.4.0-alpha.74` to
+   `v3.4.0-alpha.75`. Preserve resource settings and telemetry configuration.
+   Obtain production activation approval before merging it.
+5. After activation, verify Argo revision, all image digests and readiness,
+   account/LTI entry behavior, synthetic Chat citation behavior, and bounded
+   error evidence. Report results separately from CI or release publication.
+
+## Rollback
+
+Retain the current alpha74 registry digests before activation. The rollback
+source change restores only the 15 production image tags to
+`v3.4.0-alpha.74`; keep the current healthy replica/resource configuration and
+telemetry disabled. Do not revert the entire branch or older resource commits.
+No database reversal is introduced by this release. Rollback activation needs
+explicit authority, either in the rollout approval or separately when needed.
+
+## Verification of this preparation
+
+No new tests are needed for version metadata and release documentation.
+Validate every configured version target, preserve every other manifest field,
+check the changelog and document formatting, inspect the exact diff, and scan
+staged content for secrets. Existing exact-candidate CI covers unchanged
+application source. PRD image builds and candidate runtime acceptance remain
+publication/activation gates, not completed preparation evidence.


### PR DESCRIPTION
## Summary

Prepare `3.4.0-alpha.75` from `v3` application source `236ecd4fef9c9fddb6f4e6dd252e7e2f2226ddc4`. Generate the 21 package versions and changelog using `pnpm run release:alpha --skip.tag --commit-all`, document this required workflow in `AGENTS.md`, and record publication, activation, and rollback gates.

This PR leaves production image tags at `v3.4.0-alpha.74`. Merging it does not publish a tag or activate new images. No application logic, dependency, lockfile, Prisma, or deployment configuration changes.

## Verification

- Current preparation: all 21 manifest diffs contain only the expected version change; deployment values and lockfile unchanged; whitespace and staged Gitleaks checks pass.
- The changelog is generated by standard-version 9.5.0 through the root package script; `AGENTS.md` validation passes. Changelog and project documentation are excluded by the existing Prettier policy.
- The release command used the existing installed release tool with pnpm 11.5.0 and Node 24.16.0 on the host, where Git runs. Its per-run dependency freshness probe was disabled because the isolated worktree has no dependency installation; no repository configuration was changed.
- Reused unchanged-source evidence: [codebase checks](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947688), [eight Playwright shards](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349948438), [unit tests](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947858), [GraphQL](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947927), and [OLAT](https://github.com/uzh-bf/klicker-uzh/actions/runs/34349947565) passed at the application baseline.
- Broad local build/check hooks were not rerun for version-only metadata; focused checks and unchanged-source CI are reused. PR CI remains required.
- No visible UI change in this preparation; screenshots do not apply. STG translation proof belongs to the underlying fix and uses a `v3-ai` descendant.

Substantive diff: 42 changed manifest lines (21 additions and 21 deletions), plus release documentation. Floor exemption: isolated release preparation.

## Blocking Before Merge

Independent preparation review passed on `ca197f5407` with no blocking findings. The subsequent user-requested correction regenerates the changelog through the actual release command and adds its documented requirement; main-session diff and focused checks pass on `eaaf9a43ba`. Required current PR checks must pass. Keep draft until explicitly marked ready.

## Follow-Up After Merge

With separate authorization, publish the release tag at the verified merged commit and verify every required PRD image build and digest. Complete candidate account/Chat smoke checks, then prepare a separate PR changing the 15 production image tags. Production activation remains separately approved. Keep telemetry disabled. Rollback restores only the previous image tags and preserves current healthy resource settings.

## Local Session Artifacts

Worktree: `trees/rs/release-alpha75`. Release checklist: `project/2026-09-09-alpha75-release-preparation.md`. Local review output under ignored `project/_local/reviews/`.

