### PR TITLE
fix(chat): omit duplicate citation page labels

### DIFF
--- a/apps/chat/src/lib/sources/sourceDisplay.ts
+++ b/apps/chat/src/lib/sources/sourceDisplay.ts
@@ -194,6 +194,8 @@ export function getSourceSecondaryLine(
   // video branch above, so this filter is what keeps the two apart.
   if (
     source.labeledPage &&
+    (typeof source.page !== 'number' ||
+      source.labeledPage.trim() !== String(source.page)) &&
     parseLabeledTimestampSeconds(source.labeledPage) === undefined
   ) {
     parts.push(source.labeledPage)

--- a/apps/chat/test/source-display.test.ts
+++ b/apps/chat/test/source-display.test.ts
@@ -155,6 +155,12 @@ describe('getDisplayUrl', () => {
 })
 
 describe('getSourceSecondaryLine', () => {
+  test.each(['36', ' 36 '])('omits an identical page label (%s)', (label) => {
+    expect(
+      getSourceSecondaryLine(source({ page: 36, labeledPage: label }), t)
+    ).toBe(getSourceSecondaryLine(source({ page: 36 }), t))
+  })
+
   test('documents lead with the page', () => {
     expect(
       getSourceSecondaryLine(


### PR DESCRIPTION
## What This Fixes

Show an identical physical page and publisher page label only once in citation cards and previews. Preserve distinct publisher labels, including Roman numerals. No saved-chat payloads, citation URLs, ingestion data, or source names are changed.

<!-- screenshots:start -->
## Screenshots

| Desktop | Mobile |
| --- | --- |
| ![Citation cards on desktop](https://github.com/user-attachments/assets/011e4c6d-da86-4b04-89c3-5aa22e9e87ca) | ![Citation cards on mobile](https://github.com/user-attachments/assets/1d251790-72d5-47cf-af58-70113b5bd340) |

Local synthetic saved conversation, English, September 9; 1440×900 and 390×844. Captured on `94097a8e04` with the identical eight-line patch now isolated here. These are reused rendering checks, not current-base application or staging acceptance. No before capture or German capture is available.
<!-- screenshots:end -->

## Branch Coverage

Base: `v3` at `236ecd4fef`. One focused fix: two files, eight additions. Complete micro bug-fix package under the packaging floor; no historical branch changes included.

## Verification

Reused equivalent-file evidence: 39 source-display tests pass; Biome passes for both changed files. Browser reload retains the synthetic answer and cards, identical labels appear once, and distinct labels remain. Linked website and PDF query strings and anchors remain intact; the uploaded PDF has no external link. Exact two-file diff SHA256: `58eaed24fc68e883e91eb912fa960019596b442a337fc099e272f7bd64272639`.

Current branch: main-session diff review, whitespace check, staged Gitleaks and Git identity checks pass. Broad local build/check hooks were not rerun in this isolated worktree; focused checks above are reused, with full checks left to PR CI. The local test runtime is stopped.

## Blocking Before Merge

Required current-head CI and review must pass. Keep draft pending explicit readiness/merge authorization. Attachment rendering must be verified after publication.

## Follow-Up After Merge

Verify the corrected labels on staging after an independently authorized promotion. Missing indexed document names and extraction fidelity are separate work; this PR does not claim to fix either.

## Local Session Artifacts

Local workstation: `trees/rs/citation-page-label`. Reused capture manifest and images: `trees/rs/citation-origin-provenance/project/_local/page-label-gallery/`.
