### PR TITLE
fix(chat): bring citation page-label correction to v3-ai

### DIFF
--- a/apps/chat/src/lib/sources/sourceDisplay.ts
+++ b/apps/chat/src/lib/sources/sourceDisplay.ts
@@ -194,6 +194,8 @@ export function getSourceSecondaryLine(
   // video branch above, so this filter is what keeps the two apart.
   if (
     source.labeledPage &&
+    (typeof source.page !== 'number' ||
+      source.labeledPage.trim() !== String(source.page)) &&
     parseLabeledTimestampSeconds(source.labeledPage) === undefined
   ) {
     parts.push(source.labeledPage)

--- a/apps/chat/test/source-display.test.ts
+++ b/apps/chat/test/source-display.test.ts
@@ -155,6 +155,12 @@ describe('getDisplayUrl', () => {
 })
 
 describe('getSourceSecondaryLine', () => {
+  test.each(['36', ' 36 '])('omits an identical page label (%s)', (label) => {
+    expect(
+      getSourceSecondaryLine(source({ page: 36, labeledPage: label }), t)
+    ).toBe(getSourceSecondaryLine(source({ page: 36 }), t))
+  })
+
   test('documents lead with the page', () => {
     expect(
       getSourceSecondaryLine(


### PR DESCRIPTION
## What This Fixes

Bring the merged citation page-label correction from #5859 to the staging source branch `v3-ai`. Identical physical and publisher page values appear once; distinct publisher labels remain. Only the eight-line fix is included, not a full `v3` integration.

<!-- screenshots:start -->
## Screenshots

| Desktop | Mobile |
| --- | --- |
| ![Citation cards on desktop](https://github.com/user-attachments/assets/011e4c6d-da86-4b04-89c3-5aa22e9e87ca) | ![Citation cards on mobile](https://github.com/user-attachments/assets/1d251790-72d5-47cf-af58-70113b5bd340) |

Reused local synthetic captures from September 9, English, 1440×900 and 390×844, on `94097a8e04` plus this identical patch. No before/German capture. These demonstrate local rendering, not deployed staging acceptance. Attachment URLs were read back from #5859; forge rendering inspection remains pending.
<!-- screenshots:end -->

## Branch Coverage

Base: `v3-ai` at `7a4648aa93`. One commit, two files, eight additions. Complete micro integration package under the packaging floor. Both resulting files exactly match `v3` commit `7a7884f587`.

## Verification

Current branch: exact-file equivalence, main-session diff review, staged Gitleaks, Git identity and whitespace checks pass. Patch SHA256: `58eaed24fc68e883e91eb912fa960019596b442a337fc099e272f7bd64272639`.

Reused equivalent-file verification from #5859: 39 source-display tests and Biome pass; browser reload preserves the synthetic answer and cards, identical labels render once, and distinct labels remain. Website/PDF query strings and anchors are retained; private upload has no external link.

Broad local build/check hooks were not rerun for this unchanged patch. Current integration CI is required. No local runtime was started for this delivery.

## Blocking Before Merge

Current-head CI and required review must pass. Keep draft pending explicit readiness and merge authorization. Published screenshot rendering remains unverified.

## Follow-Up After Merge

Staging automatic promotion is enabled for `v3-ai`; merging can therefore lead to deployment when its gates pass. Verify the actual deployed revision and card/reload behavior. No saved-chat data, ingestion metadata, source names, or extracted text changes in this PR. Missing indexed names and extraction fidelity remain separate work.

## Local Session Artifacts

Local workstation: `trees/rs/citation-page-label-v3-ai`. Earlier screenshots and upload receipts: `trees/rs/citation-origin-provenance/project/_local/page-label-gallery/`.
