### PR TITLE
docs(agents): define direct feature-branch synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 
 ## Stacked PRs
 
+- To bring `v3` back into `v3-ai` or a similar feature branch, use a normal merge commit on the receiving branch and a normal, non-force push to that branch. Do not open an integration PR or substitute selective cherry-picks for this branch synchronization. This convention applies to integrating `v3` into feature branches, not promoting feature work into `v3`; retain the applicable verification and merge/deployment authorization gates.
 - GitHub stacked PRs are enabled for this repository. Always use `$stacked-change` and `$gh-stack` for larger features: substantial cross-layer or multi-concern work, changes with distinct reviewer audiences or runtime models, and existing large branches that need decomposition. Keep an ordinary single PR for small, cohesive changes only.
 - This is a KlickerUZH repository capability, not a GitHub-wide assumption. Verify native stack support before using the workflow in another repository.
 - Final AI review is standing-authorized for all KlickerUZH PRs. Once exact-head CI and ordinary feedback are settled, agents may post `/final-review` for an unstacked PR or ordinary stack layer, and `/final-review-stack` only on the top PR of a verified native stack, without asking again. This approval covers sending the public PR diff to the workflow's configured OpenRouter model and the resulting usage cost; it does not authorize merging, approving, force-pushing, or exposing uncommitted or private data.


### PR DESCRIPTION
## Summary
Record the requested convention: merge v3 into v3-ai or similar feature branches with a normal merge commit and non-force push, not an integration PR or selective cherry-picks. Promotion into v3 retains existing gates.

## Verification
One documentation line added. Main-session review, whitespace, staged Gitleaks and Git identity checks pass. Complete documentation-only micro package. Broad application hooks not run. No UI or runtime changes; screenshots do not apply.

## Blocking Before Merge
Required CI and explicit merge authorization. No application integration or deployment performed.

## Local Session Artifacts
Local workstation: trees/rs/document-branch-sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for synchronizing the `v3` branch with feature branches, including merge and push conventions.
  * Clarified that existing verification and authorization requirements still apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->