### PR TITLE
chore(deploy): roll out v3.4.0-alpha.75 to production

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -29,7 +29,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.74
+        tag: v3.4.0-alpha.75
       resources:
         requests:
           cpu: 50m
@@ -68,7 +68,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.74
+        tag: v3.4.0-alpha.75
       resources:
         requests:
           cpu: 50m
@@ -107,7 +107,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.74
+        tag: v3.4.0-alpha.75
       resources:
         requests:
           cpu: 50m
@@ -177,7 +177,7 @@ auth:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/auth-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   ingress:
     annotations:
@@ -349,7 +349,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   ingress:
     annotations:
@@ -404,7 +404,7 @@ frontendPWA:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-pwa-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   ingress:
     className: haproxy
@@ -457,7 +457,7 @@ frontendManage:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-manage-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   ingress:
     className: haproxy
@@ -495,7 +495,7 @@ frontendControl:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   autoscaling:
     enabled: false
@@ -564,7 +564,7 @@ backendGraphql:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   appManageSubdomain: manage
   appStudentSubdomain: pwa
@@ -617,7 +617,7 @@ olatApi:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/olat-api-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   autoscaling:
     enabled: false
@@ -690,7 +690,7 @@ lti:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/lti-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
 
   ingress:
     className: haproxy
@@ -722,7 +722,7 @@ responseApi:
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
-    tag: v3.4.0-alpha.74
+    tag: v3.4.0-alpha.75
     pullPolicy: IfNotPresent
 
   autoscaling:
@@ -817,7 +817,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/frontend-assessment-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.74
+      tag: v3.4.0-alpha.75
 
     ingress:
       className: haproxy
@@ -894,7 +894,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.74
+      tag: v3.4.0-alpha.75
 
     appManageSubdomain: manage
     appStudentSubdomain: assessment
@@ -973,7 +973,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.74
+      tag: v3.4.0-alpha.75
 
     ingress:
       className: haproxy


### PR DESCRIPTION
## Summary

Update all 15 production image tags in `deploy/env-uzh-prd/values.yaml` from `v3.4.0-alpha.74` to `v3.4.0-alpha.75`. The release tag points to `44e3bcdbb1de6b629b097d0150d0d21f414ea530` and contains the translation-context fix and the other changes documented in the release preparation.

Resource requests, replica counts, telemetry settings, and all other values remain unchanged. Staging values are unchanged. This is a one-file, 30-line values-only patch.

**Merging this PR activates production through Argo, which tracks `v3`. Keep draft until build and verification gates pass and production activation is explicitly approved.**

## Verification

Helm lint and production rendering pass. Exact replacement check confirms only the 15 image tags change. Whitespace and staged Gitleaks checks pass. Application build/typecheck hooks were not repeated for this declarative-only diff; focused Helm validation covers the changed surface.

The [release preparation PR](https://github.com/uzh-bf/klicker-uzh/pull/5858) records source verification. The translation fix works on STG, with the full staging Playwright run passing. This is not a claim of production-image smoke acceptance.

## Blocking Before Merge

- The [backend production image workflow](https://github.com/uzh-bf/klicker-uzh/actions/runs/34364987227) is still queued; the other 12 release build workflows passed at the latest check. Verify all required image digests exist.
- Complete production-image account/Chat smoke checks and applicable deployment review.
- Required PR checks and explicit production activation approval.

## Rollout and rollback

After authorized merge, verify Argo sync, deployed image digests, all 15 deployments ready, account/LTI entry behavior, and bounded error evidence. Keep Chat telemetry disabled.

Rollback restores only these 15 image tags to `v3.4.0-alpha.74`, preserving current resource settings. No new Prisma migration is introduced by this release. Rollback activation requires explicit authority.
