### PR TITLE
fix(chat): register Langfuse telemetry before chat turns

### DIFF
--- a/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
+++ b/apps/chat/src/app/api/chatbots/[chatbotId]/chat/route.ts
@@ -41,6 +41,7 @@ import {
   getLangfuseAiSdkIntegration,
   isAiTelemetryEnabled,
   LANGFUSE_CHAT_TRACE_NAME,
+  registerLangfuseTelemetry,
 } from '@/src/lib/server/langfuseTracing'
 import {
   REQUIRED_MCP_UNAVAILABLE_CODE,
@@ -550,6 +551,7 @@ export async function POST(
   const { chatbotId } = await params
   const requestId = randomUUID()
   const requestStartedAtMs = Date.now()
+  await registerLangfuseTelemetry()
   const authResult = await withChatbotAuth(req, chatbotId)
   if ('response' in authResult) {
     return authResult.response


### PR DESCRIPTION
## Problem

Staging Chat was not emitting Langfuse traces for chat turns. The Next.js instrumentation hook is compiled in Turbopack standalone builds, but its registered hook is not wired into the deployed route module. Consequently, telemetry registration never ran before the first chat turn, so spans were created without an active Langfuse provider.

## Change

- Import the existing idempotent telemetry initializer in the chat API route.
- Await it at the start of each `POST` request, before authentication and response generation, so the trace is created in the same module graph that emits its spans.

## Validation

- Biome reports no new issues for the touched route; remaining output consists of pre-existing warnings.
- `tsc --noEmit` passes for `apps/chat` (4,245 files checked).
- CI is authoritative for the complete repository checks.
- After the staging image deploys, I will send one synthetic chat message and confirm that its exact `generate-chat-response` trace appears in Langfuse.

## Side findings for staging operations

- Staging Infisical currently points Chat at `langfuse.df-app.ch`, which is the production v4 Langfuse instance. Staging also has `langfuse-v4.stg.df-app.ch` available. We should confirm whether staging is intended to send telemetry to production or should target the staging instance.
- The LiteLLM Python exporters are being rejected with `Invalid credentials` by the production v4 Langfuse API; their credentials need separate follow-up.

Screenshots do not apply: this is a server-side telemetry initialization change with no visible UI effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added telemetry registration at the start of chat requests to improve request tracing and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->