### PR TITLE
chore(deploy): pin PRD components to v3.4.0-alpha.75-ai.1

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -29,7 +29,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-general-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.75
+        tag: v3.4.0-alpha.75-ai.1
       resources:
         requests:
           cpu: 50m
@@ -68,7 +68,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.75
+        tag: v3.4.0-alpha.75-ai.1
       resources:
         requests:
           cpu: 50m
@@ -107,7 +107,7 @@ hatchet:
       image:
         repository: ghcr.io/uzh-bf/klicker-uzh/hatchet-worker-response-processor-arm
         pullPolicy: IfNotPresent
-        tag: v3.4.0-alpha.75
+        tag: v3.4.0-alpha.75-ai.1
       resources:
         requests:
           cpu: 50m
@@ -177,7 +177,7 @@ auth:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/auth-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   ingress:
     annotations:
@@ -349,7 +349,7 @@ chat:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/chat-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   ingress:
     annotations:
@@ -404,7 +404,7 @@ frontendPWA:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-pwa-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   ingress:
     className: haproxy
@@ -457,7 +457,7 @@ frontendManage:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-manage-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   ingress:
     className: haproxy
@@ -495,7 +495,7 @@ frontendControl:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/frontend-control-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   autoscaling:
     enabled: false
@@ -564,7 +564,7 @@ backendGraphql:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   appManageSubdomain: manage
   appStudentSubdomain: pwa
@@ -617,7 +617,7 @@ olatApi:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/olat-api-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   autoscaling:
     enabled: false
@@ -690,7 +690,7 @@ lti:
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/lti-arm
     pullPolicy: IfNotPresent
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
 
   ingress:
     className: haproxy
@@ -722,7 +722,7 @@ responseApi:
 
   image:
     repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
-    tag: v3.4.0-alpha.75
+    tag: v3.4.0-alpha.75-ai.1
     pullPolicy: IfNotPresent
 
   autoscaling:
@@ -817,7 +817,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/frontend-assessment-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.75
+      tag: v3.4.0-alpha.75-ai.1
 
     ingress:
       className: haproxy
@@ -894,7 +894,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.75
+      tag: v3.4.0-alpha.75-ai.1
 
     appManageSubdomain: manage
     appStudentSubdomain: assessment
@@ -973,7 +973,7 @@ assessment:
     image:
       repository: ghcr.io/uzh-bf/klicker-uzh/response-api-arm
       pullPolicy: IfNotPresent
-      tag: v3.4.0-alpha.75
+      tag: v3.4.0-alpha.75-ai.1
 
     ingress:
       className: haproxy


### PR DESCRIPTION
## Problem

PRD klicker components are pinned to `v3.4.0-alpha.75`, which predates the AI/KB features on `v3-ai` (KB ingestion worker, doc-query tooling, pinned-lookup fixes) and is missing the post-tag v3 fixes (chat citation, manage fixes).

## Change

Single file: `deploy/env-uzh-prd/values.yaml` — 15 `tag: v3.4.0-alpha.75` lines become `tag: v3.4.0-alpha.75-ai.1` (no other keys touched).

## Evidence

- Tag `v3.4.0-alpha.75-ai.1` points at `2c78bd1392` = `v3-ai` sync of `origin/v3` (`294e3f9f`), conflicts resolved to preserve both branches' features; the two chat MCP seed scripts are byte-identical to v3.
- Tag push triggered the PRD component image builds (queued/running at PR creation time); merge should wait for those builds to be green.
- Rollback: revert this commit to restore the `v3.4.0-alpha.75` pins.

## Gates

Draft PR. Merge authority is explicit: merging rolls the 15 PRD klicker components to the new images via Argo.