### PR TITLE
fix(chat): identify Langfuse spans with an explicit OTel service name

### DIFF
--- a/apps/chat/src/lib/server/langfuseTracing.ts
+++ b/apps/chat/src/lib/server/langfuseTracing.ts
@@ -224,7 +224,12 @@ export async function registerLangfuseTelemetry() {
         mask: maskLangfuseData,
       })
     )
-    const sdk = new NodeSDK({ spanProcessors: [processor] })
+    const sdk = new NodeSDK({
+      // Identifies spans in Langfuse as coming from the chat app; without an
+      // explicit name the exporter reports the generic unknown_service:node.
+      serviceName: 'klicker-chat',
+      spanProcessors: [processor],
+    })
 
     try {
       sdk.start()

--- a/apps/chat/test/langfuse-tracing.test.ts
+++ b/apps/chat/test/langfuse-tracing.test.ts
@@ -113,6 +113,7 @@ describe('Langfuse telemetry configuration', () => {
       secretKey: 'sk-lf-test',
     })
     expect(telemetryMocks.sdkOptions).toMatchObject({
+      serviceName: 'klicker-chat',
       spanProcessors: [expect.any(Object)],
     })
     expect(telemetryMocks.sdkStart).toHaveBeenCalledOnce()


### PR DESCRIPTION
## Problem

Chat spans exported to Langfuse all show unknown_service:node as their OTel service name, so observations cannot be filtered by originating service.

## Change

- Register the OpenTelemetry NodeSDK in apps/chat/src/lib/server/langfuseTracing.ts with an explicit serviceName: klicker-chat.
- Assert the value in the existing registration test.

## Testing

- pnpm vitest run test/langfuse-tracing.test.ts — 8/8 passing.
- Biome format clean on both files.
- Full pnpm run build and pnpm check could not run in the temporary bare clone used for this change (partial install, unrelated workspace builds fail); CI at the exact head provides the authoritative typecheck and build evidence.
