### PR TITLE
fix(deploy): configure KB ingestion for PRD hatchet worker

### DIFF
--- a/deploy/charts/klicker-uzh-v3/templates/cm-hatchet-workers.yaml
+++ b/deploy/charts/klicker-uzh-v3/templates/cm-hatchet-workers.yaml
@@ -8,6 +8,19 @@ metadata:
 data:
   HATCHET_CLIENT_TLS_STRATEGY: {{ .Values.hatchet.client.tlsStrategy | quote }}
   HATCHET_API_URL: {{ .Values.hatchet.client.apiUrl | quote }}
+  {{- if .Values.hatchet.kbIngestion }}
+  {{- if .Values.hatchet.kbIngestion.workerDisabled }}
+  KB_INGESTION_WORKER_DISABLED: {{ .Values.hatchet.kbIngestion.workerDisabled | quote }}
+  {{- end }}
+  KB_INGESTION_API_URL: {{ .Values.hatchet.kbIngestion.apiUrl | quote }}
+  KB_INGESTION_PROJECT_ID: {{ .Values.hatchet.kbIngestion.projectId | quote }}
+  KB_SOURCE_GATEWAY_URL: {{ .Values.hatchet.kbIngestion.sourceGatewayUrl | quote }}
+  {{- end }}
+  {{- if .Values.hatchet.kbGraph }}
+  {{- if .Values.hatchet.kbGraph.disabled }}
+  KB_GRAPH_DISABLED: {{ .Values.hatchet.kbGraph.disabled | quote }}
+  {{- end }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -22,6 +22,12 @@ hatchet:
   client:
     tlsStrategy: 'none'
     apiUrl: 'http://app-hatchet-svc-api.prd-hatchet-svc.svc.cluster.local:8080'
+  kbIngestion:
+    apiUrl: 'http://ingestion-resource-api.prd-ingestion.svc.cluster.local:8000'
+    sourceGatewayUrl: 'http://app-klicker-klicker-uzh-v2-backend-graphql.prd-klicker.svc.cluster.local:3000'
+    workerDisabled: false
+  kbGraph:
+    disabled: true
   workers:
     general:
       replicaCount: 4


### PR DESCRIPTION
## Problem
PRD `hatchet-worker-general` pods are crash-looping since 2026-09-10 03:57Z (77-78 restarts each; one pre-ai.1 pod still serving) with FATAL `KB_INGESTION_API_URL must be configured`. The PRD worker secret already carries `KB_INGESTION_API_KEY`, which makes `hasKBIngestionConfiguration` true, so the worker requires the full ingestion config; but the `v3` branch chart has no KB env wiring and `deploy/env-uzh-prd/values.yaml` has no `hatchet.kbIngestion` block (that wiring exists only on `stg-release`/`v3-ai` so far).

## Change
- `deploy/charts/klicker-uzh-v3/templates/cm-hatchet-workers.yaml`: nil-safe, guarded KB ingestion env block for the general worker (mirrors the `stg-release`/`v3-ai` wiring), plus a guarded `KB_GRAPH_DISABLED` passthrough so environments can explicitly disable the KB graph lane.
- `deploy/env-uzh-prd/values.yaml`: adds `hatchet.kbIngestion` (apiUrl `http://ingestion-resource-api.prd-ingestion.svc.cluster.local:8000`, sourceGatewayUrl `http://app-klicker-klicker-uzh-v2-backend-graphql.prd-klicker.svc.cluster.local:3000`, workerDisabled false) and `hatchet.kbGraph.disabled: true` (KB graph/KG lane stays out of PRD scope).

## Evidence
- `helm template` with PRD values: RC 0; worker-general ConfigMap renders `KB_INGESTION_API_URL`, `KB_SOURCE_GATEWAY_URL`, `KB_GRAPH_DISABLED: "true"`, and no `KB_INGESTION_WORKER_DISABLED`.
- Guard control: rendering `env-uzh-stg/values.yaml` (no KB blocks) against the modified chart is byte-identical to rendering against the pristine `origin/v3` chart - zero behavior change for consumers without the block.
- Deployed ai.1 gate logic: `validateKBIngestionWorkerConfig(required: true)` needs `KB_INGESTION_API_URL` + `KB_INGESTION_API_KEY` (secret) + `KB_SOURCE_GATEWAY_URL`; `validateKBGraphWorkerConfig` would also FATAL because the PRD worker secret carries `KB_GRAPH_HATCHET_CLIENT_TOKEN`, so `KB_GRAPH_DISABLED: "true"` is required to keep the graph lane off.
- Values-free PRD readback: backend-graphql secret already contains `KB_SOURCE_GATEWAY_KEY`/`KB_WEBHOOK_SECRET`; worker-general secret contains `KB_INGESTION_API_KEY`.

## Merge effects
On merge, the PRD `app-klicker` Argo app auto-syncs and the Reloader pod annotation restarts `hatchet-worker-general`; the pre-ai.1 worker rolls onto the pinned `v3.4.0-alpha.75-ai.1` image with the fixed ConfigMap. Merge is separately gated. If stabilization without activation is preferred, the one-line fallback is `hatchet.kbIngestion.workerDisabled: true`.
