### PR TITLE
fix(manage): match course title link styling to element/activity titles

### DIFF
--- a/apps/frontend-manage/src/components/courses/CourseListButton.tsx
+++ b/apps/frontend-manage/src/components/courses/CourseListButton.tsx
@@ -219,7 +219,7 @@ function CourseListButton({
             {icon ? <FontAwesomeIcon icon={icon} /> : null}
             <Link
               href={`/courses/${course.id}`}
-              className="text-primary-100 min-w-0 break-all hover:underline focus:outline-none focus-visible:underline"
+              className="hover:text-uzh-blue-100 min-w-0 break-all font-bold focus:outline-none focus-visible:underline"
               data-cy={data?.cy}
               data-test={data?.test}
             >


### PR DESCRIPTION
## Description

On the course overview page, each course card title is a link to the course details, but it was styled as a primary link: blue by default (`text-primary-100`, #0028a5) and underlined on hover. Clickable element and activity titles use a different convention: bold, the default text color, and blue on hover (`font-bold hover:text-uzh-blue-100`). A course title therefore read as an inline help link instead of the entity title that the rest of the app uses.

The course title link now follows the element/activity title convention. The keyboard focus affordance (`focus:outline-none focus-visible:underline`) and the wrapping behaviour for long course names (`min-w-0 break-all`) are unchanged.

## Proposed Changes

- `apps/frontend-manage/src/components/courses/CourseListButton.tsx`: on the course title link, drop `text-primary-100` and `hover:underline` and add `font-bold` and `hover:text-uzh-blue-100`.

## How to Test & Verification Evidence

Open the course overview page in frontend-manage and compare a course title with a clickable element or activity title: all three should be bold, keep the default text color, and turn blue on hover.

### Automated Verification

- [x] Biome format check on the changed file with the repository config (no reformat needed)
- [ ] Run `pnpm run check:all` (linting, typechecking, formatting, syncpack)
- [ ] Run target unit tests (`pnpm --filter <package> test`)

### Manual/Visual Verification

Pending. Before/after browser captures have not been taken yet: this session could not start the local runtime (the sandbox blocks `ps`, so `devrouter` cannot reconcile a runtime), so no app instance was available for `agent-browser`. The change is a one-line class swap reviewed as a diff; the rendered before/after still needs to be captured before this PR leaves draft.

### Codebase Notes & Quality Check

- [x] Updated CODEBASE_NOTES.md if any new gotchas, architectural patterns, or non-obvious constraints were introduced/modified? (N/A)
