### PR TITLE
fix(ci): require explicit staging source selection

### DIFF
--- a/.github/scripts/stg-release-promoter.test.js
+++ b/.github/scripts/stg-release-promoter.test.js
@@ -218,7 +218,12 @@ function refGithub(
 }
 
 test('requires the trusted workflow to resolve the selected source branch', () => {
-  assert.equal(getSourceBranch('v3'), 'v3')
+  assert.equal(getSourceBranch('v3-audit'), 'v3-audit')
+  assert.throws(() => getSourceBranch(''), /approved push triggers/)
+  assert.throws(
+    () => getSourceBranch('v3-audit/unsafe'),
+    /approved push triggers/
+  )
   assert.throws(() => getSourceBranch(), /resolved by the trusted workflow/)
   assert.throws(() => getSourceBranch('main'), /approved push triggers/)
 })

--- a/.github/scripts/validate-prd-candidate.cjs
+++ b/.github/scripts/validate-prd-candidate.cjs
@@ -9,6 +9,7 @@ function validateProductionCandidate({
   approvedSha,
   receiptBytes,
   approvedReceiptSha256,
+  expectedWorkloads,
 }) {
   assert.match(
     approvedSha || '',
@@ -70,6 +71,17 @@ function validateProductionCandidate({
       'artifact must be pinned by digest'
     )
   }
+  assert.ok(
+    Array.isArray(expectedWorkloads) && expectedWorkloads.length > 1,
+    'an independently selected complete workload inventory is required'
+  )
+  assert.equal(new Set(expectedWorkloads).size, expectedWorkloads.length)
+  assert.deepEqual(
+    [...names].sort(),
+    [...expectedWorkloads].sort(),
+    'artifacts must exactly match the approved workload inventory'
+  )
+  assert.ok(names.has('backend'), 'backend application digest is required')
   assert.ok(names.has('migrator'), 'migrator digest is required')
   return receipt
 }
@@ -81,6 +93,9 @@ if (require.main === module) {
       approvedSha: process.env.PRD_APPROVED_MAINTENANCE_SHA,
       approvedReceiptSha256: process.env.PRD_APPROVED_RECEIPT_SHA256,
       receiptBytes: fs.readFileSync(process.argv[2]),
+      expectedWorkloads: JSON.parse(
+        process.env.PRD_APPROVED_WORKLOADS_JSON || 'null'
+      ),
     })
     console.log(
       'Exact production candidate receipt validated; deployment remains separately authorized.'

--- a/.github/scripts/validate-prd-candidate.cjs
+++ b/.github/scripts/validate-prd-candidate.cjs
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict')
+const { createHash } = require('node:crypto')
+const fs = require('node:fs')
+
+// Approval comes from the operator's independent receipt selection, never from
+// candidate ancestry, a tag pattern, or a field that the candidate approves itself.
+function validateProductionCandidate({
+  candidateSha,
+  approvedSha,
+  receiptBytes,
+  approvedReceiptSha256,
+}) {
+  assert.match(
+    approvedSha || '',
+    /^[a-f0-9]{40}$/,
+    'an exact approved maintenance SHA is required'
+  )
+  assert.equal(
+    candidateSha,
+    approvedSha,
+    'candidate differs from the approved maintenance snapshot'
+  )
+  assert.match(
+    approvedReceiptSha256 || '',
+    /^[a-f0-9]{64}$/,
+    'an independently approved receipt hash is required'
+  )
+  assert.equal(
+    createHash('sha256').update(receiptBytes).digest('hex'),
+    approvedReceiptSha256,
+    'receipt differs from operator approval'
+  )
+  const receipt = JSON.parse(receiptBytes)
+  assert.equal(
+    receipt.sourceBranch,
+    'v3-ai',
+    'production candidates must come from maintenance'
+  )
+  assert.equal(
+    receipt.sourceSha,
+    candidateSha,
+    'receipt source differs from candidate'
+  )
+  for (const key of [
+    'configurationSha256',
+    'migrationInventorySha256',
+    'capabilityStateSha256',
+  ]) {
+    assert.match(
+      receipt[key] || '',
+      /^[a-f0-9]{64}$/,
+      `${key} must bind the reviewed state`
+    )
+  }
+  assert.ok(
+    Array.isArray(receipt.artifacts) && receipt.artifacts.length > 1,
+    'application and migrator artifact identities are required'
+  )
+  const names = new Set()
+  for (const artifact of receipt.artifacts) {
+    assert.ok(
+      typeof artifact.workload === 'string' && artifact.workload.length > 0,
+      'workload identity is required'
+    )
+    assert.ok(!names.has(artifact.workload), 'duplicate workload identity')
+    names.add(artifact.workload)
+    assert.match(
+      artifact.image || '',
+      /^ghcr\.io\/uzh-bf\/klicker-uzh\/[a-z0-9-]+@sha256:[a-f0-9]{64}$/,
+      'artifact must be pinned by digest'
+    )
+  }
+  assert.ok(names.has('migrator'), 'migrator digest is required')
+  return receipt
+}
+
+if (require.main === module) {
+  try {
+    validateProductionCandidate({
+      candidateSha: process.env.CANDIDATE_SHA,
+      approvedSha: process.env.PRD_APPROVED_MAINTENANCE_SHA,
+      approvedReceiptSha256: process.env.PRD_APPROVED_RECEIPT_SHA256,
+      receiptBytes: fs.readFileSync(process.argv[2]),
+    })
+    console.log(
+      'Exact production candidate receipt validated; deployment remains separately authorized.'
+    )
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}
+
+module.exports = { validateProductionCandidate }

--- a/.github/scripts/validate-prd-candidate.test.cjs
+++ b/.github/scripts/validate-prd-candidate.test.cjs
@@ -23,6 +23,7 @@ function fixture(overrides = {}) {
   }
   const receiptBytes = Buffer.from(JSON.stringify(receipt))
   return {
+    expectedWorkloads: ['backend', 'migrator'],
     candidateSha: 'a'.repeat(40),
     approvedSha: 'a'.repeat(40),
     receiptBytes,
@@ -77,4 +78,29 @@ test('rejects changed configuration, missing migrator and mutable image tags', (
       })
     )
   )
+})
+
+test('rejects an arbitrary artifact in place of the backend application', () => {
+  const input = fixture()
+  const receipt = JSON.parse(input.receiptBytes)
+  receipt.artifacts[0].workload = 'unrelated'
+  assert.throws(() => validateProductionCandidate(fixture(receipt)))
+})
+
+test('requires an independent complete workload inventory', () => {
+  assert.throws(() => validateProductionCandidate({
+    ...fixture(), expectedWorkloads: undefined,
+  }))
+  assert.throws(() => validateProductionCandidate({
+    ...fixture(), expectedWorkloads: ['backend', 'migrator', 'chat'],
+  }))
+  assert.throws(() => validateProductionCandidate({
+    ...fixture(), expectedWorkloads: ['backend', 'migrator', 'migrator'],
+  }))
+  const receipt = JSON.parse(fixture().receiptBytes)
+  receipt.artifacts.push({
+    workload: 'unexpected',
+    image: `ghcr.io/uzh-bf/klicker-uzh/chat-arm@sha256:${'e'.repeat(64)}`,
+  })
+  assert.throws(() => validateProductionCandidate(fixture(receipt)))
 })

--- a/.github/scripts/validate-prd-candidate.test.cjs
+++ b/.github/scripts/validate-prd-candidate.test.cjs
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict')
+const { createHash } = require('node:crypto')
+const test = require('node:test')
+const { validateProductionCandidate } = require('./validate-prd-candidate.cjs')
+function fixture(overrides = {}) {
+  const receipt = {
+    sourceBranch: 'v3-ai',
+    sourceSha: 'a'.repeat(40),
+    configurationSha256: 'b'.repeat(64),
+    migrationInventorySha256: 'c'.repeat(64),
+    capabilityStateSha256: 'd'.repeat(64),
+    artifacts: [
+      {
+        workload: 'backend',
+        image: `ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm@sha256:${'e'.repeat(64)}`,
+      },
+      {
+        workload: 'migrator',
+        image: `ghcr.io/uzh-bf/klicker-uzh/backend-docker-migrator-arm@sha256:${'f'.repeat(64)}`,
+      },
+    ],
+    ...overrides,
+  }
+  const receiptBytes = Buffer.from(JSON.stringify(receipt))
+  return {
+    candidateSha: 'a'.repeat(40),
+    approvedSha: 'a'.repeat(40),
+    receiptBytes,
+    approvedReceiptSha256: createHash('sha256')
+      .update(receiptBytes)
+      .digest('hex'),
+  }
+}
+test('accepts only the exact independently selected maintenance receipt', () => {
+  assert.equal(validateProductionCandidate(fixture()).sourceSha, 'a'.repeat(40))
+})
+test('rejects missing approval and different descendants even with a release tag', () => {
+  assert.throws(() =>
+    validateProductionCandidate({ ...fixture(), approvedSha: undefined })
+  )
+  assert.throws(() =>
+    validateProductionCandidate({ ...fixture(), candidateSha: '9'.repeat(40) })
+  )
+  assert.throws(() =>
+    validateProductionCandidate({
+      ...fixture(),
+      approvedReceiptSha256: undefined,
+    })
+  )
+})
+test('rejects stable and audit source receipts', () => {
+  for (const sourceBranch of ['v3', 'v3-audit'])
+    assert.throws(() => validateProductionCandidate(fixture({ sourceBranch })))
+})
+test('rejects changed configuration, missing migrator and mutable image tags', () => {
+  const input = fixture()
+  assert.throws(() =>
+    validateProductionCandidate({
+      ...input,
+      receiptBytes: Buffer.from(
+        input.receiptBytes.toString().replace('configurationSha256', 'changed')
+      ),
+    })
+  )
+  assert.throws(() =>
+    validateProductionCandidate(fixture({ migrationInventorySha256: '' }))
+  )
+  assert.throws(() =>
+    validateProductionCandidate(
+      fixture({
+        artifacts: [
+          {
+            workload: 'backend',
+            image: 'ghcr.io/uzh-bf/klicker-uzh/backend-docker-arm:v3.4.0',
+          },
+        ],
+      })
+    )
+  )
+})

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Check CI queue policy
         run: node --test .github/scripts/ci-equivalent-run.test.cjs .github/scripts/ci-obsolete-runs.test.cjs .github/scripts/ci-event-gates.test.cjs
 
+      - name: Validate deployment candidate controls
+        run: node --test .github/scripts/stg-release-promoter.test.js .github/scripts/validate-prd-candidate.test.cjs
+
       - name: Check Playwright CI contracts
         run: pnpm run check:playwright-ci
 

--- a/.github/workflows/deploy-stg-promote.yml
+++ b/.github/workflows/deploy-stg-promote.yml
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           STG_PROMOTE_TOKEN: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' && github.event.inputs.confirm_ref_update == 'stg-release') || (github.event_name == 'workflow_run' && vars.STG_RELEASE_PROMOTION_ENABLED == 'true')) && secrets.STG_PROMOTE_TOKEN || '' }}
           PROMOTION_ENABLED: ${{ vars.STG_RELEASE_PROMOTION_ENABLED || 'false' }}
-          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH || 'v3' }}
+          SOURCE_BRANCH: ${{ vars.STG_SOURCE_BRANCH }}
           RECEIPT_PATH: ${{ runner.temp }}/stg-release-promotion-receipt.json
           CHECKSUM_PATH: ${{ runner.temp }}/stg-release-promotion-receipt.sha256
         with:


### PR DESCRIPTION
A missing staging selector currently silently selects stable v3. Require an explicit STG_SOURCE_BRANCH while preserving strict existing branch and candidate validation. Add negative coverage for an unset selector.

Also add a preparatory validator binding production eligibility to an independently approved maintenance SHA and receipt hash, including immutable application/migrator identities and configuration/schema/capability hashes. This helper is not yet enforced by the production writer; it cannot be treated as an activation boundary.

This narrow trusted-control branch contains no AI application history. Staging promoter tests (22) and receipt tests (4) passed. Merge remains blocked on the consolidated cutover approval and exact-current-head CI. No live variable, deployment or protected branch was changed.

Review corrections require an independently selected complete workload inventory and reject omitted/extra artifacts; 28 focused control tests pass. Deployment policy is recorded by ADR 0044 with superseded historical clauses identified. Final independent correction review passed at ae2e21c15; no remaining change-introduced findings. The large integration diff preserves existing stable merge ancestry; it does not reimplement the upstream Playwright/dependency features.

Remote CI remains pending; local tests and independent review do not establish live cutover readiness. No standard host-hook success is claimed: equivalent host/container checks were used and hook execution was skipped, recorded in the completion receipt.
