### PR TITLE
fix(chat): derive telemetry release from deployed image tag

### DIFF
--- a/deploy/charts/klicker-uzh-v3/templates/cm-chat.yaml
+++ b/deploy/charts/klicker-uzh-v3/templates/cm-chat.yaml
@@ -8,9 +8,6 @@
 {{- $chatTelemetryEnabled = $chatTelemetry.enabled -}}
 {{- end -}}
 {{- $langfuseRelease := .Values.global.imageTag | default .Values.chat.image.tag | default .Chart.AppVersion -}}
-{{- with .Values.chat.podAnnotations -}}
-{{- $langfuseRelease = index . "rollout.klicker.uzh.ch/release" | default $langfuseRelease -}}
-{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Chat telemetry could report an old release because the rollout annotation overrode the deployed image tag. Remove that override so `LANGFUSE_RELEASE` uses the same global image tag, chat image tag, and chart app-version fallback as the chat Deployment.

Validation: Helm lint passed. Helm rendering verified all three fallback cases with a stale rollout annotation present; the telemetry release matched the selected image tag. The diff contains only the three-line override removal. Application builds were not run for this chart-only change. CI is pending.

The live release label remains unchanged until this chart change is merged and deployed.
