### PR TITLE
enhance(deploy): enable KB knowledge-graph generation for PRD

### DIFF
--- a/deploy/charts/klicker-uzh-v3/templates/cm-backend-graphql.yaml
+++ b/deploy/charts/klicker-uzh-v3/templates/cm-backend-graphql.yaml
@@ -28,3 +28,22 @@ data:
   HATCHET_CLIENT_TLS_STRATEGY: {{ .Values.hatchet.client.tlsStrategy | quote }}
   # Deprecated - kept for backward compatibility during transition
   HATCHET_API_URL: {{ .Values.hatchet.client.apiUrl | quote }}
+  {{- if .Values.backendGraphql.knowledgeGraph.host }}
+  KB_FALKORDB_HOST: {{ .Values.backendGraphql.knowledgeGraph.host | quote }}
+  KB_FALKORDB_PORT: {{ .Values.backendGraphql.knowledgeGraph.port | quote }}
+  KB_FALKORDB_TLS: {{ .Values.backendGraphql.knowledgeGraph.tls | quote }}
+  KB_FALKORDB_QUERY_TIMEOUT_MS: {{ .Values.backendGraphql.knowledgeGraph.queryTimeoutMs | quote }}
+  {{- end }}
+  {{- if or .Values.hatchet.kbGraph.workflowName .Values.backendGraphql.elementGeneration.enabled }}
+  # Shared graph and element-generation semester quota ledger.
+  KB_GRAPH_COST_CURRENCY: {{ required "backendGraphql.knowledgeGraph.cost.currency is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.currency | quote }}
+  KB_GRAPH_STANDARD_ESTIMATE_MINOR_UNITS: {{ required "backendGraphql.knowledgeGraph.cost.standardEstimateMinorUnits is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.standardEstimateMinorUnits | quote }}
+  KB_GRAPH_HIGH_ESTIMATE_MINOR_UNITS: {{ required "backendGraphql.knowledgeGraph.cost.highEstimateMinorUnits is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.highEstimateMinorUnits | quote }}
+  KB_GRAPH_MAX_COST_MINOR_UNITS: {{ required "backendGraphql.knowledgeGraph.cost.maxCostMinorUnits is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.maxCostMinorUnits | quote }}
+  KB_GRAPH_SEMESTER_QUOTA_MINOR_UNITS: {{ required "backendGraphql.knowledgeGraph.cost.semesterQuotaMinorUnits is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.semesterQuotaMinorUnits | quote }}
+  KB_GRAPH_COST_PRICING_VERSION: {{ required "backendGraphql.knowledgeGraph.cost.pricingVersion is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.pricingVersion | quote }}
+  KB_GRAPH_BILLING_MODE: {{ required "backendGraphql.knowledgeGraph.cost.billingMode is required when graph or element generation is enabled" .Values.backendGraphql.knowledgeGraph.cost.billingMode | quote }}
+  {{- if .Values.backendGraphql.knowledgeGraph.cost.semesterKey }}
+  KB_GRAPH_SEMESTER_KEY: {{ .Values.backendGraphql.knowledgeGraph.cost.semesterKey | quote }}
+  {{- end }}
+  {{- end }}

--- a/deploy/charts/klicker-uzh-v3/templates/cm-hatchet-workers.yaml
+++ b/deploy/charts/klicker-uzh-v3/templates/cm-hatchet-workers.yaml
@@ -1,4 +1,10 @@
 {{- $fullName := include "chart.fullname" . -}}
+{{- if and .Values.hatchet.kbGraph.workflowName (empty .Values.backendGraphql.knowledgeGraph.host) }}
+{{- fail "backendGraphql.knowledgeGraph.host must be configured when hatchet.kbGraph.workflowName is enabled" }}
+{{- end }}
+{{- if and .Values.backendGraphql.elementGeneration.enabled (empty .Values.hatchet.kbGraph.workflowName) }}
+{{- fail "hatchet.kbGraph.workflowName must be configured when element generation is enabled" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,6 +26,24 @@ data:
   {{- if .Values.hatchet.kbGraph.disabled }}
   KB_GRAPH_DISABLED: {{ .Values.hatchet.kbGraph.disabled | quote }}
   {{- end }}
+  {{- if .Values.hatchet.kbGraph.workflowName }}
+  KB_GRAPH_HATCHET_CLIENT_HOST_PORT: {{ .Values.hatchet.kbGraph.hostPort | quote }}
+  KB_GRAPH_HATCHET_API_URL: {{ .Values.hatchet.kbGraph.apiUrl | quote }}
+  KB_GRAPH_HATCHET_CLIENT_TLS_STRATEGY: {{ .Values.hatchet.kbGraph.tlsStrategy | quote }}
+  KB_GRAPH_HATCHET_WORKFLOW_NAME: {{ .Values.hatchet.kbGraph.workflowName | quote }}
+  KB_GRAPH_TIMEOUT_SECONDS: {{ .Values.hatchet.kbGraph.timeoutSeconds | quote }}
+  KB_GRAPH_STANDARD_GENERATION_MODEL: {{ .Values.hatchet.kbGraph.standardGenerationModel | quote }}
+  KB_GRAPH_STANDARD_CLEANING_MODEL: {{ .Values.hatchet.kbGraph.standardCleaningModel | quote }}
+  KB_GRAPH_HIGH_GENERATION_MODEL: {{ .Values.hatchet.kbGraph.highGenerationModel | quote }}
+  KB_GRAPH_HIGH_CLEANING_MODEL: {{ .Values.hatchet.kbGraph.highCleaningModel | quote }}
+  KB_GRAPH_UPLOAD_GENERATION_ARTIFACTS: {{ .Values.backendGraphql.elementGeneration.enabled | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.backendGraphql.knowledgeGraph.host }}
+  KB_FALKORDB_HOST: {{ .Values.backendGraphql.knowledgeGraph.host | quote }}
+  KB_FALKORDB_PORT: {{ .Values.backendGraphql.knowledgeGraph.port | quote }}
+  KB_FALKORDB_TLS: {{ .Values.backendGraphql.knowledgeGraph.tls | quote }}
+  KB_FALKORDB_QUERY_TIMEOUT_MS: {{ .Values.backendGraphql.knowledgeGraph.queryTimeoutMs | quote }}
   {{- end }}
 ---
 apiVersion: v1

--- a/deploy/charts/klicker-uzh-v3/values.yaml
+++ b/deploy/charts/klicker-uzh-v3/values.yaml
@@ -86,6 +86,17 @@ hatchet:
     apiUrl: ""
     tenantId: ""
     hostPort: ""
+  kbGraph:
+    disabled: false
+    hostPort: ""
+    apiUrl: ""
+    tlsStrategy: ""
+    workflowName: ""
+    timeoutSeconds: "21600"
+    standardGenerationModel: ""
+    standardCleaningModel: ""
+    highGenerationModel: ""
+    highCleaningModel: ""
   workers:
     general:
       replicaCount: 1
@@ -366,6 +377,42 @@ frontendControl:
 
 backendGraphql:
   priorityClassName: production-workload
+
+  knowledgeGraph:
+    host: ''
+    port: '6379'
+    tls: 'false'
+    queryTimeoutMs: '5000'
+    # One shared semester ledger covers graph builds and element-generation
+    # dispatches. These values are non-secret and must be explicit before either
+    # producer is enabled.
+    cost:
+      currency: 'CHF'
+      standardEstimateMinorUnits: ''
+      highEstimateMinorUnits: ''
+      maxCostMinorUnits: ''
+      semesterQuotaMinorUnits: ''
+      pricingVersion: ''
+      billingMode: 'SEMESTER_QUOTA'
+      semesterKey: ''
+
+  # Non-secret coordinates for the unified Klicker-element generation adapter.
+  # The dedicated Hatchet token and Azure connection string must be supplied by
+  # the externally managed backend-graphql Secret before enabling this block.
+  elementGeneration:
+    enabled: false
+    hatchetHostPort: ''
+    hatchetServerUrl: ''
+    graphArtifactContainer: 'kg-graph-artifacts'
+    graphArtifactPrefix: 'graph-artifacts'
+    inputContainer: 'question-inputs'
+    outputContainer: 'question-results'
+    outputPrefix: 'question-builds'
+    cost:
+      questionMinorUnits: ''
+      flashcardMinorUnits: ''
+      flashcardRetryMinorUnits: ''
+      pricingVersion: ''
 
   replicaCount: 3
 

--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -27,7 +27,15 @@ hatchet:
     sourceGatewayUrl: 'http://app-klicker-klicker-uzh-v2-backend-graphql.prd-klicker.svc.cluster.local:3000'
     workerDisabled: false
   kbGraph:
-    disabled: true
+    disabled: false
+    hostPort: 'hatchet-grpc.prd-hatchet-svc.svc.cluster.local:7070'
+    apiUrl: 'http://app-hatchet-svc-api.prd-hatchet-svc.svc.cluster.local:8080'
+    tlsStrategy: 'none'
+    workflowName: 'course-kg-ingestion'
+    standardGenerationModel: 'klickeruzh/azure/gpt-5.6-luna'
+    standardCleaningModel: 'klickeruzh/azure/gpt-5.6-luna'
+    highGenerationModel: 'klickeruzh/azure/gpt-5.6-luna'
+    highCleaningModel: 'klickeruzh/azure/gpt-5.6-luna'
   workers:
     general:
       replicaCount: 4
@@ -548,6 +556,21 @@ frontendControl:
 
 backendGraphql:
   priorityClassName: production-workload
+
+  knowledgeGraph:
+    host: 'prd-falkordb-aigeneric-falkordb-falkordb.prd-kb-falkordb-aigeneric.svc.cluster.local'
+    port: '6379'
+    tls: 'false'
+    queryTimeoutMs: '5000'
+    cost:
+      currency: 'CHF'
+      standardEstimateMinorUnits: '100'
+      highEstimateMinorUnits: '200'
+      maxCostMinorUnits: '250'
+      semesterQuotaMinorUnits: '1000'
+      pricingVersion: 'prd-graph-v1'
+      billingMode: 'SEMESTER_QUOTA'
+      semesterKey: '2026-H2'
 
   replicaCount: 6
 


### PR DESCRIPTION
## Problem

PRD runs the AI worker image, but the `v3` chart only rendered `KB_GRAPH_DISABLED`. With no `KB_GRAPH_HATCHET_*` keys in the worker ConfigMap, the worker excluded the `buildKBGraph`/`monitorKBGraphBuilds` workflows and logged `graphDisabled: true`, so knowledge-base graph generation was permanently unavailable in PRD even though the flag was on.

## Change

Extends the `klicker-uzh-v3` chart with the graph configuration surface that already exists on the AI chart, and turns it on for PRD:

- `cm-hatchet-workers.yaml`: renders `KB_GRAPH_HATCHET_*`, the four model keys, `KB_GRAPH_TIMEOUT_SECONDS`, `KB_GRAPH_UPLOAD_GENERATION_ARTIFACTS` and `KB_FALKORDB_*`.
- `cm-backend-graphql.yaml`: renders `KB_FALKORDB_*` and the shared semester cost ledger.
- Both templates fail the render when graph and element-generation settings are only partially configured, so a half-applied change cannot roll out.
- `values.yaml`: chart defaults for the new `hatchet.kbGraph`, `backendGraphql.knowledgeGraph` and `backendGraphql.elementGeneration` keys.
- `env-uzh-prd/values.yaml`: enables the graph with the PRD Hatchet gRPC/API endpoints, the `course-kg-ingestion` workflow, the `gpt-5.6-luna` generation/cleaning models, the PRD FalkorDB instance and the semester cost estimates.

Element generation stays disabled in PRD, so the graph builder uploads no generation artifacts. Worker FalkorDB credentials are not required — staging runs the same shape with only the ConfigMap keys, and the worker uses the FalkorDB settings for startup validation only.

On merge, ArgoCD auto-sync re-renders the ConfigMaps, the general worker rolls and registers the graph workflows. KB owners then opt individual knowledge bases into graph generation.

## Validation

- `helm template` for PRD, staging and chart defaults only, all exit 0.
- PRD render produces all 10 graph keys plus 4 FalkorDB keys on the worker ConfigMap, and 4 FalkorDB plus 8 cost keys on the backend ConfigMap, with values matching the working staging configuration.
- Removing the FalkorDB host fails the render with the expected guard message.
- Staging and defaults-only renders are unchanged from today's output (no graph keys).
- Baseline files verified byte-identical to `v3` at `b34104e9c7` via blob SHAs.

This change touches no UI, so screenshots do not apply.
