### PR TITLE
chore(audit): enable assessment audit on staging

### DIFF
--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -143,10 +143,9 @@ hatchet:
           effect: NoSchedule
 
 assessmentAudit:
-  # Keep disabled until application readiness and both dedicated worker images
-  # are verified. These values render into ConfigMaps,
+  # Enabled for staging assessment testing. These values render into ConfigMaps,
   # not ExternalSecrets; do not duplicate them in Infisical.
-  enabled: false
+  enabled: true
   environment: stg
   # Cover all assessment live quizzes once audit is enabled; no pilot allowlist.
   rollout: all

--- a/docs/assessment-audit-evidence.md
+++ b/docs/assessment-audit-evidence.md
@@ -30,7 +30,9 @@ The staging service-account names match df-cloud's `stg-audit-backend-media`,
 Staging uses `rollout: all` without a pilot allowlist: once audit is enabled,
 all assessment live quizzes are eligible for coverage activation.
 The endpoints select the provisioned `stgklickerevidenceaohwr` storage account.
-Keep `enabled: false` until application readiness and worker images are verified.
+Staging sets `enabled: true` for assessment testing. Before syncing this revision,
+verify the application images and migrations; enabled configuration is not proof
+of successful evidence delivery. Monitoring remains a separate deployment gate.
 Both dedicated audit workers use the mutable `v3-audit` image tag with
 `pullPolicy: Always`; unlike the normal workloads, their templates currently
 do not use the ArgoCD `global.imageTag` override. Updating a mutable image tag
@@ -41,8 +43,8 @@ course-copy activation, baseline-reservation, and export-integrity hardening.
 Course copies are activated after the enclosing transaction commits. Tests
 cross-check the launch producer registry against its actual source locations,
 including bulk operations in `activities.ts`. These are wiring checks, not a
-substitute for behavioral integration tests. Keep audit disabled until the
-submission layer and staging evidence delivery are verified; the baseline layer alone is
+substitute for behavioral integration tests. Verify the submission layer and
+staging evidence delivery before relying on audit coverage; the baseline layer alone is
 not a deployable complete assessment-audit feature.
 
 `@klicker-uzh/audit` now contains the Layer 1 contract, Layer 2 evidence-store


### PR DESCRIPTION
## What This Changes

Sets `assessmentAudit.enabled: true` in staging, retaining `rollout: all`. Updates audit guidance to distinguish enabled configuration from verified evidence delivery.

## Branch Coverage

- Target: `v3-audit`, based on merged PR #5893 (`045595046`). Head: `f1f639514`.
- One commit; two files; 7 insertions and 6 deletions.
- Storage endpoints, identities, and image tags are inherited from #5893. Production values and `v3` are untouched.

## Verification

- Earlier verification of this exact patch: default staging Helm render passed, with two audit worker configurations, all-mode rollout, three expected service accounts, and provisioned storage endpoints.
- Prettier and Git whitespace checks passed. Git identity check and manual staged-data review passed before commit.
- Local hooks bypassed under the earlier user approval for configuration-only work after the dependency allowBuilds mismatch. Full application checks/build were not rerun; local gitleaks is unavailable.
- No deployment, activation scan, or runtime evidence test performed. Current-head CI pending.

## Deployment Gates

- This enables staging testing, not a production-readiness claim. Monitoring remains disabled; alert routing and capacity settings require verification before relying on evidence.
- Last verified staging ArgoCD configuration tracks `stg-release` with `global.imageTag=$ARGOCD_APP_REVISION`. GitHub `STG_SOURCE_BRANCH` selects `v3-ai`.
- At preparation time, staging and audit branches diverged (7 staging-only and 6 audit-only commits before this enablement commit). Reconcile staging history into `v3-audit` and validate before selecting it for the fast-forward-only promotion controller. Do not force-update the release ref or change `v3`.
- Audit workers still use explicit mutable `v3-audit` tags. Pin both to the same verified audit SHA as the other images through reviewed deployment parameters/values for coherent testing. Verify all image builds and migrations before syncing.
- Existing assessments need an activation scan, dry-run first. New assessments are selected automatically. Verify synthetic submissions, media capture, evidence delivery, and owner export after deployment.
- The ArgoCD Application is managed by cloud desired state; manual edits may be reverted. No ArgoCD settings, GitHub variables, release refs, or cloud resources changed by this task.

## Security / Privacy

No new credentials or personal data. Workload identity and provisioned storage are reused. Once deployed, test activity may produce persistent audit evidence; use synthetic assessment data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled assessment auditing in the staging environment for assessment testing.

- **Documentation**
  - Updated staging guidance to reflect the enabled audit configuration.
  - Added verification steps for application images, migrations, submission handling, and evidence delivery before relying on audit coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->