### PR TITLE
fix(audit): capture images with generic Blob content type

### DIFF
--- a/.agents/skills/klicker-environment-doctor/SKILL.md
+++ b/.agents/skills/klicker-environment-doctor/SKILL.md
@@ -133,6 +133,13 @@ A mismatch is expected to fail at startup. Baseline media capture runs in the
 GraphQL backend under its separate Blob-only service account, so a healthy
 dispatcher does not prove that activation media capture is authorized.
 
+For image-baseline failures, check source Blob read access under the backend
+identity separately from audit destination access. After a successful read,
+compare Blob content type with `MediaFile.type`: generic binary metadata is
+accepted only when audit signature detection matches the expected image type.
+Do not rewrite source images or database metadata to hide a genuine mismatch.
+See [assessment audit evidence](../../../docs/assessment-audit-evidence.md).
+
 ## Check 8 — database state (config-derived)
 
 Seeded dev DB contains the AGENTS.md test accounts (`lecturer`, `testuser1..50` — values in AGENTS.md only). Prisma 7 reset/migrate commands are seed-free. On the legacy host stack, `pnpm run prisma:setup` wraps the reset/push/seed composite with Infisical. In the self-contained DevPod, use `pnpm --filter @klicker-uzh/prisma run prisma:reset:raw --force`, then `pnpm --filter @klicker-uzh/prisma run prisma:push:raw`, then `pnpm --filter @klicker-uzh/prisma-data run seed:raw` as shown in `.devcontainer/post-create.sh`. Use either path **only after confirming the volume holds no real work** (fresh volume, test course names like "Testkurs"). When in doubt, ask the user.

--- a/docs/assessment-audit-evidence.md
+++ b/docs/assessment-audit-evidence.md
@@ -401,6 +401,18 @@ and a differing replay a hard conflict. Capture locks the returned blob version
 with a version-level immutability policy and never exposes content update or
 delete operations.
 
+Audit capture tolerates `application/octet-stream` source metadata only for
+images whose file signature matches the database MIME type. Detection runs on
+the already-staged temporary file before immutable persistence; bytes are never
+re-encoded. The existing evidence `mimeType` is the matched image type. Exact
+metadata matches retain their existing behavior; concrete mismatches, unknown
+signatures and generic non-images fail. This is best-effort format detection,
+not full image decoding, malware scanning or proof that the file is valid.
+Generic SVG metadata is not supported by binary signature detection.
+The strict version-1 evidence schema is unchanged; separate reported-type and
+detection-method provenance would require a versioned follow-up. This path does not
+change element rendering, uploads, source Blob metadata or database records.
+
 `AuditRetentionIndex` contains an append-only reverse index from immutable media
 versions to the assessment scopes that reference them. This includes baseline
 media parts and media captured or replaced by a covered source-element change.

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -13,6 +13,7 @@
     "@azure/storage-blob": "12.25.0",
     "@klicker-uzh/prisma": "workspace:*",
     "canonicalize": "3.0.0",
+    "file-type": "21.3.4",
     "uuid": "10.0.0",
     "zod": "3.25.76"
   },

--- a/packages/audit/src/media/capture.ts
+++ b/packages/audit/src/media/capture.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { mkdtemp, open, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileTypeFromFile } from 'file-type'
 import type { OwnedBaselineMediaReference } from '../baseline/media-references.js'
 import { hashCanonicalValue } from '../canonical/hash.js'
 import { mediaStateSchema } from '../contract/payloads/assessment.js'
@@ -65,7 +66,10 @@ export async function captureAssessmentMedia(input: {
       ...input.reference,
       sourceUrl,
     })
-    if (source.mimeType !== input.reference.mimeType) {
+    const detectImageType =
+      source.mimeType === 'application/octet-stream' &&
+      input.reference.mimeType.startsWith('image/')
+    if (source.mimeType !== input.reference.mimeType && !detectImageType) {
       throw new Error('Klicker media MIME type changed during capture')
     }
 
@@ -108,6 +112,19 @@ export async function captureAssessmentMedia(input: {
       throw new Error('Klicker media length changed during capture')
     }
 
+    // Existing uploads may have generic Blob metadata. Detect from the staged
+    // bytes, never the URL/extension, before creating any immutable evidence.
+    // Signature detection is a format hint, not full decoding or a safety scan.
+    if (detectImageType) {
+      const detected = await fileTypeFromFile(tempFile)
+      if (detected?.mime !== input.reference.mimeType) {
+        throw new Error(
+          'Klicker media detected MIME type does not match reference'
+        )
+      }
+    }
+
+    const mimeType = input.reference.mimeType
     const contentHash = hash.digest('hex')
     const blobName = auditMediaContentAddress(contentHash)
     const stored = await input.store.createFromFile({
@@ -115,14 +132,14 @@ export async function captureAssessmentMedia(input: {
       blobName,
       contentHash,
       byteLength,
-      mimeType: source.mimeType,
+      mimeType,
       retainUntil: input.retainUntil,
     })
     if (
       stored.blobName !== blobName ||
       stored.contentHash !== contentHash ||
       stored.byteLength !== byteLength ||
-      stored.mimeType !== source.mimeType ||
+      stored.mimeType !== mimeType ||
       stored.retainUntil.getTime() < input.retainUntil.getTime()
     ) {
       throw new Error('Immutable audit media store returned unverifiable data')
@@ -134,7 +151,7 @@ export async function captureAssessmentMedia(input: {
         sourceUrl,
         contentHash,
         byteLength,
-        mimeType: source.mimeType,
+        mimeType,
         blobName,
         sourceReferenceHash: hashCanonicalValue({
           mediaId: input.reference.mediaId,

--- a/packages/audit/test/media-capture.test.ts
+++ b/packages/audit/test/media-capture.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
-import { describe, expect, it } from 'vitest'
+import { readFile, stat } from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
 import {
   assertAllowedKlickerMediaSource,
   auditMediaContentAddress,
@@ -12,6 +12,90 @@ const sourceUrl =
   'https://klicker-media.blob.core.windows.net/00000000-0000-4000-8000-000000000001/figure.png'
 
 describe('assessment media capture', () => {
+  it.each([
+    ['image/png', 'application/octet-stream', Buffer.from('not an image')],
+    ['image/jpeg', 'application/octet-stream', Buffer.from('GIF89a synthetic')],
+    ['image/jpeg', 'image/png', Buffer.from('GIF89a synthetic')],
+    ['application/pdf', 'application/octet-stream', Buffer.from('%PDF-1.7')],
+    ['image/svg+xml', 'application/octet-stream', Buffer.from('<svg/>')],
+  ])('rejects unsupported or mismatched %s / %s before persistence', async (expected, reported, bytes) => {
+    const createFromFile = vi.fn<ImmutableAuditMediaStore['createFromFile']>()
+    await expect(
+      captureAssessmentMedia({
+        reference: { mediaId: randomUUID(), sourceUrl, mimeType: expected },
+        source: {
+          async open() {
+            return {
+              mimeType: reported,
+              contentLength: bytes.length,
+              body: (async function* () {
+                yield bytes
+              })(),
+            }
+          },
+        },
+        store: { createFromFile },
+        allowedHosts: ['klicker-media.blob.core.windows.net'],
+        retainUntil: new Date('2027-10-01T00:00:00.000Z'),
+      })
+    ).rejects.toThrow(/MIME type/)
+    expect(createFromFile).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    // Synthetic format fixtures: detection is not full decoding/validation.
+    [
+      'image/jpeg',
+      Buffer.from('ffd8ffe000104a46494600010100000100010000ffd9', 'hex'),
+    ],
+    [
+      'image/png',
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=',
+        'base64'
+      ),
+    ],
+    [
+      'image/gif',
+      Buffer.from(
+        'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+        'base64'
+      ),
+    ],
+  ])('captures generic binary %s only after detecting its expected format', async (mimeType, bytes) => {
+    let capturedPath = ''
+    const result = await captureAssessmentMedia({
+      reference: { mediaId: randomUUID(), sourceUrl, mimeType },
+      source: {
+        async open() {
+          return {
+            mimeType: 'application/octet-stream',
+            contentLength: bytes.length,
+            body: (async function* () {
+              yield bytes.subarray(0, 2)
+              yield bytes.subarray(2)
+            })(),
+          }
+        },
+      },
+      store: {
+        async createFromFile(input) {
+          capturedPath = input.filePath
+          expect(await readFile(input.filePath)).toEqual(bytes)
+          expect(input.mimeType).toBe(mimeType)
+          return { ...input, versionId: 'version-1', outcome: 'CREATED' }
+        },
+      },
+      allowedHosts: ['klicker-media.blob.core.windows.net'],
+      retainUntil: new Date('2027-10-01T00:00:00.000Z'),
+    })
+    expect(result.media).toMatchObject({
+      mimeType,
+    })
+    expect(result.media).not.toHaveProperty('sourceMimeType')
+    await expect(stat(capturedPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
   it('streams source bytes through a temporary file and verifies the result', async () => {
     const chunks = [Buffer.from('large '), Buffer.from('synthetic media')]
     let opened = 0
@@ -65,6 +149,7 @@ describe('assessment media capture', () => {
     )
     expect(result.media.sourceUrl).toBe(sourceUrl)
     expect(result.media.sourceReferenceHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.media).not.toHaveProperty('sourceMimeType')
   })
 
   it('fails before persistence for an untrusted URL or corrupted length', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1729,6 +1729,9 @@ importers:
       canonicalize:
         specifier: 3.0.0
         version: 3.0.0
+      file-type:
+        specifier: 21.3.4
+        version: 21.3.4
       uuid:
         specifier: 10.0.0
         version: 10.0.0

--- a/project/PLAN-audit-media-mime-compatibility.md
+++ b/project/PLAN-audit-media-mime-compatibility.md
@@ -1,0 +1,43 @@
+# Audit media MIME compatibility
+
+## Goal
+
+Allow assessment audit capture of existing images served as
+`application/octet-stream` only when file-signature detection matches the
+`MediaFile.type` referenced by the assessment's ElementInstance snapshot.
+
+## Scope and non-goals
+
+- Only `packages/audit` capture, its dependency, tests, and documentation.
+- Keep the streamed original bytes and existing hash/length/immutability checks.
+- Keep the version-1 evidence contract unchanged: `mimeType` remains the matched
+  image type. Separate source-type provenance requires a versioned follow-up.
+- No upload/rendering changes, database migration, auth changes, scoring,
+  gamification, frontend/i18n, Hatchet scheduling, cloud or Argo CD changes.
+- Exact MIME matches retain existing behavior. Concrete mismatches, unknown
+  signatures, and generic non-image files remain rejected. Signature detection
+  is not full decoding or a security scan.
+
+## Verification and delivery
+
+1. Add a failing capture regression using synthetic image bytes.
+2. Add bounded-memory file detection before immutable persistence.
+   Verify rejection and temporary-file cleanup.
+3. Run focused tests, audit typecheck/build and runtime import, then independent
+   review. No new seeds or environment startup needed.
+4. Draft PR to `v3-audit`; no deployment. Staging image-baseline, submission and
+   owner-export verification remains required after deployment.
+
+## Progress
+
+- Confirmed source download succeeds after the separate manual Azure RBAC fix;
+  source metadata is generic while the database declares JPEG.
+- Regression failed before the fix with `Klicker media MIME type changed during
+  capture`; final focused suite: 27 passed. Full audit suite: 103 passed, 12
+  skipped because two integration suites refused the unverified disposable DB.
+- Audit typecheck/build passed. Repository check/build attempted but not green
+  (check-format/GraphQL and Chat build failures); standalone GraphQL TypeScript
+  check passed after builds refreshed artifacts. No guard bypass or DB reset.
+- Independent review identified the v1 compatibility risk of a provenance field;
+  removed that schema change. Final review reports no P1/P2 findings.
+- No cloud, Argo CD, source-media, database, frontend or deployment changes.


### PR DESCRIPTION
## What This Fixes

Assessment audit baseline capture rejected existing images when Blob Storage returned `application/octet-stream` but the database declared an image MIME type. This fixes the audit capture path only; element rendering and uploads are unchanged.

## How It Works

- Stage and hash the original source bytes through the existing temporary-file stream.
- For generic binary metadata with an expected image MIME type, use `file-type` on the staged file and require an exact detected/expected MIME match before immutable persistence.
- Keep concrete MIME mismatches, unknown signatures and generic non-images rejected. Exact metadata matches retain their existing behavior.
- Preserve the strict version-1 evidence schema. The existing `mimeType` contains the matched image type; separate source-type provenance is deferred to a versioned change.
- Pin `file-type` to `21.3.4`, already present in the workspace lockfile. Update the audit guide, troubleshooting guidance, and implementation plan.

## Branch Coverage

- Target: `v3-audit`; branch: `feat/audit-media-mime-compatibility`.
- Head: `4433686c7`; base at implementation: `0b7103cd0`.
- One cohesive audit-only fix: 7 files, 174 insertions, 6 deletions.
- No frontend, GraphQL API, database migration, cloud/Pulumi, Argo CD, or deployment changes.

## Review Focus

- Fallback is image-only, based on file signatures rather than extensions, and runs before creating immutable evidence.
- Signature detection is best-effort format identification, not full decoding, malware scanning or proof of file validity. Generic SVG metadata remains unsupported.
- Independent review found a version-1 compatibility issue in an initial provenance-field proposal; that schema change was removed. Final independent review reported no remaining P1/P2 findings.

## Verification

Run in the existing audit development container:

- Regression reproduced before the fix: `Klicker media MIME type changed during capture`.
- Focused media/baseline/registry suite: **27 passed**. Includes JPEG, PNG, GIF, split chunks, unchanged bytes, cleanup, incorrect/unknown types and non-image rejection.
- `pnpm --filter @klicker-uzh/audit check`: passed.
- `pnpm --filter @klicker-uzh/audit build`: passed.
- Compiled Node ESM capture smoke with synthetic JPEG signature bytes: passed.
- `pnpm --filter @klicker-uzh/audit test`: **103 passed, 12 skipped; two integration suites failed setup** because the disposable-database guard refused the environment. No guard bypass or database reset performed.
- `pnpm run check:all`: failed (GraphQL/check-format); standalone GraphQL `check:ts` subsequently passed after build artifact refresh.
- `pnpm run build`: failed in the Chat build; a full repository build is not verified.
- Changed-code Biome checks, documentation formatting and `git diff --check`: passed.
- Filtered frozen-lockfile installation passed. The initial full-workspace lockfile resolution exhausted Node's heap; no unrelated lockfile updates were retained.

## Security / Privacy

Original image bytes, source Blob metadata and database records are not changed. URL allowlisting, byte-count checks, hashes and immutable-store verification remain in place. Fixtures are synthetic; no real image or participant data is included.

Local commit/push hooks are bypassed with user approval: the host hook fails on pnpm `allowBuilds` state, and `gitleaks` is unavailable locally. Staged content was manually inspected. CI secret scanning and normal checks remain required before merge.

## Blocking Before Merge / Deployment

- [ ] Review CI results, including secret scanning, and resolve any relevant failures.
- [ ] Complete database-backed verification in a correctly provisioned disposable environment.
- [ ] After an authorized staging deployment, verify a fresh image assessment becomes `COVERED`, its image is captured/locked, submitted-answer events are delivered, and owner export verifies.

No merge or deployment is performed by this PR. Existing failed coverage must not be relabeled as complete historical evidence. Azure source-media read access is a separate infrastructure prerequisite; this PR does not alter RBAC or reconcile manual cloud changes.
