### PR TITLE
fix(audit): handle case-insensitive Blob metadata

### DIFF
--- a/docs/assessment-audit-evidence.md
+++ b/docs/assessment-audit-evidence.md
@@ -401,6 +401,13 @@ and a differing replay a hard conflict. Capture locks the returned blob version
 with a version-level immutability policy and never exposes content update or
 delete operations.
 
+Audit Blob adapters write `sha256` and `bytelength` metadata with lowercase
+names. Azure property responses lowercased the former `byteLength` name, which
+caused valid media copies and manifest replays to fail integrity validation.
+Reads accept case-insensitive names for existing copies, require every matching
+value to agree, and reject missing or conflicting integrity metadata. Existing
+Blob metadata is never rewritten to repair casing.
+
 Audit capture tolerates `application/octet-stream` source metadata only for
 images whose file signature matches the database MIME type. Detection runs on
 the already-staged temporary file before immutable persistence; bytes are never

--- a/packages/audit/src/azure/blob-metadata.ts
+++ b/packages/audit/src/azure/blob-metadata.ts
@@ -1,0 +1,12 @@
+// Azure metadata names are case-insensitive; validate every matching entry so
+// conflicting aliases cannot hide an integrity mismatch.
+export function matchesBlobMetadata(
+  metadata: Record<string, string> | undefined,
+  key: 'sha256' | 'bytelength',
+  expected: string
+): boolean {
+  const entries = Object.entries(metadata ?? {}).filter(
+    ([name]) => name.toLowerCase() === key
+  )
+  return entries.length > 0 && entries.every(([, value]) => value === expected)
+}

--- a/packages/audit/src/azure/blob-store.ts
+++ b/packages/audit/src/azure/blob-store.ts
@@ -1,5 +1,6 @@
 import type { ContainerClient } from '@azure/storage-blob'
 import { sha256Hex } from '../canonical/hash.js'
+import { matchesBlobMetadata } from './blob-metadata.js'
 
 export type ImmutableAuditBlob = {
   blobName: string
@@ -77,7 +78,7 @@ export class AzureImmutableAuditBlobStore {
         conditions: { ifNoneMatch: '*' },
         metadata: {
           sha256: contentHash,
-          byteLength: String(input.content.byteLength),
+          bytelength: String(input.content.byteLength),
         },
         blobHTTPHeaders: { blobContentType: input.contentType },
       })
@@ -91,8 +92,12 @@ export class AzureImmutableAuditBlobStore {
       const existing = await blob.downloadToBuffer()
       if (
         sha256Hex(existing) !== contentHash ||
-        properties.metadata?.sha256 !== contentHash ||
-        properties.metadata?.byteLength !== String(input.content.byteLength) ||
+        !matchesBlobMetadata(properties.metadata, 'sha256', contentHash) ||
+        !matchesBlobMetadata(
+          properties.metadata,
+          'bytelength',
+          String(input.content.byteLength)
+        ) ||
         properties.contentType !== input.contentType
       ) {
         throw new AuditBlobConflictError(blobName)

--- a/packages/audit/src/azure/media-store.ts
+++ b/packages/audit/src/azure/media-store.ts
@@ -6,6 +6,7 @@ import type {
   ImmutableAuditMediaStore,
 } from '../media/capture.js'
 import { auditMediaContentAddress } from '../media/content-address.js'
+import { matchesBlobMetadata } from './blob-metadata.js'
 
 export class AuditMediaConflictError extends Error {
   readonly blobName: string
@@ -114,7 +115,7 @@ export class AzureImmutableAuditMediaStore
           conditions: { ifNoneMatch: '*' },
           metadata: {
             sha256: input.contentHash,
-            byteLength: String(input.byteLength),
+            bytelength: String(input.byteLength),
           },
           blobHTTPHeaders: { blobContentType: input.mimeType },
         }
@@ -130,8 +131,12 @@ export class AzureImmutableAuditMediaStore
     const storedHash = await hashBlobDownload(blob)
     if (
       storedHash !== input.contentHash ||
-      properties.metadata?.sha256 !== input.contentHash ||
-      properties.metadata?.byteLength !== String(input.byteLength) ||
+      !matchesBlobMetadata(properties.metadata, 'sha256', input.contentHash) ||
+      !matchesBlobMetadata(
+        properties.metadata,
+        'bytelength',
+        String(input.byteLength)
+      ) ||
       properties.contentLength !== input.byteLength ||
       properties.contentType !== input.mimeType
     ) {
@@ -196,14 +201,16 @@ export class AzureImmutableAuditMediaStore
     }
     const blob = this.container.getBlockBlobClient(input.blobName)
     const baseProperties = await blob.getProperties()
-    if (baseProperties.metadata?.sha256 !== input.contentHash) {
+    if (
+      !matchesBlobMetadata(baseProperties.metadata, 'sha256', input.contentHash)
+    ) {
       throw new AuditMediaConflictError(input.blobName)
     }
     const versionId = requireVersionId(baseProperties.versionId, input.blobName)
     const version = blob.withVersion(versionId)
     const properties = await version.getProperties()
     if (
-      properties.metadata?.sha256 !== input.contentHash ||
+      !matchesBlobMetadata(properties.metadata, 'sha256', input.contentHash) ||
       properties.immutabilityPolicyMode !== 'Locked' ||
       properties.immutabilityPolicyExpiresOn === undefined
     ) {
@@ -227,7 +234,7 @@ export class AzureImmutableAuditMediaStore
     })
     const extended = await version.getProperties()
     if (
-      extended.metadata?.sha256 !== input.contentHash ||
+      !matchesBlobMetadata(extended.metadata, 'sha256', input.contentHash) ||
       extended.immutabilityPolicyMode !== 'Locked' ||
       extended.immutabilityPolicyExpiresOn === undefined ||
       extended.immutabilityPolicyExpiresOn.getTime() <

--- a/packages/audit/test/blob-store.test.ts
+++ b/packages/audit/test/blob-store.test.ts
@@ -36,7 +36,12 @@ class MemoryContainer {
         }
         container.stored.set(name, {
           content: Buffer.from(content),
-          metadata: options.metadata,
+          metadata: Object.fromEntries(
+            Object.entries(options.metadata).map(([key, value]) => [
+              key.toLowerCase(),
+              value,
+            ])
+          ),
           contentType: options.blobHTTPHeaders.blobContentType,
           versionId: 'version-1',
         })
@@ -167,5 +172,62 @@ describe('immutable audit blob store', () => {
         retainUntil: new Date('2030-03-01T00:00:00.000Z'),
       })
     ).rejects.toBeInstanceOf(AuditBlobConflictError)
+  })
+
+  it.each([
+    'byteLength',
+    'BYTELENGTH',
+  ])('replays existing %s metadata without rewriting it', async (lengthKey) => {
+    const { container, store } = storeFixture()
+    const input = {
+      kind: 'manifest' as const,
+      content: Buffer.from('metadata regression'),
+      contentType: 'application/json',
+      retainUntil: new Date('2030-03-01T00:00:00.000Z'),
+    }
+    const first = await store.create(input)
+    const stored = container.stored.get(first.blobName)!
+    const metadata = {
+      SHA256: first.contentHash,
+      [lengthKey]: String(first.byteLength),
+    }
+    stored.metadata = metadata
+    await expect(store.create(input)).resolves.toMatchObject({
+      outcome: 'IDENTICAL_REPLAY',
+    })
+    expect(stored.metadata).toBe(metadata)
+    expect(container.policyCalls).toHaveLength(1)
+  })
+
+  it.each([
+    'missing length',
+    'wrong length',
+    'missing hash',
+    'wrong hash',
+    'conflicting length alias',
+    'conflicting hash alias',
+    'wrong MIME',
+  ])('rejects %s before changing retention', async (conflict) => {
+    const { container, store } = storeFixture()
+    const input = {
+      kind: 'manifest' as const,
+      content: Buffer.from('metadata regression'),
+      contentType: 'application/json',
+      retainUntil: new Date('2030-03-01T00:00:00.000Z'),
+    }
+    const first = await store.create(input)
+    const stored = container.stored.get(first.blobName)!
+    if (conflict === 'missing length') delete stored.metadata.bytelength
+    if (conflict === 'wrong length') stored.metadata.bytelength = '999'
+    if (conflict === 'missing hash') delete stored.metadata.sha256
+    if (conflict === 'wrong hash') stored.metadata.sha256 = 'wrong'
+    if (conflict === 'conflicting length alias')
+      stored.metadata.byteLength = '999'
+    if (conflict === 'conflicting hash alias') stored.metadata.SHA256 = 'wrong'
+    if (conflict === 'wrong MIME') stored.contentType = 'text/plain'
+    await expect(store.create(input)).rejects.toBeInstanceOf(
+      AuditBlobConflictError
+    )
+    expect(container.policyCalls).toHaveLength(1)
   })
 })

--- a/packages/audit/test/media-azure.test.ts
+++ b/packages/audit/test/media-azure.test.ts
@@ -23,6 +23,9 @@ type StoredMedia = {
 
 class MemoryMediaContainer {
   stored = new Map<string, StoredMedia>()
+  policyCalls: string[] = []
+  versionReads: string[] = []
+  persistPolicy = true
 
   getBlockBlobClient(name: string) {
     const container = this
@@ -45,7 +48,12 @@ class MemoryMediaContainer {
         for await (const chunk of stream) chunks.push(Buffer.from(chunk))
         container.stored.set(name, {
           content: Buffer.concat(chunks),
-          metadata: options.metadata,
+          metadata: Object.fromEntries(
+            Object.entries(options.metadata).map(([key, value]) => [
+              key.toLowerCase(),
+              value,
+            ])
+          ),
           contentType: options.blobHTTPHeaders.blobContentType,
           versionId: 'version-1',
         })
@@ -69,15 +77,19 @@ class MemoryMediaContainer {
           ),
         }
       },
-      withVersion() {
+      withVersion(versionId: string) {
         return {
           async setImmutabilityPolicy(policy: { expiriesOn?: Date }) {
             const stored = container.stored.get(name)!
-            stored.expiresOn = policy.expiriesOn
-            stored.policyMode = 'Locked'
+            container.policyCalls.push(versionId)
+            if (container.persistPolicy) {
+              stored.expiresOn = policy.expiriesOn
+              stored.policyMode = 'Locked'
+            }
             return {}
           },
           async getProperties() {
+            container.versionReads.push(versionId)
             return client.getProperties()
           },
         }
@@ -159,6 +171,12 @@ describe('Azure immutable audit media store', () => {
     const created = await store.createFromFile(input)
     const replay = await store.createFromFile(input)
 
+    expect(container.policyCalls).toEqual(['version-1'])
+    expect(container.versionReads).toEqual(['version-1', 'version-1'])
+    expect(container.stored.get(input.blobName)?.metadata).toEqual({
+      sha256: input.contentHash,
+      bytelength: String(input.byteLength),
+    })
     expect(created.outcome).toBe('CREATED')
     expect(replay.outcome).toBe('IDENTICAL_REPLAY')
     expect(container.stored.get(input.blobName)?.policyMode).toBe('Locked')
@@ -204,5 +222,116 @@ describe('Azure immutable audit media store', () => {
         retainUntil: input.retainUntil,
       })
     ).toMatchObject({ outcome: 'ALREADY_SUFFICIENT', retainUntil: later })
+  })
+
+  it.each([
+    'byteLength',
+    'BYTELENGTH',
+  ])('replays existing %s metadata without rewriting it', async (lengthKey) => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('metadata regression'))
+    const first = await store.createFromFile(input)
+    const stored = container.stored.get(first.blobName)!
+    const metadata = {
+      SHA256: first.contentHash,
+      [lengthKey]: String(first.byteLength),
+    }
+    stored.metadata = metadata
+    await expect(store.createFromFile(input)).resolves.toMatchObject({
+      outcome: 'IDENTICAL_REPLAY',
+    })
+    expect(stored.metadata).toBe(metadata)
+    expect(container.policyCalls).toHaveLength(1)
+  })
+
+  it.each([
+    'missing length',
+    'wrong length',
+    'missing hash',
+    'wrong hash',
+    'conflicting length alias',
+    'conflicting hash alias',
+    'wrong MIME',
+  ])('rejects %s before changing retention', async (conflict) => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('metadata regression'))
+    const first = await store.createFromFile(input)
+    const stored = container.stored.get(first.blobName)!
+    if (conflict === 'missing length') delete stored.metadata.bytelength
+    if (conflict === 'wrong length') stored.metadata.bytelength = '999'
+    if (conflict === 'missing hash') delete stored.metadata.sha256
+    if (conflict === 'wrong hash') stored.metadata.sha256 = 'wrong'
+    if (conflict === 'conflicting length alias')
+      stored.metadata.byteLength = '999'
+    if (conflict === 'conflicting hash alias') stored.metadata.SHA256 = 'wrong'
+    if (conflict === 'wrong MIME') stored.contentType = 'text/plain'
+    await expect(store.createFromFile(input)).rejects.toBeInstanceOf(
+      AuditMediaConflictError
+    )
+    expect(container.policyCalls).toHaveLength(1)
+  })
+
+  it('rejects a lock that was not persisted on the returned version', async () => {
+    const container = new MemoryMediaContainer()
+    container.persistPolicy = false
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('unlocked media'))
+    await expect(store.createFromFile(input)).rejects.toThrow(
+      'was not durably locked'
+    )
+    expect(container.policyCalls).toEqual(['version-1'])
+    expect(container.versionReads).toEqual(['version-1'])
+  })
+
+  it('locks an existing lowercase copy left by a failed activation', async () => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('metadata regression'))
+    const first = await store.createFromFile(input)
+    const stored = container.stored.get(first.blobName)!
+    stored.policyMode = undefined
+    stored.expiresOn = undefined
+    await expect(store.createFromFile(input)).resolves.toMatchObject({
+      outcome: 'IDENTICAL_REPLAY',
+    })
+    expect(container.policyCalls).toEqual(['version-1', 'version-1'])
+    expect(stored.policyMode).toBe('Locked')
+  })
+
+  it('validates case-insensitive hashes during retention renewal', async () => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('metadata regression'))
+    const first = await store.createFromFile(input)
+    const stored = container.stored.get(first.blobName)!
+    stored.metadata = {
+      SHA256: first.contentHash,
+      byteLength: String(first.byteLength),
+    }
+    const renewal = {
+      blobName: first.blobName,
+      contentHash: first.contentHash,
+      retainUntil: new Date('2031-01-01T00:00:00.000Z'),
+    }
+    await expect(store.extendRetention(renewal)).resolves.toMatchObject({
+      outcome: 'EXTENDED',
+    })
+    stored.metadata.sha256 = 'wrong'
+    await expect(store.extendRetention(renewal)).rejects.toBeInstanceOf(
+      AuditMediaConflictError
+    )
+    expect(container.policyCalls).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## What This Fixes

Azure returned `bytelength` metadata while the audit adapters read `byteLength`, causing valid image copies to fail before version locking and identical manifest replays to report integrity conflicts.

Both adapters now write lowercase metadata and validate names case-insensitively. Every matching value must agree, so missing, mismatched, or conflicting case variants still fail closed. Media retention renewal uses the same hash validation. Existing Blob metadata is not rewritten.

## Branch Coverage

One commit (`3ab09361b`), 6 files, 236 insertions and 14 deletions, targeting `v3-audit`: shared metadata validation, both Blob adapters, regression tests, and the audit engineering guide. No evidence-schema, database, frontend, source-media, infrastructure, or deployment changes.

## Verification

- Lowercasing the fake provider metadata reproduced six failures before the fix.
- Focused Blob/media tests: **30 passed**, covering creation, legacy casing, identical replay, integrity conflicts, renewal, replay of an unlocked copy, and verification of the returned version's lock.
- Audit suite excluding `test/monitor.integration.test.ts` and `test/outbox.integration.test.ts`: **124 passed across 20 files**, including Azurite Table conformance tests. The two excluded suites previously refused this environment's disposable-database guard; it was not bypassed.
- `pnpm --filter @klicker-uzh/audit check` and `build`: passed.
- Changed-code Biome, documentation Prettier, and diff whitespace checks: passed.
- Independent source review: no actionable findings.
- Repository-wide `pnpm run check:all`: failed in GraphQL checking and formatting; full repository checks are not green.
- Repository-wide `pnpm run build`: failed in `@klicker-uzh/chat`; full repository build is not verified.

## Security / Privacy

Hash, byte-length, MIME, retention, and conflict checks remain in place. Test data is synthetic. The six changed files were manually inspected for secrets and personal data; local gitleaks is unavailable, so CI secret scanning remains required.

Host commit/push hooks were bypassed with explicit user approval for this draft PR after the commit hook failed with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN` (`allowBuilds` changed). Git identity and staged whitespace checks passed manually.

## Remaining Verification

- Review CI before merge, including secret scanning.
- Run the guarded database suites in a correctly provisioned disposable environment.
- After an authorized staging deployment, prove version locking and complete coverage using a fresh image assessment, submission evidence, and owner export. Local fake-provider tests do not prove Azure lock permissions.

Existing failed coverage remains historical evidence and must not be relabeled as covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Azure audit and media validation to handle integrity metadata regardless of capitalization.
  - Fixed valid content replays and media copies that could fail integrity checks due to metadata casing.
  - Conflicting, incomplete, or incorrect integrity metadata is now rejected consistently.
  - Existing metadata is preserved without automatic rewriting, while retention updates continue to be validated safely.

- **Documentation**
  - Added documentation explaining Azure integrity metadata handling and compatibility with existing stored content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->