### PR TITLE
fix: increase course deletion timeout to twenty minutes

### DIFF
--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -3350,7 +3350,7 @@ export async function deleteCourse(
 
       return { deleted, deletionCancelled: false }
     },
-    { timeout: 60000 }
+    { timeout: 300000 }
   )
 
   if (!deletedCourse.deleted) {

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -3350,7 +3350,7 @@ export async function deleteCourse(
 
       return { deleted, deletionCancelled: false }
     },
-    { timeout: 300000 }
+    { timeout: 1200000 }
   )
 
   if (!deletedCourse.deleted) {


### PR DESCRIPTION
Increase the course deletion transaction timeout from 60 seconds to 1,200,000 milliseconds (20 minutes), leaving headroom for deletions that take around 15 minutes. The transaction includes cascading deletes and sequential permission recomputation.

The final branch diff is one line against `v3`. Course deletion runs in a background Hatchet task, so the UI request waits for scheduling rather than completion. The existing 30-minute worker execution timeout accommodates this limit. The transaction can still hold database locks and delay conflicting writes for its duration; course deletion jobs are serialized with concurrency one.

Validation: reviewed the complete diff and `git diff --check` passed. Full typecheck, build, and database-backed tests were not run: this fresh worktree has no installed dependencies or provisioned test container. Local Husky hooks are not installed in this worktree. A real 15-minute deletion has not been tested; CI validation for the updated head remains pending.
