### PR TITLE
ci(ocr): use DeepSeek V4.1 Flash for draft reviews

### DIFF
--- a/.github/scripts/final-ai-review.test.js
+++ b/.github/scripts/final-ai-review.test.js
@@ -589,14 +589,14 @@ test('uses one qualified canary and OCR release in both manual jobs', () => {
   }
 })
 
-test('keeps DeepSeek V4 Flash 0731 for automatic draft reviews', () => {
+test('keeps DeepSeek V4.1 Flash for automatic draft reviews', () => {
   const source = fs.readFileSync(
     path.join(__dirname, '../workflows/check-ocr-review.yml'),
     'utf8'
   )
 
   assert.equal(
-    source.match(/llm_model: deepseek\/deepseek-v4-flash-0731/g)?.length,
+    source.match(/llm_model: deepseek\/deepseek-v4\.1-flash/g)?.length,
     1
   )
   assert.doesNotMatch(source, /z-ai\/glm-5\.3-flash/)

--- a/.github/workflows/check-ocr-review.yml
+++ b/.github/workflows/check-ocr-review.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           llm_url: https://openrouter.ai/api/v1/chat/completions
           llm_auth_token: ${{ secrets.OPENROUTER_API_KEY }}
-          llm_model: deepseek/deepseek-v4-flash-0731
+          llm_model: deepseek/deepseek-v4.1-flash
           background: ${{ steps.context.outputs.background }}
           llm_use_anthropic: 'false'
           llm_timeout: '480'


### PR DESCRIPTION
## Summary

- Update automatic draft OCR reviews from the pinned DeepSeek V4 Flash 0731 slug to deepseek/deepseek-v4.1-flash.
- Keep manual final and cumulative stack reviews on z-ai/glm-5.3-flash.
- Update the workflow-policy test to protect the new DeepSeek slug and ensure draft reviews remain separate from GLM final review.

## Verification

- Confirmed both model slugs and tool-call support through the live OpenRouter model catalog.
- Ran the focused DeepSeek V4.1 Flash Node test.
- Ran Prettier on the workflow and Biome on the touched test; Biome reports only pre-existing warnings.
- Verified the diff is limited to the model slug and its test assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Automatic draft reviews now use the DeepSeek V4.1 Flash model.
  - OCR review checks have been updated to use the same model configuration.
  - Verification coverage was updated to reflect the new model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->