### PR TITLE
rs/idle architecture/ia 2026 09 07/03 scoring characterization

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'apps/frontend-pwa/**'
       - 'apps/chat/**'
+      - 'apps/hatchet-worker-response-processor/**'
       - 'packages/grading/**'
       - 'packages/graphql/**'
       - 'packages/i18n/**'
@@ -31,6 +32,7 @@ on:
     paths:
       - 'apps/frontend-pwa/**'
       - 'apps/chat/**'
+      - 'apps/hatchet-worker-response-processor/**'
       - 'packages/grading/**'
       - 'packages/graphql/**'
       - 'packages/i18n/**'
@@ -189,6 +191,10 @@ jobs:
       - name: Test grading package
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: pnpm --filter @klicker-uzh/grading test
+
+      - name: Test response processor helpers
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: pnpm --filter @klicker-uzh/hatchet-worker-response-processor test:run
 
       - name: Test markdown package
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/apps/hatchet-worker-response-processor/package.json
+++ b/apps/hatchet-worker-response-processor/package.json
@@ -25,7 +25,8 @@
     "npm-run-all": "~4.1.5",
     "rollup": "~4.34.9",
     "tsx": "~4.19.4",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "~3.2.4"
   },
   "scripts": {
     "build": "run-s --npm-path pnpm build:ts",
@@ -40,7 +41,8 @@
     "dev:run": "nodemon -w dist/ --exec 'node --env-file .env dist/index.js'",
     "dev:test": "cross-env NODE_ENV=test ASSESSMENT_MODE=false tsx --env-file .env src/index.ts",
     "dev:watch": "run-p --npm-path pnpm dev:build dev:run",
-    "start:test": "node --env-file .env dist/index.js"
+    "start:test": "node --env-file .env dist/index.js",
+    "test:run": "vitest run"
   },
   "engines": {
     "node": "=24"

--- a/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
+++ b/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
@@ -1,0 +1,506 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCaseStudyQuestionPoints,
+  getCaseStudyQuestionPointsDetails,
+  getChoicesQuestionPoints,
+  getChoicesQuestionPointsDetails,
+  getFreeTextQuestionPoints,
+  getFreeTextQuestionPointsDetails,
+  getNumericalQuestionPoints,
+  getNumericalQuestionPointsDetails,
+  getSelectionQuestionPoints,
+  getSelectionQuestionPointsDetails,
+} from '../src/processors/helpers.js'
+
+// ! Characterization battery for the response-processor scoring helpers.
+//
+// The expected values are derived by hand from the current implementation
+// (helpers.ts + @klicker-uzh/grading) and pin the observable scoring
+// behavior, including the per-type differences that a future consolidation
+// must preserve:
+// - choices/selection/case-study award via `pointsPercentage`, numerical and
+//   free text via `getsMaxPoints` (equivalent at the produced percentages)
+// - XP is 10 iff the percentage is exactly 1, otherwise 0 (null coerces to 0)
+// - the bonus declines linearly from maxBonusPoints to zero after
+//   timeToZeroBonus seconds, measured against firstResponseReceivedAt
+// With empty instance info the defaults are: maxBonus 45, timeToZeroBonus 20
+// (slope 2.25/s), defaultPoints 10, defaultCorrectPoints 5.
+
+const RESPONSE_TIMESTAMP = 1_000_000
+
+const instanceInfoWith = (values: Record<string, string> = {}) => ({
+  ...values,
+})
+
+const choicesResponse = (selected: number[]) => ({
+  choices: [0, 1, 2, 3].map((ix) => ({ ix, selected: selected.includes(ix) })),
+})
+
+const choicesResponse5 = (selected: number[]) => ({
+  choices: [0, 1, 2, 3, 4].map((ix) => ({
+    ix,
+    selected: selected.includes(ix),
+  })),
+})
+
+describe('characterization of the response processor scoring helpers', () => {
+  describe('single choice (choices helpers with type SC)', () => {
+    const base = {
+      type: 'SC' as const,
+      choiceCount: '4',
+      parsedSolutions: [0],
+      instanceInfo: instanceInfoWith(),
+      responseTimestamp: RESPONSE_TIMESTAMP,
+    }
+
+    it('awards correctness and full first-response bonus for a correct answer', () => {
+      const result = getChoicesQuestionPoints({
+        ...base,
+        response: choicesResponse([0]),
+        basePoints: 'false',
+      })
+
+      // correctness 1 * 5 + bonus 1 * 45 (no prior response -> zero timing)
+      expect(result).toEqual({
+        pointsAwarded: 50,
+        xpAwarded: 10,
+        pointsPercentage: 1,
+      })
+    })
+
+    it('adds base points when the basePoints flag is set', () => {
+      const result = getChoicesQuestionPoints({
+        ...base,
+        response: choicesResponse([0]),
+        basePoints: 'true',
+      })
+
+      expect(result.pointsAwarded).toBe(60)
+    })
+
+    it('awards zero points and xp for a wrong answer', () => {
+      const result = getChoicesQuestionPoints({
+        ...base,
+        response: choicesResponse([1]),
+        basePoints: 'false',
+      })
+
+      expect(result).toEqual({
+        pointsAwarded: 0,
+        xpAwarded: 0,
+        pointsPercentage: 0,
+      })
+    })
+
+    it('decomposition into correctness and bonus points matches the total', () => {
+      const result = getChoicesQuestionPointsDetails({
+        ...base,
+        response: choicesResponse([0]),
+      })
+
+      expect(result).toEqual({
+        correctnessPoints: 5,
+        bonusPoints: 45,
+        xpAwarded: 10,
+        pointsPercentage: 1,
+      })
+    })
+
+    it('declines the bonus linearly against the first response timestamp', () => {
+      // 10s after the first response: bonus 45 - 2.25 * 10 = 22.5; total 5 + 22.5 = 27.5 -> 28
+      const result = getChoicesQuestionPoints({
+        ...base,
+        response: choicesResponse([0]),
+        firstResponseReceivedAt: String(RESPONSE_TIMESTAMP - 10_000),
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(28)
+    })
+
+    it('floors the bonus at zero once the decline window has passed', () => {
+      // 30s after the first response: 45 - 2.25 * 30 < 0 -> bonus 0
+      const result = getChoicesQuestionPoints({
+        ...base,
+        response: choicesResponse([0]),
+        firstResponseReceivedAt: String(RESPONSE_TIMESTAMP - 30_000),
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(5)
+    })
+  })
+
+  describe('multiple choice (choices helpers with type MC)', () => {
+    it('awards partial credit with a hamming-distance penalty', () => {
+      // solution [0, 1], response selects only ix 0 -> distance 1 of 5 -> 1 - 2 * 1/5 = 0.6
+      const result = getChoicesQuestionPoints({
+        type: 'MC' as const,
+        choiceCount: '5',
+        parsedSolutions: [0, 1],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        response: choicesResponse5([0]),
+        basePoints: 'false',
+      })
+
+      // correctness 0.6 * 5 = 3, bonus 0.6 * 45 = 27, total 30 (rounded)
+      expect(result.pointsAwarded).toBe(30)
+      expect(result.pointsPercentage).toBeCloseTo(0.6)
+      expect(result.xpAwarded).toBe(0)
+    })
+  })
+
+  describe('k-prim (choices helpers with type KPRIM)', () => {
+    it('awards half credit for a single wrong statement', () => {
+      // the solution lists the indexes of the true statements (0 and 1);
+      // selecting statement 2 as well is a single deviation -> half credit
+      const response = {
+        choices: [
+          { ix: 0, selected: true },
+          { ix: 1, selected: true },
+          { ix: 2, selected: true },
+          { ix: 3, selected: false },
+        ],
+      }
+
+      const result = getChoicesQuestionPoints({
+        type: 'KPRIM' as const,
+        choiceCount: '4',
+        parsedSolutions: [0, 1],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        response,
+        basePoints: 'false',
+      })
+
+      // distance 1 -> percentage 0.5; correctness 2.5 + bonus 22.5 = 25
+      expect(result.pointsAwarded).toBe(25)
+      expect(result.pointsPercentage).toBe(0.5)
+      expect(result.xpAwarded).toBe(0)
+    })
+  })
+
+  describe('numerical', () => {
+    const exactBase = {
+      parsedSolutions: [5] as Array<number | string>,
+      instanceInfo: instanceInfoWith(),
+      responseTimestamp: RESPONSE_TIMESTAMP,
+    }
+
+    it('grades exact solutions via the getsMaxPoints path', () => {
+      const result = getNumericalQuestionPoints({
+        ...exactBase,
+        response: { value: '5' },
+        basePoints: 'true',
+      })
+
+      // correctness 5 + bonus 45 + base 10
+      expect(result.pointsAwarded).toBe(60)
+      expect(result.pointsPercentage).toBe(1)
+      expect(result.xpAwarded).toBe(10)
+    })
+
+    it('grades solution ranges when no exact solutions are defined', () => {
+      const result = getNumericalQuestionPoints({
+        ...exactBase,
+        parsedSolutions: [{ min: 1, max: 10 }] as any,
+        response: { value: '5' },
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(50)
+    })
+
+    it('awards zero for a wrong numeric answer', () => {
+      const result = getNumericalQuestionPoints({
+        ...exactBase,
+        response: { value: '99' },
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(0)
+      expect(result.pointsPercentage).toBe(0)
+      expect(result.xpAwarded).toBe(0)
+    })
+
+    it('decomposition matches the total for a correct answer', () => {
+      const result = getNumericalQuestionPointsDetails({
+        ...exactBase,
+        response: { value: '5' },
+      })
+
+      expect(result).toEqual({
+        correctnessPoints: 5,
+        bonusPoints: 45,
+        xpAwarded: 10,
+        pointsPercentage: 1,
+      })
+    })
+  })
+
+  describe('free text', () => {
+    const base = {
+      parsedSolutions: ['Hello World'],
+      instanceInfo: instanceInfoWith(),
+      responseTimestamp: RESPONSE_TIMESTAMP,
+    }
+
+    it('matches case-insensitively after trimming the response', () => {
+      const result = getFreeTextQuestionPoints({
+        ...base,
+        response: { value: '  hello world  ' },
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(50)
+      expect(result.pointsPercentage).toBe(1)
+      expect(result.xpAwarded).toBe(10)
+    })
+
+    it('awards only base points when no solutions are defined (percentage null)', () => {
+      const result = getFreeTextQuestionPoints({
+        ...base,
+        parsedSolutions: [],
+        response: { value: 'anything' },
+        basePoints: 'true',
+      })
+
+      expect(result.pointsAwarded).toBe(10)
+      expect(result.pointsPercentage).toBeNull()
+      expect(result.xpAwarded).toBe(0)
+    })
+
+    it('decomposition yields zero correctness and bonus without solutions', () => {
+      const result = getFreeTextQuestionPointsDetails({
+        ...base,
+        parsedSolutions: [],
+        response: { value: 'anything' },
+      })
+
+      expect(result).toEqual({
+        correctnessPoints: 0,
+        bonusPoints: 0,
+        xpAwarded: 0,
+        pointsPercentage: null,
+      })
+    })
+  })
+
+  describe('selection', () => {
+    const base = {
+      instanceInfo: instanceInfoWith({ numberOfInputs: '2' }),
+      responseTimestamp: RESPONSE_TIMESTAMP,
+      parsedSolutions: [0, 1],
+    }
+
+    it('awards fractional credit over the number of inputs, ignoring skipped fields', () => {
+      const result = getSelectionQuestionPoints({
+        ...base,
+        // -1 marks a skipped input; only ix 0 is correct -> 1 of 2 inputs
+        response: { selection: [0, -1] },
+        basePoints: 'false',
+      })
+
+      // correctness 0.5 * 5 = 2.5 + bonus 0.5 * 45 = 22.5 -> 25 (rounded)
+      expect(result.pointsAwarded).toBe(25)
+      expect(result.pointsPercentage).toBe(0.5)
+      expect(result.xpAwarded).toBe(0)
+    })
+
+    it('awards full credit when every input is answered correctly', () => {
+      const result = getSelectionQuestionPoints({
+        ...base,
+        response: { selection: [0, 1] },
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(50)
+      expect(result.xpAwarded).toBe(10)
+    })
+
+    it('decomposition keeps the fractional percentage', () => {
+      const result = getSelectionQuestionPointsDetails({
+        ...base,
+        response: { selection: [0, -1] },
+      })
+
+      expect(result.correctnessPoints).toBe(2.5)
+      expect(result.bonusPoints).toBe(22.5)
+      expect(result.pointsPercentage).toBe(0.5)
+    })
+  })
+
+  describe('case study', () => {
+    const solutions = [
+      {
+        caseId: 'case-1',
+        itemSolutions: [
+          {
+            itemId: 'item-1',
+            criteriaSolutions: [
+              { criterionId: 'criterion-1', min: 0, max: 5 },
+              { criterionId: 'criterion-2', min: 0, max: 5 },
+            ],
+          },
+        ],
+      },
+    ] as any
+
+    const base = {
+      parsedSolutions: solutions,
+      instanceInfo: instanceInfoWith(),
+      responseTimestamp: RESPONSE_TIMESTAMP,
+    }
+
+    const correctAssessment = {
+      assessment: [
+        {
+          caseId: 'case-1',
+          itemResponses: [
+            {
+              itemId: 'item-1',
+              criterionResponses: [
+                { criterionId: 'criterion-1', response: 3 },
+                { criterionId: 'criterion-2', response: 4 },
+              ],
+            },
+          ],
+        },
+      ] as any,
+    }
+
+    const partialAssessment = {
+      assessment: [
+        {
+          caseId: 'case-1',
+          itemResponses: [
+            {
+              itemId: 'item-1',
+              criterionResponses: [
+                { criterionId: 'criterion-1', response: 3 },
+                { criterionId: 'criterion-2', response: 50 }, // out of range
+              ],
+            },
+          ],
+        },
+      ] as any,
+    }
+
+    it('awards full credit when all criteria are within range', () => {
+      const result = getCaseStudyQuestionPoints({
+        ...base,
+        response: correctAssessment,
+        basePoints: 'false',
+      })
+
+      expect(result.pointsAwarded).toBe(50)
+      expect(result.pointsPercentage).toBe(1)
+      expect(result.xpAwarded).toBe(10)
+    })
+
+    it('awards fractional credit for partially correct assessments', () => {
+      const result = getCaseStudyQuestionPoints({
+        ...base,
+        response: partialAssessment,
+        basePoints: 'false',
+      })
+
+      // percentage 0.5 -> correctness 2.5 + bonus 22.5 = 25
+      expect(result.pointsAwarded).toBe(25)
+      expect(result.pointsPercentage).toBe(0.5)
+      expect(result.xpAwarded).toBe(0)
+    })
+
+    it('decomposition matches the total for a correct assessment', () => {
+      const result = getCaseStudyQuestionPointsDetails({
+        ...base,
+        response: correctAssessment,
+      })
+
+      expect(result).toEqual({
+        correctnessPoints: 5,
+        bonusPoints: 45,
+        xpAwarded: 10,
+        pointsPercentage: 1,
+      })
+    })
+  })
+
+  describe('instance-info defaults and multipliers', () => {
+    it('falls back to the default points configuration on empty instance values', () => {
+      const result = getChoicesQuestionPoints({
+        type: 'SC' as const,
+        choiceCount: '4',
+        parsedSolutions: [0],
+        instanceInfo: instanceInfoWith({
+          maxBonusPoints: '',
+          timeToZeroBonus: '',
+          defaultPoints: '',
+          defaultCorrectPoints: '',
+        }),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        response: choicesResponse([0]),
+        basePoints: 'false',
+      })
+
+      // same as the default configuration: 5 + 45
+      expect(result.pointsAwarded).toBe(50)
+    })
+
+    it('applies a points multiplier to correctness and bonus points', () => {
+      const result = getChoicesQuestionPointsDetails({
+        type: 'SC' as const,
+        choiceCount: '4',
+        parsedSolutions: [0],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        pointsMultiplier: '2',
+        response: choicesResponse([0]),
+      })
+
+      expect(result.correctnessPoints).toBe(10)
+      expect(result.bonusPoints).toBe(90)
+    })
+
+    it('treats multipliers below one or non-numeric as one', () => {
+      const half = getChoicesQuestionPointsDetails({
+        type: 'SC' as const,
+        choiceCount: '4',
+        parsedSolutions: [0],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        pointsMultiplier: '0.5',
+        response: choicesResponse([0]),
+      })
+      expect(half.correctnessPoints).toBe(5)
+
+      const invalid = getChoicesQuestionPointsDetails({
+        type: 'SC' as const,
+        choiceCount: '4',
+        parsedSolutions: [0],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        pointsMultiplier: 'not-a-number',
+        response: choicesResponse([0]),
+      })
+      expect(invalid.correctnessPoints).toBe(5)
+    })
+
+    it('yields the full bonus when the recorded first response has identical timing', () => {
+      // the caller guards recording via !firstResponseReceivedAt; given a
+      // recorded response with zero time difference the bonus is untouched
+      const result = getChoicesQuestionPointsDetails({
+        type: 'SC' as const,
+        choiceCount: '4',
+        parsedSolutions: [0],
+        instanceInfo: instanceInfoWith(),
+        responseTimestamp: RESPONSE_TIMESTAMP,
+        firstResponseReceivedAt: String(RESPONSE_TIMESTAMP),
+        response: choicesResponse([0]),
+      })
+
+      expect(result.bonusPoints).toBe(45)
+    })
+  })
+})

--- a/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
+++ b/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
@@ -10,7 +10,7 @@ import {
   getNumericalQuestionPointsDetails,
   getSelectionQuestionPoints,
   getSelectionQuestionPointsDetails,
-} from '../src/processors/helpers.js'
+} from '@/src/processors/helpers.js'
 
 // ! Characterization battery for the response-processor scoring helpers.
 //

--- a/apps/hatchet-worker-response-processor/tsconfig.json
+++ b/apps/hatchet-worker-response-processor/tsconfig.json
@@ -1,5 +1,10 @@
 {
-  "include": ["./src/**/*", "./scripts/**/*"],
+  "include": [
+    "./src/**/*",
+    "./scripts/**/*",
+    "./test/**/*",
+    "./vitest.config.ts"
+  ],
   "compilerOptions": {
     /* Base Options: */
     "esModuleInterop": true,

--- a/apps/hatchet-worker-response-processor/tsconfig.json
+++ b/apps/hatchet-worker-response-processor/tsconfig.json
@@ -8,6 +8,9 @@
   "compilerOptions": {
     /* Base Options: */
     "esModuleInterop": true,
+    "paths": {
+      "@/*": ["./*"]
+    },
     "skipLibCheck": true,
     "target": "es2022",
     "allowJs": true,

--- a/apps/hatchet-worker-response-processor/vitest.config.ts
+++ b/apps/hatchet-worker-response-processor/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 30000,
+    silent: false,
+    reporters: ['verbose'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true, // equivalent to Jest's maxWorkers: 1
+      },
+    },
+  },
+  resolve: {
+    // Let Node handle workspace packages naturally with proper conditions
+    conditions: ['node', 'import', 'default'],
+  },
+})

--- a/apps/hatchet-worker-response-processor/vitest.config.ts
+++ b/apps/hatchet-worker-response-processor/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -15,6 +16,12 @@ export default defineConfig({
     },
   },
   resolve: {
+    alias: [
+      {
+        find: /^@\//,
+        replacement: `${fileURLToPath(new URL('.', import.meta.url))}/`,
+      },
+    ],
     // Let Node handle workspace packages naturally with proper conditions
     conditions: ['node', 'import', 'default'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23139,7 +23139,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.8)':
     dependencies:
-      '@types/react': 19.2.18
+      '@types/react': 19.2.17
       react: 19.2.8
 
   '@docusaurus/responsive-loader@1.7.1(sharp@0.32.6)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,6 +1400,9 @@ importers:
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ~3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.19.4)(yaml@2.9.0)
 
   apps/lti:
     dependencies:
@@ -23136,7 +23139,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.8)':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       react: 19.2.8
 
   '@docusaurus/responsive-loader@1.7.1(sharp@0.32.6)':


### PR DESCRIPTION
**Stack position:** layer 1 of 2 (base `v3`); layer 2: #5902. Native stack #5903.

## Problem

The response-processor worker had **no test suite at all**: the ten scoring helpers in `apps/hatchet-worker-response-processor/src/processors/helpers.ts` — the total (`computeAwardedPoints`) and correctness/bonus decomposition (`computeAwardedCorrectnessPoints`) variants for choices (SC/MC/KPRIM), numerical, free text, selection and case study — decide live-quiz points, bonus and XP for every response, and nothing pinned their behavior. A follow-up consolidation of these helpers (#5902) needs exactly that pinning.

## Change (test-only)

- **Characterization battery** (`test/scoringHelpers.test.ts`, 28 cases) pinning the observable behavior, hand-derived from the implementation + `@klicker-uzh/grading`:
  - per-type grading: SC exact-match, MC hamming-distance penalty, KPRIM half-credit rule (solutions = indexes of true statements), numerical exact vs range solutions (shape sniffing), free-text trim/case-insensitive match, selection skip-field (`-1`) filtering with fractional credit over `numberOfInputs`, case-study range assessment
  - award math: base-points toggle, linear bonus decline against `firstResponseReceivedAt` (28 = 5 + round(45 − 2.25·10)) with floor at zero, points multipliers incl. the below-one/non-numeric→1 quirk, instance-info defaults with empty-string NaN fallbacks
  - decomposition invariants: Details variants agree with totals; the null-percentage path (free text without solutions) awards base points only and no XP
  - the first-response guard predicates (introduced by #5902) incl. the preserved empty-array-is-truthy quirk
- **Test infrastructure**: `vitest ~3.2.4` + `test:run` script (matching ten other workspace packages), `vitest.config.ts` modeled on the grading package, worker `tsconfig` include extended to the test directory (previously the tests would escape `tsc --noEmit` entirely)
- **CI wiring**: `apps/hatchet-worker-response-processor/**` added to test-unit.yml path triggers; a "Test response processor helpers" step runs the battery (the helpers are pure — no services needed)

## Tests (consolidation mapping)

Pure addition — 0 tests removed/merged/skipped; the suite goes 0 → 28 for this package.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm --filter @klicker-uzh/hatchet-worker-response-processor test:run` (container) | ✅ 28/28 |
| `pnpm --filter @klicker-uzh/hatchet-worker-response-processor check` (tsc now covers test/) | ✅ |
| `pnpm run check:all` (host boundary — the new host-only launcher tests from #5868 cannot run in-container) | ✅ 35/35 |
| `pnpm run build` (host) | ✅ 23/23 |
| Exact-head CI (incl. test-unit step + full Playwright suite) | see status below |
| Production-readiness audit (stack report, tracked) | ✅ see project/2026-09-11-pr5901-5902-production-readiness.md |

Rollback: revert the single commit.

## Status

- [x] Implementation (test-only)
- [x] Local gates
- [ ] Exact-head CI green
- [ ] Final review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for response-processing scoring, XP, bonuses, partial credit, multipliers, defaults, and edge cases across supported question types.
  * Unit tests now run automatically when response-processor changes are pushed or submitted for review.
* **Chores**
  * Added the test runner and configuration required to execute these checks consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->