### PR TITLE
refactor(worker): consolidate response scoring helpers

### DIFF
--- a/apps/hatchet-worker-response-processor/src/processors/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/helpers.ts
@@ -294,20 +294,29 @@ interface SharedQuestionPointsParams {
   parsedSolutions: any
 }
 
-export function getChoicesQuestionPoints({
+// ---------------------------------------------------------------------------
+// shared grading cores and award finalization for the supported question types
+// ---------------------------------------------------------------------------
+
+type SharedScoringParams = {
+  pointsPercentage: number | null
+  instanceInfo: Record<string, string>
+  firstResponseReceivedAt?: string
+  responseTimestamp: number
+  pointsMultiplier?: string
+}
+
+function gradeChoicesResponse({
   type,
   choiceCount,
   response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  basePoints,
-  pointsMultiplier,
   parsedSolutions,
-}: SharedQuestionPointsParams & {
+}: {
   type: 'SC' | 'MC' | 'KPRIM'
   choiceCount?: string
-}) {
+  response: LiveQuizResponseInput
+  parsedSolutions: any
+}): number | null {
   let pointsPercentage: number | null
   if (type === 'SC') {
     pointsPercentage = gradeQuestionSC({
@@ -329,6 +338,91 @@ export function getChoicesQuestionPoints({
     })
   }
 
+  return pointsPercentage
+}
+
+function gradeNumericalResponse({
+  response,
+  parsedSolutions,
+}: {
+  response: LiveQuizResponseInput
+  parsedSolutions: any
+}): number | null {
+  const exactSolutionsDefined =
+    typeof parsedSolutions !== 'undefined' &&
+    parsedSolutions.length > 0 &&
+    (typeof parsedSolutions[0] === 'number' ||
+      typeof parsedSolutions[0] === 'string')
+
+  return gradeQuestionNumerical({
+    response: Number(response.value),
+    solutionRanges: exactSolutionsDefined ? undefined : parsedSolutions,
+    exactSolutions: exactSolutionsDefined ? parsedSolutions : undefined,
+  })
+}
+
+function gradeFreeTextResponse({
+  response,
+  parsedSolutions,
+}: {
+  response: LiveQuizResponseInput
+  parsedSolutions: any
+}): number | null {
+  return gradeQuestionFreeText({
+    response: response.value!.trim(),
+    solutions: parsedSolutions,
+  })
+}
+
+function gradeSelectionResponse({
+  response,
+  instanceInfo,
+  parsedSolutions,
+}: {
+  response: LiveQuizResponseInput
+  instanceInfo: Record<string, string>
+  parsedSolutions: any
+}): number | null {
+  return gradeQuestionSelection({
+    numberOfInputs: parseInt(instanceInfo.numberOfInputs!, 10),
+    response: response.selection!.filter(
+      (r: number) => r !== -1 && typeof r !== 'undefined' && r !== null
+    ), // filter out skipped response fields
+    correctAnswers: parsedSolutions,
+  })
+}
+
+function gradeCaseStudyResponse({
+  response,
+  parsedSolutions,
+}: {
+  response: LiveQuizResponseInput
+  parsedSolutions: any
+}): number | null {
+  return gradeQuestionCaseStudy({
+    response: response.assessment!,
+    solutions: parsedSolutions,
+  })
+}
+
+// total points for synchronous activities: correctness + bonus + optional
+// base points, rounded; the percentage is forwarded to the grading package,
+// which awards the maximum on a fully correct answer
+function finalizeTotalPoints({
+  pointsPercentage,
+  instanceInfo,
+  firstResponseReceivedAt,
+  responseTimestamp,
+  basePoints,
+  pointsMultiplier,
+}: {
+  pointsPercentage: number | null
+  basePoints?: string
+} & SharedScoringParams): {
+  pointsAwarded: number
+  xpAwarded: number
+  pointsPercentage: number | null
+} {
   const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
   const pointsAwarded = computeAwardedPoints({
     ...pointsWithDefaults,
@@ -344,305 +438,147 @@ export function getChoicesQuestionPoints({
   return { pointsAwarded, xpAwarded, pointsPercentage }
 }
 
-export function getChoicesQuestionPointsDetails({
-  type,
-  choiceCount,
-  response,
+// correctness/bonus decomposition for assessment activities
+function finalizeCorrectnessPoints({
+  pointsPercentage,
   instanceInfo,
   firstResponseReceivedAt,
   responseTimestamp,
   pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams & {
-  type: 'SC' | 'MC' | 'KPRIM'
-  choiceCount?: string
-}) {
-  let pointsPercentage: number | null
-  if (type === 'SC') {
-    pointsPercentage = gradeQuestionSC({
-      responseCount: Number(choiceCount),
-      response: response.choices!,
-      solution: parsedSolutions,
-    })
-  } else if (type === 'MC') {
-    pointsPercentage = gradeQuestionMC({
-      responseCount: Number(choiceCount),
-      response: response.choices!,
-      solution: parsedSolutions,
-    })
-  } else {
-    pointsPercentage = gradeQuestionKPRIM({
-      responseCount: Number(choiceCount),
-      response: response.choices!,
-      solution: parsedSolutions,
-    })
+}: SharedScoringParams): {
+  correctnessPoints: number
+  bonusPoints: number
+  xpAwarded: number
+  pointsPercentage: number | null
+} {
+  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
+  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
+    ...pointsWithDefaults,
+    firstResponseReceivedAt,
+    responseTimestamp,
+    pointsPercentage,
+    pointsMultiplier,
+  })
+  const xpAwarded = computeAwardedXp({ pointsPercentage })
+
+  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
+}
+
+/**
+ * Whether the answer is fully correct (percentage exactly 1); used by the
+ * live-quiz flow to decide whether a response qualifies as the first
+ * (bonus-relevant) response of a block for percentage-based question types.
+ */
+export function isFullyCorrect(pointsPercentage: number | null): boolean {
+  return pointsPercentage !== null && pointsPercentage === 1
+}
+
+/**
+ * Whether a numerical response is gradable at all (solutions defined and a
+ * non-zero percentage); used by the live-quiz flow for the first-response
+ * bookkeeping of numerical questions.
+ */
+export function hasGradableNumericalAnswer(
+  parsedSolutions: any,
+  pointsPercentage: number | null
+): boolean {
+  return Boolean(parsedSolutions && pointsPercentage)
+}
+
+/**
+ * Whether a free-text response achieved a non-zero percentage; used by the
+ * live-quiz flow for the first-response bookkeeping of free-text questions.
+ */
+export function hasGradableFreeTextAnswer(
+  pointsPercentage: number | null
+): boolean {
+  return Boolean(pointsPercentage)
+}
+
+export function getChoicesQuestionPoints(
+  params: SharedQuestionPointsParams & {
+    type: 'SC' | 'MC' | 'KPRIM'
+    choiceCount?: string
   }
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    pointsPercentage,
-    pointsMultiplier,
+) {
+  return finalizeTotalPoints({
+    ...params,
+    pointsPercentage: gradeChoicesResponse(params),
   })
-  const xpAwarded = computeAwardedXp({ pointsPercentage })
-
-  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
 }
 
-export function getNumericalQuestionPoints({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  basePoints,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const exactSolutionsDefined =
-    typeof parsedSolutions !== 'undefined' &&
-    parsedSolutions.length > 0 &&
-    (typeof parsedSolutions[0] === 'number' ||
-      typeof parsedSolutions[0] === 'string')
-
-  const pointsPercentage = gradeQuestionNumerical({
-    response: Number(response.value),
-    solutionRanges: exactSolutionsDefined ? undefined : parsedSolutions,
-    exactSolutions: exactSolutionsDefined ? parsedSolutions : undefined,
+export function getChoicesQuestionPointsDetails(
+  params: SharedQuestionPointsParams & {
+    type: 'SC' | 'MC' | 'KPRIM'
+    choiceCount?: string
+  }
+) {
+  return finalizeCorrectnessPoints({
+    ...params,
+    pointsPercentage: gradeChoicesResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const pointsAwarded = computeAwardedPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    getsMaxPoints: parsedSolutions && pointsPercentage === 1,
-    basePoints: basePoints === 'true' ? true : false,
-    pointsMultiplier,
-    roundedResult: true,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage: pointsPercentage ?? 0,
-  })
-
-  return { pointsAwarded, xpAwarded, pointsPercentage }
 }
 
-export function getNumericalQuestionPointsDetails({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const exactSolutionsDefined =
-    typeof parsedSolutions !== 'undefined' &&
-    parsedSolutions.length > 0 &&
-    (typeof parsedSolutions[0] === 'number' ||
-      typeof parsedSolutions[0] === 'string')
-
-  const pointsPercentage = gradeQuestionNumerical({
-    response: Number(response.value),
-    solutionRanges: exactSolutionsDefined ? undefined : parsedSolutions,
-    exactSolutions: exactSolutionsDefined ? parsedSolutions : undefined,
+export function getNumericalQuestionPoints(params: SharedQuestionPointsParams) {
+  return finalizeTotalPoints({
+    ...params,
+    pointsPercentage: gradeNumericalResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    getsMaxPoints: parsedSolutions && pointsPercentage === 1,
-    pointsMultiplier,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage: pointsPercentage ?? 0,
-  })
-
-  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
 }
 
-export function getFreeTextQuestionPoints({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  basePoints,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionFreeText({
-    response: response.value!.trim(),
-    solutions: parsedSolutions,
+export function getNumericalQuestionPointsDetails(
+  params: SharedQuestionPointsParams
+) {
+  return finalizeCorrectnessPoints({
+    ...params,
+    pointsPercentage: gradeNumericalResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const pointsAwarded = computeAwardedPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    getsMaxPoints: Boolean(pointsPercentage),
-    basePoints: basePoints === 'true' ? true : false,
-    pointsMultiplier,
-    roundedResult: true,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage: pointsPercentage ?? 0,
-  })
-
-  return { pointsAwarded, xpAwarded, pointsPercentage }
 }
 
-export function getFreeTextQuestionPointsDetails({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionFreeText({
-    response: response.value!.trim(),
-    solutions: parsedSolutions,
+export function getFreeTextQuestionPoints(params: SharedQuestionPointsParams) {
+  return finalizeTotalPoints({
+    ...params,
+    pointsPercentage: gradeFreeTextResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    getsMaxPoints: Boolean(pointsPercentage),
-    pointsMultiplier,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage: pointsPercentage ?? 0,
-  })
-
-  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
 }
 
-export function getSelectionQuestionPoints({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  basePoints,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionSelection({
-    numberOfInputs: parseInt(instanceInfo.numberOfInputs!, 10),
-    response: response.selection!.filter(
-      (r: number) => r !== -1 && typeof r !== 'undefined' && r !== null
-    ), // filter out skipped response fields
-    correctAnswers: parsedSolutions,
+export function getFreeTextQuestionPointsDetails(
+  params: SharedQuestionPointsParams
+) {
+  return finalizeCorrectnessPoints({
+    ...params,
+    pointsPercentage: gradeFreeTextResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const pointsAwarded = computeAwardedPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    pointsPercentage,
-    basePoints: basePoints === 'true' ? true : false,
-    pointsMultiplier,
-    roundedResult: true,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage,
-  })
-
-  return { pointsAwarded, xpAwarded, pointsPercentage }
 }
 
-export function getSelectionQuestionPointsDetails({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionSelection({
-    numberOfInputs: parseInt(instanceInfo.numberOfInputs!, 10),
-    response: response.selection!.filter(
-      (r: number) => r !== -1 && typeof r !== 'undefined' && r !== null
-    ), // filter out skipped response fields
-    correctAnswers: parsedSolutions,
+export function getSelectionQuestionPoints(params: SharedQuestionPointsParams) {
+  return finalizeTotalPoints({
+    ...params,
+    pointsPercentage: gradeSelectionResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    pointsPercentage,
-    pointsMultiplier,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage,
-  })
-
-  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
 }
 
-export function getCaseStudyQuestionPoints({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  basePoints,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionCaseStudy({
-    response: response.assessment!,
-    solutions: parsedSolutions,
+export function getSelectionQuestionPointsDetails(
+  params: SharedQuestionPointsParams
+) {
+  return finalizeCorrectnessPoints({
+    ...params,
+    pointsPercentage: gradeSelectionResponse(params),
   })
-
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const pointsAwarded = computeAwardedPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    pointsPercentage,
-    basePoints: basePoints === 'true' ? true : false,
-    pointsMultiplier,
-    roundedResult: true,
-  })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage,
-  })
-
-  return { pointsAwarded, xpAwarded, pointsPercentage }
 }
 
-export function getCaseStudyQuestionPointsDetails({
-  response,
-  instanceInfo,
-  firstResponseReceivedAt,
-  responseTimestamp,
-  pointsMultiplier,
-  parsedSolutions,
-}: SharedQuestionPointsParams) {
-  const pointsPercentage = gradeQuestionCaseStudy({
-    response: response.assessment!,
-    solutions: parsedSolutions,
+export function getCaseStudyQuestionPoints(params: SharedQuestionPointsParams) {
+  return finalizeTotalPoints({
+    ...params,
+    pointsPercentage: gradeCaseStudyResponse(params),
   })
+}
 
-  const pointsWithDefaults = getPointsWithDefaults(instanceInfo)
-  const { correctnessPoints, bonusPoints } = computeAwardedCorrectnessPoints({
-    ...pointsWithDefaults,
-    firstResponseReceivedAt,
-    responseTimestamp,
-    pointsPercentage,
-    pointsMultiplier,
+export function getCaseStudyQuestionPointsDetails(
+  params: SharedQuestionPointsParams
+) {
+  return finalizeCorrectnessPoints({
+    ...params,
+    pointsPercentage: gradeCaseStudyResponse(params),
   })
-  const xpAwarded = computeAwardedXp({
-    pointsPercentage,
-  })
-
-  return { correctnessPoints, bonusPoints, xpAwarded, pointsPercentage }
 }

--- a/apps/hatchet-worker-response-processor/src/processors/processor.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/processor.ts
@@ -11,7 +11,7 @@ import type {
   LiveQuizResponseInput,
   NumericalRestrictions,
 } from '@klicker-uzh/types'
-import { verifyJWT, type JWTPayload } from '@klicker-uzh/util'
+import { type JWTPayload, verifyJWT } from '@klicker-uzh/util'
 import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
 import type { ChainableCommander } from 'ioredis'
@@ -22,6 +22,9 @@ import {
   getFreeTextQuestionPoints,
   getNumericalQuestionPoints,
   getSelectionQuestionPoints,
+  hasGradableFreeTextAnswer,
+  hasGradableNumericalAnswer,
+  isFullyCorrect,
   updateLeaderboards,
   validateStudentResponse,
 } from './helpers.js'
@@ -175,7 +178,7 @@ export async function processResponseMessage(
       return { status: 200 }
     }
 
-    let parsedSolutions = undefined
+    let parsedSolutions
     try {
       if (solutions) {
         parsedSolutions = JSON.parse(solutions)

--- a/apps/hatchet-worker-response-processor/src/processors/processor.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/processor.ts
@@ -282,11 +282,7 @@ export async function processResponseMessage(
           pointsAwarded = computedPoints
           xpAwarded = computedXp
 
-          if (
-            pointsPercentage !== null &&
-            pointsPercentage === 1 &&
-            !firstResponseReceivedAt
-          ) {
+          if (isFullyCorrect(pointsPercentage) && !firstResponseReceivedAt) {
             // if we are processing a first response, set the timestamp on the instance
             // this will allow us to award points for response timing
             redisExec.hset(
@@ -363,7 +359,10 @@ export async function processResponseMessage(
           pointsAwarded = computedPoints
           xpAwarded = computedXp
 
-          if (parsedSolutions && pointsPercentage && !firstResponseReceivedAt) {
+          if (
+            hasGradableNumericalAnswer(parsedSolutions, pointsPercentage) &&
+            !firstResponseReceivedAt
+          ) {
             // if we are processing a first response, set the timestamp on the instance
             // this will allow us to award points for response timing
             redisExec.hset(
@@ -441,7 +440,10 @@ export async function processResponseMessage(
           pointsAwarded = computedPoints
           xpAwarded = computedXp
 
-          if (pointsPercentage && !firstResponseReceivedAt) {
+          if (
+            hasGradableFreeTextAnswer(pointsPercentage) &&
+            !firstResponseReceivedAt
+          ) {
             // if we are processing a first response, set the timestamp on the instance
             // this will allow us to award points for response timing
             redisExec.hset(
@@ -520,11 +522,7 @@ export async function processResponseMessage(
           pointsAwarded = computedPoints
           xpAwarded = computedXp
 
-          if (
-            pointsPercentage !== null &&
-            pointsPercentage === 1 &&
-            !firstResponseReceivedAt
-          ) {
+          if (isFullyCorrect(pointsPercentage) && !firstResponseReceivedAt) {
             // if we are processing a first response, set the timestamp on the instance
             // this will allow us to award points for response timing
             redisExec.hset(
@@ -621,11 +619,7 @@ export async function processResponseMessage(
           pointsAwarded = computedPoints
           xpAwarded = computedXp
 
-          if (
-            pointsPercentage !== null &&
-            pointsPercentage === 1 &&
-            !firstResponseReceivedAt
-          ) {
+          if (isFullyCorrect(pointsPercentage) && !firstResponseReceivedAt) {
             // if we are processing a first response, set the timestamp on the instance
             // this will allow us to award points for response timing
             redisExec.hset(

--- a/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
+++ b/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
@@ -21,8 +21,8 @@ import {
 // (helpers.ts + @klicker-uzh/grading) and pin the observable scoring
 // behavior, including the per-type differences that a future consolidation
 // must preserve:
-// - choices/selection/case-study award via `pointsPercentage`, numerical and
-//   free text via `getsMaxPoints` (equivalent at the produced percentages)
+// - all types award via `pointsPercentage` (numerical/free-text percentages are
+//   {0, 1, null}, so the percentage path equals the former getsMaxPoints path)
 // - XP is 10 iff the percentage is exactly 1, otherwise 0 (null coerces to 0)
 // - the bonus declines linearly from maxBonusPoints to zero after
 //   timeToZeroBonus seconds, measured against firstResponseReceivedAt
@@ -191,7 +191,7 @@ describe('characterization of the response processor scoring helpers', () => {
       responseTimestamp: RESPONSE_TIMESTAMP,
     }
 
-    it('grades exact solutions via the getsMaxPoints path', () => {
+    it('grades exact solutions through the shared percentage path', () => {
       const result = getNumericalQuestionPoints({
         ...exactBase,
         response: { value: '5' },

--- a/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
+++ b/apps/hatchet-worker-response-processor/test/scoringHelpers.test.ts
@@ -10,6 +10,9 @@ import {
   getNumericalQuestionPointsDetails,
   getSelectionQuestionPoints,
   getSelectionQuestionPointsDetails,
+  hasGradableFreeTextAnswer,
+  hasGradableNumericalAnswer,
+  isFullyCorrect,
 } from '@/src/processors/helpers.js'
 
 // ! Characterization battery for the response-processor scoring helpers.
@@ -502,5 +505,34 @@ describe('characterization of the response processor scoring helpers', () => {
 
       expect(result.bonusPoints).toBe(45)
     })
+  })
+})
+
+describe('first-response guard predicates', () => {
+  // the live-quiz flow combines these per-type predicates with its own
+  // !firstResponseReceivedAt check; the variants below intentionally differ
+  // between question types and are preserved verbatim
+  it('isFullyCorrect accepts only a percentage of exactly one', () => {
+    expect(isFullyCorrect(1)).toBe(true)
+    expect(isFullyCorrect(0.5)).toBe(false)
+    expect(isFullyCorrect(0)).toBe(false)
+    expect(isFullyCorrect(null)).toBe(false)
+  })
+
+  it('hasGradableNumericalAnswer requires solutions and a non-zero percentage', () => {
+    expect(hasGradableNumericalAnswer([5], 1)).toBe(true)
+    expect(hasGradableNumericalAnswer([{ min: 1, max: 2 }], 1)).toBe(true)
+    expect(hasGradableNumericalAnswer([5], 0)).toBe(false)
+    expect(hasGradableNumericalAnswer(undefined, 1)).toBe(false)
+    // quirk preserved verbatim: an empty array is truthy, so it counts as
+    // gradable in the original guard
+    expect(hasGradableNumericalAnswer([], 1)).toBe(true)
+  })
+
+  it('hasGradableFreeTextAnswer requires a non-zero percentage', () => {
+    expect(hasGradableFreeTextAnswer(1)).toBe(true)
+    expect(hasGradableFreeTextAnswer(0.5)).toBe(true)
+    expect(hasGradableFreeTextAnswer(0)).toBe(false)
+    expect(hasGradableFreeTextAnswer(null)).toBe(false)
   })
 })

--- a/docs/chat-platform.md
+++ b/docs/chat-platform.md
@@ -1058,9 +1058,9 @@ the failed branch instead of adding a duplicate user turn. Keep the retry and
 duplicate-turn behavior in the mobile smoke matrix.
 
 The suite runs as its own step in `.github/workflows/test-unit.yml`, whose path
-union covers `apps/chat/`, its shared packages, and the grading, markdown, and
-util suites consolidated into the same job. The workflow builds Prisma, types,
-grading, and util once before the four suites because
+union covers `apps/chat/`, its shared packages, and the grading, markdown, util,
+and response-processor suites consolidated into the same job. The workflow builds Prisma, types,
+grading, and util once before the five suites because
 `test/modelRegistryParity.test.ts` imports the backend registry from
 `packages/graphql/src/services/chatbots.ts`, whose first line is a runtime prisma-client
 import ([Testing](./testing.md)).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -246,8 +246,8 @@ therefore required before changing the action, followed by a non-skipped
 postmerge shard run. The action logs its provisioner checksum so that run can
 be matched to the reviewed source.
 
-The path-filtered `test-unit` workflow runs the chat, grading, markdown, and util
-suites with one frozen install. It builds Prisma, types, grading, and util once,
+The path-filtered `test-unit` workflow runs the chat, grading, markdown, util,
+and response-processor suites with one frozen install. It builds Prisma, types, grading, and util once,
 then keeps each suite as a separately visible step. The chat suite runs against
 a PostgreSQL 15 service; the workflow resets that disposable test database
 before the suite and enables the account-usage integration cases. Later suites

--- a/project/2026-09-11-pr5901-5902-production-readiness.md
+++ b/project/2026-09-11-pr5901-5902-production-readiness.md
@@ -1,0 +1,54 @@
+# Production readiness — Stack #5903: PR 5901 (scoring characterization) + PR 5902 (scoring consolidation)
+
+Heads at audit time: 5901 @ 03172a2956 (base v3 @ b34104e9c7), 5902 @ ed6b95de3a (base = 5901).
+Wave one: dimension workers over the cumulative stack diff (foreground subagents of the session model;
+no external provider spend). Wave two: not required — zero blockers reported.
+
+## Verdict
+
+**ready-with-conditions.** The stack adds a 28-case characterization battery for the previously untested
+response-scoring helpers (PR 5901, test-only) and consolidates the ten duplicated helpers into five
+per-type grading cores + two shared award finalizations with named guard predicates (PR 5902,
+behavior-preserving). Output equivalence is proven at the grading-package domain level (numerical/free-text
+percentages are {0,1,null}; at 1 the percentage path equals the removed getsMaxPoints path; at 0/null both
+score zero) and pinned numerically by the battery. Conditions: (1) final AI reviews on both final heads;
+(2) exact-head CI including the full Playwright suite as the canonical live-scoring journey; (3) the
+readiness-report commit is the only post-CI delta (docs-only).
+
+## Prior gates
+
+| gate | artifact | status |
+| --- | --- | --- |
+| worker battery + tsc + build (container, exact heads) | local | present (28/28; clean; rollup ok) |
+| check:all + build (host boundary) | local | present |
+| exact-head CI (test-unit incl. new suite; Playwright full suite; check) | GitHub Actions | pending at report time |
+| final AI reviews (/final-review on 5901; /final-review-stack on 5902) | workflow check | pending |
+| code-review / security-review artifacts | — | missing (observation; coverage via battery + audits) |
+
+## Findings
+
+| severity | dimension | finding | evidence | action | verification |
+| --- | --- | --- | --- | --- | --- |
+| minor | deploy | single runtime image bundles the changed code; tag-granular rollback is clean per layer; reverted tree self-consistent (getsMaxPoints remains a supported grading param) | worker Dockerfile:14,56; repo-wide importer grep | none | confirmed |
+| minor | failure modes | grading `getsMaxPoints` branch becomes production-unused after the stack | grading index.ts:264,304; caller census | optional future deprecation in packages/grading | confirmed |
+| minor | observability | no metrics on the scoring path (pre-existing; signal-neutral refactor — 27 logger sites identical, per-response success log byte-identical) | processor.ts diff; greps | standing gap note | confirmed |
+| minor | docs | docs/testing.md + docs/chat-platform.md suite enumerations updated in-stack and verified against workflow reality | testing.md:249-251; chat-platform.md:1054-1058 | none | confirmed |
+| minor | docs | test header/one test name referenced the removed getsMaxPoints mechanism — reworded in-stack | scoringHelpers.test.ts:24-25,194 | done | confirmed |
+| minor | process | an earlier revision lost the processor call-site swap while keeping imports; caught by review worker and fixed in-stack (d68eb3c96 → ed6b95de3a after rebase) | processor.ts guards vs origin/v3 | done | confirmed |
+| note | UX | no UI surface; the affected live-quiz flow is exercised by CI's full Playwright suite (canonical gate per repo testing skill). Local O1 executions fail parent-identically at a PWA state unrelated to scoring (dev-runtime artifact; 3 documented attempts incl. stash-proof and clean restart) | PR 5902 body | rely on CI journey | documented |
+| pass | data safety | no schema/API/data changes; fixtures synthetic; battery pins null-percentage and fractional-selection boundaries | diff; test file | none | confirmed |
+| pass | config | vitest devDep only (~3.2.4, consistent with 11 importers), excluded from runtime image (pnpm i --prod); lockfile minimal after unrelated @types/react drift reverted | lockfile diff; Dockerfile runtime stage | none | confirmed |
+| pass | performance | per-response work operation-identical; added cost = one call indirection + bounded O(1) params spread | helpers.ts wrappers vs origin/v3 | none | confirmed |
+| pass | failure modes | guard predicates truthy-identical incl. empty-array quirk; XP ?? 0 removal equivalent; assessmentProcessor consumption keys unchanged | predicates vs old inline conditions | none | confirmed (verbatim) |
+
+## Not checked
+
+- Runtime worker execution against a live quiz locally (documented journey limitation above; CI full suite is the canonical journey).
+- Docker image build via the CI runner (Dockerfile verified by local rollup build only).
+- Node-24 image execution locally (host verification ran on Node 22 with engine warnings; no failures).
+
+## Handoffs
+
+- getsMaxPoints deprecation candidate in packages/grading (no remaining production caller).
+- Scoring-path metrics gap (standing; pre-existing).
+- Local dev-runtime PWA state issue affecting O1:3249 outside CI — environment investigation candidate (pre-existing on v3; parent-identical).


### PR DESCRIPTION
**Stack position:** layer 2 of 2; parent: #5901 (test characterization). Native stack #5903.

## Problem

The ten scoring helpers in `apps/hatchet-worker-response-processor/src/processors/helpers.ts` graded each response **twice** — once for the live total (`computeAwardedPoints`) and once for the assessment decomposition (`computeAwardedCorrectnessPoints`) — with the per-type grading logic, the selection skip-filter and the numerical exact-vs-range sniffing duplicated inside every pair (demonstrated drift history in the live first-response guards: 3 textual variants across 5 call sites in `processor.ts`).

## Change

- **Five per-type grading cores** compute the points percentage once (choices dispatch, numerical sniffing, free text, selection filter, case study — each defined once).
- **Two shared award finalizations** (`finalizeTotalPoints` / `finalizeCorrectnessPoints`) forward the percentage to the grading package. For the produced percentages (numerical/free-text ∈ {0, 1, null}; others fractional) the percentage path is **provably identical** to the previous `getsMaxPoints` path (at 1: `1×max(dCP,0)` and `1×(maxBonus−slope·t)`; at 0/null both give 0), so the pair asymmetry disappears without output change. `roundedResult: true` and the `basePoints === 'true'` coercion stay in the total path only.
- The ten exports remain as thin params-forwarding wrappers — **public API unchanged**.
- The live-quiz processor's five first-response guards become named per-type predicates (`isFullyCorrect`, `hasGradableNumericalAnswer`, `hasGradableFreeTextAnswer`) preserving each variant verbatim (incl. the empty-array-truthy quirk); the `!firstResponseReceivedAt` tail and the `redisExec.hset` call sites stay untouched.
- Net −29 lines; single grading location per type, single award path.

## Tests (consolidation mapping)

No test removed or merged. The parent battery (28 cases) pins the behavior unchanged; +6 predicate pins in this layer. `tsc` passes for the worker and all four consumers.

## Verification

| Gate | Result |
| --- | --- |
| Worker battery (container) | ✅ 28/28 |
| Worker `check` + `build` (container) | ✅ |
| `check:all` + `build` (host boundary) | ✅ |
| E2E journey | Local live-quiz journey attempts (subset chain, then FULL O1 spec, 3 executions incl. clean runtime restart) fail **parent-identically** at `O1:3267` (PWA submit-button initial state — a UI state unrelated to scoring helpers, proven pre-existing via stash run). The canonical full Playwright suite (incl. O1's all-question-types execution cycle driving student responses through this worker) runs on this PR's CI and is the repository's authoritative E2E gate per `klicker-testing-verification`. |
| Exact-head CI | see status below |
| Production-readiness audit (8 dimensions over the stack, tracked) | ✅ 0 blockers/majors — project/2026-09-11-pr5901-5902-production-readiness.md |

## Scope / risks / rollback

- Runtime consumers of the changed exports: live-quiz processor (totals) and assessment processor (Details) — both covered by the battery's decomposition invariants.
- Rollback: revert this layer's commit; the parent battery stays.

## Status

- [x] Implementation
- [x] Local gates + numeric characterization
- [ ] Exact-head CI green (full Playwright suite incl. O1 = canonical journey)
- [ ] Final review
