### PR TITLE
ci(playwright): sample bounded in-job resource pressure

### DIFF
--- a/.github/actions/playwright-build/action.yml
+++ b/.github/actions/playwright-build/action.yml
@@ -107,9 +107,9 @@ runs:
         started=$(date +%s)
         set +e
         set -o pipefail
-        pnpm run --filter @klicker-uzh/prisma build:test 2>&1 | tee turbo-build.log
+        node .ci-control/.github/scripts/playwright-resource-sampler.cjs playwright-resources-prisma.jsonl pnpm run --filter @klicker-uzh/prisma build:test 2>&1 | tee turbo-build.log
         prisma_status=("${PIPESTATUS[@]}")
-        pnpm run build:test --concurrency=4 2>&1 | tee -a turbo-build.log
+        node .ci-control/.github/scripts/playwright-resource-sampler.cjs playwright-resources-build.jsonl pnpm run build:test --concurrency=4 2>&1 | tee -a turbo-build.log
         build_status=("${PIPESTATUS[@]}")
         status=0
         if [ "${prisma_status[0]}" -ne 0 ] ||
@@ -217,6 +217,9 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: playwright-build-telemetry
-        path: playwright-build-telemetry.json
+        path: |
+          playwright-build-telemetry.json
+          playwright-resources-prisma.jsonl
+          playwright-resources-build.jsonl
         if-no-files-found: ignore
         retention-days: 7

--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -224,7 +224,7 @@ runs:
           exit 1
         fi
         echo "Running tests for shard ${SHARD_INDEX}/${SHARD_TOTAL} with profile $PROFILE: ${TEST_FILES[*]}"
-        .github/scripts/wait-for-services.sh -- \
+        node .ci-control/.github/scripts/playwright-resource-sampler.cjs "playwright-resources-shard-${SHARD_INDEX}.jsonl" .github/scripts/wait-for-services.sh -- \
           env NODE_ENV=test \
           pnpm --filter @klicker-uzh/playwright exec playwright test \
             --project=chromium \
@@ -321,6 +321,8 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: playwright-telemetry-${{ inputs.shard-index }}-of-${{ inputs.shard-total }}
-        path: playwright-telemetry-${{ inputs.shard-index }}.json
+        path: |
+          playwright-telemetry-${{ inputs.shard-index }}.json
+          playwright-resources-shard-${{ inputs.shard-index }}.jsonl
         if-no-files-found: ignore
         retention-days: 7

--- a/.github/scripts/playwright-resource-sampler.cjs
+++ b/.github/scripts/playwright-resource-sampler.cjs
@@ -1,0 +1,107 @@
+const fs = require('node:fs')
+const { spawn } = require('node:child_process')
+
+function counters(text, prefix) {
+  const line = text.split('\n').find((entry) => entry.startsWith(prefix))
+  if (!line) return null
+  const values = line.trim().split(/\s+/).slice(1).map(Number)
+  return values.every(Number.isFinite) ? values : null
+}
+
+function pressure(text) {
+  const result = {}
+  for (const kind of ['some', 'full']) {
+    const match = text.match(new RegExp(`^${kind} .*total=(\\d+)$`, 'm'))
+    result[kind] = match ? Number(match[1]) : null
+  }
+  return result
+}
+
+function snapshot(read = (path) => fs.readFileSync(path, 'utf8')) {
+  const safe = (path) => {
+    try {
+      return read(path)
+    } catch {
+      return ''
+    }
+  }
+  const cpu = counters(safe('/proc/stat'), 'cpu ')
+  const memory = safe('/proc/meminfo').match(/^MemAvailable:\s+(\d+) kB$/m)
+  return {
+    timestamp: new Date().toISOString(),
+    scope: 'procfs-visible-system',
+    // Exclude guest/guest_nice: Linux already includes them in user/nice.
+    cpuTicks: cpu && cpu.length >= 8 ? cpu.slice(0, 8) : null,
+    memoryAvailableKb: memory ? Number(memory[1]) : null,
+    pressureMicroseconds: Object.fromEntries(
+      ['cpu', 'memory', 'io'].map((kind) => [
+        kind,
+        pressure(safe(`/proc/pressure/${kind}`)),
+      ])
+    ),
+  }
+}
+
+function run(output, command, args) {
+  let fd
+  try {
+    fd = fs.openSync(output, 'wx', 0o600)
+  } catch {
+    console.error('Resource sampling unavailable; continuing command')
+  }
+  let count = 0
+  const sample = () => {
+    if (count >= 361 || fd === undefined) return
+    count++
+    try {
+      fs.writeSync(fd, `${JSON.stringify(snapshot())}\n`)
+    } catch {
+      // Diagnostics never determine the command result.
+    }
+  }
+  sample()
+  const timer = setInterval(() => {
+    sample()
+    if (count >= 361 || fd === undefined) clearInterval(timer)
+  }, 10000)
+  const child = spawn(command, args, { stdio: 'inherit', detached: true })
+  let killTimer
+  const forward = (signal) => {
+    try {
+      process.kill(-child.pid, signal)
+    } catch {}
+    if (!killTimer) {
+      killTimer = setTimeout(() => {
+        try {
+          process.kill(-child.pid, 'SIGKILL')
+        } catch {}
+      }, 5000)
+    }
+  }
+  const interrupt = () => forward('SIGINT')
+  const terminate = () => forward('SIGTERM')
+  process.on('SIGINT', interrupt)
+  process.on('SIGTERM', terminate)
+  child.on('error', () => console.error('Wrapped command could not start'))
+  child.on('close', (code, signal) => {
+    clearInterval(timer)
+    clearTimeout(killTimer)
+    sample()
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd)
+      } catch {}
+    }
+    process.removeListener('SIGINT', interrupt)
+    process.removeListener('SIGTERM', terminate)
+    process.exitCode = code ?? (signal === 'SIGINT' ? 130 : 143)
+  })
+}
+
+if (require.main === module) {
+  const [output, command, ...args] = process.argv.slice(2)
+  if (!output || !command) process.exit(2)
+  run(output, command, args)
+}
+
+module.exports = { counters, pressure, snapshot }

--- a/.github/scripts/playwright-resource-sampler.test.cjs
+++ b/.github/scripts/playwright-resource-sampler.test.cjs
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawn, spawnSync } = require('node:child_process')
+const { once } = require('node:events')
+const { test } = require('node:test')
+const { snapshot } = require('./playwright-resource-sampler.cjs')
+
+test('records numeric system metrics without double counting guest CPU', () => {
+  const files = {
+    '/proc/stat': 'cpu  1 2 3 4 5 6 7 8 9 10\n',
+    '/proc/meminfo': 'MemAvailable: 1234 kB\n',
+    '/proc/pressure/io': 'some avg10=0.00 avg60=0.00 avg300=0.00 total=42\n',
+  }
+  const result = snapshot((file) => files[file] || '')
+  assert.deepEqual(result.cpuTicks, [1, 2, 3, 4, 5, 6, 7, 8])
+  assert.equal(result.memoryAvailableKb, 1234)
+  assert.deepEqual(result.pressureMicroseconds.io, { some: 42, full: null })
+  assert.equal(result.pressureMicroseconds.cpu.some, null)
+})
+
+test('unavailable counters are null rather than idle measurements', () => {
+  const result = snapshot(() => {
+    throw new Error('unavailable')
+  })
+  assert.equal(result.cpuTicks, null)
+  assert.equal(result.memoryAvailableKb, null)
+})
+
+test('preserves failed command exit and writes bounded numeric output', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'resource-test-'))
+  try {
+    const output = path.join(directory, 'samples.jsonl')
+    const result = spawnSync(process.execPath, [
+      path.join(__dirname, 'playwright-resource-sampler.cjs'),
+      output,
+      process.execPath,
+      '-e',
+      'process.exit(7)',
+    ])
+    assert.equal(result.status, 7)
+    const rows = fs
+      .readFileSync(output, 'utf8')
+      .trim()
+      .split('\n')
+      .map(JSON.parse)
+    assert.equal(rows.length, 2)
+    const unavailable = spawnSync(process.execPath, [
+      path.join(__dirname, 'playwright-resource-sampler.cjs'),
+      output,
+      process.execPath,
+      '-e',
+      'process.exit(0)',
+    ])
+    assert.equal(unavailable.status, 0)
+    assert.equal(fs.readFileSync(output, 'utf8').trim().split('\n').length, 2)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('forwards cancellation and exits with signal status', {
+  timeout: 10000,
+}, async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'resource-test-'))
+  const child = spawn(process.execPath, [
+    path.join(__dirname, 'playwright-resource-sampler.cjs'),
+    path.join(directory, 'samples.jsonl'),
+    process.execPath,
+    '-e',
+    'console.log("ready"); setInterval(() => {}, 1000)',
+  ])
+  try {
+    await once(child.stdout, 'data')
+    const exited = once(child, 'exit')
+    child.kill('SIGTERM')
+    const [code] = await exited
+    assert.equal(code, 143)
+  } finally {
+    child.kill('SIGKILL')
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,9 @@ jobs:
         run: node --test .github/scripts/ci-equivalent-run.test.cjs .github/scripts/ci-obsolete-runs.test.cjs .github/scripts/ci-event-gates.test.cjs
 
       - name: Check Playwright CI contracts
-        run: pnpm run check:playwright-ci
+        run: |
+          pnpm run check:playwright-ci
+          node --test .github/scripts/playwright-resource-sampler.test.cjs
 
       - name: Check Playwright host launcher
         run: pnpm run check:playwright-host

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -167,6 +167,22 @@ available memory, Docker-disk pressure, conclusion, and artifact. This separates
 cache misses, host contention, service setup, test structure, and scheduling;
 do not infer one cause from total duration alone.
 
+### In-job resource samples
+
+Build and shard telemetry artifacts also contain `playwright-resources-*.jsonl`.
+The command wrapper samples every ten seconds for up to one hour (361 rows).
+Prisma and application builds have separate files; shard samples span service
+readiness and tests. Sampling failures do not change the wrapped command result.
+Artifacts retain the existing seven-day lifetime. No VM update is required.
+
+Samples contain only numeric procfs observations and timestamps. CPU tick order
+is user, nice, system, idle, iowait, irq, softirq, steal; guest ticks are already
+included in user/nice. Compute interval shares from successive counter deltas,
+not cumulative totals. Pressure totals are microseconds; divide their deltas by
+elapsed microseconds. Missing metrics are null, not zero. Counters describe the
+system visible from the container, not exclusive usage by its job. They do not
+measure per-process activity or establish a causal performance diagnosis alone.
+
 ## Image builds
 
 The selected staging source currently has 15 `v3_*-stg.yml` workflows with 16

--- a/project/2026-09-12-playwright-resource-sampling-plan.md
+++ b/project/2026-09-12-playwright-resource-sampling-plan.md
@@ -43,5 +43,11 @@ or hard-to-reverse architecture decision changes; no ADR is needed.
 
 ## Progress
 
-Isolated clean worktree created; implementation pending. Existing primary and
-runner-operations worktree changes are untouched. No new CI run launched.
+Implemented sampler and existing artifact wiring. Four focused Node tests pass:
+numeric parsing, missing counters, child failure with unavailable output, and
+cancellation forwarding. The one-hour cap is inspected in source; a full-hour
+runtime test has not been run. Formatting and diff checks pass. Main-session
+review covers bounded output, no secret collection, missing metrics, and unchanged
+exit behavior; no independent review is claimed under the user's override.
+Full monorepo builds are not claimed. Existing primary and runner-operations
+worktree changes are untouched. Remote CI and Linux runtime evidence are pending.

--- a/project/2026-09-12-playwright-resource-sampling-plan.md
+++ b/project/2026-09-12-playwright-resource-sampling-plan.md
@@ -1,0 +1,47 @@
+# Playwright resource sampling
+
+## Approval summary
+
+The user approved bounded in-job resource sampling to explain broad self-hosted
+test slowdown. Add a dependency-free command wrapper to existing build and shard
+actions and upload numeric samples with existing telemetry artifacts. Keep job
+exit status, full coverage, cache policy, runner count, permissions, and group
+restrictions unchanged. No host configuration or new service is required.
+
+Approval mode: executable batch. Authority: implementation, focused verification,
+ordinary push and draft PR. No merge, runner mutation or canary activation.
+Terminal: verified source package and draft PR; trusted reusable workflow runtime
+proof remains a post-merge gate. Boundary owner: self.
+
+## Execution details
+
+Owner: main, following the user's no-subagent instruction. Planning and review
+are main-session checks, not claimed independent specialist passes.
+One cohesive package on `rs/playwright-resource-sampling`, targeting `v3` at
+`42864be70b0a9059aaa1c81e265a153a842aac96`.
+
+Sample every ten seconds, at most 361 rows per command. Read numeric CPU counters,
+available memory and pressure stall totals from Linux procfs. These are host-wide
+observations visible inside the job container, not job-exclusive usage. Missing
+metrics remain null. CPU guest counters must not be double-counted. Pressure
+totals permit interval pressure calculations without enumerating disk devices.
+Do not read environment contents, command lines, process lists or network data.
+No new privilege or host mount. Preserve command exit and forward cancellation
+to the wrapped process group; no detached sampler survives command completion.
+Sampling errors must not fail otherwise successful tests.
+
+Wrap Prisma build, application build, and service-readiness/test execution.
+Keep their separate bounded files in the existing seven-day telemetry artifact.
+Tests cover numeric parsing, missing data, nonzero child exit, sample bounds and
+termination. Verify action wiring and syntax, inspect the full diff and scan
+staged content. No app runtime is needed for this diagnostic wrapper.
+
+This extends the earlier operator telemetry with an in-job timeline after actual
+measurements showed start/end snapshots could not explain the slowdown. It does
+not imply the prior host configuration needs another apply. No product primitive
+or hard-to-reverse architecture decision changes; no ADR is needed.
+
+## Progress
+
+Isolated clean worktree created; implementation pending. Existing primary and
+runner-operations worktree changes are untouched. No new CI run launched.


### PR DESCRIPTION
## Summary

Add bounded resource sampling to Playwright builds and shards so we can investigate self-hosted performance without manually collecting VM logs. Existing start/end snapshots cannot explain resource pressure during a job.

## How it works

- A dependency-free wrapper samples CPU ticks, including steal and I/O wait, available memory, and CPU/memory/I/O pressure totals every **10 seconds**, capped at **361 rows per command**.
- Prisma builds, application builds, and shard service-startup/test execution produce separate JSONL files in the existing telemetry artifacts, with **seven-day retention**.
- Missing metrics are recorded as `null`, not zero. Counters describe the system visible from the container, not resource usage exclusive to that job.
- The wrapper preserves command failures and forwards cancellation to its process group. Sampling failures do not fail the wrapped command.

## Boundaries

No environment values, process arguments, or network data are collected. Runner concurrency, workflow allowlists, permissions, cache behavior, and full test coverage remain unchanged. **No VM update is required.**

## Validation

- [Exact-head codebase CI passed](https://github.com/uzh-bf/klicker-uzh/actions/runs/34690304181) at `e90ae8a254`, including all four sampler tests on Linux.
- Focused tests cover numeric parsing, unavailable counters, command failure/output handling, and cancellation forwarding.
- Scoped formatting, diff checks, and staged Gitleaks checks passed.
- The one-hour cap was inspected in source rather than exercised for a full hour. Main-session review was completed; independent review is not claimed.

## Remaining gates

- Automated OCR review failed with **provider HTTP 402**; final review remains pending. No billing retry was requested.
- Actual build/shard resource-artifact collection needs **post-merge verification**. Callers use the trusted `v3` reusable workflow, so this draft does not prove that the new collection is active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI telemetry now includes periodic CPU, memory, and system pressure resource samples for builds and Playwright test shards.
  * Resource data is collected separately for Prisma builds, application builds, service readiness, and test execution.
  * Resource samples are included with existing telemetry artifacts.

* **Documentation**
  * Added guidance on interpreting resource samples, unavailable metrics, sampling limits, and retention.

* **Tests**
  * Added coverage for resource collection, signal handling, exit codes, and missing metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->