### PR TITLE
fix(kb): build knowledge graphs only from course-content resources

### DIFF
--- a/packages/graphql/src/services/knowledge.ts
+++ b/packages/graphql/src/services/knowledge.ts
@@ -2876,6 +2876,10 @@ export async function rebuildKbKnowledgeGraph(
         kbId,
         deletedAt: null,
         activeContentSha256: { not: null },
+        // Graph builds intentionally cover only lecturer-curated course
+        // material: administrative uploads (tutorials, syllabi, rules) must
+        // not leak into graph nodes and generated questions.
+        materialType: DB.KBResourceMaterialType.COURSE_CONTENT,
       },
       select: {
         id: true,
@@ -2888,9 +2892,12 @@ export async function rebuildKbKnowledgeGraph(
       orderBy: { id: 'asc' },
     })
     if (resources.length === 0) {
-      throw new GraphQLError('KB has no active graph sources', {
-        extensions: { code: 'KB_GRAPH_EMPTY' },
-      })
+      throw new GraphQLError(
+        'KB has no course-content resources with served content',
+        {
+          extensions: { code: 'KB_GRAPH_NO_COURSE_CONTENT' },
+        }
+      )
     }
 
     const validatedResources = resources.map((resource) => ({

--- a/packages/graphql/test/knowledge.test.ts
+++ b/packages/graphql/test/knowledge.test.ts
@@ -471,6 +471,7 @@ describe('Integration tests for knowledge base CRUD', () => {
         kbId: kb.id,
         type: KBResourceType.URL,
         title: 'Graph source',
+        materialType: KBResourceMaterialType.COURSE_CONTENT,
         sourceUrl: 'https://example.com/graph-source',
         status: KBResourceStatus.READY,
         activeResourceVersion: 1,
@@ -527,6 +528,71 @@ describe('Integration tests for knowledge base CRUD', () => {
     await expect(
       prisma.kBGraphBuild.count({ where: { kbId: kb.id } })
     ).resolves.toBe(1)
+  })
+
+  it('builds only from course-content resources and refuses builds without any', async () => {
+    const kb = await createKb({ name: 'Tagged graph sources' }, userOneCtx)
+    await setKbKnowledgeGraphEnabled({ kbId: kb.id, enabled: true }, userOneCtx)
+    await prisma.kBResource.create({
+      data: {
+        kbId: kb.id,
+        type: KBResourceType.URL,
+        title: 'Lecture script',
+        materialType: KBResourceMaterialType.COURSE_CONTENT,
+        sourceUrl: 'https://example.com/script',
+        status: KBResourceStatus.READY,
+        activeResourceVersion: 1,
+        activeContentSha256: 'c'.repeat(64),
+      },
+    })
+    await prisma.kBResource.create({
+      data: {
+        kbId: kb.id,
+        type: KBResourceType.URL,
+        title: 'Platform tutorial',
+        materialType: KBResourceMaterialType.ADMINISTRATIVE,
+        sourceUrl: 'https://example.com/tutorial',
+        status: KBResourceStatus.READY,
+        activeResourceVersion: 1,
+        activeContentSha256: 'd'.repeat(64),
+      },
+    })
+
+    const config = await rebuildKbKnowledgeGraph({ kbId: kb.id }, userOneCtx)
+    const sources = await prisma.kBGraphBuildSource.findMany({
+      where: { buildId: config.buildId! },
+    })
+    expect(sources.map(({ title }) => title)).toEqual(['Lecture script'])
+
+    const untaggedKb = await createKb(
+      { name: 'Untagged graph sources' },
+      userOneCtx
+    )
+    await setKbKnowledgeGraphEnabled(
+      { kbId: untaggedKb.id, enabled: true },
+      userOneCtx
+    )
+    await prisma.kBResource.create({
+      data: {
+        kbId: untaggedKb.id,
+        type: KBResourceType.URL,
+        title: 'Syllabus',
+        materialType: KBResourceMaterialType.ADMINISTRATIVE,
+        sourceUrl: 'https://example.com/syllabus',
+        status: KBResourceStatus.READY,
+        activeResourceVersion: 1,
+        activeContentSha256: 'e'.repeat(64),
+      },
+    })
+
+    await expect(
+      rebuildKbKnowledgeGraph({ kbId: untaggedKb.id }, userOneCtx)
+    ).rejects.toMatchObject({
+      extensions: { code: 'KB_GRAPH_NO_COURSE_CONTENT' },
+    })
+    await expect(
+      prisma.kBGraphBuild.count({ where: { kbId: untaggedKb.id } })
+    ).resolves.toBe(0)
   })
 
   it('creates and lists only the current users knowledge bases', async () => {

--- a/packages/graphql/test/knowledge.test.ts
+++ b/packages/graphql/test/knowledge.test.ts
@@ -498,6 +498,7 @@ describe('Integration tests for knowledge base CRUD', () => {
         type: KBResourceType.URL,
         title: 'Graph source',
         sourceUrl: 'https://example.com/ambiguous-graph-source',
+        materialType: KBResourceMaterialType.COURSE_CONTENT,
         status: KBResourceStatus.READY,
         activeResourceVersion: 1,
         activeContentSha256: 'b'.repeat(64),

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1958,6 +1958,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
     graphLoadError: 'Der Graphstatus konnte nicht geladen werden.',
     graphRetry: 'Erneut versuchen',
     graphBuildError: 'Der Graphaufbau konnte nicht gestartet werden.',
+    graphNoCourseContent:
+      'Keine Ressourcen sind als „Kursinhalt“ kategorisiert. Markieren Sie Ihre Kursmaterialien, bevor Sie den Graphen erstellen – Verwaltungsressourcen werden ausgeschlossen.',
     graphQuotaInsufficient:
       'Der ausgewählte Aufbau kostet schätzungsweise {estimate}, im Semesterkontingent sind jedoch nur noch {remaining} verfügbar. Wählen Sie wenn möglich eine günstigere Qualitätsstufe oder warten Sie auf die Zurücksetzung des Kontingents.',
     graphPreviewTitle: 'Veröffentlichter Graph',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1933,6 +1933,8 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
     graphLoadError: 'The graph status could not be loaded.',
     graphRetry: 'Retry',
     graphBuildError: 'The graph build could not be started.',
+    graphNoCourseContent:
+      'No resources are categorized as “Course content”. Tag your course materials before building the graph — administrative resources are excluded.',
     graphQuotaInsufficient:
       'The selected build is estimated at {estimate}, but only {remaining} remains in your semester quota. Choose a lower-cost quality level if available, or wait for the quota to reset.',
     graphPreviewTitle: 'Published graph',

--- a/packages/kb-management/src/components/KnowledgeGraphPanel.tsx
+++ b/packages/kb-management/src/components/KnowledgeGraphPanel.tsx
@@ -394,6 +394,8 @@ function KnowledgeGraphPanel({ kbId }: { kbId: string }) {
             kbId,
           })
         }
+      } else if (details?.code === 'KB_GRAPH_NO_COURSE_CONTENT') {
+        setOperationError(t('kb.graphNoCourseContent'))
       } else {
         setOperationError(t('kb.graphBuildError'))
       }


### PR DESCRIPTION
## Problem

On STG, generated questions sampled administrative material (OLAT tutorial p. 6, Kursinformationen p. 3) even though those resources were correctly tagged. `rebuildKbKnowledgeGraph` selected **every** KB resource with served content and ignored the `materialType` tag, so ADMINISTRATIVE uploads leaked into graph nodes and, through the graph bundle, into question generation.

## Change

- `rebuildKbKnowledgeGraph` now selects only `COURSE_CONTENT` resources (deleted resources and resources without served content were already excluded).
- If a KB has no course-content resources with served content, the build is rejected up front with a dedicated `KB_GRAPH_NO_COURSE_CONTENT` GraphQL error instead of the generic `KB_GRAPH_EMPTY`.
- The manage UI maps the new code to a toast explaining that course materials must be tagged before building; en/de strings added.
- Existing rebuild tests now tag their sources; a new integration test covers mixed-tag selection (only the COURSE_CONTENT resource becomes a build source) and the no-course-content rejection with zero build rows.

Element and question generation read the graph bundle, so filtering at graph-build time propagates everywhere; this is the only resource-selection point for graph builds.

## Validation

- `tsc --noEmit` clean for `@klicker-uzh/graphql` (`tsconfig.check.json`) and `@klicker-uzh/kb-management`
- Biome check clean on all changed files; staged diff gitleaks-clean
- The [GraphQL integration suite passes on corrected head `0b8cf089d2`](https://github.com/uzh-bf/klicker-uzh/actions/runs/34691244322), including source filtering and dispatch fencing. The dispatch fixture now explicitly marks its resource as course content.
- Browser interaction verification and en/de screenshots of the new error message remain outstanding; UI verification is not complete.

## Deployment note

Graph builds on STG keep the old behavior until this is merged, built, and synced. After deploy, affected KBs only need a graph rebuild — no re-tagging is required where resources are already tagged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Knowledge graph builds now use only resources categorized as course content.
  - Administrative resources are excluded from graph nodes and generated questions.
  - Added localized guidance when no course-content resources are available.

- **Bug Fixes**
  - Knowledge graph rebuilds now show a specific error when no eligible course-content resources exist, instead of a generic failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
