### PR TITLE
rs/idle architecture/ia 2026 09 07/05 response invariants

### DIFF
--- a/apps/hatchet-worker-response-processor/src/processors/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/helpers.ts
@@ -229,9 +229,7 @@ export function validateStudentResponse({
       response.selection.length === 0 ||
       // TODO: re-introduce the following check once the incoming responses are guaranteed to be correct through response-api validation
       // !response.selection.every((r) => typeof r === 'number') ||
-      response.selection.filter(
-        (r) => r !== -1 && typeof r !== 'undefined' && r !== null
-      ).length === 0 // at least one selection must be made (excluding skipped fields with value -1 / undefined / null)
+      filterSkippedSelectionResponses(response.selection).length === 0 // at least one selection must be made (excluding skipped fields with value -1 / undefined / null)
     ) {
       return {
         valid: false,

--- a/apps/hatchet-worker-response-processor/src/processors/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/helpers.ts
@@ -2,6 +2,7 @@ import {
   computeAwardedCorrectnessPoints,
   computeAwardedPoints,
   computeAwardedXp,
+  filterSkippedSelectionResponses,
   gradeQuestionCaseStudy,
   gradeQuestionFreeText,
   gradeQuestionKPRIM,
@@ -9,6 +10,7 @@ import {
   gradeQuestionNumerical,
   gradeQuestionSC,
   gradeQuestionSelection,
+  resolveNumericalSolutions,
 } from '@klicker-uzh/grading'
 import type {
   FreeTextRestrictions,
@@ -348,16 +350,13 @@ function gradeNumericalResponse({
   response: LiveQuizResponseInput
   parsedSolutions: any
 }): number | null {
-  const exactSolutionsDefined =
-    typeof parsedSolutions !== 'undefined' &&
-    parsedSolutions.length > 0 &&
-    (typeof parsedSolutions[0] === 'number' ||
-      typeof parsedSolutions[0] === 'string')
+  const { exactSolutions, solutionRanges } =
+    resolveNumericalSolutions(parsedSolutions)
 
   return gradeQuestionNumerical({
     response: Number(response.value),
-    solutionRanges: exactSolutionsDefined ? undefined : parsedSolutions,
-    exactSolutions: exactSolutionsDefined ? parsedSolutions : undefined,
+    solutionRanges,
+    exactSolutions,
   })
 }
 
@@ -385,9 +384,7 @@ function gradeSelectionResponse({
 }): number | null {
   return gradeQuestionSelection({
     numberOfInputs: parseInt(instanceInfo.numberOfInputs!, 10),
-    response: response.selection!.filter(
-      (r: number) => r !== -1 && typeof r !== 'undefined' && r !== null
-    ), // filter out skipped response fields
+    response: filterSkippedSelectionResponses(response.selection!),
     correctAnswers: parsedSolutions,
   })
 }

--- a/apps/hatchet-worker-response-processor/src/processors/processor.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/processor.ts
@@ -6,6 +6,7 @@ import type {
   DurableContext,
   JsonObject,
 } from '@hatchet-dev/typescript-sdk/index.js'
+import { filterSkippedSelectionResponses } from '@klicker-uzh/grading'
 import type {
   FreeTextRestrictions,
   LiveQuizResponseInput,
@@ -503,7 +504,7 @@ export async function processResponseMessage(
             participantData.role === 'TEMPORARY_PARTICIPANT'
               ? `temporary-${participantData.sub}`
               : participantData.sub,
-            `[${String(response.selection.filter((r: number) => r !== -1 && typeof r !== 'undefined' && r !== null))}]` // filter out skipped response fields
+            `[${String(filterSkippedSelectionResponses(response.selection))}]` // filter out skipped response fields
           )
 
           const {

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -91,7 +91,7 @@ export function gradeQuestionKPRIM({
 interface GradeQuestionNumericalArgs {
   response: number
   solutionRanges?: NumericalSolutionRange[] | null
-  exactSolutions?: number[] | null
+  exactSolutions?: (number | string)[] | null
 }
 
 export function gradeQuestionNumerical({
@@ -398,4 +398,45 @@ export function computeAwardedXp({ pointsPercentage }: ComputeAwardedXpArgs) {
     return 10
   }
   return 0
+}
+
+// ! Shared response-validity invariants
+//
+// These helpers single-source the rules that were previously duplicated
+// across the response processor, the GraphQL services, the cached block
+// results and the client-side validator. The expressions are preserved
+// verbatim, including the truthiness quirks (an empty array counts as
+// present, and `typeof undefined` filters skipped entries).
+
+/**
+ * Removes skipped entries (-1, undefined and null) from a selection
+ * response. The result feeds both grading (where skipped inputs do not
+ * count towards the achieved percentage) and response validation.
+ */
+export function filterSkippedSelectionResponses(selection: number[]): number[] {
+  return selection.filter(
+    (r) => r !== -1 && typeof r !== 'undefined' && r !== null
+  )
+}
+
+/**
+ * Resolves which solution shape a numerical question uses: a list of
+ * exact solutions (numbers or numeric strings) or a list of solution
+ * ranges. Exactly one of the returned keys is defined, mirroring the
+ * arguments of {@link gradeQuestionNumerical}.
+ */
+export function resolveNumericalSolutions(
+  solutions: NumericalSolutionRange[] | number[] | string[] | null | undefined
+): {
+  exactSolutions?: number[] | string[]
+  solutionRanges?: NumericalSolutionRange[]
+} {
+  const exactSolutionsDefined =
+    !!solutions &&
+    solutions.length > 0 &&
+    (typeof solutions[0] === 'number' || typeof solutions[0] === 'string')
+
+  return exactSolutionsDefined
+    ? { exactSolutions: solutions as number[] | string[] }
+    : { solutionRanges: solutions as NumericalSolutionRange[] }
 }

--- a/packages/grading/test/index.test.ts
+++ b/packages/grading/test/index.test.ts
@@ -2,6 +2,7 @@ import {
   computeAwardedPoints,
   computeAwardedXp,
   computeSimpleAwardedPoints,
+  filterSkippedSelectionResponses,
   gradeQuestionCaseStudy,
   gradeQuestionFreeText,
   gradeQuestionKPRIM,
@@ -9,6 +10,7 @@ import {
   gradeQuestionNumerical,
   gradeQuestionSC,
   gradeQuestionSelection,
+  resolveNumericalSolutions,
 } from '../src/index.js'
 
 describe('@klicker-uzh/grading', () => {
@@ -1493,5 +1495,57 @@ describe('@klicker-uzh/grading', () => {
       pointsPercentage: 0,
     })
     expect(xp3).toEqual(0)
+  })
+})
+
+describe('shared response-validity invariants', () => {
+  describe('filterSkippedSelectionResponses', () => {
+    it('removes skipped entries while keeping valid selections in order', () => {
+      expect(filterSkippedSelectionResponses([0, -1, 2, 1])).toEqual([0, 2, 1])
+    })
+
+    it('treats undefined and null entries as skipped', () => {
+      expect(
+        filterSkippedSelectionResponses([0, undefined as any, null as any, 3])
+      ).toEqual([0, 3])
+    })
+
+    it('returns an empty array when every entry is skipped', () => {
+      expect(filterSkippedSelectionResponses([-1, -1])).toEqual([])
+    })
+  })
+
+  describe('resolveNumericalSolutions', () => {
+    it('resolves numeric lists as exact solutions', () => {
+      expect(resolveNumericalSolutions([5, 7])).toEqual({
+        exactSolutions: [5, 7],
+      })
+    })
+
+    it('resolves numeric strings as exact solutions', () => {
+      expect(resolveNumericalSolutions(['5.5'])).toEqual({
+        exactSolutions: ['5.5'],
+      })
+    })
+
+    it('resolves range objects as solution ranges', () => {
+      const ranges = [{ min: 1, max: 10 }]
+      expect(resolveNumericalSolutions(ranges)).toEqual({
+        solutionRanges: ranges,
+      })
+    })
+
+    it('resolves an empty list as solution ranges (not exact solutions)', () => {
+      expect(resolveNumericalSolutions([])).toEqual({ solutionRanges: [] })
+    })
+
+    it('resolves a missing list as solution ranges', () => {
+      expect(resolveNumericalSolutions(undefined)).toEqual({
+        solutionRanges: undefined,
+      })
+      expect(resolveNumericalSolutions(null)).toEqual({
+        solutionRanges: null,
+      })
+    })
   })
 })

--- a/packages/graphql/src/services/stacks.ts
+++ b/packages/graphql/src/services/stacks.ts
@@ -1,7 +1,8 @@
-import { ICaseStudyElementEvaluationResults } from '@/schema/evaluation.js'
+import { createHash } from 'node:crypto'
 import {
   computeAwardedXp,
   computeSimpleAwardedPoints,
+  filterSkippedSelectionResponses,
   gradeQuestionCaseStudy,
   gradeQuestionFreeText,
   gradeQuestionKPRIM,
@@ -54,12 +55,12 @@ import type {
 import { FlashcardCorrectness, StackFeedbackStatus } from '@klicker-uzh/types'
 import {
   getInitialInstanceResults,
-  PrismaTransactionClient,
+  type PrismaTransactionClient,
 } from '@klicker-uzh/util'
 import dayjs from 'dayjs'
 import { max, mean, median, min, quantileSeq, round, std } from 'mathjs'
-import { createHash } from 'node:crypto'
 import { toLowerCase } from 'remeda'
+import type { ICaseStudyElementEvaluationResults } from '@/schema/evaluation.js'
 import type { Context } from '../lib/context.js'
 import type {
   CaseStudyCaseResponse,
@@ -1640,7 +1641,7 @@ export function updateChoicesResults({
   response: ResponseInput
 }): { results: ElementResultsChoices; modified: boolean } {
   const results = previousResults
-  let updatedResults = results
+  const updatedResults = results
 
   if (
     !('choices' in response) ||
@@ -1678,7 +1679,7 @@ export function updateNumericalResults({
 
   const MD5 = createHash('md5')
   const results = previousResults
-  let updatedResults = results
+  const updatedResults = results
 
   // validate format of response
   if (
@@ -1744,7 +1745,7 @@ export function updateFreeTextResults({
 
   const MD5 = createHash('md5')
   const results = previousResults
-  let updatedResults = results
+  const updatedResults = results
 
   // validate format of response and check that restrictions are fulfilled
   if (
@@ -1800,7 +1801,7 @@ export function updateSelectionResults({
   }
 
   // increment all values in updatedSelections that are contained in response.selection
-  let updatedSelections = { ...previousResults.selections }
+  const updatedSelections = { ...previousResults.selections }
   response.selection.forEach((ix) => {
     if (ix in updatedSelections && typeof updatedSelections[ix] === 'number') {
       updatedSelections[ix] = updatedSelections[ix] + 1
@@ -2164,7 +2165,7 @@ function computeAggregatedResponsesChoices({
   existingResponse: DB.QuestionResponse | null
   response: ResponseInput
 }): ElementResultsChoices {
-  let newAggResponses = (existingResponse?.aggregatedResponses ??
+  const newAggResponses = (existingResponse?.aggregatedResponses ??
     getInitialInstanceResults(instance.elementData)) as ElementResultsChoices
 
   // update aggregated responses for choices
@@ -2190,7 +2191,7 @@ function computeAggregatedResponsesOpen({
   responseValue: string
   correctness: number
 }) {
-  let newAggResponses = (existingResponse?.aggregatedResponses ??
+  const newAggResponses = (existingResponse?.aggregatedResponses ??
     getInitialInstanceResults(instance.elementData)) as ElementResultsOpen
 
   // update aggregated responses for open questions
@@ -3087,9 +3088,10 @@ async function respondToElement({
         id: response.instanceId,
         courseId,
         response: {
-          selection: response.selectionResponse?.filter(
-            (r) => r !== -1 && typeof r !== 'undefined' && r !== null
-          ), // only forward valid responses
+          // only forward valid responses
+          selection: response.selectionResponse
+            ? filterSkippedSelectionResponses(response.selectionResponse)
+            : undefined,
         },
         answerTime,
         participation,
@@ -3199,7 +3201,7 @@ export async function respondToElementStack(
     }
   }
 
-  let stackScore: number | undefined = undefined
+  let stackScore: number | undefined
   let stackFeedback = StackFeedbackStatus.UNANSWERED
   const evaluationsArr: InstanceEvaluation[] = []
 

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -33,6 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@klicker-uzh/grading": "workspace:*",
     "@klicker-uzh/graphql": "workspace:*",
     "@klicker-uzh/markdown": "workspace:*",
     "@klicker-uzh/word-cloud": "workspace:*",

--- a/packages/shared-components/src/utils/validateResponse.ts
+++ b/packages/shared-components/src/utils/validateResponse.ts
@@ -1,3 +1,4 @@
+import { filterSkippedSelectionResponses } from '@klicker-uzh/grading'
 import type {
   FreeTextElementOptions,
   NumericalElementOptions,
@@ -112,14 +113,8 @@ export function validateSelectionResponse({
     Object.values(response).every(
       (value) => value === -1 || typeof value === 'undefined' || value === null
     ) ||
-    new Set(
-      Object.values(response).filter(
-        (r) => r !== -1 && typeof r !== 'undefined' && r !== null
-      )
-    ).size !==
-      Object.values(response).filter(
-        (r) => r !== -1 && typeof r !== 'undefined' && r !== null
-      ).length
+    new Set(filterSkippedSelectionResponses(Object.values(response))).size !==
+      filterSkippedSelectionResponses(Object.values(response)).length
   ) {
     return false
   }

--- a/packages/util/src/blocks.ts
+++ b/packages/util/src/blocks.ts
@@ -1,18 +1,19 @@
 import {
   gradeQuestionFreeText,
   gradeQuestionNumerical,
+  resolveNumericalSolutions,
 } from '@klicker-uzh/grading'
 import * as DB from '@klicker-uzh/prisma/client'
-import {
-  type CaseStudyCaseSolution,
-  type ElementResultsCaseStudy,
-  type ElementResultsChoices,
-  type ElementResultsContent,
-  type ElementResultsFlashcard,
-  type ElementResultsOpen,
-  type ElementResultsSelection,
+import type {
+  CaseStudyCaseSolution,
+  ElementResultsCaseStudy,
+  ElementResultsChoices,
+  ElementResultsContent,
+  ElementResultsFlashcard,
+  ElementResultsOpen,
+  ElementResultsSelection,
 } from '@klicker-uzh/types'
-import { Redis } from 'ioredis'
+import type { Redis } from 'ioredis'
 import { omitBy } from 'remeda'
 import { getInitialInstanceResults } from './elements.js'
 
@@ -130,14 +131,13 @@ export async function getCachedBlockResults({
           let grading: number | undefined
           if (solutions && solutions.length > 0) {
             if (instance.elementType === DB.ElementType.NUMERICAL) {
-              const exactSolutionsDefined =
-                typeof solutions[0] === 'number' ||
-                typeof solutions[0] === 'string'
+              const { exactSolutions, solutionRanges } =
+                resolveNumericalSolutions(solutions)
               grading =
                 gradeQuestionNumerical({
                   response: parseFloat(String(response)),
-                  solutionRanges: exactSolutionsDefined ? undefined : solutions,
-                  exactSolutions: exactSolutionsDefined ? solutions : undefined,
+                  solutionRanges,
+                  exactSolutions,
                 }) ?? undefined
             } else if (instance.elementType === DB.ElementType.FREE_TEXT) {
               grading =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2281,6 +2281,9 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^0.2.2
         version: 0.2.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.2.8)
+      '@klicker-uzh/grading':
+        specifier: workspace:*
+        version: link:../grading
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3

--- a/project/2026-09-11-pr5901-5902-production-readiness.md
+++ b/project/2026-09-11-pr5901-5902-production-readiness.md
@@ -52,3 +52,18 @@ readiness-report commit is the only post-CI delta (docs-only).
 - getsMaxPoints deprecation candidate in packages/grading (no remaining production caller).
 - Scoring-path metrics gap (standing; pre-existing).
 - Local dev-runtime PWA state issue affecting O1:3249 outside CI — environment investigation candidate (pre-existing on v3; parent-identical).
+
+## Addendum — PR 5918 (layer 3: response-validity invariants), heads 70b10b4bc + c58da6263
+
+Proportionate audit (equivalence/config/performance/docs worker + local verification):
+
+| severity | dimension | finding | evidence | action | verification |
+| --- | --- | --- | --- | --- | --- |
+| info | equivalence | all six adoption sites expression-identical to origin/v3 (verbatim helper body); stacks undefined propagation preserved exactly for every input | grading index.ts:417-419; stacks.ts:3088-3091; validateResponse.ts:117-119 | none | confirmed (verbatim quotes) |
+| low | failure modes | worker numerical core: null solutions now yield null grading instead of TypeError — strictly safer superset; blocks.ts site exactly equivalent (outer guard) | grading index.ts:99 guard | none | confirmed |
+| low | config | client bundles gain grading's two helpers (~few hundred bytes); grading not previously in client JS despite transitive node_modules presence; remeda already a shared-components dep | shared-components imports; graphql dist/ops has no grading import | bundle note in PR body | confirmed |
+| low | maintainability | one validation-side duplicate remained unadopted — adopted in c58da6263 | helpers.ts validation guard | done | confirmed |
+| info | performance | per-call cost identical (one filter pass; one O(1) object return against JSON.parse+Redis in the same path) | wrapper comparison | none | confirmed |
+| pass | data safety / UX / observability / docs | N/A — no schema/data/UI/logging change; GraphQL snapshot unchanged; no doc describes the old duplicated expressions (greps) | diff + greps | none | confirmed |
+
+Verdict for 5918: ready-with-conditions (final AI review of the cumulative stack — see stack-level status; all automated checks green at c58da6263 incl. full Playwright suite).


### PR DESCRIPTION
**Stack position:** layer 3 of 3 (parents: #5901 → #5902). Native stack #5903.

## Problem

The selection skip filter (drop `-1`/`undefined`/`null` entries) was duplicated across **six** sites — worker helpers (×2), processor response log, GraphQL stacks service, client validator — and the numerical exact-vs-range solution sniffing across **three** (worker helper pre-#5902, cached block results in `packages/util`). Historical drift between these copies of the same invariant required a repair migration (`2025-09-15_fix_case_study_results`); the client validator has already drifted further (adds uniqueness and overflow checks the server never applies).

## Change

Single-source both invariants in the grading package and adopt everywhere:

- `filterSkippedSelectionResponses(selection)` — verbatim filter, adopted at the worker grading core, the processor's response log string, the stacks service (keeping its `undefined` propagation for absent selections), and the client validator (via `Object.values` of the response record) and the worker validation guard — every duplicated copy of the invariant now lives at its grading-package home.
- `resolveNumericalSolutions(solutions)` — verbatim shape sniff, adopted in the worker numerical core and the cached block-results path; exactly one return key is defined, mirroring `gradeQuestionNumerical`'s arguments. `gradeQuestionNumerical`'s `exactSolutions` parameter widens to `(number | string)[]` — the runtime already handled numeric strings via `parseFloat`; the parameter type now says so.

All expressions preserved verbatim (including the empty-array truthiness quirk, pinned by a test); the resolver adds a null-safe guard as the safe superset of the callers' previous separate guards. New grading unit tests (8 cases) pin both helpers; the worker battery (28), util (65) and grading suites pin the adopted behavior.

## Tests (consolidation mapping)

No test removed or merged. New: 8 grading unit tests for the two helpers. The duplicated expressions had no dedicated tests before — their behavior is now directly pinned at the invariant's home.

## Verification

| Gate | Result |
| --- | --- |
| grading tests (container) | ✅ 18/18 (incl. 8 new) |
| worker battery + tsc + build (container) | ✅ 28/28, clean |
| util tests + tsc; graphql check; shared-components tsc | ✅ 65/65; all clean |
| lockfile | minimal: shared-components peer dep (+3 lines); unrelated transitive `@types/react` float reverted |
| `check:all` + `build` (host boundary) | ✅ |
| Exact-head CI (full Playwright suite incl. O1 execution cycle through the changed grading path) | see status below |

## Scope / risks / rollback

- Nine files across five packages; adoptions are 1:1 expression replacements. One strictly-safer delta: the worker numerical core now returns a null grading instead of crashing when solutions are `null` (previously an unguarded `null.length`). The client bundle gains grading's two helpers (~few hundred bytes; grading was not previously in client JS despite being transitively present in node_modules).
- Rollback: revert the single commit.

## Status

- [x] Implementation + grading unit tests
- [x] Local gates
- [ ] Exact-head CI green
- [ ] Final review (stack review — note the OpenRouter quota blocker documented on #5901/#5902 applies repo-wide)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of skipped selection answers during validation, grading, and result calculation.
  - Improved numerical grading for answers configured as numeric values or numeric strings.
  - Improved support for numerical solution ranges and exact-value solutions.
  - Prevented grading issues when numerical solutions are missing or incomplete.

- **Consistency**
  - Standardized response filtering and numerical solution handling across grading and result-processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->