### PR TITLE
enhance: review generated question titles and tag suggestions

### DIFF
--- a/apps/frontend-manage/src/components/elements/generation/GeneratedElementReview.tsx
+++ b/apps/frontend-manage/src/components/elements/generation/GeneratedElementReview.tsx
@@ -1,13 +1,15 @@
-import { useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client'
 import {
   ElementDisplayMode,
   ElementStatus,
   ElementType,
   GeneratableElementType,
   GeneratedElementDecision,
+  GetUserTagsDocument,
   KeepGeneratedElementDraftDocument,
   SaveGeneratedElementsDocument,
   SetGeneratedElementDecisionDocument,
+  type Tag,
 } from '@klicker-uzh/graphql/dist/ops'
 import { Button, toast, UserNotification } from '@uzh-bf/design-system'
 import { useFormatter, useTranslations } from 'next-intl'
@@ -23,6 +25,14 @@ import type {
   ElementGenerationBuildData,
   GeneratedElementDraftData,
 } from './elementGenerationTypes'
+import GeneratedTagSelector from './GeneratedTagSelector'
+import {
+  draftSuggestedTags,
+  groupTagSuggestions,
+  persistedTagSelection,
+  selectedTagNames,
+} from './generatedTagSelection'
+import useGeneratedTagSelection from './useGeneratedTagSelection'
 
 type ReviewFilter = 'all' | 'open' | 'attention' | 'kept' | 'discarded'
 
@@ -287,12 +297,63 @@ function GeneratedDraftEditor({
   const initialValues = useMemo(() => draftToFormValues(draft), [draft])
   const [keepDraft] = useMutation(KeepGeneratedElementDraftDocument)
   const [setDecision] = useMutation(SetGeneratedElementDecisionDocument)
+  const isQuestion = draft.elementType !== GeneratableElementType.Flashcard
+  const {
+    data: tagData,
+    loading: tagsLoading,
+    error: tagsError,
+    refetch: refreshTags,
+  } = useQuery(GetUserTagsDocument, {
+    skip: !isQuestion,
+    fetchPolicy: 'network-only',
+  })
+  const ownerTags = useMemo(
+    () => (tagData?.userTags ?? []).filter((tag): tag is Tag => tag !== null),
+    [tagData]
+  )
+  const persistedSelection = useMemo(
+    () => persistedTagSelection(draft.current),
+    [draft.current]
+  )
+  const selection = useGeneratedTagSelection({
+    persistedSelection,
+    selectableExisting: ownerTags,
+  })
+  const [revision, setRevision] = useState(draft.revision)
+  const [savingDraft, setSavingDraft] = useState(false)
+  const groups = useMemo(
+    () => groupTagSuggestions(draftSuggestedTags(draft), ownerTags),
+    [draft, ownerTags]
+  )
+  const readyValues = useMemo(
+    () => ({
+      ...initialValues,
+      tags: isQuestion
+        ? selectedTagNames(persistedSelection, ownerTags)
+        : initialValues.tags,
+    }),
+    [initialValues, isQuestion, persistedSelection, ownerTags]
+  )
+  if (isQuestion && !tagData) {
+    return (
+      <div role="status" className="mt-4">
+        <UserNotification type={tagsError ? 'error' : 'info'}>
+          {tagsError ? tShared('systemError') : tShared('loading')}
+        </UserNotification>
+        {!tagsLoading ? (
+          <Button onClick={onClose}>{tShared('close')}</Button>
+        ) : null}
+      </div>
+    )
+  }
 
   return (
     <ElementEditForm
       mode={ElementEditMode.EDIT}
       loading={false}
-      initialValues={initialValues}
+      inputsDisabled={savingDraft}
+      initialValues={readyValues}
+      hideCanonicalTags={isQuestion}
       titleOverride={t('review.editTitle')}
       submitLabel={t('review.keep')}
       submitErrorMessage={t('review.actionError')}
@@ -331,7 +392,22 @@ function GeneratedDraftEditor({
         },
       }}
       supplementaryContent={
-        <GeneratedDraftSources build={build} draft={draft} />
+        <>
+          <GeneratedDraftSources build={build} draft={draft} />
+          {isQuestion ? (
+            <GeneratedTagSelector
+              draftId={draft.id}
+              revision={revision}
+              selection={selection}
+              selectableExisting={ownerTags}
+              suggestedExisting={groups.suggestedExisting}
+              newProposals={groups.newProposals}
+              onDraftSaved={setRevision}
+              onSaved={onChanged}
+              onSaving={setSavingDraft}
+            />
+          ) : null}
+        </>
       }
       discardChangesPrompt={{
         title: t('review.discardChangesTitle'),
@@ -373,7 +449,7 @@ function GeneratedDraftEditor({
           const result = await keepDraft({
             variables: {
               draftId: draft.id,
-              expectedRevision: draft.revision,
+              expectedRevision: revision,
               status: values.status,
               type,
               name: variables.name,
@@ -382,7 +458,9 @@ function GeneratedDraftEditor({
               options: 'options' in variables ? variables.options : undefined,
               basePoints: variables.basePoints,
               pointsMultiplier: variables.pointsMultiplier,
-              tags: variables.tags,
+              ...(isQuestion
+                ? { tagSelection: selection.selection }
+                : { tags: variables.tags }),
               choiceIds:
                 values.type === ElementType.Sc ||
                 values.type === ElementType.Mc ||
@@ -398,6 +476,7 @@ function GeneratedDraftEditor({
         }
 
         try {
+          if (isQuestion) await refreshTags()
           await onChanged()
         } catch {
           toast({ type: 'error', message: tShared('systemError') })

--- a/apps/frontend-manage/src/components/elements/generation/GeneratedTagSelector.tsx
+++ b/apps/frontend-manage/src/components/elements/generation/GeneratedTagSelector.tsx
@@ -1,0 +1,307 @@
+import { useMutation } from '@apollo/client'
+import {
+  ElementType,
+  type Tag,
+  UpdateGeneratedElementDraftDocument,
+  type UpdateGeneratedElementDraftInput,
+} from '@klicker-uzh/graphql/dist/ops'
+import { Button, FormLabel, UserNotification } from '@uzh-bf/design-system'
+import { useFormikContext } from 'formik'
+import { useTranslations } from 'next-intl'
+import { useEffect, useMemo, useState } from 'react'
+import Creatable from 'react-select/creatable'
+import type { ElementFormTypes } from '../manipulation/types'
+import { elementGenerationErrorCode } from './elementGenerationTypes'
+import type { GeneratedTagSelection } from './generatedTagSelection'
+
+function TagChip({
+  label,
+  selected,
+  dataCy,
+  onToggle,
+  disabled,
+}: {
+  label: string
+  selected: boolean
+  dataCy: string
+  onToggle: () => void
+  disabled: boolean
+}) {
+  return (
+    <Button
+      type="button"
+      aria-pressed={selected}
+      onClick={onToggle}
+      disabled={disabled}
+      data={{ cy: dataCy }}
+      className={{
+        root: `rounded-full border px-3 py-1 text-xs ${
+          selected
+            ? 'border-primary-100 bg-slate-100 font-medium text-primary-100'
+            : 'border-slate-300 text-slate-700'
+        }`,
+      }}
+    >
+      {label}
+    </Button>
+  )
+}
+
+// Tag workspace for a generated question draft. Owner tags are toggled by id so
+// renames keep their identity, new proposals stay names until the draft is kept,
+// and manual search or free entry stays available. Save draft persists the
+// visible title and selection with the revision the editor was loaded from.
+export default function GeneratedTagSelector({
+  draftId,
+  revision,
+  selection,
+  selectableExisting,
+  suggestedExisting,
+  newProposals,
+  onDraftSaved,
+  onSaved,
+  onSaving,
+}: {
+  draftId: string
+  revision: number
+  selection: {
+    selection: GeneratedTagSelection
+    names: string[]
+    toggleExistingTag: (tagId: number) => void
+    toggleNewTagName: (name: string) => void
+    setManualNames: (names: string[]) => void
+  }
+  selectableExisting: Tag[]
+  suggestedExisting: Tag[]
+  newProposals: string[]
+  onDraftSaved: (revision: number) => void
+  onSaving: (saving: boolean) => void
+  onSaved: () => Promise<void>
+}) {
+  const t = useTranslations('manage.elementGeneration')
+  const formik = useFormikContext<ElementFormTypes>()
+  const [updateDraft, updateState] = useMutation(
+    UpdateGeneratedElementDraftDocument
+  )
+  const [saveState, setSaveState] = useState<
+    'idle' | 'saving' | 'saved' | 'error' | 'conflict'
+  >('idle')
+
+  const {
+    selection: tagSelection,
+    names,
+    toggleExistingTag,
+    toggleNewTagName,
+    setManualNames,
+  } = selection
+
+  const setFieldValue = formik.setFieldValue
+  useEffect(() => {
+    void setFieldValue('tags', names, false)
+  }, [setFieldValue, names])
+
+  const options = useMemo(
+    () =>
+      selectableExisting.map((tag) => ({ label: tag.name, value: tag.name })),
+    [selectableExisting]
+  )
+
+  const isDirty = formik.dirty
+  const savingDraft = saveState === 'saving' || updateState.loading
+
+  useEffect(() => {
+    if (!isDirty) return
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', warnBeforeUnload)
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload)
+  }, [isDirty])
+
+  async function handleSaveDraft() {
+    if (savingDraft) return
+
+    // Keep sends the merged content block as the prompt and reconstructs the
+    // stem on the server; mirror that mapping here.
+    const values = formik.values
+    if (
+      values.type !== ElementType.Sc &&
+      values.type !== ElementType.Mc &&
+      values.type !== ElementType.Kprim
+    )
+      return
+    const input: UpdateGeneratedElementDraftInput = {
+      draftId,
+      expectedRevision: revision,
+      current: {
+        name: values.name,
+        prompt: values.content,
+        context: null,
+        explanation: values.explanation || null,
+        tagSelection,
+        choices: values.options.choices.map((choice, ix) => ({
+          id: choice.id,
+          label: String.fromCharCode(65 + ix),
+          text: choice.value ?? '',
+          correct: choice.correct ?? false,
+          feedback: values.options.hasAnswerFeedbacks
+            ? choice.feedback || null
+            : null,
+        })),
+      },
+    }
+
+    setSaveState('saving')
+    onSaving(true)
+    try {
+      const result = await updateDraft({
+        variables: { input },
+      })
+      const saved = result.data?.updateGeneratedElementDraft
+      if (!saved) {
+        setSaveState('error')
+        return
+      }
+      formik.resetForm({ values })
+      setSaveState('saved')
+      onDraftSaved(saved.revision)
+      try {
+        await onSaved()
+      } catch {
+        // The draft is saved; a failed list refresh must not look like a lost save.
+      }
+    } catch (error) {
+      setSaveState(
+        elementGenerationErrorCode(error) === 'CONCURRENT_MODIFICATION'
+          ? 'conflict'
+          : 'error'
+      )
+    } finally {
+      onSaving(false)
+    }
+  }
+
+  return (
+    <section
+      className="mt-5 rounded-lg border border-slate-200 bg-slate-50 p-4"
+      data-cy="generated-element-tags"
+    >
+      <h3 className="font-semibold text-slate-900">
+        {t('review.tagSelection.title')}
+      </h3>
+
+      {suggestedExisting.length > 0 ? (
+        <div className="mt-3">
+          <FormLabel
+            label={t('review.tagSelection.existingLabel')}
+            labelType="small"
+            required={false}
+          />
+          <div className="flex flex-wrap gap-2">
+            {suggestedExisting.map((tag) => (
+              <TagChip
+                key={tag.id}
+                label={tag.name}
+                selected={tagSelection.existingTagIds.includes(tag.id)}
+                disabled={savingDraft}
+                dataCy={`generated-tag-existing-${tag.id}`}
+                onToggle={() => toggleExistingTag(tag.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {newProposals.length > 0 ? (
+        <div className="mt-3">
+          <FormLabel
+            label={t('review.tagSelection.newLabel')}
+            labelType="small"
+            required={false}
+          />
+          <div className="flex flex-wrap gap-2">
+            {newProposals.map((name) => (
+              <TagChip
+                key={name}
+                label={name}
+                selected={tagSelection.newTagNames.includes(name)}
+                disabled={savingDraft}
+                dataCy={`generated-tag-new-${name}`}
+                onToggle={() => toggleNewTagName(name)}
+              />
+            ))}
+          </div>
+          <p className="mt-1 text-xs text-slate-500">
+            {t('review.tagSelection.newHint')}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="mt-3" data-cy="generated-tag-input">
+        <FormLabel
+          label={t('review.tagSelection.manualLabel')}
+          labelType="small"
+          required={false}
+        />
+        <Creatable
+          isDisabled={savingDraft}
+          isClearable
+          isMulti
+          value={names.map((name) => ({ label: name, value: name }))}
+          options={options}
+          classNames={{ container: () => 'w-full h-9' }}
+          onChange={(newValue) =>
+            setManualNames(newValue.map((option) => option.value))
+          }
+          onCreateOption={(newTag) => setManualNames([...names, newTag])}
+          placeholder={t('review.tagSelection.placeholder')}
+        />
+        <p className="mt-1 text-xs text-slate-500">
+          {t('review.tagSelection.existingHint')}
+        </p>
+      </div>
+
+      {saveState === 'conflict' ? (
+        <UserNotification type="error" className={{ root: 'mt-3' }}>
+          {t('review.tagSelection.conflict')}
+        </UserNotification>
+      ) : null}
+      {saveState === 'error' ? (
+        <UserNotification type="error" className={{ root: 'mt-3' }}>
+          {t('review.tagSelection.saveError')}
+        </UserNotification>
+      ) : null}
+      {saveState === 'saved' && !isDirty ? (
+        <UserNotification type="success" className={{ root: 'mt-3' }}>
+          {t('review.tagSelection.saved')}
+        </UserNotification>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        <Button
+          primary
+          type="button"
+          disabled={savingDraft || !isDirty || saveState === 'conflict'}
+          loading={savingDraft}
+          onClick={handleSaveDraft}
+          data={{ cy: `generated-element-save-draft-${draftId}` }}
+        >
+          <Button.Label>
+            {savingDraft
+              ? t('review.savingDraft')
+              : t('review.tagSelection.saveDraft')}
+          </Button.Label>
+        </Button>
+        {isDirty ? (
+          <span
+            className="text-xs text-amber-800"
+            data-cy={`generated-element-unsaved-${draftId}`}
+          >
+            {t('review.tagSelection.unsaved')}
+          </span>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/apps/frontend-manage/src/components/elements/generation/generatedTagSelection.ts
+++ b/apps/frontend-manage/src/components/elements/generation/generatedTagSelection.ts
@@ -1,0 +1,129 @@
+import type { Tag } from '@klicker-uzh/graphql/dist/ops'
+import {
+  type GeneratedQuestionTagSelection,
+  normalizeGeneratedQuestionTagLabel,
+  suggestGeneratedQuestionTags,
+} from '@klicker-uzh/types'
+
+// Structured tag selection for generated question drafts. Owner tags are
+// addressed by their persisted id so a rename keeps their identity; proposals
+// are exact names and are created only with a successful Keep.
+export type GeneratedTagSelection = GeneratedQuestionTagSelection
+
+export const EMPTY_TAG_SELECTION: GeneratedTagSelection = {
+  existingTagIds: [],
+  newTagNames: [],
+}
+
+// Advisory labels produced by generation. The generated GraphQL client is
+// regenerated from the tracked operations, so this reader tolerates a snapshot
+// that does not expose the field yet and never treats it as required.
+export function draftSuggestedTags(draft: {
+  suggestedTags?: readonly string[] | null
+}): string[] {
+  return Array.isArray(draft.suggestedTags) ? [...draft.suggestedTags] : []
+}
+
+// The persisted structured selection on the draft's current payload. It is the
+// authoritative source of selected ids and proposals, so reload never has to
+// re-derive an owner tag from a display name.
+export function persistedTagSelection(current: {
+  tagSelection?: {
+    existingTagIds?: readonly number[] | null
+    newTagNames?: readonly string[] | null
+  } | null
+}): GeneratedTagSelection {
+  const selection = current.tagSelection
+  if (!selection) return EMPTY_TAG_SELECTION
+  return {
+    existingTagIds: Array.isArray(selection.existingTagIds)
+      ? [...selection.existingTagIds]
+      : [],
+    newTagNames: Array.isArray(selection.newTagNames)
+      ? [...selection.newTagNames]
+      : [],
+  }
+}
+
+export type TagSuggestionGroups = {
+  // Owner tags matching a generation suggestion, offered as independent toggles
+  suggestedExisting: Tag[]
+  // Exact-name owner tags available for manual selection
+  selectableExisting: Tag[]
+  // Suggestions without an owner tag yet; these are created only on Keep
+  newProposals: string[]
+}
+
+// Rank the generated advisory labels against the owner's tags with the same
+// lexical rules the service uses. Matching stays local, uses no model call, and
+// never merges tags or preselects a suggestion.
+export function groupTagSuggestions(
+  suggestedTags: string[],
+  userTags: Tag[]
+): TagSuggestionGroups {
+  const match = suggestGeneratedQuestionTags(suggestedTags, userTags)
+  const byId = new Map(userTags.map((tag) => [tag.id, tag]))
+
+  return {
+    suggestedExisting: match.existingTagIds.flatMap((id) => {
+      const tag = byId.get(id)
+      return tag ? [tag] : []
+    }),
+    selectableExisting: userTags,
+    newProposals: match.newTagNames,
+  }
+}
+
+// Display order and deduplication of the names that mirror the selection into
+// the form's legacy `tags` field and the draft's persisted `current.tags`.
+export function selectedTagNames(
+  selection: GeneratedTagSelection,
+  userTags: Tag[]
+): string[] {
+  const byId = new Map(userTags.map((tag) => [tag.id, tag.name]))
+  const existingNames = selection.existingTagIds.flatMap((id) => {
+    const name = byId.get(id)
+    return name ? [name] : []
+  })
+  return [...new Set([...existingNames, ...selection.newTagNames])]
+}
+
+// Resolve manually entered tag names against the owner's tags using exact-name
+// identity only. A typed name equal to an existing tag name becomes an id
+// selection, so a rename is never duplicated by name, while fuzzy matches are
+// deliberately not used as a persistence key.
+export function resolveManualTagNames(
+  names: string[],
+  userTags: Tag[]
+): GeneratedTagSelection {
+  const existingIdsByLabel = new Map<string, number[]>()
+  for (const tag of userTags) {
+    const label = tag.name
+    const ids = existingIdsByLabel.get(label) ?? []
+    ids.push(tag.id)
+    existingIdsByLabel.set(label, ids)
+  }
+
+  const existingTagIds: number[] = []
+  const newTagNames: string[] = []
+  const seenIds = new Set<number>()
+  const seenNames = new Set<string>()
+  for (const name of names) {
+    const label = normalizeGeneratedQuestionTagLabel(name)
+    if (!label) continue
+
+    const match = existingIdsByLabel.get(label)?.[0]
+    if (typeof match === 'number') {
+      if (!seenIds.has(match)) {
+        seenIds.add(match)
+        existingTagIds.push(match)
+      }
+      continue
+    }
+    if (!seenNames.has(label)) {
+      seenNames.add(label)
+      newTagNames.push(label)
+    }
+  }
+  return { existingTagIds, newTagNames }
+}

--- a/apps/frontend-manage/src/components/elements/generation/useGeneratedTagSelection.ts
+++ b/apps/frontend-manage/src/components/elements/generation/useGeneratedTagSelection.ts
@@ -1,0 +1,67 @@
+import type { Tag } from '@klicker-uzh/graphql/dist/ops'
+import { useMemo, useState } from 'react'
+import {
+  type GeneratedTagSelection,
+  resolveManualTagNames,
+  selectedTagNames,
+} from './generatedTagSelection'
+
+// Owner-scoped tag selection for a generated question draft. The persisted
+// structured selection is authoritative: owner tags stay addressed by their id
+// so a rename keeps the tag's identity, new proposals stay names until the draft
+// is kept, and a deleted tag is never silently recreated by name. Matching stays
+// local and lexical, so no tag collection leaves Klicker and no model call is
+// involved.
+export default function useGeneratedTagSelection({
+  persistedSelection,
+  selectableExisting,
+}: {
+  persistedSelection: GeneratedTagSelection
+  selectableExisting: Tag[]
+}) {
+  // `undefined` keeps the persisted selection; the first user change commits an
+  // explicit selection.
+  const [edit, setEdit] = useState<GeneratedTagSelection | undefined>()
+  const selection = edit ?? persistedSelection
+
+  const names = useMemo(
+    () => selectedTagNames(selection, selectableExisting),
+    [selection, selectableExisting]
+  )
+
+  function commit(next: GeneratedTagSelection) {
+    setEdit(next)
+  }
+
+  function toggleExistingTag(tagId: number) {
+    commit({
+      existingTagIds: selection.existingTagIds.includes(tagId)
+        ? selection.existingTagIds.filter((id) => id !== tagId)
+        : [...selection.existingTagIds, tagId],
+      newTagNames: selection.newTagNames,
+    })
+  }
+
+  function toggleNewTagName(name: string) {
+    commit({
+      existingTagIds: selection.existingTagIds,
+      newTagNames: selection.newTagNames.includes(name)
+        ? selection.newTagNames.filter((entry) => entry !== name)
+        : [...selection.newTagNames, name],
+    })
+  }
+
+  // Manual edits own the complete union of selected tags, so they replace the
+  // selection instead of extending it.
+  function setManualNames(nextNames: string[]) {
+    commit(resolveManualTagNames(nextNames, selectableExisting))
+  }
+
+  return {
+    selection,
+    names,
+    toggleExistingTag,
+    toggleNewTagName,
+    setManualNames,
+  }
+}

--- a/apps/frontend-manage/src/components/elements/manipulation/ElementEditForm.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementEditForm.tsx
@@ -57,6 +57,7 @@ function ElementEditForm({
   inputsDisabled = false,
   templateId,
   preserveDraftOnDismiss = false,
+  hideCanonicalTags = false,
   onClose,
   onSuccess,
   mode,
@@ -84,6 +85,7 @@ function ElementEditForm({
   templateId?: string
   // flag to preserve dirty drafts when the modal is dismissed (creation only)
   preserveDraftOnDismiss?: boolean
+  hideCanonicalTags?: boolean
   // modal state props
   onClose: () => void
   onSuccess: () => void
@@ -307,10 +309,14 @@ function ElementEditForm({
                   setElementDataTypename={setElementDataTypename}
                   validateForm={validateForm}
                 />
-                <div ref={formBodyRef} className="flex flex-row gap-12">
-                  <div className="flex-1">
+                <div
+                  ref={formBodyRef}
+                  className="flex flex-col gap-6 lg:flex-row lg:gap-12"
+                >
+                  <div className="min-w-0 flex-1">
                     <Form className="w-full" id="question-manipulation-form">
                       <ElementInformationFields
+                        hideCanonicalTags={hideCanonicalTags}
                         isTemplate={isTemplate}
                         elementId={elementId}
                         inputsDisabled={inputsDisabled}

--- a/apps/frontend-manage/src/components/elements/manipulation/ElementInformationFields.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementInformationFields.tsx
@@ -27,6 +27,7 @@ interface ElementInformationFieldsProps {
   values: ElementFormTypes
   isSubmitting: boolean
   inputsDisabled?: boolean
+  hideCanonicalTags?: boolean
 }
 
 function ElementInformationFields({
@@ -36,6 +37,7 @@ function ElementInformationFields({
   values,
   isSubmitting,
   inputsDisabled = false,
+  hideCanonicalTags = false,
 }: ElementInformationFieldsProps) {
   const t = useTranslations()
   const statusOptions = useStatusOptions()
@@ -129,7 +131,7 @@ function ElementInformationFields({
       </div>
 
       <div className="mt-2 flex flex-row gap-2">
-        {!isTemplate ? (
+        {!isTemplate && !hideCanonicalTags ? (
           <div className="flex w-full flex-col" data-cy="element-tag-input">
             <FormLabel
               required={false}

--- a/packages/graphql/src/graphql/ops/FElementGenerationBuild.graphql
+++ b/packages/graphql/src/graphql/ops/FElementGenerationBuild.graphql
@@ -131,7 +131,12 @@ fragment ElementGenerationBuildData on ElementGenerationBuild {
       }
       cardType
       tags
+      tagSelection {
+        existingTagIds
+        newTagNames
+      }
     }
+    suggestedTags
     revision
     decision
     bloomLevel

--- a/packages/graphql/src/graphql/ops/MKeepGeneratedElementDraft.graphql
+++ b/packages/graphql/src/graphql/ops/MKeepGeneratedElementDraft.graphql
@@ -10,6 +10,7 @@ mutation KeepGeneratedElementDraft(
   $basePoints: Boolean!
   $pointsMultiplier: Int!
   $tags: [String!]
+  $tagSelection: GeneratedElementTagSelectionInput
   $choiceIds: [ID!]
 ) {
   keepGeneratedElementDraft(
@@ -24,6 +25,7 @@ mutation KeepGeneratedElementDraft(
     basePoints: $basePoints
     pointsMultiplier: $pointsMultiplier
     tags: $tags
+    tagSelection: $tagSelection
     choiceIds: $choiceIds
   ) {
     id

--- a/packages/graphql/src/graphql/ops/MUpdateGeneratedElementDraft.graphql
+++ b/packages/graphql/src/graphql/ops/MUpdateGeneratedElementDraft.graphql
@@ -18,6 +18,10 @@ mutation UpdateGeneratedElementDraft(
       }
       cardType
       tags
+      tagSelection {
+        existingTagIds
+        newTagNames
+      }
     }
     updatedAt
   }

--- a/packages/graphql/src/public/schema.graphql
+++ b/packages/graphql/src/public/schema.graphql
@@ -2000,6 +2000,7 @@ type GeneratedElementDraft {
   savedAt: Date
   savedElementId: Int
   sourceElementId: ID!
+  suggestedTags: [String!]!
   targetDifficulty: Int
   updatedAt: Date!
 }
@@ -2015,6 +2016,7 @@ type GeneratedElementEditable {
   explanation: String
   name: String!
   prompt: String!
+  tagSelection: GeneratedElementTagSelection
   tags: [String!]!
 }
 
@@ -2025,7 +2027,18 @@ input GeneratedElementEditableInput {
   explanation: String
   name: String!
   prompt: String!
+  tagSelection: GeneratedElementTagSelectionInput
   tags: [String!]
+}
+
+type GeneratedElementTagSelection {
+  existingTagIds: [Int!]!
+  newTagNames: [String!]!
+}
+
+input GeneratedElementTagSelectionInput {
+  existingTagIds: [Int!]
+  newTagNames: [String!]
 }
 
 type GroupAchievementInstance {
@@ -2727,7 +2740,7 @@ type Mutation {
   joinCourseWithPin(pin: Int!): Participant
   joinParticipantGroup(code: Int!, courseId: String!): String
   joinRandomCourseGroupPool(courseId: String!): Boolean!
-  keepGeneratedElementDraft(basePoints: Boolean!, choiceIds: [ID!], content: String!, draftId: ID!, expectedRevision: Int!, explanation: String, name: String!, options: OptionsChoicesInput, pointsMultiplier: Int!, status: ElementStatus!, tags: [String!], type: GeneratableElementType!): GeneratedElementDraft!
+  keepGeneratedElementDraft(basePoints: Boolean!, choiceIds: [ID!], content: String!, draftId: ID!, expectedRevision: Int!, explanation: String, name: String!, options: OptionsChoicesInput, pointsMultiplier: Int!, status: ElementStatus!, tagSelection: GeneratedElementTagSelectionInput, tags: [String!], type: GeneratableElementType!): GeneratedElementDraft!
   leaveCourseLeaderboard(courseId: String!): LeaveCourseParticipation
   leaveParticipantGroup(courseId: String!, groupId: String!): ParticipantGroup
   leaveRandomCourseGroupPool(courseId: String!): Boolean!

--- a/packages/graphql/src/schema/elementGeneration.ts
+++ b/packages/graphql/src/schema/elementGeneration.ts
@@ -6,6 +6,8 @@ import type {
   GeneratedQuestionCitation,
   GeneratedQuestionEditable,
   GeneratedQuestionOriginal,
+  GeneratedQuestionTagSelection,
+  GeneratedQuestionTagSelectionInput,
   QuestionGenerationConfiguration,
   QuestionGenerationDesignSummary,
   QuestionGenerationPlanSummary,
@@ -478,6 +480,17 @@ GeneratedElementChoiceRef.implement({
   }),
 })
 
+const GeneratedElementTagSelectionRef =
+  builder.objectRef<GeneratedQuestionTagSelection>(
+    'GeneratedElementTagSelection'
+  )
+GeneratedElementTagSelectionRef.implement({
+  fields: (t) => ({
+    existingTagIds: t.exposeIntList('existingTagIds'),
+    newTagNames: t.exposeStringList('newTagNames'),
+  }),
+})
+
 type GeneratedElementEditableView = {
   name: string
   prompt: string
@@ -486,6 +499,7 @@ type GeneratedElementEditableView = {
   choices: GeneratedElementChoiceView[]
   cardType: GeneratedElementCardTypeValue | null
   tags: string[]
+  tagSelection: GeneratedQuestionTagSelection | null
 }
 const GeneratedElementEditableRef =
   builder.objectRef<GeneratedElementEditableView>('GeneratedElementEditable')
@@ -501,6 +515,11 @@ GeneratedElementEditableRef.implement({
       nullable: true,
     }),
     tags: t.exposeStringList('tags'),
+    tagSelection: t.field({
+      type: GeneratedElementTagSelectionRef,
+      nullable: true,
+      resolve: (view) => view.tagSelection,
+    }),
   }),
 })
 
@@ -522,6 +541,7 @@ function editableView(
       choices: [],
       cardType: card.cardType,
       tags: card.tags,
+      tagSelection: null,
     }
   }
   const question = value as GeneratedQuestionEditable
@@ -533,7 +553,15 @@ function editableView(
     choices: question.choices,
     cardType: null,
     tags: [],
+    tagSelection: question.tagSelection ?? null,
   }
+}
+
+// Advisory labels produced by generation; they are matched against the owner's
+// tags by the reviewing client and never populate the draft automatically.
+function draftSuggestedTags(draft: DB.GeneratedElementDraft): string[] {
+  if (draft.elementType === DB.ElementType.FLASHCARD) return []
+  return (draft.original as GeneratedQuestionOriginal).suggestedTags ?? []
 }
 
 const GeneratedElementCitationRef =
@@ -582,6 +610,10 @@ GeneratedElementDraftRef.implement({
     current: t.field({
       type: GeneratedElementEditableRef,
       resolve: (draft) => editableView(draft.elementType, draft.current),
+    }),
+    suggestedTags: t.field({
+      type: ['String'],
+      resolve: (draft) => draftSuggestedTags(draft),
     }),
     revision: t.exposeInt('revision'),
     decision: t.expose('decision', { type: GeneratedElementDecision }),
@@ -816,6 +848,23 @@ const GeneratedElementChoiceInputRef = builder
     }),
   })
 
+export const GeneratedElementTagSelectionInputRef = builder
+  .inputRef<GeneratedQuestionTagSelectionInput>(
+    'GeneratedElementTagSelectionInput'
+  )
+  .implement({
+    fields: (t) => ({
+      existingTagIds: t.intList({
+        required: false,
+        validate: { maxLength: 100 },
+      }),
+      newTagNames: t.stringList({
+        required: false,
+        validate: { maxLength: 100 },
+      }),
+    }),
+  })
+
 const GeneratedElementEditableInputRef = builder
   .inputRef<GeneratedElementEditableInputValue>('GeneratedElementEditableInput')
   .implement({
@@ -845,6 +894,10 @@ const GeneratedElementEditableInputRef = builder
       tags: t.stringList({
         required: false,
         validate: { maxLength: 20 },
+      }),
+      tagSelection: t.field({
+        type: GeneratedElementTagSelectionInputRef,
+        required: false,
       }),
     }),
   })

--- a/packages/graphql/src/schema/mutation.ts
+++ b/packages/graphql/src/schema/mutation.ts
@@ -56,6 +56,7 @@ import {
   GeneratableElementType,
   GeneratedElementDraftInputRef,
   GeneratedElementDraftRef,
+  GeneratedElementTagSelectionInputRef,
   PublishIncompleteElementGenerationInputRef,
   ReviewElementGenerationInputRef,
   SetGeneratedElementDecisionInputRef,
@@ -2292,6 +2293,10 @@ export const Mutation = builder.mutationType({
           tags: t.arg.stringList({
             required: false,
             validate: { maxLength: 20 },
+          }),
+          tagSelection: t.arg({
+            type: GeneratedElementTagSelectionInputRef,
+            required: false,
           }),
           choiceIds: t.arg.idList({
             required: false,

--- a/packages/graphql/src/services/elementGeneration.ts
+++ b/packages/graphql/src/services/elementGeneration.ts
@@ -4,6 +4,7 @@ import type {
   ElementManipulationInput,
   GeneratedFlashcardEditable,
   GeneratedQuestionEditable,
+  GeneratedQuestionTagSelectionInput,
 } from '@klicker-uzh/types'
 import { ELEMENT_GENERATION_CAPABILITIES } from '@klicker-uzh/types'
 import type { ContextWithUser } from '../lib/context.js'
@@ -22,6 +23,11 @@ import {
   setGeneratedFlashcardDecision,
   updateGeneratedFlashcardDraft,
 } from './flashcardGenerationDrafts.js'
+import {
+  questionTagSelectionWrite,
+  resolveQuestionTagSelection,
+  withQuestionTagConflictRetry,
+} from './generatedQuestionTags.js'
 import {
   getQuestionGenerationBuild,
   reviewQuestionGenerationDesign,
@@ -88,6 +94,7 @@ export type GeneratedElementEditableInput = {
   }> | null
   cardType?: 'definition' | 'formula' | 'calculation' | null
   tags?: string[] | null
+  tagSelection?: GeneratedQuestionTagSelectionInput | null
 }
 
 export type KeepGeneratedElementDraftInput = {
@@ -101,6 +108,7 @@ export type KeepGeneratedElementDraftInput = {
   basePoints: boolean
   pointsMultiplier: number
   tags?: string[] | null
+  tagSelection?: GeneratedQuestionTagSelectionInput | null
   choiceIds?: string[] | null
   options?: ElementManipulationInput['options']
 }
@@ -260,6 +268,12 @@ function normalizedKeepPayload(
         'Generated element type cannot be changed'
       )
     }
+    if (input.tagSelection != null) {
+      throw questionGenerationServiceError(
+        'DRAFT_INVALID',
+        'Flashcard generation does not use tag selections'
+      )
+    }
     const storedCurrent = draft.current as GeneratedFlashcardEditable
     const current = normalizeGeneratedFlashcardEditable({
       name: input.name,
@@ -279,7 +293,7 @@ function normalizedKeepPayload(
       pointsMultiplier: 1,
       tags: current.tags,
     }
-    return { current, elementInput }
+    return { current, elementInput, tagWrite: { mode: 'none' } as const }
   }
 
   if (!isQuestionElementType(input.type) || draft.elementType !== input.type) {
@@ -317,6 +331,12 @@ function normalizedKeepPayload(
       feedback: choice.feedback ?? null,
     }))
   const questionType = input.type
+  const storedCurrent = draft.current as GeneratedQuestionEditable
+  const tagWrite = questionTagSelectionWrite(
+    { tagSelection: input.tagSelection, tags: input.tags },
+    storedCurrent.tagSelection
+  )
+  const tagSelection = tagWrite.mode === 'none' ? undefined : tagWrite.selection
   const current: GeneratedQuestionEditable = {
     itemType: questionType,
     name: input.name,
@@ -324,6 +344,7 @@ function normalizedKeepPayload(
     context: null,
     explanation: input.explanation ?? null,
     choices,
+    ...(tagSelection ? { tagSelection } : {}),
   }
   const elementInput: ElementManipulationInput = {
     status: input.status,
@@ -345,9 +366,9 @@ function normalizedKeepPayload(
     },
     basePoints: input.basePoints,
     pointsMultiplier: input.pointsMultiplier,
-    tags: input.tags ?? [],
+    tags: tagWrite.mode === 'legacy' ? tagWrite.selection.newTagNames : [],
   }
-  return { current, elementInput }
+  return { current, elementInput, tagWrite }
 }
 
 type SavedElementForRetry = {
@@ -361,17 +382,22 @@ type SavedElementForRetry = {
   pointsMultiplier: number
   difficultyLevel: number | null
   options: unknown
-  tags: Array<{ name: string }>
+  tags: Array<{ id: number; name: string }>
 }
 
 function normalizedTagNames(tags: string[] | null | undefined) {
   return [...new Set(tags ?? [])].sort((a, b) => a.localeCompare(b))
 }
 
+type KeepTagExpectation =
+  | { kind: 'names' }
+  | { kind: 'ids'; tagIds: number[] | null }
+
 function savedElementMatchesKeepRequest(
   savedElement: SavedElementForRetry,
   elementInput: ElementManipulationInput,
-  ownerId: string
+  ownerId: string,
+  tagExpectation: KeepTagExpectation = { kind: 'names' }
 ) {
   // manipulateElement persists this validator result for every Element type;
   // optionless types therefore intentionally compare against an empty object.
@@ -393,12 +419,30 @@ function savedElementMatchesKeepRequest(
     savedElement.pointsMultiplier === elementInput.pointsMultiplier &&
     savedElement.difficultyLevel === (elementInput.difficultyLevel ?? null) &&
     isDeepStrictEqual(savedElement.options, persistedOptions) &&
-    isDeepStrictEqual(
+    savedElementTagsMatch(savedElement, elementInput, tagExpectation)
+  )
+}
+
+function savedElementTagsMatch(
+  savedElement: SavedElementForRetry,
+  elementInput: ElementManipulationInput,
+  tagExpectation: KeepTagExpectation
+) {
+  if (tagExpectation.kind === 'names') {
+    return isDeepStrictEqual(
       savedElement.tags
         .map((tag) => tag.name)
         .sort((a, b) => a.localeCompare(b)),
       normalizedTagNames(elementInput.tags)
     )
+  }
+  // A `resolve-only` miss means the request cannot reproduce the saved element,
+  // so a proposal that was never created does not count as an exact retry.
+  if (tagExpectation.tagIds === null) return false
+
+  return isDeepStrictEqual(
+    [...new Set(tagExpectation.tagIds)].sort((a, b) => a - b),
+    savedElement.tags.map((tag) => tag.id).sort((a, b) => a - b)
   )
 }
 
@@ -414,7 +458,7 @@ export async function keepGeneratedElementDraft(
     )
   }
 
-  return ctx.prisma.$transaction(async (transaction) => {
+  const run = async (transaction: DB.Prisma.TransactionClient) => {
     const owned = await transaction.generatedElementDraft.findFirst({
       where: {
         id: input.draftId,
@@ -453,7 +497,7 @@ export async function keepGeneratedElementDraft(
             pointsMultiplier: true,
             difficultyLevel: true,
             options: true,
-            tags: { select: { name: true } },
+            tags: { select: { id: true, name: true } },
           },
         },
       },
@@ -475,8 +519,23 @@ export async function keepGeneratedElementDraft(
       )
     }
 
-    const { current, elementInput } = normalizedKeepPayload(draft, input)
+    const { current, elementInput, tagWrite } = normalizedKeepPayload(
+      draft,
+      input
+    )
     if (draft.savedElementId !== null) {
+      const tagExpectation: KeepTagExpectation =
+        tagWrite.mode === 'selection'
+          ? {
+              kind: 'ids',
+              tagIds: await resolveQuestionTagSelection(
+                transaction,
+                ctx.user.sub,
+                tagWrite.selection,
+                'resolve-only'
+              ),
+            }
+          : { kind: 'names' }
       if (
         draft.decision === DB.GeneratedElementDecision.ACCEPTED &&
         draft.revision === input.expectedRevision + 1 &&
@@ -484,7 +543,8 @@ export async function keepGeneratedElementDraft(
         savedElementMatchesKeepRequest(
           draft.savedElement,
           elementInput,
-          ctx.user.sub
+          ctx.user.sub,
+          tagExpectation
         )
       ) {
         return draft
@@ -516,6 +576,15 @@ export async function keepGeneratedElementDraft(
       )
     }
 
+    const resolvedTagIds =
+      tagWrite.mode === 'selection'
+        ? await resolveQuestionTagSelection(
+            transaction,
+            ctx.user.sub,
+            tagWrite.selection,
+            'resolve-or-create'
+          )
+        : null
     const element = await manipulateElement(elementInput, {
       ...ctx,
       prisma: transaction,
@@ -525,6 +594,18 @@ export async function keepGeneratedElementDraft(
         'SAVE_VALIDATION_FAILED',
         'Generated element is not a valid element'
       )
+    }
+    if (tagWrite.mode === 'selection') {
+      // Connect by validated owner tag id instead of re-creating a tag by name,
+      // so a renamed tag keeps its identity and a deleted one is never revived.
+      await transaction.element.update({
+        where: { id: element.id },
+        data: {
+          tags: {
+            set: [...new Set(resolvedTagIds ?? [])].map((id) => ({ id })),
+          },
+        },
+      })
     }
     const savedAt = new Date()
     const linked = await transaction.generatedElementDraft.updateMany({
@@ -551,7 +632,9 @@ export async function keepGeneratedElementDraft(
     return transaction.generatedElementDraft.findUniqueOrThrow({
       where: { id: draft.id },
     })
-  })
+  }
+
+  return withQuestionTagConflictRetry(() => ctx.prisma.$transaction(run))
 }
 
 export async function updateGeneratedElementDraft(
@@ -568,6 +651,7 @@ export async function updateGeneratedElementDraft(
       !input.current.explanation ||
       !input.current.cardType ||
       input.current.context != null ||
+      input.current.tagSelection != null ||
       (input.current.choices?.length ?? 0) > 0
     ) {
       throw questionGenerationServiceError(
@@ -594,14 +678,20 @@ export async function updateGeneratedElementDraft(
   if (
     !isQuestionElementType(elementType) ||
     !input.current.choices ||
-    input.current.cardType != null ||
-    (input.current.tags?.length ?? 0) > 0
+    input.current.cardType != null
   ) {
     throw questionGenerationServiceError(
       'DRAFT_INVALID',
       'An assessment element requires answer choices'
     )
   }
+  const tagWrite = questionTagSelectionWrite(
+    {
+      tagSelection: input.current.tagSelection,
+      tags: input.current.tags,
+    },
+    undefined
+  )
   const current: GeneratedQuestionEditable = {
     itemType: elementType,
     name: input.current.name,
@@ -618,6 +708,7 @@ export async function updateGeneratedElementDraft(
       draftId: input.draftId,
       expectedRevision: input.expectedRevision,
       current,
+      ...(tagWrite.mode === 'none' ? {} : { tagSelection: tagWrite.selection }),
     },
     ctx
   )

--- a/packages/graphql/src/services/generatedQuestionTags.ts
+++ b/packages/graphql/src/services/generatedQuestionTags.ts
@@ -1,0 +1,237 @@
+import * as DB from '@klicker-uzh/prisma/client'
+import {
+  type GeneratedQuestionTagSelection,
+  type GeneratedQuestionTagSelectionInput,
+  normalizeGeneratedQuestionTagLabel,
+} from '@klicker-uzh/types'
+import { questionGenerationServiceError } from './questionGenerationErrors.js'
+
+export type QuestionTagSelection = GeneratedQuestionTagSelection
+
+// A draft keeps the requested selection, not the resolved tag set, so an
+// identical retry stays an exact retry after a proposal became an existing tag.
+export type QuestionTagSelectionWrite =
+  | { mode: 'legacy'; selection: QuestionTagSelection }
+  | { mode: 'selection'; selection: QuestionTagSelection }
+  | { mode: 'none' }
+
+export type QuestionTagResolutionMode = 'resolve-or-create' | 'resolve-only'
+
+const MAX_NEW_TAG_NAME_LENGTH = 200
+const MAX_TAG_SELECTION_SIZE = 100
+const MAX_TAG_NAME_CONFLICT_ATTEMPTS = 3
+
+function tagSelectionError(message: string): never {
+  throw questionGenerationServiceError('DRAFT_INVALID', message)
+}
+
+export function normalizeQuestionTagSelection(
+  value: GeneratedQuestionTagSelectionInput | null | undefined
+): QuestionTagSelection {
+  const existingTagIds: number[] = []
+  for (const raw of value?.existingTagIds ?? []) {
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) {
+      tagSelectionError('Selected tag identifiers are invalid')
+    }
+    if (!existingTagIds.includes(raw)) existingTagIds.push(raw)
+  }
+
+  const newTagNames: string[] = []
+  for (const raw of value?.newTagNames ?? []) {
+    if (typeof raw !== 'string') {
+      tagSelectionError('Proposed tag names are invalid')
+    }
+    const label = normalizeGeneratedQuestionTagLabel(raw)
+    if (!label || label.length > MAX_NEW_TAG_NAME_LENGTH) {
+      tagSelectionError('Proposed tag names are invalid')
+    }
+    if (!newTagNames.includes(label)) newTagNames.push(label)
+  }
+
+  if (existingTagIds.length + newTagNames.length > MAX_TAG_SELECTION_SIZE) {
+    tagSelectionError('Tag selection is too large')
+  }
+
+  return { existingTagIds, newTagNames }
+}
+
+// Resolves the selection a request wants to persist. `tags` is the legacy
+// string-name input and replaces the selection; supplying both representations
+// is ambiguous and rejected. An omitted field preserves the stored selection.
+export function questionTagSelectionWrite(
+  input: {
+    tagSelection?: GeneratedQuestionTagSelectionInput | null
+    tags?: string[] | null
+  },
+  stored: GeneratedQuestionTagSelection | null | undefined
+): QuestionTagSelectionWrite {
+  const hasSelection =
+    input.tagSelection !== undefined && input.tagSelection !== null
+  const hasLegacyTags = input.tags !== undefined
+  if (hasSelection && hasLegacyTags) {
+    tagSelectionError('Supply either tags or a tag selection, not both')
+  }
+  if (hasSelection) {
+    return {
+      mode: 'selection',
+      selection: normalizeQuestionTagSelection(input.tagSelection),
+    }
+  }
+  if (hasLegacyTags) {
+    return {
+      mode: 'legacy',
+      selection: normalizeQuestionTagSelection({
+        existingTagIds: [],
+        newTagNames: input.tags ?? [],
+      }),
+    }
+  }
+  return stored
+    ? { mode: 'selection', selection: normalizeQuestionTagSelection(stored) }
+    : { mode: 'none' }
+}
+
+export function questionTagSelectionsEqual(
+  left: GeneratedQuestionTagSelection | null | undefined,
+  right: GeneratedQuestionTagSelection | null | undefined
+): boolean {
+  if (!left || !right) return !left === !right
+  return (
+    left.existingTagIds.length === right.existingTagIds.length &&
+    left.existingTagIds.every(
+      (id, index) => id === right.existingTagIds[index]
+    ) &&
+    left.newTagNames.length === right.newTagNames.length &&
+    left.newTagNames.every((name, index) => name === right.newTagNames[index])
+  )
+}
+
+// Existing ids are validated against the owner in the same transaction that
+// writes the element, and new names resolve to an exact-name owner tag before
+// any tag is created. `resolve-only` never creates a tag and reports whether
+// the request can still be satisfied, keeping retry matching side-effect free.
+export async function resolveQuestionTagSelection(
+  transaction: DB.Prisma.TransactionClient,
+  ownerId: string,
+  selection: QuestionTagSelection,
+  mode: QuestionTagResolutionMode = 'resolve-or-create'
+): Promise<number[] | null> {
+  const resolvedIds: number[] = []
+  const seen = new Set<number>()
+
+  if (selection.existingTagIds.length > 0) {
+    const owned = await transaction.tag.findMany({
+      where: { ownerId, id: { in: selection.existingTagIds } },
+      select: { id: true },
+    })
+    const ownedIds = new Set(owned.map((tag) => tag.id))
+    for (const tagId of selection.existingTagIds) {
+      if (!ownedIds.has(tagId)) {
+        tagSelectionError('Selected tags are not available to this owner')
+      }
+      if (!seen.has(tagId)) {
+        seen.add(tagId)
+        resolvedIds.push(tagId)
+      }
+    }
+  }
+
+  for (const name of selection.newTagNames) {
+    const existing = await transaction.tag.findUnique({
+      where: { ownerId_name: { ownerId, name } },
+      select: { id: true },
+    })
+    if (existing) {
+      if (!seen.has(existing.id)) {
+        seen.add(existing.id)
+        resolvedIds.push(existing.id)
+      }
+      continue
+    }
+    if (mode === 'resolve-only') return null
+
+    const created = await transaction.tag.create({
+      data: { name, owner: { connect: { id: ownerId } } },
+      select: { id: true },
+    })
+    seen.add(created.id)
+    resolvedIds.push(created.id)
+  }
+
+  return resolvedIds
+}
+
+const OWNER_NAME_TAG_COLUMNS = ['ownerId', 'name'] as const
+
+// Constraint columns arrive as bare names in some reports and as quoted SQL
+// identifiers in others. Only a complete wrapping quote pair is removed, so an
+// unrecognized shape stays unrecognized instead of matching by accident.
+function unquotedColumn(column: string): string {
+  const trimmed = column.trim()
+  const quote = trimmed[0]
+  if (
+    trimmed.length >= 3 &&
+    (quote === '"' || quote === '`') &&
+    trimmed[trimmed.length - 1] === quote
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function isOwnerNameColumnList(columns: unknown): boolean {
+  if (!Array.isArray(columns)) return false
+  const names = columns.map((column) =>
+    typeof column === 'string' ? unquotedColumn(column) : ''
+  )
+  return OWNER_NAME_TAG_COLUMNS.every((column) => names.includes(column))
+}
+
+function isOwnerNameTagConflict(error: unknown): boolean {
+  if (!(error instanceof DB.Prisma.PrismaClientKnownRequestError)) return false
+  if (error.code !== 'P2002') return false
+  const meta = error.meta as
+    | {
+        target?: unknown
+        modelName?: unknown
+        driverAdapterError?: { cause?: unknown }
+      }
+    | undefined
+  if (typeof meta?.modelName === 'string' && meta.modelName !== 'Tag') {
+    return false
+  }
+  if (typeof meta?.target === 'string') {
+    return meta.target.includes('ownerId') && meta.target.includes('name')
+  }
+  if (Array.isArray(meta?.target)) return isOwnerNameColumnList(meta.target)
+
+  // Prisma 7 driver adapters report the violated constraint on the cause of the
+  // adapter error rather than on `target`.
+  const cause = meta?.driverAdapterError?.cause as
+    | { kind?: unknown; constraint?: { fields?: unknown } }
+    | undefined
+  if (cause?.kind !== 'UniqueConstraintViolation') return false
+  return isOwnerNameColumnList(cause.constraint?.fields)
+}
+
+// Two builds can accept the same new tag concurrently. Retrying the whole
+// transaction re-resolves each proposed name, so the loser connects to the tag
+// the winner created instead of failing or creating a duplicate.
+export async function withQuestionTagConflictRetry<T>(
+  run: () => Promise<T>
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await run()
+    } catch (error) {
+      if (
+        !isOwnerNameTagConflict(error) ||
+        attempt >= MAX_TAG_NAME_CONFLICT_ATTEMPTS
+      ) {
+        throw error
+      }
+    }
+  }
+}
+
+export { suggestGeneratedQuestionTags } from '@klicker-uzh/types'

--- a/packages/graphql/src/services/questionGeneration.ts
+++ b/packages/graphql/src/services/questionGeneration.ts
@@ -9,13 +9,6 @@ import type {
 } from '@klicker-uzh/types'
 import type { ContextWithUser } from '../lib/context.js'
 import {
-  canonicalElementGenerationJson,
-  elementGenerationArtifactPayload,
-  elementGenerationOutputBlobName,
-  loadReadyElementGenerationGraph,
-  normalizeElementGenerationIdempotencyKey,
-} from './elementGenerationProvider.js'
-import {
   assertElementGenerationCostAccounted,
   createElementGenerationBuildWithSpend,
   releaseUnclaimedElementGenerationSpend,
@@ -27,11 +20,23 @@ import {
   releaseElementGenerationLease,
 } from './elementGenerationLease.js'
 import {
+  canonicalElementGenerationJson,
+  elementGenerationArtifactPayload,
+  elementGenerationOutputBlobName,
+  loadReadyElementGenerationGraph,
+  normalizeElementGenerationIdempotencyKey,
+} from './elementGenerationProvider.js'
+import {
   generatedKPRIMElementInput,
   generatedMCElementInput,
   generatedSCElementInput,
   manipulateElement,
 } from './elements.js'
+import {
+  normalizeQuestionTagSelection,
+  resolveQuestionTagSelection,
+  withQuestionTagConflictRetry,
+} from './generatedQuestionTags.js'
 import {
   parseQuestionGenerationDesign,
   parseQuestionGenerationFinalBank,
@@ -1191,7 +1196,7 @@ export async function saveGeneratedQuestions(
 }> {
   await assertQuestionGenerationPreviewAccess(ctx)
 
-  return ctx.prisma.$transaction(async (transaction) => {
+  const run = async (transaction: DB.Prisma.TransactionClient) => {
     await transaction.$queryRaw`
       SELECT "id"
       FROM "ElementGenerationBuild"
@@ -1238,8 +1243,8 @@ export async function saveGeneratedQuestions(
       if (draft.savedElementId !== null) continue
 
       let input: ElementManipulationInput
+      const current = draft.current as GeneratedQuestionEditable
       try {
-        const current = draft.current as GeneratedQuestionEditable
         if (draft.targetDifficulty === null) {
           return serviceError(
             'SAVE_VALIDATION_FAILED',
@@ -1268,6 +1273,14 @@ export async function saveGeneratedQuestions(
           'A generated question draft is not a valid question element'
         )
       }
+      const resolvedTagIds = current.tagSelection
+        ? await resolveQuestionTagSelection(
+            transaction,
+            ctx.user.sub,
+            normalizeQuestionTagSelection(current.tagSelection),
+            'resolve-or-create'
+          )
+        : null
       const element = await manipulateElement(input, {
         ...ctx,
         prisma: transaction,
@@ -1277,6 +1290,16 @@ export async function saveGeneratedQuestions(
           'SAVE_VALIDATION_FAILED',
           'A generated question draft is not a valid question element'
         )
+      }
+      if (current.tagSelection) {
+        await transaction.element.update({
+          where: { id: element.id },
+          data: {
+            tags: {
+              set: [...new Set(resolvedTagIds ?? [])].map((id) => ({ id })),
+            },
+          },
+        })
       }
       const linked = await transaction.generatedElementDraft.updateMany({
         where: {
@@ -1299,7 +1322,9 @@ export async function saveGeneratedQuestions(
     }
 
     return { createdElementIds, alreadySavedElementIds }
-  })
+  }
+
+  return withQuestionTagConflictRetry(() => ctx.prisma.$transaction(run))
 }
 
 export {

--- a/packages/graphql/src/services/questionGenerationArtifacts.ts
+++ b/packages/graphql/src/services/questionGenerationArtifacts.ts
@@ -471,7 +471,8 @@ const resultSchema = z
 const finalQuestionSchema = z
   .object({
     id: canonicalIdentifier(200),
-    title: boundedText(500).optional(),
+    title: z.unknown().optional(),
+    suggested_tags: z.unknown().optional(),
     stem: boundedText(10_000),
     context_inline: z.string().trim().max(20_000).nullable().optional(),
     explanation: z.string().trim().max(20_000).nullable().optional(),
@@ -601,11 +602,28 @@ function normalizedPlainText(value: string): string {
     .trim()
 }
 
+export function normalizeGeneratedTagSuggestions(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const suggestions = new Set<string>()
+  const segmenter = new Intl.Segmenter('und', { granularity: 'grapheme' })
+  for (const candidate of value) {
+    if (typeof candidate !== 'string') continue
+    const label = normalizedPlainText(candidate)
+    if (label && Array.from(segmenter.segment(label)).length <= 60) {
+      suggestions.add(label)
+    }
+    if (suggestions.size === 5) break
+  }
+  return [...suggestions]
+}
+
 export function deriveGeneratedQuestionName(
-  title: string | undefined,
+  title: unknown,
   stem: string
 ): string {
-  const value = normalizedPlainText(title?.trim() || stem)
+  const value =
+    normalizedPlainText(typeof title === 'string' ? title : '') ||
+    normalizedPlainText(stem)
   if (!value) return artifactError('Generated question has no usable name')
 
   const segments = new Intl.Segmenter('und', {
@@ -1436,6 +1454,13 @@ function normalizeFinalQuestion(
     itemType,
     sourceQuestionId: question.id,
     name: deriveGeneratedQuestionName(question.title, question.stem),
+    ...(question.suggested_tags === undefined
+      ? {}
+      : {
+          suggestedTags: normalizeGeneratedTagSuggestions(
+            question.suggested_tags
+          ),
+        }),
     stem: question.stem.trim(),
     context: optionalText(question.context_inline),
     explanation: optionalText(question.explanation),

--- a/packages/graphql/src/services/questionGenerationDrafts.ts
+++ b/packages/graphql/src/services/questionGenerationDrafts.ts
@@ -1,6 +1,7 @@
 import * as DB from '@klicker-uzh/prisma/client'
 import type {
   GeneratedQuestionEditable,
+  GeneratedQuestionTagSelection,
   QuestionGenerationItemType,
 } from '@klicker-uzh/types'
 import type { ContextWithUser } from '../lib/context.js'
@@ -18,11 +19,13 @@ export type UpdateGeneratedQuestionDraftInput = {
   draftId: string
   expectedRevision: number
   current: GeneratedQuestionEditableInputValue
+  // Omitted preserves the stored selection; an explicit selection replaces it.
+  tagSelection?: GeneratedQuestionTagSelection
 }
 
 export type GeneratedQuestionEditableInputValue = Omit<
   GeneratedQuestionEditable,
-  'itemType' | 'context' | 'explanation' | 'choices'
+  'itemType' | 'context' | 'explanation' | 'choices' | 'tagSelection'
 > & {
   itemType?: QuestionGenerationItemType | null
   context?: string | null
@@ -214,6 +217,10 @@ export async function updateGeneratedQuestionDraft(
       input.current,
       storedCurrent.itemType ?? 'SC'
     )
+    const tagSelection = input.tagSelection ?? storedCurrent.tagSelection
+    const nextCurrent: GeneratedQuestionEditable = tagSelection
+      ? { ...current, tagSelection }
+      : current
 
     const updated = await transaction.generatedElementDraft.updateMany({
       where: {
@@ -221,7 +228,7 @@ export async function updateGeneratedQuestionDraft(
         revision: input.expectedRevision,
         savedElementId: null,
       },
-      data: { current, revision: { increment: 1 } },
+      data: { current: nextCurrent, revision: { increment: 1 } },
     })
     if (updated.count !== 1) {
       throw questionGenerationServiceError(

--- a/packages/graphql/test/elementGenerationCompletion.integration.test.ts
+++ b/packages/graphql/test/elementGenerationCompletion.integration.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { prisma } from '@klicker-uzh/prisma'
+import { prisma, requireDisposableDatabase } from '@klicker-uzh/prisma'
 import * as DB from '@klicker-uzh/prisma/client'
 import type {
   GeneratedFlashcard,
@@ -31,6 +31,7 @@ function question(
 ): GeneratedQuestionWithProvenance {
   return {
     sourceQuestionId: 'question-1',
+    suggestedTags: ['synthetic-topic'],
     itemType,
     name: 'Synthetic question',
     stem: 'Choose the correct answer',
@@ -231,6 +232,7 @@ async function bounded<T>(promise: Promise<T>): Promise<T> {
 
 describe('initial Element completion', () => {
   beforeEach(async () => {
+    await requireDisposableDatabase(prisma)
     ownerId = randomUUID()
     const kbId = randomUUID()
     graphBuildId = randomUUID()
@@ -255,6 +257,7 @@ describe('initial Element completion', () => {
     })
   })
   afterEach(async () => {
+    await requireDisposableDatabase(prisma)
     await prisma.user.delete({ where: { id: ownerId } })
   })
   afterAll(async () => {
@@ -276,6 +279,7 @@ describe('initial Element completion', () => {
       predictedDifficulty,
       qualityFlags,
       citations,
+      suggestedTags,
       ...current
     } = generated
     const { provenance: _provenance, ...original } = generated
@@ -320,6 +324,8 @@ describe('initial Element completion', () => {
       lastSynchronizedAt: expect.any(Date),
     })
     expect(after.spends).toEqual([])
+    expect(after.drafts[0]?.original).toMatchObject({ suggestedTags })
+    expect(after.drafts[0]?.current).not.toHaveProperty('suggestedTags')
     expect(await prisma.element.count({ where: { ownerId } })).toBe(0)
   })
 

--- a/packages/graphql/test/elementGenerationDraftPersistence.test.ts
+++ b/packages/graphql/test/elementGenerationDraftPersistence.test.ts
@@ -128,15 +128,17 @@ function savedElement() {
         correct: choice.correct,
       })),
     },
-    tags: [{ name: 'generated' }],
+    tags: [{ id: 12, name: 'generated' }],
   }
 }
 
 function context(fullDraft: ReturnType<typeof draft>) {
-  const findFirst = vi
-    .fn()
-    .mockResolvedValueOnce({ buildId })
-    .mockResolvedValueOnce(fullDraft)
+  // A retry runs the same reads against committed state again, so the ownership
+  // probe and the detail read are modelled by query shape rather than a one-shot
+  // queue that a second transaction would exhaust.
+  const findFirst = vi.fn(async (args: Record<string, unknown>) =>
+    'select' in args ? { buildId } : fullDraft
+  )
   const transaction = {
     $queryRaw: vi.fn(async () => []),
     generatedElementDraft: {
@@ -150,6 +152,14 @@ function context(fullDraft: ReturnType<typeof draft>) {
         savedElementId: 91,
         savedAt,
       })),
+    },
+    tag: {
+      findMany: vi.fn(async () => [] as Array<{ id: number }>),
+      findUnique: vi.fn(async () => null),
+      create: vi.fn(async () => ({ id: 900 })),
+    },
+    element: {
+      update: vi.fn(async () => ({ id: 91 })),
     },
   }
   return {
@@ -201,7 +211,11 @@ describe('atomic generated-element keep', () => {
         savedElementId: null,
       },
       data: {
-        current,
+        // The legacy name input is stored as the requested selection intent.
+        current: {
+          ...current,
+          tagSelection: { existingTagIds: [], newTagNames: ['generated'] },
+        },
         revision: { increment: 1 },
         decision: DB.GeneratedElementDecision.ACCEPTED,
         savedElementId: 91,
@@ -589,5 +603,208 @@ describe('atomic generated-element keep', () => {
       keepGeneratedElementDraft(input, ctx as never)
     ).rejects.toMatchObject({ code: 'GENERATED_QUESTION_DRAFT_NOT_FOUND' })
     expect(manipulateElement).not.toHaveBeenCalled()
+  })
+
+  it('connects a selection by validated owner id instead of by name', async () => {
+    const { ctx, transaction } = context(draft())
+    transaction.tag.findMany.mockResolvedValue([{ id: 7 }, { id: 8 }])
+    vi.mocked(manipulateElement).mockResolvedValue(savedElement() as never)
+
+    await keepGeneratedElementDraft(
+      {
+        ...input,
+        tags: undefined,
+        tagSelection: { existingTagIds: [7, 8], newTagNames: [] },
+      },
+      ctx as never
+    )
+
+    expect(transaction.tag.create).not.toHaveBeenCalled()
+    expect(manipulateElement).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: [] }),
+      expect.objectContaining({ prisma: transaction })
+    )
+    expect(transaction.element.update).toHaveBeenCalledWith({
+      where: { id: 91 },
+      data: { tags: { set: [{ id: 7 }, { id: 8 }] } },
+    })
+  })
+
+  it('creates a new proposal in the keep transaction and connects it by id', async () => {
+    const { ctx, transaction } = context(draft())
+    transaction.tag.create.mockResolvedValue({ id: 901 })
+    vi.mocked(manipulateElement).mockResolvedValue(savedElement() as never)
+
+    await keepGeneratedElementDraft(
+      {
+        ...input,
+        tags: undefined,
+        tagSelection: { existingTagIds: [], newTagNames: ['Frisch'] },
+      },
+      ctx as never
+    )
+
+    expect(transaction.tag.create).toHaveBeenCalledWith({
+      data: { name: 'Frisch', owner: { connect: { id: ownerId } } },
+      select: { id: true },
+    })
+    expect(transaction.element.update).toHaveBeenCalledWith({
+      where: { id: 91 },
+      data: { tags: { set: [{ id: 901 }] } },
+    })
+  })
+
+  it('preserves the stored selection when both tag fields are omitted', async () => {
+    const storedSelection = { existingTagIds: [7], newTagNames: [] }
+    const { ctx, transaction } = context(
+      draft({ current: { ...current, tagSelection: storedSelection } })
+    )
+    transaction.tag.findMany.mockResolvedValue([{ id: 7 }])
+    vi.mocked(manipulateElement).mockResolvedValue(savedElement() as never)
+
+    await keepGeneratedElementDraft({ ...input, tags: undefined }, ctx as never)
+
+    expect(transaction.element.update).toHaveBeenCalledWith({
+      where: { id: 91 },
+      data: { tags: { set: [{ id: 7 }] } },
+    })
+    expect(transaction.generatedElementDraft.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          current: expect.objectContaining({ tagSelection: storedSelection }),
+        }),
+      })
+    )
+  })
+
+  it('clears the stored selection with an explicitly empty selection', async () => {
+    const { ctx, transaction } = context(
+      draft({
+        current: {
+          ...current,
+          tagSelection: { existingTagIds: [7], newTagNames: [] },
+        },
+      })
+    )
+    vi.mocked(manipulateElement).mockResolvedValue(savedElement() as never)
+
+    await keepGeneratedElementDraft(
+      {
+        ...input,
+        tags: undefined,
+        tagSelection: { existingTagIds: [], newTagNames: [] },
+      },
+      ctx as never
+    )
+
+    expect(transaction.tag.findMany).not.toHaveBeenCalled()
+    expect(transaction.tag.create).not.toHaveBeenCalled()
+    expect(transaction.element.update).toHaveBeenCalledWith({
+      where: { id: 91 },
+      data: { tags: { set: [] } },
+    })
+  })
+
+  it('rejects a request supplying both legacy tags and a selection', async () => {
+    const { ctx } = context(draft())
+
+    await expect(
+      keepGeneratedElementDraft(
+        { ...input, tagSelection: { existingTagIds: [], newTagNames: [] } },
+        ctx as never
+      )
+    ).rejects.toMatchObject({ code: 'DRAFT_INVALID' })
+    expect(manipulateElement).not.toHaveBeenCalled()
+  })
+
+  it('rejects a selection referencing a tag of another owner', async () => {
+    const { ctx, transaction } = context(draft())
+    transaction.tag.findMany.mockResolvedValue([])
+
+    await expect(
+      keepGeneratedElementDraft(
+        {
+          ...input,
+          tags: undefined,
+          tagSelection: { existingTagIds: [7], newTagNames: [] },
+        },
+        ctx as never
+      )
+    ).rejects.toMatchObject({ code: 'DRAFT_INVALID' })
+    expect(manipulateElement).not.toHaveBeenCalled()
+    expect(transaction.element.update).not.toHaveBeenCalled()
+  })
+
+  it('returns the linked element for an exact selection retry', async () => {
+    const existing = draft({
+      revision: 3,
+      decision: DB.GeneratedElementDecision.ACCEPTED,
+      savedElementId: 91,
+      current: {
+        ...current,
+        tagSelection: { existingTagIds: [7], newTagNames: [] },
+      },
+      savedElement: {
+        ...savedElement(),
+        tags: [{ id: 7, name: 'Portfolio' }],
+      },
+      savedAt,
+    })
+    const { ctx, transaction } = context(existing)
+    transaction.tag.findMany.mockResolvedValue([{ id: 7 }])
+
+    await expect(
+      keepGeneratedElementDraft({ ...input, tags: undefined }, ctx as never)
+    ).resolves.toMatchObject({ savedElementId: 91 })
+    expect(manipulateElement).not.toHaveBeenCalled()
+    expect(transaction.tag.create).not.toHaveBeenCalled()
+    expect(transaction.element.update).not.toHaveBeenCalled()
+  })
+
+  it('retries the keep transaction after a concurrent owner/name tag conflict', async () => {
+    const { ctx, transaction } = context(draft())
+    transaction.tag.create
+      .mockRejectedValueOnce(
+        // The real Prisma 7 driver-adapter report for a duplicate owner/name tag.
+        new DB.Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: ("ownerId", name)',
+          {
+            code: 'P2002',
+            clientVersion: '7.8.0',
+            meta: {
+              modelName: 'Tag',
+              driverAdapterError: {
+                cause: {
+                  kind: 'UniqueConstraintViolation',
+                  originalCode: '23505',
+                  constraint: { fields: ['"ownerId"', 'name'] },
+                  originalMessage:
+                    'duplicate key value violates unique constraint "Tag_ownerId_name_key"',
+                },
+              },
+            },
+          }
+        )
+      )
+      .mockResolvedValue({ id: 901 })
+    vi.mocked(manipulateElement).mockResolvedValue(savedElement() as never)
+
+    await expect(
+      keepGeneratedElementDraft(
+        {
+          ...input,
+          tags: undefined,
+          tagSelection: { existingTagIds: [], newTagNames: ['Frisch'] },
+        },
+        ctx as never
+      )
+    ).resolves.toMatchObject({ savedElementId: 91 })
+
+    expect(ctx.prisma.$transaction).toHaveBeenCalledTimes(2)
+    expect(transaction.element.update).toHaveBeenCalledTimes(1)
+    expect(transaction.element.update).toHaveBeenCalledWith({
+      where: { id: 91 },
+      data: { tags: { set: [{ id: 901 }] } },
+    })
   })
 })

--- a/packages/graphql/test/elementGenerationPersistence.integration.test.ts
+++ b/packages/graphql/test/elementGenerationPersistence.integration.test.ts
@@ -1,12 +1,16 @@
 import { randomUUID } from 'node:crypto'
 import { EventEmitter } from 'node:events'
-import { prisma } from '@klicker-uzh/prisma'
+import { prisma, requireDisposableDatabase } from '@klicker-uzh/prisma'
 import * as DB from '@klicker-uzh/prisma/client'
 import { DisplayMode } from '@klicker-uzh/types'
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { ContextWithUser } from '../src/lib/context.js'
-import { keepGeneratedElementDraft } from '../src/services/elementGeneration.js'
+import {
+  keepGeneratedElementDraft,
+  updateGeneratedElementDraft,
+} from '../src/services/elementGeneration.js'
 import { manipulateElement } from '../src/services/elements.js'
+import { saveGeneratedQuestions } from '../src/services/questionGeneration.js'
 
 const current = {
   itemType: 'SC' as const,
@@ -83,6 +87,15 @@ function keepInput(name = current.name, tag = 'synthetic-generated') {
   }
 }
 
+function keepSelectionInput(
+  tagSelection: { existingTagIds: number[]; newTagNames: string[] },
+  draftIdOverride?: string
+) {
+  const { tags: _tags, ...rest } = keepInput()
+  const input = { ...rest, tagSelection }
+  return draftIdOverride ? { ...input, draftId: draftIdOverride } : input
+}
+
 function concurrentContext() {
   let arrivals = 0
   let release!: () => void
@@ -106,6 +119,57 @@ function concurrentContext() {
     },
   })
   return context(ownerId, client as unknown as DB.PrismaClient)
+}
+
+// Both real transactions resolve the same proposed tag name before either
+// inserts it, so the second insert always hits the owner/name uniqueness and
+// the retry has to run for this test to pass.
+function concurrentTagProposalContext() {
+  let arrivals = 0
+  let release!: () => void
+  const bothTransactions = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const client = prisma.$extends({
+    query: {
+      tag: {
+        async findUnique({ args, query }) {
+          const result = await query(args)
+          arrivals += 1
+          if (arrivals === 2) release()
+          await bothTransactions
+          return result
+        },
+      },
+    },
+  })
+  return context(ownerId, client as unknown as DB.PrismaClient)
+}
+
+// Fails only the final draft-link write. The transaction, the tag resolution,
+// and the Element service stay real, so a passing test proves database rollback.
+function finalLinkFailureClient(failure: Error) {
+  let injected = 0
+  const client = prisma.$extends({
+    query: {
+      generatedElementDraft: {
+        async updateMany({ args, query }) {
+          if (
+            args.where?.id === draftId &&
+            args.where.revision === 0 &&
+            args.where.savedElementId === null &&
+            args.data.savedElementId != null &&
+            args.data.decision === DB.GeneratedElementDecision.ACCEPTED
+          ) {
+            injected += 1
+            throw failure
+          }
+          return query(args)
+        },
+      },
+    },
+  })
+  return { client, injections: () => injected }
 }
 
 async function persistedCounts() {
@@ -134,8 +198,70 @@ async function expectUnchangedDraft() {
   })
 }
 
+// One completed synthetic build with exactly one SC draft. The cross-build
+// concurrency test seeds a sibling draft through the same helper, so the two
+// drafts share nothing but the owner.
+async function seedDraft(targetDraftId: string, sourceElementId: string) {
+  const kb = await prisma.kB.create({
+    data: { ownerId, name: 'Synthetic generation persistence KB' },
+  })
+  const graph = await prisma.kBGraphBuild.create({
+    data: {
+      id: randomUUID(),
+      kbId: kb.id,
+      requestedById: ownerId,
+      sourceContentDigest: 'a'.repeat(64),
+      graphName: `synthetic:${randomUUID()}`,
+    },
+  })
+  const build = await prisma.elementGenerationBuild.create({
+    data: {
+      id: randomUUID(),
+      ownerId,
+      sourceGraphBuildId: graph.id,
+      elementType: DB.ElementType.SC,
+      idempotencyKey: randomUUID(),
+      configurationHash: 'synthetic-persistence',
+      configuration: {
+        itemType: 'SC',
+        language: 'en',
+        questionCount: 1,
+        objectives: [],
+        sourceScopes: [],
+        bloomLevels: ['remember'],
+        difficultyPreset: 'D1',
+        difficultyCounts: { d1: 1, d2: 0, d3: 0, d4: 0, d5: 0 },
+      },
+      requestedElementCount: 1,
+      status: DB.ElementGenerationBuildStatus.COMPLETED,
+    },
+  })
+  await prisma.generatedElementDraft.create({
+    data: {
+      id: targetDraftId,
+      buildId: build.id,
+      sourceElementId,
+      order: 0,
+      elementType: DB.ElementType.SC,
+      original: {
+        ...current,
+        sourceQuestionId: sourceElementId,
+        bloomLevel: 'remember',
+        targetDifficulty: 3,
+        predictedDifficulty: null,
+        qualityFlags: [],
+        citations: [],
+      },
+      current,
+      targetDifficulty: 3,
+      citations: [],
+    },
+  })
+}
+
 describe('real generated Element persistence', () => {
   beforeEach(async () => {
+    await requireDisposableDatabase(prisma)
     ownerId = randomUUID()
     foreignId = randomUUID()
     draftId = randomUUID()
@@ -147,64 +273,11 @@ describe('real generated Element persistence', () => {
         aiFeaturesEnabled: true,
       })),
     })
-    const kb = await prisma.kB.create({
-      data: { ownerId, name: 'Synthetic generation persistence KB' },
-    })
-    const graph = await prisma.kBGraphBuild.create({
-      data: {
-        id: randomUUID(),
-        kbId: kb.id,
-        requestedById: ownerId,
-        sourceContentDigest: 'a'.repeat(64),
-        graphName: `synthetic:${randomUUID()}`,
-      },
-    })
-    const build = await prisma.elementGenerationBuild.create({
-      data: {
-        id: randomUUID(),
-        ownerId,
-        sourceGraphBuildId: graph.id,
-        elementType: DB.ElementType.SC,
-        idempotencyKey: randomUUID(),
-        configurationHash: 'synthetic-persistence',
-        configuration: {
-          itemType: 'SC',
-          language: 'en',
-          questionCount: 1,
-          objectives: [],
-          sourceScopes: [],
-          bloomLevels: ['remember'],
-          difficultyPreset: 'D1',
-          difficultyCounts: { d1: 1, d2: 0, d3: 0, d4: 0, d5: 0 },
-        },
-        requestedElementCount: 1,
-        status: DB.ElementGenerationBuildStatus.COMPLETED,
-      },
-    })
-    await prisma.generatedElementDraft.create({
-      data: {
-        id: draftId,
-        buildId: build.id,
-        sourceElementId: 'synthetic-source',
-        order: 0,
-        elementType: DB.ElementType.SC,
-        original: {
-          ...current,
-          sourceQuestionId: 'synthetic-source',
-          bloomLevel: 'remember',
-          targetDifficulty: 3,
-          predictedDifficulty: null,
-          qualityFlags: [],
-          citations: [],
-        },
-        current,
-        targetDifficulty: 3,
-        citations: [],
-      },
-    })
+    await seedDraft(draftId, 'synthetic-source')
   })
 
   afterEach(async () => {
+    await requireDisposableDatabase(prisma)
     await prisma.user.deleteMany({
       where: { id: { in: [ownerId, foreignId] } },
     })
@@ -286,35 +359,16 @@ describe('real generated Element persistence', () => {
 
   it('rolls back real Element writes when the final draft link fails', async () => {
     const failure = new Error('synthetic final-link failure')
-    let injected = 0
-    const client = prisma.$extends({
-      query: {
-        generatedElementDraft: {
-          async updateMany({ args, query }) {
-            if (
-              args.where?.id === draftId &&
-              args.where.revision === 0 &&
-              args.where.savedElementId === null &&
-              args.data.savedElementId != null &&
-              args.data.decision === DB.GeneratedElementDecision.ACCEPTED
-            ) {
-              injected += 1
-              throw failure
-            }
-            return query(args)
-          },
-        },
-      },
-    })
     // Only the final link call fails. The transaction and Element service are real;
     // this proves database rollback, not a SQL constraint or in-memory event rollback.
+    const { client, injections } = finalLinkFailureClient(failure)
     await expect(
       keepGeneratedElementDraft(
         keepInput(),
         context(ownerId, client as unknown as DB.PrismaClient)
       )
     ).rejects.toThrow(failure)
-    expect(injected).toBe(1)
+    expect(injections()).toBe(1)
     expect(await persistedCounts()).toEqual({
       elements: 0,
       tags: 0,
@@ -372,6 +426,228 @@ describe('real generated Element persistence', () => {
       tags: 1,
       logs: 1,
       permissions: 1,
+    })
+    await expectUnchangedDraft()
+  })
+
+  it('connects two concurrent builds to the one tag their shared proposal created', async () => {
+    const siblingDraftId = randomUUID()
+    await seedDraft(siblingDraftId, 'synthetic-sibling-source')
+    const selection = {
+      existingTagIds: [],
+      newTagNames: ['synthetic-shared-tag'],
+    }
+    const ctx = concurrentTagProposalContext()
+    const results = await Promise.allSettled([
+      keepGeneratedElementDraft(keepSelectionInput(selection), ctx),
+      keepGeneratedElementDraft(
+        keepSelectionInput(selection, siblingDraftId),
+        ctx
+      ),
+    ])
+    expect(
+      results.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : []
+      )
+    ).toEqual([])
+
+    // The losing transaction is retried after the winner committed, so the
+    // proposal resolves to the winner's tag instead of failing or duplicating.
+    expect(await prisma.tag.count({ where: { ownerId } })).toBe(1)
+    const tag = await prisma.tag.findFirstOrThrow({
+      where: { ownerId, name: 'synthetic-shared-tag' },
+    })
+    const elements = await prisma.element.findMany({
+      where: { ownerId },
+      include: { tags: true },
+    })
+    expect(elements).toHaveLength(2)
+    for (const element of elements) {
+      expect(element.tags.map((connected) => connected.id)).toEqual([tag.id])
+    }
+    const drafts = await prisma.generatedElementDraft.findMany({
+      where: { id: { in: [draftId, siblingDraftId] } },
+    })
+    expect(drafts.map((draft) => draft.savedElementId)).not.toContain(null)
+    expect(new Set(drafts.map((draft) => draft.savedElementId)).size).toBe(2)
+    for (const id of [draftId, siblingDraftId]) {
+      const retry = await keepGeneratedElementDraft(
+        keepSelectionInput(selection, id),
+        context()
+      )
+      expect(retry.savedElementId).toBe(
+        drafts.find((draft) => draft.id === id)?.savedElementId
+      )
+    }
+    expect(await prisma.tag.count({ where: { ownerId } })).toBe(1)
+    expect(await prisma.element.count({ where: { ownerId } })).toBe(2)
+  })
+
+  it('recovers an accepted draft with its stored selection exactly once', async () => {
+    const tag = await prisma.tag.create({
+      data: { ownerId, name: 'synthetic-existing-recovery-tag' },
+    })
+    const draft = await prisma.generatedElementDraft.update({
+      where: { id: draftId },
+      data: {
+        decision: DB.GeneratedElementDecision.ACCEPTED,
+        current: {
+          ...current,
+          tagSelection: {
+            existingTagIds: [tag.id],
+            newTagNames: ['synthetic-new-recovery-tag'],
+          },
+        },
+      },
+    })
+    const saved = await saveGeneratedQuestions(draft.buildId, context())
+    expect(saved.createdElementIds).toHaveLength(1)
+    const element = await prisma.element.findUniqueOrThrow({
+      where: { id: saved.createdElementIds[0] },
+      include: { tags: true },
+    })
+    expect(element.tags.map((item) => item.id)).toContain(tag.id)
+    expect(element.tags).toHaveLength(2)
+    expect(await saveGeneratedQuestions(draft.buildId, context())).toEqual({
+      createdElementIds: [],
+      alreadySavedElementIds: saved.createdElementIds,
+    })
+    expect(await prisma.element.count({ where: { ownerId } })).toBe(1)
+    expect(await prisma.tag.count({ where: { ownerId } })).toBe(2)
+  })
+
+  it('rolls back the tag created for a selection keep when the final link fails', async () => {
+    const failure = new Error('synthetic selection link failure')
+    const { client, injections } = finalLinkFailureClient(failure)
+    await expect(
+      keepGeneratedElementDraft(
+        keepSelectionInput({
+          existingTagIds: [],
+          newTagNames: ['synthetic-rollback-tag'],
+        }),
+        context(ownerId, client as unknown as DB.PrismaClient)
+      )
+    ).rejects.toThrow(failure)
+    expect(injections()).toBe(1)
+    // The proposal was created inside the same transaction, so it must be gone.
+    expect(await persistedCounts()).toEqual({
+      elements: 0,
+      tags: 0,
+      logs: 0,
+      permissions: 0,
+    })
+    await expectUnchangedDraft()
+  })
+
+  it('preserves an omitted selection and clears an explicit empty one', async () => {
+    const tag = await prisma.tag.create({
+      data: {
+        name: 'synthetic-existing-tag',
+        owner: { connect: { id: ownerId } },
+      },
+    })
+    const draftCurrent = {
+      name: current.name,
+      prompt: current.stem,
+      context: current.context,
+      explanation: current.explanation,
+      choices: current.choices,
+    }
+    const storedSelection = {
+      existingTagIds: [tag.id],
+      newTagNames: ['synthetic-proposal'],
+    }
+
+    await updateGeneratedElementDraft(
+      {
+        draftId,
+        expectedRevision: 0,
+        current: { ...draftCurrent, tagSelection: storedSelection },
+      },
+      context()
+    )
+    await expect(
+      prisma.generatedElementDraft.findUniqueOrThrow({ where: { id: draftId } })
+    ).resolves.toMatchObject({ current: { tagSelection: storedSelection } })
+
+    // An edit that sends no selection leaves the stored selection untouched.
+    await updateGeneratedElementDraft(
+      { draftId, expectedRevision: 1, current: draftCurrent },
+      context()
+    )
+    await expect(
+      prisma.generatedElementDraft.findUniqueOrThrow({ where: { id: draftId } })
+    ).resolves.toMatchObject({ current: { tagSelection: storedSelection } })
+
+    await updateGeneratedElementDraft(
+      {
+        draftId,
+        expectedRevision: 2,
+        current: {
+          ...draftCurrent,
+          tagSelection: { existingTagIds: [], newTagNames: [] },
+        },
+      },
+      context()
+    )
+    await expect(
+      prisma.generatedElementDraft.findUniqueOrThrow({ where: { id: draftId } })
+    ).resolves.toMatchObject({
+      current: { tagSelection: { existingTagIds: [], newTagNames: [] } },
+    })
+  })
+
+  it('replays a kept selection by tag id after the tag was renamed', async () => {
+    const tag = await prisma.tag.create({
+      data: {
+        name: 'synthetic-original-name',
+        owner: { connect: { id: ownerId } },
+      },
+    })
+    const selection = { existingTagIds: [tag.id], newTagNames: [] }
+    const first = await keepGeneratedElementDraft(
+      keepSelectionInput(selection),
+      context()
+    )
+    await prisma.tag.update({
+      where: { id: tag.id },
+      data: { name: 'synthetic-renamed-name' },
+    })
+
+    const retry = await keepGeneratedElementDraft(
+      keepSelectionInput(selection),
+      context()
+    )
+    expect(retry.savedElementId).toBe(first.savedElementId)
+    expect(await prisma.element.count({ where: { ownerId } })).toBe(1)
+    expect(await prisma.tag.count({ where: { ownerId } })).toBe(1)
+    const saved = await prisma.element.findUniqueOrThrow({
+      where: { id: first.savedElementId! },
+      include: { tags: true },
+    })
+    expect(saved.tags.map((connected) => connected.id)).toEqual([tag.id])
+  })
+
+  it('refuses a selection whose tag was deleted instead of recreating it by name', async () => {
+    const tag = await prisma.tag.create({
+      data: {
+        name: 'synthetic-deleted-tag',
+        owner: { connect: { id: ownerId } },
+      },
+    })
+    await prisma.tag.delete({ where: { id: tag.id } })
+
+    await expect(
+      keepGeneratedElementDraft(
+        keepSelectionInput({ existingTagIds: [tag.id], newTagNames: [] }),
+        context()
+      )
+    ).rejects.toMatchObject({ code: 'DRAFT_INVALID' })
+    expect(await persistedCounts()).toEqual({
+      elements: 0,
+      tags: 0,
+      logs: 0,
+      permissions: 0,
     })
     await expectUnchangedDraft()
   })

--- a/packages/graphql/test/generatedQuestionDraftTags.test.ts
+++ b/packages/graphql/test/generatedQuestionDraftTags.test.ts
@@ -1,0 +1,157 @@
+import * as DB from '@klicker-uzh/prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock(
+  '../src/services/questionGenerationGraph.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../src/services/questionGenerationGraph.js')
+      >()
+    return {
+      ...actual,
+      assertQuestionGenerationPreviewAccess: vi.fn(async () => undefined),
+    }
+  }
+)
+
+import { updateGeneratedQuestionDraft } from '../src/services/questionGenerationDrafts.js'
+
+const ownerId = '123e4567-e89b-42d3-a456-426614174000'
+const buildId = '223e4567-e89b-42d3-a456-426614174000'
+const draftId = '323e4567-e89b-42d3-a456-426614174000'
+
+const choices = [
+  {
+    id: 'choice-a',
+    label: 'A',
+    text: 'Answer A',
+    correct: true,
+    feedback: null,
+  },
+  {
+    id: 'choice-b',
+    label: 'B',
+    text: 'Answer B',
+    correct: false,
+    feedback: null,
+  },
+]
+
+const currentInput = {
+  name: 'Edited question',
+  stem: 'Which answer is correct?',
+  context: null,
+  explanation: null,
+  choices,
+}
+
+const expectedCurrent = {
+  itemType: 'SC' as const,
+  name: currentInput.name,
+  stem: currentInput.stem,
+  context: null,
+  explanation: null,
+  choices,
+}
+
+function storedDraft(tagSelection?: {
+  existingTagIds: number[]
+  newTagNames: string[]
+}) {
+  return {
+    id: draftId,
+    buildId,
+    elementType: DB.ElementType.SC,
+    savedElementId: null,
+    revision: 4,
+    current: {
+      ...expectedCurrent,
+      ...(tagSelection ? { tagSelection } : {}),
+    },
+    build: { status: DB.ElementGenerationBuildStatus.COMPLETED },
+  }
+}
+
+function draftContext(fullDraft: ReturnType<typeof storedDraft>) {
+  const updateMany = vi.fn(async () => ({ count: 1 }))
+  const transaction = {
+    $queryRaw: vi.fn(async () => []),
+    generatedElementDraft: {
+      findFirst: vi.fn(async () => fullDraft),
+      updateMany,
+      findUniqueOrThrow: vi.fn(async () => ({ ...fullDraft, revision: 5 })),
+    },
+  }
+  return {
+    updateMany,
+    ctx: {
+      user: { sub: ownerId },
+      prisma: {
+        generatedElementDraft: { findFirst: vi.fn(async () => fullDraft) },
+        $transaction: vi.fn(async (callback) => callback(transaction)),
+      },
+    },
+  }
+}
+
+describe('generated question draft tag selection', () => {
+  it('preserves the stored selection when a legacy client omits the selection', async () => {
+    const tagSelection = { existingTagIds: [7], newTagNames: ['Frisch'] }
+    const { ctx, updateMany } = draftContext(storedDraft(tagSelection))
+
+    await updateGeneratedQuestionDraft(
+      { draftId, expectedRevision: 4, current: currentInput },
+      ctx as never
+    )
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: draftId, revision: 4, savedElementId: null },
+      data: {
+        current: { ...expectedCurrent, tagSelection },
+        revision: { increment: 1 },
+      },
+    })
+  })
+
+  it('clears the stored selection with an explicitly empty selection', async () => {
+    const { ctx, updateMany } = draftContext(
+      storedDraft({ existingTagIds: [7], newTagNames: [] })
+    )
+
+    await updateGeneratedQuestionDraft(
+      {
+        draftId,
+        expectedRevision: 4,
+        current: currentInput,
+        tagSelection: { existingTagIds: [], newTagNames: [] },
+      },
+      ctx as never
+    )
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: draftId, revision: 4, savedElementId: null },
+      data: {
+        current: {
+          ...expectedCurrent,
+          tagSelection: { existingTagIds: [], newTagNames: [] },
+        },
+        revision: { increment: 1 },
+      },
+    })
+  })
+
+  it('adds no selection field when the draft never held one', async () => {
+    const { ctx, updateMany } = draftContext(storedDraft())
+
+    await updateGeneratedQuestionDraft(
+      { draftId, expectedRevision: 4, current: currentInput },
+      ctx as never
+    )
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: draftId, revision: 4, savedElementId: null },
+      data: { current: expectedCurrent, revision: { increment: 1 } },
+    })
+  })
+})

--- a/packages/graphql/test/generatedQuestionTags.test.ts
+++ b/packages/graphql/test/generatedQuestionTags.test.ts
@@ -1,0 +1,377 @@
+import * as DB from '@klicker-uzh/prisma/client'
+import { suggestGeneratedQuestionTags } from '@klicker-uzh/types'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  normalizeQuestionTagSelection,
+  questionTagSelectionsEqual,
+  questionTagSelectionWrite,
+  resolveQuestionTagSelection,
+  withQuestionTagConflictRetry,
+} from '../src/services/generatedQuestionTags.js'
+
+type TagRow = { id: number; name: string }
+
+function tagTransaction(ownerTags: TagRow[]) {
+  const created: TagRow[] = []
+  const transaction = {
+    tag: {
+      findMany: async ({
+        where,
+      }: {
+        where: { ownerId: string; id: { in: number[] } }
+      }) => ownerTags.filter((tag) => where.id.in.includes(tag.id)),
+      findUnique: async ({
+        where,
+      }: {
+        where: { ownerId_name: { ownerId: string; name: string } }
+      }) =>
+        ownerTags.find((tag) => tag.name === where.ownerId_name.name) ?? null,
+      create: async ({ data }: { data: { name: string } }) => {
+        const row = { id: 900 + created.length, name: data.name }
+        created.push(row)
+        ownerTags.push(row)
+        return { id: row.id }
+      },
+    },
+  }
+  return {
+    transaction: transaction as unknown as DB.Prisma.TransactionClient,
+    created,
+  }
+}
+
+describe('generated question tag suggestions', () => {
+  const ownerTags: TagRow[] = [
+    { id: 1, name: 'Portfolio' },
+    { id: 2, name: 'Diversifikation' },
+    { id: 3, name: 'Statistik Grundlagen' },
+    { id: 4, name: 'Regression' },
+  ]
+
+  it('ranks exact matches before normalized matches', () => {
+    expect(
+      suggestGeneratedQuestionTags(['portfolio', 'Regression'], ownerTags)
+    ).toEqual({ existingTagIds: [4, 1], newTagNames: [] })
+  })
+
+  it('matches conservative token overlap and drops weak overlaps', () => {
+    expect(
+      suggestGeneratedQuestionTags(
+        ['Statistik Grundlagen Übersicht', 'Portfolio Theorie'],
+        ownerTags
+      )
+    ).toEqual({
+      existingTagIds: [3],
+      newTagNames: ['Portfolio Theorie'],
+    })
+  })
+
+  it('proposes unmatched labels without duplicating owner tags', () => {
+    expect(
+      suggestGeneratedQuestionTags(
+        ['Volatilität', 'volatilität', 'Diversifikation'],
+        ownerTags
+      )
+    ).toEqual({ existingTagIds: [2], newTagNames: ['Volatilität'] })
+  })
+
+  it('counts a repeated token once when scoring overlap', () => {
+    expect(
+      suggestGeneratedQuestionTags(
+        ['Diversifikation Diversifikation Strategie'],
+        ownerTags
+      )
+    ).toEqual({
+      existingTagIds: [],
+      newTagNames: ['Diversifikation Diversifikation Strategie'],
+    })
+  })
+
+  it('caps recommendations at five existing and five new proposals', () => {
+    const manyTags = Array.from({ length: 8 }, (_, index) => ({
+      id: 10 + index,
+      name: `Thema ${index}`,
+    }))
+    const matched = suggestGeneratedQuestionTags(
+      manyTags.map((tag) => tag.name),
+      manyTags
+    )
+    expect(matched.existingTagIds).toEqual([10, 11, 12, 13, 14])
+    expect(matched.newTagNames).toEqual([])
+
+    const proposals = suggestGeneratedQuestionTags(
+      Array.from({ length: 8 }, (_, index) => `Neuartig ${index}`),
+      []
+    )
+    expect(proposals.existingTagIds).toEqual([])
+    expect(proposals.newTagNames).toHaveLength(5)
+  })
+})
+
+describe('generated question tag selection', () => {
+  it('normalizes, deduplicates and validates a selection', () => {
+    expect(
+      normalizeQuestionTagSelection({
+        existingTagIds: [3, 3, 1],
+        newTagNames: ['  Ordinal  ', 'Ordinal'],
+      })
+    ).toEqual({ existingTagIds: [3, 1], newTagNames: ['Ordinal'] })
+
+    expect(() =>
+      normalizeQuestionTagSelection({ existingTagIds: [0], newTagNames: [] })
+    ).toThrowError(/identifiers are invalid/)
+    expect(() =>
+      normalizeQuestionTagSelection({
+        existingTagIds: [],
+        newTagNames: ['  '],
+      })
+    ).toThrowError(/names are invalid/)
+  })
+
+  it('preserves an omitted selection, clears an empty one and replaces for legacy tags', () => {
+    const stored = { existingTagIds: [7], newTagNames: [] }
+
+    expect(questionTagSelectionWrite({}, stored)).toEqual({
+      mode: 'selection',
+      selection: stored,
+    })
+    expect(questionTagSelectionWrite({}, undefined)).toEqual({ mode: 'none' })
+    expect(
+      questionTagSelectionWrite(
+        { tagSelection: { existingTagIds: [], newTagNames: [] } },
+        stored
+      )
+    ).toEqual({
+      mode: 'selection',
+      selection: { existingTagIds: [], newTagNames: [] },
+    })
+    expect(questionTagSelectionWrite({ tags: [' Neu '] }, stored)).toEqual({
+      mode: 'legacy',
+      selection: { existingTagIds: [], newTagNames: ['Neu'] },
+    })
+  })
+
+  it('rejects requests that supply both representations', () => {
+    expect(() =>
+      questionTagSelectionWrite(
+        {
+          tags: ['Alt'],
+          tagSelection: { existingTagIds: [1], newTagNames: [] },
+        },
+        undefined
+      )
+    ).toThrowError(/not both/)
+  })
+
+  it('compares selections by order-insensitive ids', () => {
+    expect(
+      questionTagSelectionsEqual(
+        { existingTagIds: [1], newTagNames: ['A'] },
+        { existingTagIds: [1], newTagNames: ['A'] }
+      )
+    ).toBe(true)
+    expect(questionTagSelectionsEqual(undefined, undefined)).toBe(true)
+    expect(
+      questionTagSelectionsEqual(undefined, {
+        existingTagIds: [],
+        newTagNames: [],
+      })
+    ).toBe(false)
+  })
+})
+
+describe('generated question tag resolution', () => {
+  const selection = { existingTagIds: [1], newTagNames: [] }
+
+  it('validates existing ids against the owner', async () => {
+    const { transaction } = tagTransaction([{ id: 1, name: 'Portfolio' }])
+    await expect(
+      resolveQuestionTagSelection(transaction, 'owner-1', selection)
+    ).resolves.toEqual([1])
+
+    const { transaction: foreign } = tagTransaction([{ id: 2, name: 'Other' }])
+    await expect(
+      resolveQuestionTagSelection(foreign, 'owner-1', selection)
+    ).rejects.toThrowError(/not available to this owner/)
+  })
+
+  it('resolves a proposal to an existing exact-name tag without creating it', async () => {
+    const { transaction, created } = tagTransaction([
+      { id: 5, name: 'Volatilität' },
+    ])
+    await expect(
+      resolveQuestionTagSelection(transaction, 'owner-1', {
+        existingTagIds: [],
+        newTagNames: ['Volatilität'],
+      })
+    ).resolves.toEqual([5])
+    expect(created).toEqual([])
+  })
+
+  it('creates a missing proposal only when creating is allowed', async () => {
+    const { transaction, created } = tagTransaction([])
+    await expect(
+      resolveQuestionTagSelection(transaction, 'owner-1', {
+        existingTagIds: [],
+        newTagNames: ['Neuartig'],
+      })
+    ).resolves.toEqual([900])
+    expect(created).toEqual([{ id: 900, name: 'Neuartig' }])
+
+    const { transaction: resolveOnly, created: untouched } = tagTransaction([])
+    await expect(
+      resolveQuestionTagSelection(
+        resolveOnly,
+        'owner-1',
+        { existingTagIds: [], newTagNames: ['Neuartig'] },
+        'resolve-only'
+      )
+    ).resolves.toBeNull()
+    expect(untouched).toEqual([])
+  })
+
+  it('resolves a shared name and id once', async () => {
+    const { transaction } = tagTransaction([{ id: 5, name: 'Volatilität' }])
+    await expect(
+      resolveQuestionTagSelection(transaction, 'owner-1', {
+        existingTagIds: [5],
+        newTagNames: ['Volatilität'],
+      })
+    ).resolves.toEqual([5])
+  })
+})
+
+describe('generated question tag conflict retry', () => {
+  function ownerNameConflict() {
+    return new DB.Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      {
+        code: 'P2002',
+        clientVersion: '7.8.0',
+        meta: { target: ['ownerId', 'name'] },
+      }
+    )
+  }
+
+  // The shape Prisma 7 with a driver adapter reports for a real duplicate: the
+  // violated columns sit on the adapter cause, quoted as SQL identifiers.
+  function adapterConflict(
+    causeOverrides: Record<string, unknown> = {},
+    modelName = 'Tag'
+  ) {
+    return new DB.Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed on the fields: ("ownerId", name)',
+      {
+        code: 'P2002',
+        clientVersion: '7.8.0',
+        meta: {
+          modelName,
+          driverAdapterError: {
+            cause: {
+              kind: 'UniqueConstraintViolation',
+              originalCode: '23505',
+              constraint: { fields: ['"ownerId"', 'name'] },
+              originalMessage:
+                'duplicate key value violates unique constraint "Tag_ownerId_name_key"',
+              ...causeOverrides,
+            },
+          },
+        },
+      }
+    )
+  }
+
+  it('retries the whole transaction and settles on success', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(ownerNameConflict())
+      .mockResolvedValueOnce('kept')
+    await expect(withQuestionTagConflictRetry(run)).resolves.toBe('kept')
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after three attempts of the owner/name conflict', async () => {
+    const run = vi.fn().mockRejectedValue(ownerNameConflict())
+    await expect(withQuestionTagConflictRetry(run)).rejects.toThrowError(
+      /Unique constraint failed/
+    )
+    expect(run).toHaveBeenCalledTimes(3)
+  })
+
+  it('propagates unrelated conflicts and failures immediately', async () => {
+    const unrelated = new DB.Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      {
+        code: 'P2002',
+        clientVersion: '7.8.0',
+        meta: { target: ['draftId'] },
+      }
+    )
+    const conflictRun = vi.fn().mockRejectedValue(unrelated)
+    await expect(withQuestionTagConflictRetry(conflictRun)).rejects.toThrow()
+    expect(conflictRun).toHaveBeenCalledTimes(1)
+
+    const failureRun = vi.fn().mockRejectedValue(new Error('boom'))
+    await expect(withQuestionTagConflictRetry(failureRun)).rejects.toThrowError(
+      'boom'
+    )
+    expect(failureRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a conflict it cannot attribute to the owner/name tag', async () => {
+    const unidentified = new DB.Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '7.8.0' }
+    )
+    const foreignModel = new DB.Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      {
+        code: 'P2002',
+        clientVersion: '7.8.0',
+        meta: { modelName: 'Other', target: ['ownerId', 'name'] },
+      }
+    )
+
+    for (const conflict of [unidentified, foreignModel]) {
+      const run = vi.fn().mockRejectedValue(conflict)
+      await expect(withQuestionTagConflictRetry(run)).rejects.toThrowError(
+        /Unique constraint failed/
+      )
+      expect(run).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('retries the driver-adapter owner/name constraint report', async () => {
+    const reports = [
+      adapterConflict(),
+      adapterConflict({ constraint: { fields: ['"ownerId"', '"name"'] } }),
+      adapterConflict({ constraint: { fields: ['ownerId', 'name'] } }),
+    ]
+
+    for (const report of reports) {
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(report)
+        .mockResolvedValueOnce('kept')
+      await expect(withQuestionTagConflictRetry(run)).resolves.toBe('kept')
+      expect(run).toHaveBeenCalledTimes(2)
+    }
+  })
+
+  it('keeps failing closed for unrelated driver-adapter reports', async () => {
+    const reports = [
+      adapterConflict({ kind: 'ForeignKeyViolation' }),
+      adapterConflict({ kind: undefined }),
+      adapterConflict({ constraint: { fields: ['"draftId"'] } }),
+      adapterConflict({ constraint: { fields: ['"ownerId"'] } }),
+      adapterConflict({ constraint: { fields: 'ownerId' } }),
+      adapterConflict({}, 'Other'),
+    ]
+
+    for (const report of reports) {
+      const run = vi.fn().mockRejectedValue(report)
+      await expect(withQuestionTagConflictRetry(run)).rejects.toThrow()
+      expect(run).toHaveBeenCalledTimes(1)
+    }
+  })
+})

--- a/packages/graphql/test/questionGenerationArtifacts.test.ts
+++ b/packages/graphql/test/questionGenerationArtifacts.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '@klicker-uzh/types'
 import {
   deriveGeneratedQuestionName,
+  normalizeGeneratedTagSuggestions,
   parseQuestionGenerationDesign,
   parseQuestionGenerationFinalBank,
   parseQuestionGenerationGraphManifest,
@@ -2196,6 +2197,39 @@ describe('question-generation artifact normalization', () => {
         new Intl.Segmenter('und', { granularity: 'grapheme' }).segment(name)
       )
     ).toHaveLength(120)
+  })
+
+  it('treats malformed advisory metadata as optional', () => {
+    const fallback = 'synthetic fallback'
+    for (const title of [undefined, null, 123, {}, '<p></p>']) {
+      expect(deriveGeneratedQuestionName(title, fallback)).toBe(fallback)
+    }
+    expect(normalizeGeneratedTagSuggestions({})).toEqual([])
+    expect(
+      normalizeGeneratedTagSuggestions([
+        null,
+        'topic',
+        'topic',
+        'x'.repeat(61),
+        '👨‍👩‍👧‍👦',
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+    ).toEqual(['topic', '👨‍👩‍👧‍👦', 'a', 'b', 'c'])
+    const result = parseQuestionGenerationResult(bytes(completedResult()), {
+      buildId: BUILD_ID,
+      questionCount: 1,
+    })
+    const questions = parseQuestionGenerationFinalBank(
+      bytes(finalBank({ title: { invalid: true }, suggested_tags: ['topic'] })),
+      { questionCount: 1, sourceSnapshot, expectedQuestionIds: ['q01'], result }
+    )
+    expect(questions[0]?.suggestedTags).toEqual(['topic'])
+    expect(questions[0]?.name).toBe(
+      deriveGeneratedQuestionName(undefined, questions[0]!.stem)
+    )
   })
 
   it.each([

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2835,6 +2835,23 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
           'Das Element konnte nicht aktualisiert werden. Versuchen Sie es erneut.',
         saveElementsError:
           'Die angenommenen Elemente konnten nicht gespeichert werden. Versuchen Sie es erneut.',
+        tagSelection: {
+          title: 'Tags',
+          existingLabel: 'Passende Tags',
+          existingHint:
+            'Ein bereits vorhandener Name wählt den bestehenden Tag aus, statt einen neuen zu erstellen.',
+          newLabel: 'Vorgeschlagene neue Tags',
+          newHint: 'Neue Tags werden erst beim Behalten des Elements erstellt.',
+          manualLabel: 'Alle Tags',
+          placeholder: 'Tags auswählen oder eingeben',
+          saveDraft: 'Entwurf speichern',
+          unsaved: 'Ungespeicherte Änderungen',
+          saved: 'Entwurf gespeichert.',
+          saveError:
+            'Der Entwurf konnte nicht gespeichert werden. Versuchen Sie es erneut.',
+          conflict:
+            'Dieser Entwurf wurde anderswo geändert. Laden Sie neu, bevor Sie speichern.',
+        },
       },
       decisions: {
         OPEN: 'Offen',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2794,6 +2794,22 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
         actionError: 'The element could not be updated. Please try again.',
         saveElementsError:
           'The accepted elements could not be saved. Please try again.',
+        tagSelection: {
+          title: 'Tags',
+          existingLabel: 'Matching tags',
+          existingHint:
+            'Typing a name that already exists selects the existing tag instead of creating a new one.',
+          newLabel: 'Suggested new tags',
+          newHint: 'New tags are created only when you keep the element.',
+          manualLabel: 'All tags',
+          placeholder: 'Select or type tags',
+          saveDraft: 'Save draft',
+          unsaved: 'Unsaved changes',
+          saved: 'Draft saved.',
+          saveError: 'The draft could not be saved. Please try again.',
+          conflict:
+            'This draft changed elsewhere. Reload before saving your edits.',
+        },
       },
       decisions: {
         OPEN: 'Open',

--- a/packages/types/src/questionGeneration.ts
+++ b/packages/types/src/questionGeneration.ts
@@ -171,9 +171,29 @@ export type GeneratedQuestionEditable = {
     correct: boolean
     feedback: string | null
   }>
+  tagSelection?: GeneratedQuestionTagSelection
+}
+
+// Requested tag selection for a generated question draft. `existingTagIds`
+// references tags of the reviewing owner by id; `newTagNames` are proposals
+// that are only created with a successful save. This is the requested intent,
+// not the resolved tag set, so an identical retry stays an exact retry after a
+// proposal has become an existing tag.
+export type GeneratedQuestionTagSelection = {
+  existingTagIds: number[]
+  newTagNames: string[]
+}
+
+// Input form of a selection as it arrives over GraphQL. Either list may be
+// omitted or null and is then treated as empty; normalization validates and
+// deduplicates the arrived values.
+export type GeneratedQuestionTagSelectionInput = {
+  existingTagIds?: number[] | null
+  newTagNames?: string[] | null
 }
 
 export type GeneratedQuestionOriginal = GeneratedQuestionEditable & {
+  suggestedTags?: string[]
   sourceQuestionId: string
   bloomLevel: QuestionGenerationBloomLevel
   targetDifficulty: number
@@ -248,3 +268,139 @@ export const QUESTION_GENERATION_CAPABILITIES = {
   requiresPlanReview: true,
   supportsIndividualRegeneration: false,
 } as const
+
+export type GeneratedQuestionTagCandidate = {
+  id: number
+  name: string
+}
+
+export type GeneratedQuestionTagMatch = {
+  existingTagIds: number[]
+  newTagNames: string[]
+}
+
+const MAX_GENERATED_QUESTION_TAG_MATCHES = 5
+const TOKEN_OVERLAP_THRESHOLD = 0.5
+const MIN_SHARED_TOKEN_LENGTH = 3
+
+export function normalizeGeneratedQuestionTagLabel(value: string): string {
+  return value.trim().replace(/\s+/gu, ' ')
+}
+
+function generatedQuestionTagKey(value: string): string {
+  return normalizeGeneratedQuestionTagLabel(value).toLocaleLowerCase()
+}
+
+function generatedQuestionTagTokens(value: string): string[] {
+  return generatedQuestionTagKey(value)
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean)
+}
+
+// Conservative token overlap: at least one shared token of three or more
+// characters and strictly more than half of the union's tokens shared, counting
+// every token once no matter how often it repeats. Weak matches are dropped
+// instead of filling a suggestion quota.
+function conservativeTokenOverlap(
+  left: string[],
+  right: string[]
+): number | null {
+  if (left.length === 0 || right.length === 0) return null
+  const leftTokens = new Set(left)
+  const rightTokens = new Set(right)
+  const shared = [...leftTokens].filter((token) => rightTokens.has(token))
+  if (
+    shared.length === 0 ||
+    !shared.some((token) => token.length >= MIN_SHARED_TOKEN_LENGTH)
+  ) {
+    return null
+  }
+  const union = new Set([...leftTokens, ...rightTokens]).size
+  const score = shared.length / union
+  return score > TOKEN_OVERLAP_THRESHOLD ? score : null
+}
+
+// Ranks advisory generation labels against the reviewing owner's tags: exact
+// name first, then case/whitespace-normalized, then conservative token overlap.
+// Returns at most five existing recommendations and five new proposals and
+// never preselects them. Matching is advisory only and never merges tags.
+export function suggestGeneratedQuestionTags(
+  suggestedTags: readonly string[],
+  existingTags: readonly GeneratedQuestionTagCandidate[]
+): GeneratedQuestionTagMatch {
+  const exactMatches = new Map<string, GeneratedQuestionTagCandidate>()
+  for (const tag of existingTags) {
+    const label = normalizeGeneratedQuestionTagLabel(tag.name)
+    if (label && !exactMatches.has(label)) exactMatches.set(label, tag)
+  }
+
+  const ranked: Array<{
+    rank: number
+    index: number
+    tag: GeneratedQuestionTagCandidate
+  }> = []
+  const proposals: Array<{ index: number; label: string }> = []
+
+  suggestedTags.forEach((suggestion, index) => {
+    if (typeof suggestion !== 'string') return
+    const label = normalizeGeneratedQuestionTagLabel(suggestion)
+    if (!label) return
+
+    const exact = exactMatches.get(label)
+    if (exact) {
+      ranked.push({ rank: 0, index, tag: exact })
+      return
+    }
+
+    const key = generatedQuestionTagKey(label)
+    const normalized = existingTags.find(
+      (tag) => generatedQuestionTagKey(tag.name) === key
+    )
+    if (normalized) {
+      ranked.push({ rank: 1, index, tag: normalized })
+      return
+    }
+
+    const tokens = generatedQuestionTagTokens(label)
+    let best: { score: number; tag: GeneratedQuestionTagCandidate } | null =
+      null
+    for (const tag of existingTags) {
+      const score = conservativeTokenOverlap(
+        tokens,
+        generatedQuestionTagTokens(tag.name)
+      )
+      if (score === null) continue
+      if (!best || score > best.score) best = { score, tag }
+    }
+    if (best) {
+      ranked.push({ rank: 2, index, tag: best.tag })
+      return
+    }
+
+    proposals.push({ index, label })
+  })
+
+  const existingTagIds: number[] = []
+  for (const entry of ranked.sort(
+    (left, right) => left.rank - right.rank || left.index - right.index
+  )) {
+    if (existingTagIds.length === MAX_GENERATED_QUESTION_TAG_MATCHES) break
+    if (existingTagIds.includes(entry.tag.id)) continue
+    existingTagIds.push(entry.tag.id)
+  }
+
+  const newTagNames: string[] = []
+  const proposedKeys = new Set<string>()
+  for (const proposal of proposals) {
+    if (newTagNames.length === MAX_GENERATED_QUESTION_TAG_MATCHES) break
+    const key = generatedQuestionTagKey(proposal.label)
+    if (proposedKeys.has(key)) continue
+    if (existingTags.some((tag) => generatedQuestionTagKey(tag.name) === key)) {
+      continue
+    }
+    proposedKeys.add(key)
+    newTagNames.push(proposal.label)
+  }
+
+  return { existingTagIds, newTagNames }
+}

--- a/playwright/util/fixtures/questionGenerationReview.ts
+++ b/playwright/util/fixtures/questionGenerationReview.ts
@@ -15,6 +15,34 @@ export type QuestionGenerationReviewFixture = {
   primaryBuildId: string
   primaryDraftIds: string[]
   draftIdsByType: Record<'SC' | 'MC' | 'KPRIM' | 'FLASHCARD', string>
+  // Synthetic owner tags that make the suggestion matching verifiable.
+  tagIdByExistingName: Record<string, number>
+}
+
+// One suggestion resolves to each seeded owner tag and one stays a proposal, so
+// the review UI can be exercised for existing and new tags at the same time.
+export const REVIEW_EXISTING_TAG_NAMES = [
+  'QG-fixture portfolio diversification',
+  'QG-fixture bond duration',
+] as const
+export const REVIEW_NEW_TAG_SUGGESTION = 'QG-fixture liquidity risk'
+export const REVIEW_SUGGESTED_TAGS = [
+  REVIEW_EXISTING_TAG_NAMES[0],
+  REVIEW_NEW_TAG_SUGGESTION,
+] as const
+
+function suggestedTagsFor(type: 'SC' | 'MC' | 'KPRIM' | 'FLASHCARD') {
+  return type === 'FLASHCARD' ? undefined : [...REVIEW_SUGGESTED_TAGS]
+}
+
+async function deleteFixtureTags() {
+  const prisma = await getPrisma()
+  await prisma.tag.deleteMany({
+    where: {
+      ownerId: USER_ID_TEST,
+      name: { in: [...REVIEW_EXISTING_TAG_NAMES, REVIEW_NEW_TAG_SUGGESTION] },
+    },
+  })
 }
 
 function questionChoices(type: 'SC' | 'MC' | 'KPRIM', index: number) {
@@ -110,11 +138,19 @@ async function deleteFixtureRows() {
   })
   await prisma.kBGraphBuild.deleteMany({ where: { id: GRAPH_BUILD_ID } })
   await prisma.kB.deleteMany({ where: { id: KB_ID } })
+  await deleteFixtureTags()
 }
 
 export async function seedQuestionGenerationReviewFixture(): Promise<QuestionGenerationReviewFixture> {
   await deleteFixtureRows()
   const prisma = await getPrisma()
+  const tagIdByExistingName: Record<string, number> = {}
+  for (const name of REVIEW_EXISTING_TAG_NAMES) {
+    const tag = await prisma.tag.create({
+      data: { name, ownerId: USER_ID_TEST },
+    })
+    tagIdByExistingName[name] = tag.id
+  }
 
   await prisma.kB.create({
     data: {
@@ -217,7 +253,12 @@ export async function seedQuestionGenerationReviewFixture(): Promise<QuestionGen
             sourceElementId: `synthetic-source-${type}-${(index % 5) + 1}`,
             order: index,
             elementType: type,
-            original: values.original,
+            original: {
+              ...values.original,
+              ...(type === 'FLASHCARD'
+                ? {}
+                : { suggestedTags: suggestedTagsFor(type) }),
+            },
             current: values.current,
             citations: [
               {
@@ -247,6 +288,7 @@ export async function seedQuestionGenerationReviewFixture(): Promise<QuestionGen
 
   return {
     primaryBuildId,
+    tagIdByExistingName,
     primaryDraftIds: Array.from(
       { length: 5 },
       (_, index) =>

--- a/project/2026-09-12-generated-question-titles-and-tag-suggestions-plan.md
+++ b/project/2026-09-12-generated-question-titles-and-tag-suggestions-plan.md
@@ -200,3 +200,35 @@ overwriting reviewed work, or separately gated deployment.
   starts at merged `529bd0cf64`; service worktree of the same branch name
   starts at `origin/main` `7480c7f`. Producer worker owns only the service;
   parent owns Klicker integration, persistence and verification.
+- Backend implementation now includes tolerant metadata ingestion, structured
+  selection, exact-ID writes, legacy omission/clear behavior, and bounded
+  transaction retries. Real Prisma 7 concurrency exposed adapter-specific
+  constraint metadata; the retry predicate now recognizes the observed shape
+  and rejects unrelated or unidentified conflicts.
+- Local verification on the uncommitted task tree: GraphQL TypeScript check
+  passed after rebuilding shared types; artifact normalization 77/77;
+  completion/replay integration 26/26; tag helper and persistence integration
+  29/29. Expanded persistence coverage then passed 11/11, including identical
+  retries after concurrent creation and accepted-unsaved recovery.
+- Runtime: exact checkout `trees/rs/question-titles-tags`, managed `manage`
+  profile, isolated blob port 10193. Delegated local login passed. Runtime is
+  active for ongoing browser verification and must be stopped at completion.
+- Producer and UI workers hit terminal provider gateway errors mid-work.
+  Partial edits were preserved; trusted generic-continuity workers own only
+  their original disjoint scopes. UI, producer tests, committed reviews and
+  draft PR/MR delivery remain incomplete; no deployment or live provider run.
+
+- Resumed integration: service pipeline suite passes 66/66 in ephemeral
+  `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` with pytest 8.3.5, httpx
+  0.28.1, python-dotenv 1.1.0 and NumPy 2.2.6. Source mounted read-only;
+  no model calls. This resolves the earlier missing-environment blocker.
+- Browser proof on synthetic local fixtures: Save draft preserves selected
+  existing/new tags across reload; edited title persists; Keep creates the
+  element and canonical library editor shows title and both tags; discard
+  changes draft state. Found and fixed modal loading unmounting the form
+  during save. The shared editor now stacks preview below form on narrow
+  screens. English/German desktop/mobile captures live in ignored
+  `project/_local/question-titles-tags/`. Initial pointer automation did not
+  activate handlers reliably; observed DOM clicks were used for interactions.
+- Latest frontend-manage TypeScript check passes. Required committed reviews,
+  full checks and draft publication remain pending. STG is unchanged.

--- a/project/2026-09-12-generated-question-titles-and-tag-suggestions-plan.md
+++ b/project/2026-09-12-generated-question-titles-and-tag-suggestions-plan.md
@@ -1,0 +1,202 @@
+# Descriptive question titles and reviewable tag suggestions
+
+## Approval summary
+
+Generated questions should arrive with a short descriptive title and useful tag
+suggestions. Lecturers can edit the title, choose existing tags, accept new tag
+proposals, or keep no tags. New tags are created only with a successful save.
+
+The KG generation service will produce a title and up to five topic labels in
+its existing question-generation calls. Klicker will match those labels against
+the reviewing owner's existing tags and show existing matches before new
+proposals. Suggested tags and selected tags remain separate. The review flow
+will persist selections and preserve edited titles across reloads and retries.
+An explicit Save draft action persists edits before reload; unsaved edits remain
+visibly marked and require confirmation before leaving the editor.
+
+Recommendation: start with exact, normalized and conservative token matching
+inside Klicker. This adds no embedding service or model call and does not send
+the owner's tag collection to a model. It misses some synonyms and translations;
+manual tag search remains available. Matching normalization never merges tags
+or changes their existing owner-and-exact-name identity.
+
+Completion requires compatible old/new generation outputs, atomic and
+owner-scoped saves, preserved edits on replay, and browser proof of selection,
+save and reload in English and German. The user approved implementation on
+2026-09-12 after merging PR #5910. Approval authorizes these source changes,
+tests, reviews and ordinary draft PR/MR delivery. Merge, deployment, historical data
+rewrites and live provider quality runs remain separate actions.
+
+## Scope and ownership
+
+Approval mode: executable batch. Boundary owner: self.
+
+The parent owns the generation contract, user-control decisions, integration
+and verification. After those contracts are fixed, delegate the service
+producer slice and the Klicker selection/persistence slice to separate workers
+with disjoint repositories; integrate before the UI slice. Reviewers remain
+independent of writers. Authority derives from the user's approval, not this file.
+
+| Product primitive | Change | Invariant |
+| --- | --- | --- |
+| Generated question draft | Add advisory metadata and persisted selections | User edits win over generation replay |
+| Owner's tag | Reuse existing identity | Owner plus exact name; no automatic merges |
+| Keep generated element | Compose selection with existing atomic save | Element, tags and draft linkage commit or roll back together |
+
+Question formats in scope: SC, MC and KPRIM. Preserve flashcard behavior.
+No migration is expected because draft content already uses JSON and elements
+already relate to tags. Reassess before adding schema or changing tag identity.
+
+## Evidence and affected contracts
+
+Evidence baseline: Klicker PR [#5910](https://github.com/uzh-bf/klicker-uzh/pull/5910),
+head `0b8cf089d2`, against `v3-ai`; service checkout
+`trees/rs/graph-bundle-source-provenance`, head `02d6dcecf4da`.
+The PR's graph-filter change remains a separate repair package.
+
+- `packages/graphql/src/services/questionGenerationArtifacts.ts`: the optional
+  title falls back to the stem, truncated to 120 graphemes; normalized questions
+  currently have no tag proposals.
+- Service `lightrag_research/questions_generation/two_stage.py`: final question
+  construction lacks descriptive metadata. Trace generation, repair and resume
+  paths together; use the existing recipe/checkpoint version mechanism.
+- `packages/graphql/src/schema/elementGeneration.ts`: question draft views
+  return `tags: []`. `questionGenerationDrafts.ts` and the question editable type
+  lack persisted tag selection; both canonical Keep and accepted-draft recovery
+  must be covered.
+- `packages/graphql/src/services/elements.ts` and Prisma `Tag`: existing tag
+  creation uses owner/exact-name connect-or-create. Preserve this identity.
+- `docs/solutions/best-practice/generated-element-keep-is-one-transaction.md`
+  defines the save invariant. Related planning lives in
+  `project/2026-08-29-pr-5667-question-generation-ux-audit-and-roadmap.md` and
+  `project/2026-09-04-pr-5777-generation-lifecycle-contracts-plan.md`.
+
+Before implementation, refresh both remotes and inspect overlapping open work.
+Klicker targets `v3-ai`; the service's configured remote default is `main`.
+Resolve any service MR-specific base before creating its task branch. Use one
+coherent draft per repository; do not introduce a stack without approval.
+
+## Execution sequence
+
+### 1. Generate and ingest compatible metadata
+
+Add optional `title` and `suggested_tags` to service question outputs and carry
+them through all supported formats, validation, repair, serialization and resume.
+Generate metadata within existing calls. Titles should describe the assessed
+concept or operation in the requested generation language, roughly 3–10 words,
+without exposing the answer. Preserve the generated-name limit of 120 graphemes.
+Bound proposals to five short labels, at most 60 graphemes each.
+
+Add tolerant optional readers in Klicker types and artifact ingestion. Missing
+suggestions become empty. Invalid advisory metadata must not invalidate an
+otherwise valid question; malformed titles use the existing stem fallback,
+including titles that become empty after markup removal. Preserve strict answer
+and provenance validation. Store generated metadata separately from edited
+draft content and initialize defaults only once.
+
+Acceptance: old banks still ingest, new metadata survives service repair and
+checkpoint paths, and replay does not replace reviewed content.
+
+### 2. Match, select and persist tags
+
+Resolve suggestions using only the authenticated owner's tags. Rank exact
+matches first, then case/whitespace-normalized matches, then conservative token
+overlap. Do not present weak matches merely to fill a quota. Return at most five
+existing recommendations and five new proposals; do not preselect them.
+
+Preserve IDs and canonical names for existing selections, and names for new
+proposals. Add optional structured selection to draft JSON and generation
+save/update inputs; retain legacy string-tag input compatibility and reject
+ambiguous requests supplying both. Validate selected existing IDs against the
+owner inside the save transaction and connect by ID at the actual element write;
+do not translate existing IDs back into name-based connect-or-create. Renamed
+tags retain their identity and display the current name after refresh. Deleted selections require reselection,
+rather than silently recreating a deleted tag.
+
+Omitted selection on draft updates and Keep preserves the stored selection;
+an explicitly empty selection clears it. Explicit legacy `tags` replaces the
+selection using the established string-name semantics, while an omitted legacy
+field preserves it. Reject requests specifying both old and new fields, but
+accept old-client updates to new-format drafts without losing stored selections.
+
+Resolve a new proposal to an exact-name owner tag if it was created meanwhile.
+Deduplicate exact names and IDs; never use fuzzy matching as a persistence key.
+Keep selection canonicalization stable for exact retries. Both Keep and
+accepted-unsaved recovery must persist the same selections and preserve revision
+fences. Handle concurrent exact-name creation without orphan tags or duplicate
+elements. Add at most three attempts of the entire save transaction for the
+specific owner/name tag uniqueness conflict, re-resolving the name each time;
+propagate other errors and an exhausted conflict without partial writes. Store
+the normalized requested selection intent separately from resolved tag IDs in
+draft JSON, so the same request remains an exact retry after a proposed new tag
+becomes existing. Do not use resolved names or IDs to rewrite that request intent.
+
+Acceptance: cross-owner IDs fail, discarded proposals create nothing, stale
+edits fail without side effects, successful retries return the same element,
+and explicit empty selections survive reload.
+Include existing-tag rename/deletion between validation and write, legacy-client
+omission/clear semantics, and two builds concurrently accepting the same new tag
+followed by identical Keep retries: one tag and one element per draft.
+
+### 3. Review UI and integrated verification
+
+Extend `GeneratedElementReview.tsx` and the existing tag editor minimally. Show
+existing matches and clearly labeled new suggestions with independent selection
+and removal; retain manual tag search and entry. A selected suggestion becomes
+part of editable state; refreshing suggestions never resets dirty form fields.
+Refresh owner tag data after successful creation.
+
+Wire an explicit Save draft action to the revision-checked draft update for
+title and selected tags. On success, replace the local revision with the server
+revision and mark the editor saved. On failure, keep local edits visible and
+unsaved; on a revision conflict, require reload/reconciliation instead of
+overwriting remote edits. Preserve dirty state when refreshing suggestions.
+Only successfully saved drafts promise server-backed reload preservation;
+warn before navigation with unsaved changes. Keep still atomically saves the
+currently visible edits and selections without requiring a prior Save draft.
+
+Extend existing tests at contract boundaries: service output and repairs,
+artifact compatibility, draft persistence, completion replay, owner-scoped save,
+rollback and concurrency. Use synthetic fixtures and structured assertions;
+do not snapshot generated prose. Run affected repository checks in their
+supported environments and regenerate GraphQL outputs where required.
+
+Browser acceptance: edit title, choose existing and new tags, remove suggestions,
+Save draft, reload, discard, Keep, reopen the saved element, and retry a completed save.
+Capture English/German desktop and narrow layouts with the screenshot-gallery
+workflow and embed verified screenshots in the draft PR. Assess descriptive
+quality with a small synthetic matrix across supported formats and languages.
+Any live model run needs a named provider, bounded input set and spend approval.
+
+## Rollout and recovery
+
+Deliver additive Klicker readers/save support before enabling service metadata
+and the suggestion UI. Verify new-reader/old-producer and old-reader/new-producer
+compatibility explicitly. Source delivery is separate from deployment.
+
+Rollback stops producer emission and suggestion presentation while retaining
+readers for already persisted metadata and selections. Historical banks and
+reviewed drafts receive no automatic backfill. Existing graph rebuild behavior
+is unrelated to this metadata change.
+
+Terminal: reviewed source packages with passing relevant checks and actual
+browser evidence, delivered as draft PR/MRs once implementation is approved.
+Pause for a new provider/data boundary, schema migration, tag identity change,
+overwriting reviewed work, or separately gated deployment.
+
+## Progress
+
+- Planning construction completed by independent native planner Gibbs on
+  2026-09-12; parent verified the title fallback, empty draft-tag view and exact
+  owner/name persistence contracts.
+- Round 1 native planner challenge: accepted four findings covering explicit
+  draft persistence, ID-based writes under rename/deletion, omitted-field
+  compatibility, and cross-build uniqueness retries. The plan now specifies
+  each mechanism and acceptance check. Round 2 returned APPROVED.
+- Optional AGY/Gemini review was blocked by automatic approval review because
+  the payload/destination lacked explicit egress approval. No optional review
+  was sent; native review remains the planning gate.
+- Implementation approved; Klicker worktree `trees/rs/question-titles-tags`
+  starts at merged `529bd0cf64`; service worktree of the same branch name
+  starts at `origin/main` `7480c7f`. Producer worker owns only the service;
+  parent owns Klicker integration, persistence and verification.


### PR DESCRIPTION
Generated questions arrive with truncated stems as titles and no topic tags. This branch adds compatible title/tag metadata ingestion plus a review flow that proposes matching owner tags before new labels, without preselecting either.

## What changes

Lecturers can edit the title, select or enter tags, and save a draft explicitly before reloading. Keep persists the visible edits and the tag selection atomically with the element.

The tag input sits in the shared editor's canonical tag slot directly below the title, so the library editor keeps its normal layout, autosave, and save/dismissal behavior. Suggestions appear beside that input as independent toggles; a selected tag that is no longer available is shown with an explicit removal action instead of failing the save silently.

Existing tags keep their IDs across renames, and new tags are created only by a successful Keep. Owner checks, revision fences, exact retries, and bounded concurrent-name retries protect against foreign tags, lost edits, and duplicate saves. Older generation banks and legacy tag inputs stay supported. No database migration and no historical backfill.

## Review follow-up

The automated review found six issues; all are addressed in this revision.

- Typed tag names are normalized before the exact-name lookup, so a name matching an existing tag selects it instead of proposing a duplicate.
- The tag key pins its locale; an unpinned locale lowercases differently under e.g. Turkish.
- A null legacy `tags` field is treated as absent rather than silently clearing a stored selection.
- Proposal resolution batches its existence check into one lookup instead of one query per name inside the locked keep transaction.
- The draft editor remounts per draft, so a local tag override, the revision fence and the form values cannot leak between drafts.
- The unused selection comparator and the unused service re-export are removed.

The remaining summary findings were already settled: the unreachable proposal guard was removed earlier on this branch, and the shared empty selection now returns a fresh object.

## Validation

<!-- screenshots:start -->
| English desktop | German mobile |
| --- | --- |
| ![Existing and proposed tags in English](https://github.com/user-attachments/assets/d4c03d83-2363-442c-9d88-9b8a185b06f7) | ![German tag review at 390px](https://github.com/user-attachments/assets/138acd96-78ba-454e-9899-461513a73d38) |

Captured from the equivalent local source tree with synthetic fixtures. The tag section fits narrow screens; some existing toolbar/scoring content still overflows. Handler interactions used observed DOM clicks because pointer automation was unreliable.
<!-- screenshots:end -->

- GraphQL, types and frontend-manage type checks pass.
- 289 generation-related GraphQL tests pass, including the tag selection, resolution and conflict-retry coverage.
- 8 frontend-manage node tests pass, including a new regression test for normalized manual tag entry.
- Required hosted checks pass on the current head.

Browser verification of the repositioned tag field still needs a fresh capture on this revision: the local generation page reports missing configuration and the devcontainer runtime needs recreation. The screenshots above predate the placement correction, so they show the tag review panel rather than its final location below the title. That gap is the main outstanding verification on this PR.
