### PR TITLE
enhance(element-generation): keep generated question tags

### DIFF
--- a/packages/graphql/src/schema/elementGeneration.ts
+++ b/packages/graphql/src/schema/elementGeneration.ts
@@ -532,7 +532,7 @@ function editableView(
     explanation: question.explanation,
     choices: question.choices,
     cardType: null,
-    tags: [],
+    tags: question.tags ?? [],
   }
 }
 

--- a/packages/graphql/src/services/elementGeneration.ts
+++ b/packages/graphql/src/services/elementGeneration.ts
@@ -323,6 +323,7 @@ function normalizedKeepPayload(
     stem: input.content,
     context: null,
     explanation: input.explanation ?? null,
+    tags: input.tags ?? [],
     choices,
   }
   const elementInput: ElementManipulationInput = {
@@ -345,7 +346,7 @@ function normalizedKeepPayload(
     },
     basePoints: input.basePoints,
     pointsMultiplier: input.pointsMultiplier,
-    tags: input.tags ?? [],
+    tags: current.tags,
   }
   return { current, elementInput }
 }
@@ -594,8 +595,7 @@ export async function updateGeneratedElementDraft(
   if (
     !isQuestionElementType(elementType) ||
     !input.current.choices ||
-    input.current.cardType != null ||
-    (input.current.tags?.length ?? 0) > 0
+    input.current.cardType != null
   ) {
     throw questionGenerationServiceError(
       'DRAFT_INVALID',
@@ -608,6 +608,7 @@ export async function updateGeneratedElementDraft(
     stem: input.current.prompt,
     context: input.current.context ?? null,
     explanation: input.current.explanation ?? null,
+    tags: input.current.tags ?? [],
     choices: input.current.choices.map((choice) => ({
       ...choice,
       feedback: choice.feedback ?? null,

--- a/packages/graphql/src/services/elements.ts
+++ b/packages/graphql/src/services/elements.ts
@@ -119,7 +119,7 @@ function generatedChoicesElementInput(
     basePoints: true,
     pointsMultiplier: 1,
     difficultyLevel,
-    tags: [],
+    tags: draft.tags ?? [],
     options: {
       displayMode: DisplayMode.LIST,
       hasSampleSolution: true,

--- a/packages/graphql/src/services/questionGenerationArtifacts.ts
+++ b/packages/graphql/src/services/questionGenerationArtifacts.ts
@@ -472,6 +472,7 @@ const finalQuestionSchema = z
   .object({
     id: canonicalIdentifier(200),
     title: boundedText(500).optional(),
+    suggested_tags: z.array(boundedText(200)).max(50).optional(),
     stem: boundedText(10_000),
     context_inline: z.string().trim().max(20_000).nullable().optional(),
     explanation: z.string().trim().max(20_000).nullable().optional(),
@@ -599,6 +600,17 @@ function normalizedPlainText(value: string): string {
     .replace(/[`*_~>#]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+function normalizeSuggestedTags(value: string[] | undefined): string[] {
+  const tags: string[] = []
+  for (const candidate of value ?? []) {
+    const tag = normalizedPlainText(candidate)
+    if (!tag || tags.includes(tag)) continue
+    tags.push(tag)
+    if (tags.length === 5) break
+  }
+  return tags
 }
 
 export function deriveGeneratedQuestionName(
@@ -1439,6 +1451,7 @@ function normalizeFinalQuestion(
     stem: question.stem.trim(),
     context: optionalText(question.context_inline),
     explanation: optionalText(question.explanation),
+    tags: normalizeSuggestedTags(question.suggested_tags),
     choices,
     bloomLevel: question.bloom_level,
     targetDifficulty:

--- a/packages/graphql/src/services/questionGenerationDrafts.ts
+++ b/packages/graphql/src/services/questionGenerationDrafts.ts
@@ -13,6 +13,8 @@ const MAX_OPTION_LENGTH = 10_000
 const MAX_OPTION_COUNT = 10
 const MC_OPTION_COUNT = 5
 const KPRIM_OPTION_COUNT = 4
+const MAX_TAG_COUNT = 20
+const MAX_TAG_LENGTH = 200
 
 export type UpdateGeneratedQuestionDraftInput = {
   draftId: string
@@ -22,16 +24,30 @@ export type UpdateGeneratedQuestionDraftInput = {
 
 export type GeneratedQuestionEditableInputValue = Omit<
   GeneratedQuestionEditable,
-  'itemType' | 'context' | 'explanation' | 'choices'
+  'itemType' | 'context' | 'explanation' | 'choices' | 'tags'
 > & {
   itemType?: QuestionGenerationItemType | null
   context?: string | null
   explanation?: string | null
+  tags?: string[] | null
   choices: Array<
     Omit<GeneratedQuestionEditable['choices'][number], 'feedback'> & {
       feedback?: string | null
     }
   >
+}
+
+function normalizeTags(value: string[] | null | undefined): string[] {
+  const tags = [...new Set((value ?? []).map((tag) => tag.trim()))].filter(
+    (tag) => tag.length > 0
+  )
+  if (
+    tags.length > MAX_TAG_COUNT ||
+    tags.some((tag) => tag.length > MAX_TAG_LENGTH)
+  ) {
+    return draftError('Generated question tags are invalid')
+  }
+  return tags
 }
 
 export type GeneratedQuestionDecisionInput = 'OPEN' | 'ACCEPTED' | 'REJECTED'
@@ -100,6 +116,7 @@ export function normalizeGeneratedQuestionEditable(
       MAX_OPTION_LENGTH
     ),
   }))
+  const tags = normalizeTags(value.tags)
   if (
     choices.some((choice) => typeof choice.correct !== 'boolean') ||
     (itemType === 'SC' &&
@@ -133,6 +150,7 @@ export function normalizeGeneratedQuestionEditable(
       'Draft explanation',
       MAX_STEM_LENGTH
     ),
+    tags,
     choices,
   }
 }

--- a/packages/graphql/test/elementGenerationDraftPersistence.test.ts
+++ b/packages/graphql/test/elementGenerationDraftPersistence.test.ts
@@ -36,6 +36,7 @@ const current = {
   stem: 'Which answer is correct?',
   context: null,
   explanation: 'A is correct.',
+  tags: ['generated'],
   choices: [
     {
       id: 'choice-a',

--- a/packages/graphql/test/questionGenerationArtifacts.test.ts
+++ b/packages/graphql/test/questionGenerationArtifacts.test.ts
@@ -1218,6 +1218,16 @@ describe('question-generation artifact normalization', () => {
     }
     const currentBank = finalBank({
       provenance: completeQuestionProvenance(),
+      title: 'Malolaktische Gärung',
+      suggested_tags: [
+        ' Gärung ',
+        'Gärung',
+        'Weinchemie',
+        '<b>Biologie</b>',
+        'extra',
+        '**Detailwissen**',
+        'ignoriert',
+      ],
     })
     currentBank.metadata.format = 'SC'
     currentBank.metadata.item_format = 'sc'
@@ -1230,6 +1240,13 @@ describe('question-generation artifact normalization', () => {
       provenanceAuthority: provenanceAuthority(),
     })
 
+    expect(questions[0]?.tags).toEqual([
+      'Gärung',
+      'Weinchemie',
+      'Biologie',
+      'extra',
+      'Detailwissen',
+    ])
     expect(questions[0]?.provenance).toMatchObject({
       lineageStatus: 'complete',
       graphVersionId: 'graph-version-1',
@@ -1768,6 +1785,7 @@ describe('question-generation artifact normalization', () => {
         sourceQuestionId: 'q01',
         name: 'Welche Umwandlung findet bei der malolaktischen Gärung statt?',
         stem: 'Welche Umwandlung findet bei der malolaktischen Gärung statt?',
+        tags: [],
         context: 'Eine Weinprobe wird nach der Gärung untersucht.',
         explanation: null,
         choices: [

--- a/packages/types/src/questionGeneration.ts
+++ b/packages/types/src/questionGeneration.ts
@@ -164,6 +164,7 @@ export type GeneratedQuestionEditable = {
   stem: string
   context: string | null
   explanation: string | null
+  tags?: string[]
   choices: Array<{
     id: string
     label: string


### PR DESCRIPTION
# Keep generated question tags

## Problem and resulting behavior

The KG worker already returns `suggested_tags` for generated questions, but Klicker discarded them downstream: the final-bank parser dropped the field, the editable view hardcoded question tags to `[]`, and both the single-keep and bulk-keep paths saved empty tag lists. Generated questions therefore arrived in the review editor without tags, and kept elements were persisted without them.

The parser now reads `suggested_tags` and normalizes them to plain-text tags: markdown and HTML are stripped with the same `normalizedPlainText` helper used for question names, entries are trimmed and deduplicated, and the list is capped at five. The normalized tags seed the generated draft's `current` state, so they prepopulate the normal element-editor tag input and can be edited exactly like tags on any other element — no generation-specific tag UI. Draft updates accept tag edits with bounds (max 20 tags, max 200 characters each), and both keep paths now persist the draft's tags with the saved element.

## Scope and limits

- No database migration: `GeneratedElementDraft.current` is JSON and elements already support tags.
- Existing terminal builds are not re-parsed, so drafts from earlier builds (including the current STG build) remain without tags; tags appear only for generation runs started after this is deployed.
- End-to-end editor behavior (generated tags prepopulating the normal tag input and persisting on keep) is not yet browser-verified because it requires a fresh generation run against a deployed build; the parser and normalization layers are covered by unit tests.

## Validation

- `pnpm --filter @klicker-uzh/types build` — passes.
- `pnpm --filter @klicker-uzh/graphql exec vitest run test/questionGenerationArtifacts.test.ts` — 76 passed, including new coverage for trim, dedupe, HTML/markdown stripping, and the five-tag cap; banks without suggested tags normalize to `tags: []`.
- `elementGenerationDraftPersistence.test.ts` — updated for the new contract: the seeded `tags` now appear in the persisted draft's `current` state alongside the saved element's tags; suite green (95 tests across both files at 9b700daad).
- `pnpm --filter @klicker-uzh/graphql check` — codegen regenerates an unchanged public schema snapshot and `tsc --noEmit` passes.
- Exact-head CI on 9b700daad: `test-graphql` and `check` green. `ocr-review` (automatic draft review) fails on the external DeepSeek provider gate — every item is provider-classified ("provider or subtask request failed"), unrelated to this branch's changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated questions can now include tags throughout drafting, editing, and final output.
  * Suggested tags are cleaned up, deduplicated, and limited before being applied.
  * Tags are preserved when generating question and choice-based elements.

* **Bug Fixes**
  * Corrected generated views and saved elements so associated tags are no longer lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->