### PR TITLE
fix(ci): start chat for chatbot authoring tests

### DIFF
--- a/playwright/profiles.json
+++ b/playwright/profiles.json
@@ -32,7 +32,11 @@
     },
     {
       "profile": "manage,chat",
-      "specs": ["A-login.spec.ts", "T-chatbot-authoring.spec.ts", "Y-chat.spec.ts"]
+      "specs": [
+        "A-login.spec.ts",
+        "T-chatbot-authoring.spec.ts",
+        "Y-chat.spec.ts"
+      ]
     },
     {
       "profile": "manage,live-quiz",

--- a/playwright/profiles.json
+++ b/playwright/profiles.json
@@ -2,10 +2,6 @@
   "version": 1,
   "groups": [
     {
-      "profile": "manage",
-      "specs": ["T-chatbot-authoring.spec.ts"]
-    },
-    {
       "profile": "manage,pwa",
       "specs": [
         "0-baseline-ops.spec.ts",
@@ -36,7 +32,7 @@
     },
     {
       "profile": "manage,chat",
-      "specs": ["A-login.spec.ts", "Y-chat.spec.ts"]
+      "specs": ["A-login.spec.ts", "T-chatbot-authoring.spec.ts", "Y-chat.spec.ts"]
     },
     {
       "profile": "manage,live-quiz",


### PR DESCRIPTION
The trusted Playwright profile assigned chatbot authoring tests to Manage alone. Integration branches now exercise the owner preview in Chat, so shard 6 reached an unavailable port 3004 and failed before validating the preview.

Move that existing spec to the `manage,chat` group. This keeps trusted profile selection and enables the app required by the test. It is a prerequisite for the failing preview case in #5917.

Validation: 22 existing selector and route tests passed; JSON and diff checks passed. No application code changes. Hosted CI is pending; the fix must land on `v3` before the trusted runner can use it for downstream PRs.
