### PR TITLE
fix(audit): accept Azure lock-state response casing

### DIFF
--- a/packages/audit/src/azure/blob-store.ts
+++ b/packages/audit/src/azure/blob-store.ts
@@ -104,7 +104,8 @@ export class AzureImmutableAuditBlobStore {
       }
       versionId = properties.versionId
       const existingExpiry = properties.immutabilityPolicyExpiresOn
-      const existingLocked = properties.immutabilityPolicyMode === 'Locked'
+      const existingLocked =
+        properties.immutabilityPolicyMode?.toLowerCase() === 'locked'
       if (
         existingLocked &&
         existingExpiry !== undefined &&

--- a/packages/audit/src/azure/media-store.ts
+++ b/packages/audit/src/azure/media-store.ts
@@ -146,7 +146,8 @@ export class AzureImmutableAuditMediaStore
     const requiredVersionId = requireVersionId(versionId, input.blobName)
     const version = blob.withVersion(requiredVersionId)
     const existingExpiry = properties.immutabilityPolicyExpiresOn
-    const alreadyLocked = properties.immutabilityPolicyMode === 'Locked'
+    const alreadyLocked =
+      properties.immutabilityPolicyMode?.toLowerCase() === 'locked'
     if (
       !alreadyLocked ||
       existingExpiry === undefined ||
@@ -165,7 +166,7 @@ export class AzureImmutableAuditMediaStore
     const lockedProperties = await version.getProperties()
     const lockedUntil = lockedProperties.immutabilityPolicyExpiresOn
     if (
-      lockedProperties.immutabilityPolicyMode !== 'Locked' ||
+      lockedProperties.immutabilityPolicyMode?.toLowerCase() !== 'locked' ||
       lockedUntil === undefined ||
       lockedUntil.getTime() < input.retainUntil.getTime()
     ) {
@@ -211,7 +212,7 @@ export class AzureImmutableAuditMediaStore
     const properties = await version.getProperties()
     if (
       !matchesBlobMetadata(properties.metadata, 'sha256', input.contentHash) ||
-      properties.immutabilityPolicyMode !== 'Locked' ||
+      properties.immutabilityPolicyMode?.toLowerCase() !== 'locked' ||
       properties.immutabilityPolicyExpiresOn === undefined
     ) {
       throw new AuditMediaConflictError(input.blobName)
@@ -235,7 +236,7 @@ export class AzureImmutableAuditMediaStore
     const extended = await version.getProperties()
     if (
       !matchesBlobMetadata(extended.metadata, 'sha256', input.contentHash) ||
-      extended.immutabilityPolicyMode !== 'Locked' ||
+      extended.immutabilityPolicyMode?.toLowerCase() !== 'locked' ||
       extended.immutabilityPolicyExpiresOn === undefined ||
       extended.immutabilityPolicyExpiresOn.getTime() <
         input.retainUntil.getTime()

--- a/packages/audit/src/azure/media-store.ts
+++ b/packages/audit/src/azure/media-store.ts
@@ -146,6 +146,7 @@ export class AzureImmutableAuditMediaStore
     const requiredVersionId = requireVersionId(versionId, input.blobName)
     const version = blob.withVersion(requiredVersionId)
     const existingExpiry = properties.immutabilityPolicyExpiresOn
+    // Azure returns lowercase policy modes; SDK writes still require 'Locked'.
     const alreadyLocked =
       properties.immutabilityPolicyMode?.toLowerCase() === 'locked'
     if (

--- a/packages/audit/test/blob-store.test.ts
+++ b/packages/audit/test/blob-store.test.ts
@@ -11,7 +11,7 @@ type StoredBlob = {
   contentType: string
   versionId: string
   expiresOn?: Date
-  policyMode?: 'Locked'
+  policyMode?: 'locked'
 }
 
 class MemoryContainer {
@@ -68,7 +68,7 @@ class MemoryContainer {
           }) {
             const stored = container.stored.get(name)!
             stored.expiresOn = policy.expiriesOn
-            stored.policyMode = 'Locked'
+            stored.policyMode = 'locked'
             container.policyCalls.push({
               name,
               versionId,

--- a/packages/audit/test/media-azure.test.ts
+++ b/packages/audit/test/media-azure.test.ts
@@ -18,7 +18,7 @@ type StoredMedia = {
   contentType: string
   versionId: string
   expiresOn?: Date
-  policyMode?: 'Locked'
+  policyMode?: 'locked' | 'Locked' | 'unlocked'
 }
 
 class MemoryMediaContainer {
@@ -84,7 +84,7 @@ class MemoryMediaContainer {
             container.policyCalls.push(versionId)
             if (container.persistPolicy) {
               stored.expiresOn = policy.expiriesOn
-              stored.policyMode = 'Locked'
+              stored.policyMode = 'locked'
             }
             return {}
           },
@@ -179,7 +179,7 @@ describe('Azure immutable audit media store', () => {
     })
     expect(created.outcome).toBe('CREATED')
     expect(replay.outcome).toBe('IDENTICAL_REPLAY')
-    expect(container.stored.get(input.blobName)?.policyMode).toBe('Locked')
+    expect(container.stored.get(input.blobName)?.policyMode).toBe('locked')
     expect(replay.retainUntil).toEqual(input.retainUntil)
   })
 
@@ -305,7 +305,7 @@ describe('Azure immutable audit media store', () => {
       outcome: 'IDENTICAL_REPLAY',
     })
     expect(container.policyCalls).toEqual(['version-1', 'version-1'])
-    expect(stored.policyMode).toBe('Locked')
+    expect(stored.policyMode).toBe('locked')
   })
 
   it('validates case-insensitive hashes during retention renewal', async () => {
@@ -333,5 +333,41 @@ describe('Azure immutable audit media store', () => {
       AuditMediaConflictError
     )
     expect(container.policyCalls).toHaveLength(2)
+  })
+  it.each([
+    'locked',
+    'Locked',
+  ] as const)('accepts a sufficient %s policy without another write', async (policyMode) => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('policy case compatibility'))
+    await store.createFromFile(input)
+    container.stored.get(input.blobName)!.policyMode = policyMode
+    await expect(store.createFromFile(input)).resolves.toMatchObject({
+      outcome: 'IDENTICAL_REPLAY',
+    })
+    await expect(store.extendRetention(input)).resolves.toMatchObject({
+      outcome: 'ALREADY_SUFFICIENT',
+    })
+    expect(container.policyCalls).toHaveLength(1)
+  })
+
+  it('rejects an unlocked policy during verification and renewal', async () => {
+    const container = new MemoryMediaContainer()
+    const store = new AzureImmutableAuditMediaStore(
+      container as unknown as ContainerClient
+    )
+    const input = await mediaFixture(Buffer.from('unlocked policy'))
+    await store.createFromFile(input)
+    container.stored.get(input.blobName)!.policyMode = 'unlocked'
+    container.persistPolicy = false
+    await expect(store.createFromFile(input)).rejects.toThrow(
+      'was not durably locked'
+    )
+    await expect(store.extendRetention(input)).rejects.toBeInstanceOf(
+      AuditMediaConflictError
+    )
   })
 })


### PR DESCRIPTION
Azure returns the blob immutability policy mode as lowercase `locked`. The existing adapters compared it with `Locked`, causing already-locked evidence to be treated as insufficient and media lock verification to reject valid responses.

Normalize the mode only when reading it. Retention expiry, content hashes and version checks remain enforced, and unlocked policies are rejected. This isolates the lock-verification repair discussed in #5905; that PR remains unmerged. No additional source-account support, IAM, deployment configuration or migration is included.

Validation: all 33 blob/media adapter tests and the audit package type check passed in an isolated container. The audit package build passed. An offline run passed 125 tests; three integration suites could not run without Azurite/PostgreSQL. Slice review found no issues; final review requested one explanatory comment, now added. Hosted CI remains pending and inherits the audit image contract fix from #5917. No live Azure or staging acceptance is claimed.




### Integrated audit-base refresh

Head `6c70751118` merges `v3-audit@7d92c005c44c3b5e6d2231bb046776f0b9629e29` without conflicts. The resulting PR still changes only the four intended Azure adapter/test files. All 33 focused adapter tests and audit type checking pass on the refreshed source using the cached container toolchain. The updated repository lockfile differs from that cache, so full current-lockfile verification remains assigned to hosted CI. The isolated test container exited and was removed. No staging or production settings changed.
