### PR TITLE
fix(element-generation): preserve generated question tags in drafts

### DIFF
--- a/packages/graphql/src/services/elementGenerationCompletion.ts
+++ b/packages/graphql/src/services/elementGenerationCompletion.ts
@@ -110,6 +110,7 @@ export async function completeElementGeneration(
                   stem: original.stem,
                   context: original.context,
                   explanation: original.explanation,
+                  tags: original.tags,
                   choices: original.choices.map((choice) => ({ ...choice })),
                 },
                 bloomLevel: original.bloomLevel,

--- a/packages/graphql/test/elementGenerationCompletion.integration.test.ts
+++ b/packages/graphql/test/elementGenerationCompletion.integration.test.ts
@@ -36,6 +36,7 @@ function question(
     stem: 'Choose the correct answer',
     context: null,
     explanation: 'Explanation',
+    tags: ['synthetic-question'],
     choices: Array.from(
       { length: itemType === 'MC' ? 5 : itemType === 'KPRIM' ? 4 : 2 },
       (_, index) => ({


### PR DESCRIPTION
## Problem and resulting behavior

PR #5927 seeds generated question tags and the normal editor can edit them, but the initial completion handoff omitted `tags` when copying a generated question into `GeneratedElementDraft.current`. Tags could therefore disappear when the draft was first persisted.

This follow-up carries `original.tags` into the completion draft for SC, MC, and KPRIM questions. The existing completion integration fixture now includes a synthetic tag, so the persistence assertion covers the handoff.

## Validation

- `pnpm --filter @klicker-uzh/graphql exec vitest run test/elementGenerationCompletion.integration.test.ts` — 26 passed in the isolated runtime.
- `pnpm --filter @klicker-uzh/graphql check` — passed in the isolated runtime, including code generation and TypeScript checks.
- `git diff --cached --check` and staged `gitleaks` scan — passed.
- The normal pre-commit and pre-push hooks were not completed because the managed devrouter runtime had recorded-configuration drift and the host fallback uses Node 22 with missing repository tools. Those are environment/toolchain failures; the focused container verification passed before the runtime stopped.
